### PR TITLE
Fixed warning about overflow, rtl-string line 3663.

### DIFF
--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -3660,7 +3660,7 @@ private function hEvalAscCase _
 	else
 		chara = asc( "a" )
 		charz = asc( "z" )
-		chardiff = asc( "A" ) - asc( "a" )
+		chardiff = cint(asc( "A" )) - cint(asc( "a" ))
 	end if
 
 	if( symbGetType( literal ) = FB_DATATYPE_WCHAR ) then


### PR DESCRIPTION
ASC function return value is uinteger, uinteger - uinteger = uinteger.
Previous code would put incorrect value into chardiff.
