### PR TITLE
Fixed issue where screeninfo would return incorrect information.

### DIFF
--- a/src/gfxlib2/win32/gfx_win32.c
+++ b/src/gfxlib2/win32/gfx_win32.c
@@ -753,7 +753,7 @@ void fb_hScreenInfo(ssize_t *width, ssize_t *height, ssize_t *depth, ssize_t *re
 {
 	DEVMODE cur;
 
-	EnumDisplaySettings(NULL,-1,&cur);
+	EnumDisplaySettings(NULL,ENUM_CURRENT_SETTINGS,&cur);
 	*width = cur.dmPelsWidth;
 	*height = cur.dmPelsHeight;
 	*depth = cur.dmBitsPerPel;


### PR DESCRIPTION
Appropriate method determined by mysoft in ##freebasic.
