### PR TITLE
Fix lset/rset when the rhs was an empty var-len string (was mistakenly a...

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -204,6 +204,7 @@ Version 0.91.0:
 - 0.90.0 regression: Some cases of binary operations involving unsigned operands and constants could cause the compiler to show "implicit conversion" warnings due to internal transformations, for example: dim as uinteger a, b : print a - (b - 1)
 - Bad code generated for temporary variable destruction in local array initializers: temporary strings or UDTs with destructors could be destroyed before first used
 - #728: Buggy overload resolution for Byval As Const parameters
+- LSET / RSET were aborting when the rhs was an empty var-len string
 
 
 Version 0.90.1:

--- a/src/rtlib/str_set.c
+++ b/src/rtlib/str_set.c
@@ -6,7 +6,7 @@ FBCALL void fb_StrLset ( FBSTRING *dst, FBSTRING *src )
 {
 	ssize_t slen, dlen, len;
 
-	if( (dst != NULL) && (dst->data != NULL) && (src != NULL) && (src->data != NULL) )
+	if( (dst != NULL) && (dst->data != NULL) && (src != NULL) )
 	{
 		slen = FB_STRSIZE( src );
 		dlen = FB_STRSIZE( dst );
@@ -39,7 +39,7 @@ FBCALL void fb_StrRset ( FBSTRING *dst, FBSTRING *src )
 {
 	ssize_t slen, dlen, len, padlen;
 
-	if( (dst != NULL) && (dst->data != NULL) && (src != NULL) && (src->data != NULL) )
+	if( (dst != NULL) && (dst->data != NULL) && (src != NULL) )
 	{
 		slen = FB_STRSIZE( src );
 		dlen = FB_STRSIZE( dst );

--- a/tests/string/lrset.bas
+++ b/tests/string/lrset.bas
@@ -1,0 +1,58 @@
+# include "fbcu.bi"
+
+namespace fbc_tests.string_.lrset
+
+#macro TEST_LSET(s1, s2, l1, l2)
+	s1 = left("ABCDEFGH", (l1) )
+	s2 = left("01234567", (l2) )
+	lset s1 = s2
+	if( (l1) >= (l2) ) then
+		CU_ASSERT_EQUAL( s1, (s2) & space( (l1) - (l2) ) )
+	else
+		CU_ASSERT_EQUAL( s1, left( s2, l1 ) )
+	end if
+#endmacro
+
+#macro TEST_RSET(s1, s2, l1, l2)
+	s1 = left("ABCDEFGH", (l1) )
+	s2 = left("01234567", (l2) )
+	rset (s1) = (s2)
+	if( (l1) >= (l2) ) then
+		CU_ASSERT_EQUAL( s1, space( (l1) - (l2) ) & (s2) )
+	else
+		CU_ASSERT_EQUAL( s1, left( s2, l1 ) )
+	end if
+#endmacro
+
+sub test_lrset cdecl ()
+
+	const MAX = 8
+	dim as string s1, s2
+	dim as zstring*(MAX+1) z1, z2
+
+	for i1 as integer = 0 to MAX
+		for i2 as integer = 0 to MAX
+
+			TEST_LSET( s1, s2, i1, i2 )
+			TEST_LSET( s1, z2, i1, i2 )
+			TEST_LSET( z1, s2, i1, i2 )
+			TEST_LSET( z1, z2, i1, i2 )
+
+			TEST_RSET( s1, s2, i1, i2 )
+			TEST_RSET( s1, z2, i1, i2 )
+			TEST_RSET( z1, s2, i1, i2 )
+			TEST_RSET( z1, z2, i1, i2 )
+
+		next i2
+	next i1
+
+end sub
+
+sub ctor () constructor
+
+	fbcu.add_suite("fbc_tests.string_.lrset")
+	fbcu.add_test("test_lrset", @test_lrset)
+
+end sub
+
+end namespace


### PR DESCRIPTION
Fix lset/rset when the rhs was an empty var-len string
