### PR TITLE
Lots of rtlib & gfxlib stuff for unix-like systems

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Version 1.04.0
 - On Darwin, linking with rtlib failed due to __fb_errmsg being discarded
 - Correctly implemented fb_hGetExeName for FreeBSD, NetBSD, Darwin and Solaris (needed by gfxlib2)
 - The FB makefile can now detect the OS when building on Solaris
+- fbc will now pass the proper parameters to "as" on OS X
 
 
 Version 1.03.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,8 @@ Version 1.04.0
 [changed]
 
 [added]
-- exepath() now works on FreeBSD
+- exepath() now works on FreeBSD, NetBSD, Darwin and Solaris
+- The FB gfxlib can now be built on OS X using XQuartz by passing ENABLE_XQUARTZ=1 to make
 
 [fixed]
 - False-positive "ambigious sizeof" warnings if the identifier could refer only to a type or procedure (in that case it should already be fairly clear that the type will be chosen, not the procedure, because sizeof() can't be applied to procedures at all), or if an expression such as "array(0)" is given to sizeof() (i.e. something that starts with an identifier but is followed by further tokens that clarify that it's not refering to a type)
@@ -18,6 +19,10 @@ Version 1.04.0
 - __FB_ASM__ wasn't #defined for x86_64 even though the -asm option can be used on x86_64 too
 - C backend: UDTs using Field=N were emitted incorrectly (causing gcc errors), if they contained a field of type of another UDT that didn't use Field=N.
 - False-positive "ambigious sizeof" warnings if the identifier could refer to a type or variable of that type (in this case the size is obviously the same, and it doesn't matter which one is used)
+- rtlib & gfxlib compilation was broken on NetBSD, Darwin and Solaris (header & include-path issues)
+- On Darwin, linking with rtlib failed due to __fb_errmsg being discarded
+- Correctly implemented fb_hGetExeName for FreeBSD, NetBSD, Darwin and Solaris (needed by gfxlib2)
+- The FB makefile can now detect the OS when building on Solaris
 
 
 Version 1.03.0

--- a/makefile
+++ b/makefile
@@ -419,6 +419,10 @@ ifeq ($(TARGET_OS),netbsd)
     -I/usr/pkg/include
 endif
 
+ifeq ($(TARGET_OS),darwin)
+  ALLCFLAGS += -I/opt/X11/include -I/usr/include/ffi
+endif
+
 ifneq ($(filter cygwin win32,$(TARGET_OS)),)
   # Increase compiler's available stack size, it uses lots of recursion
   ALLFBLFLAGS += -t 2048

--- a/makefile
+++ b/makefile
@@ -414,6 +414,11 @@ ifeq ($(TARGET_OS),xbox)
   DISABLE_MT := YesPlease
 endif
 
+ifeq ($(TARGET_OS),netbsd)
+  ALLCFLAGS += -I/usr/X11R7/include \
+    -I/usr/pkg/include
+endif
+
 ifneq ($(filter cygwin win32,$(TARGET_OS)),)
   # Increase compiler's available stack size, it uses lots of recursion
   ALLFBLFLAGS += -t 2048

--- a/makefile
+++ b/makefile
@@ -233,6 +233,9 @@ else
     ifeq ($(uname),OpenBSD)
       TARGET_OS := openbsd
     endif
+    ifeq ($(uname),SunOS)
+      TARGET_OS := solaris
+    endif
   endif
 
   ifndef TARGET_ARCH

--- a/makefile
+++ b/makefile
@@ -425,7 +425,9 @@ endif
 ifeq ($(TARGET_OS),darwin)
   ALLCFLAGS += -I/opt/X11/include -I/usr/include/ffi
   
-  ifndef ENABLE_XQUARTZ
+  ifdef ENABLE_XQUARTZ
+    ALLFBCFLAGS += -d ENABLE_XQUARTZ
+  else
     ALLCFLAGS += -DDISABLE_X11
   endif
 endif

--- a/makefile
+++ b/makefile
@@ -421,6 +421,10 @@ endif
 
 ifeq ($(TARGET_OS),darwin)
   ALLCFLAGS += -I/opt/X11/include -I/usr/include/ffi
+  
+  ifndef ENABLE_XQUARTZ
+    ALLCFLAGS += -DDISABLE_X11
+  endif
 endif
 
 ifneq ($(filter cygwin win32,$(TARGET_OS)),)

--- a/src/gfxlib2/unix/gfx_unix.c
+++ b/src/gfxlib2/unix/gfx_unix.c
@@ -5,7 +5,7 @@
 #include "../linux/fb_gfx_linux.h"
 #endif
 
-#if defined HOST_FREEBSD || defined HOST_OPENBSD || defined HOST_LINUX
+#if defined HOST_FREEBSD || defined HOST_OPENBSD || defined HOST_LINUX || defined HOST_DARWIN
 
 const GFXDRIVER *__fb_gfx_drivers_list[] = {
 

--- a/src/gfxlib2/unix/gfx_x11.c
+++ b/src/gfxlib2/unix/gfx_x11.c
@@ -1,5 +1,7 @@
 /* x11 window management code shared by x11 and opengl drivers */
 
+#include <sys/types.h>
+
 #ifndef DISABLE_X11
 
 #include "../fb_gfx.h"

--- a/src/rtlib/darwin/sys_getexename.c
+++ b/src/rtlib/darwin/sys_getexename.c
@@ -1,0 +1,23 @@
+/* get the executable's name */
+
+#include "../fb.h"
+#include "mach-o/dyld.h"
+
+char *fb_hGetExeName( char *dst, ssize_t maxlen )
+{
+	char *p;
+	uint32_t len = maxlen;
+
+	if (_NSGetExecutablePath(dst, &len) == 0) {
+		dst[len] = '\0';
+		p = strrchr(dst, '/');
+		if (p != NULL)
+			++p;
+		else
+			p = dst;
+	} else {
+		p = NULL;
+	}
+
+	return p;
+}

--- a/src/rtlib/darwin/sys_getexepath.c
+++ b/src/rtlib/darwin/sys_getexepath.c
@@ -1,0 +1,28 @@
+/* get the executable path */
+
+#include "../fb.h"
+#include "mach-o/dyld.h"
+
+char *fb_hGetExePath( char *dst, ssize_t maxlen )
+{
+	char *p;
+	uint32_t len = maxlen;
+
+	if (_NSGetExecutablePath(dst, &len) == 0) {
+		dst[len] = '\0';
+		p = strrchr(dst, '/');
+		if (p == dst) /* keep the "/" rather than returning "" */
+			*(p + 1) = '\0';
+		else if (p) {
+			*p = '\0';
+			/* OS X likes to append "/." to the path, so remove it */
+			if (*(p-2) == '/' && *(p-1) == '.')
+				*(p-2) = '\0';
+		} else
+			dst[0] = '\0';
+	} else {
+		p = NULL;
+	}
+
+	return p;
+}

--- a/src/rtlib/error_message.c
+++ b/src/rtlib/error_message.c
@@ -2,4 +2,4 @@
 
 #include "fb.h"
 
-char __fb_errmsg[FB_ERRMSG_SIZE];
+char __fb_errmsg[FB_ERRMSG_SIZE] = "";

--- a/src/rtlib/fb.h
+++ b/src/rtlib/fb.h
@@ -100,6 +100,11 @@
 	#include "xbox/fb_xbox.h"
 #endif
 
+#if defined HOST_SOLARIS
+	#undef alloca
+	#define alloca(x) __builtin_alloca(x)
+#endif
+
 #if defined ENABLE_MT && !defined HOST_DOS && !defined HOST_XBOX
 	FBCALL void fb_Lock( void );
 	FBCALL void fb_Unlock( void );

--- a/src/rtlib/freebsd/sys_getexename.c
+++ b/src/rtlib/freebsd/sys_getexename.c
@@ -1,13 +1,28 @@
 /* get the executable's name */
 
 #include "../fb.h"
+#include "sys/sysctl.h"
 
 char *fb_hGetExeName( char *dst, ssize_t maxlen )
 {
-	const char *p = strrchr( __fb_ctx.argv[0], '/' );
-	if( p )
-		strlcpy( dst, p + 1, maxlen );
-	else
-		strlcpy( dst, __fb_ctx.argv[0], maxlen );
-	return dst;
+	size_t len = maxlen;
+	char *p;
+	int mib[4];
+	mib[0] = CTL_KERN;
+	mib[1] = KERN_PROC;
+	mib[2] = KERN_PROC_PATHNAME;
+	mib[3] = -1;
+	
+	if (sysctl(mib, 4, dst, &len, NULL, 0) == 0) {
+		dst[len] = '\0';
+		p = strrchr(dst, '/');
+		if (p != NULL)
+			++p;
+		else
+			p = dst;
+	} else {
+		p = NULL;
+	}
+	
+	return p;
 }

--- a/src/rtlib/linux/sys_getexepath.c
+++ b/src/rtlib/linux/sys_getexepath.c
@@ -6,12 +6,10 @@
 char *fb_hGetExePath( char *dst, ssize_t maxlen )
 {
 	char *p;
-	char linkname[1024];
 	struct stat finfo;
 	ssize_t len;
 
-	sprintf(linkname, "/proc/%d/exe", getpid());
-	if ((stat(linkname, &finfo) == 0) && ((len = readlink(linkname, dst, maxlen - 1)) > -1)) {
+	if ((stat("/proc/self/exe", &finfo) == 0) && ((len = readlink("/proc/self/exe", dst, maxlen - 1)) > -1)) {
 		/* Linux-like proc fs is available */
 		dst[len] = '\0';
 		p = strrchr(dst, '/');

--- a/src/rtlib/netbsd/io_mouse.c
+++ b/src/rtlib/netbsd/io_mouse.c
@@ -1,7 +1,6 @@
 /* console mode mouse functions */
 
 #include "../fb.h"
-#include "fb_private_console.h"
 
 int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 {

--- a/src/rtlib/netbsd/sys_getexename.c
+++ b/src/rtlib/netbsd/sys_getexename.c
@@ -1,13 +1,25 @@
 /* get the executable's name */
 
 #include "../fb.h"
+#include <sys/stat.h>
 
 char *fb_hGetExeName( char *dst, ssize_t maxlen )
 {
-	const char *p = strrchr( __fb_ctx.argv[0], '/' );
-	if( p )
-		strlcpy( dst, p + 1, maxlen );
-	else
-		strlcpy( dst, __fb_ctx.argv[0], maxlen );
-	return dst;
+	char *p;
+	struct stat finfo;
+	ssize_t len;
+	
+	if ((stat("/proc/curproc/exe", &finfo) == 0) && ((len = readlink("/proc/curproc/exe", dst, maxlen - 1)) > -1)) {
+		/* NetBSD-like proc fs is available */
+		dst[len] = '\0';
+		p = strrchr(dst, '/');
+		if (p != NULL)
+			++p;
+		else
+			p = dst;
+	} else {
+		p = NULL;
+	}
+
+	return p;
 }

--- a/src/rtlib/netbsd/sys_getexepath.c
+++ b/src/rtlib/netbsd/sys_getexepath.c
@@ -1,24 +1,27 @@
 /* get the executable path */
 
 #include "../fb.h"
+#include <sys/stat.h>
 
 char *fb_hGetExePath( char *dst, ssize_t maxlen )
 {
-	const char *p = strrchr( __fb_ctx.argv[0], '/' );
-	if( p ) {
-		ssize_t len = p - __fb_ctx.argv[0];
-		if( len > maxlen ) {
-			len = maxlen;
-		}
-		else if( len == 0 ) {
-		/* keep the "/" rather than returning "" */
-			len = 1;
-		}
+	char *p;
+	struct stat finfo;
+	ssize_t len;
 
-		memcpy( dst, __fb_ctx.argv[0], len );
+	if ((stat("/proc/curproc/exe", &finfo) == 0) && ((len = readlink("/proc/curproc/exe", dst, maxlen - 1)) > -1)) {
+		/* NetBSD-like proc fs is available */
 		dst[len] = '\0';
+		p = strrchr(dst, '/');
+		if (p == dst) /* keep the "/" rather than returning "" */
+			*(p + 1) = '\0';
+		else if (p)
+			*p = '\0';
+		else
+			dst[0] = '\0';
 	} else {
-		*dst = '\0';
+		p = NULL;
 	}
-	return dst;
+
+	return p;
 }

--- a/src/rtlib/solaris/sys_getexename.c
+++ b/src/rtlib/solaris/sys_getexename.c
@@ -1,0 +1,27 @@
+/* get the executable's name */
+
+#include "../fb.h"
+#include <sys/stat.h>
+
+char *fb_hGetExeName( char *dst, ssize_t maxlen )
+{
+	char *p;
+	char linkname[1024];
+	struct stat finfo;
+	ssize_t len;
+
+	sprintf(linkname, "/proc/%lu/path/a.out", getpid());
+	if ((stat(linkname, &finfo) == 0) && ((len = readlink(linkname, dst, maxlen - 1)) > -1)) {
+		/* Solaris-like proc fs is available */
+		dst[len] = '\0';
+		p = strrchr(dst, '/');
+		if (p != NULL)
+			++p;
+		else
+			p = dst;
+	} else {
+		p = NULL;
+	}
+
+	return p;
+}

--- a/src/rtlib/solaris/sys_getexepath.c
+++ b/src/rtlib/solaris/sys_getexepath.c
@@ -1,0 +1,29 @@
+/* get the executable path */
+
+#include "../fb.h"
+#include <sys/stat.h>
+
+char *fb_hGetExePath( char *dst, ssize_t maxlen )
+{
+	char *p;
+	char linkname[1024];
+	struct stat finfo;
+	ssize_t len;
+
+	sprintf(linkname, "/proc/%lu/path/a.out", getpid());
+	if ((stat(linkname, &finfo) == 0) && ((len = readlink(linkname, dst, maxlen - 1)) > -1)) {
+		/* Solaris-like proc fs is available */
+		dst[len] = '\0';
+		p = strrchr(dst, '/');
+		if (p == dst) /* keep the "/" rather than returning "" */
+			*(p + 1) = '\0';
+		else if (p)
+			*p = '\0';
+		else
+			dst[0] = '\0';
+	} else {
+		p = NULL;
+	}
+
+	return p;
+}

--- a/src/rtlib/unix/hinit.c
+++ b/src/rtlib/unix/hinit.c
@@ -485,7 +485,7 @@ static void hInit( void )
 	if (!tgetflag("am"))
 		return;
 	for (i = 0; i < SEQ_MAX; i++)
-		__fb_con.seq[i] = tgetstr(seq[i], NULL);
+		__fb_con.seq[i] = tgetstr((char*)seq[i], NULL);
 
 	/* !!!TODO!!! detect other OS consoles? (freebsd: 'cons25', etc?) */
 	if ((!strcmp(term, "console")) || (!strncmp(term, "linux", 5)))


### PR DESCRIPTION
There are lots of small changes, so I'll provide a detailed list. With these changes, it's possible to run graphical fb-programs (with minor headaches remaining) on FreeBSD and OS X (and I think Solaris and NetBSD too, but I'm not sure right now).
If something's problematic (especially the makefile changes), please provide feedback so I can change the stuff.

Commit | Explanation | Tested on
--------- | --------------- | ------------
27bf4b6 | The NetBSD-specific code included a header that didn't exist in the same directory. Since it wasn't needed anyway, I simply removed the #include. | NetBSD 6.1.5 i386
e42f942 | NetBSD has several separate include-directories. I added the one for packages installed via "pkg" and the one for X11. I'm not sure this is enough though, because the X11 include path is version specific and could change in the future. | NetBSD 6.1.5 i386
5edcb59 | There wasn't a correct implementation of fb_hGetExePath for NetBSD yet, so I implemented it using /proc/curproc/exe and parts of the Linux-specific implementation. | NetBSD 6.1.5 i386
f90f829 | This patch isn't really needed because the old code worked fine already, but it simplifies the code a bit and reduces the room for problems. | Kubuntu 15.04 i386 with Linux 3.19.0-22
cd7d9ad | The fbc-makefile didn't find the headers for X11 and libffi on OS X because they're in different paths than on Linux. With this patch the makefile appends the X11- and libffi-specific search paths to the C-flags when building on OS X. They're not version-specific like the NetBSD ones, so they should be fine. | OS X Yosemite x86_64
f5e5879 | There was no implementation for fb_hGetExePath for OS X before, which lead to problems when trying to use exepath in FB-code or even trying to compile fbc. The code uses _NSGetExecutablePath and removes the "/." which OS X appends. | OS X Yosemite x86_64
a3e6c4d | hInit() was passing a const char * to tgestr which made the compiler complain. Since afaik ncurses doesn't change the passed string, I added a cast to char * which makes the complaint go away. | OS X, Kubuntu, NetBSD
d7a5306 | The linker on OS X likes to remove symbols when it thinks they aren't used. Because the __fb_errmsg-string wasn't initialized, it got removed on OS X which lead to problems when linking FB-programs. Now it's initialized to an empty string which fixes the problem (alternative would be to run ranlib -c on the rtlib). | OS X Yosemite x86_64
7bc051f | fb_hGetExeName wasn't implemented for OS X, but it's needed for running gfxlib2-programs, so I wrote an implementation based on the Linux-specific code and _NSGetExecutablePath. | OS X Yosemite x86_64
9ec36c6 | When not including X11-support on OS X, gcc couldn't resolve the ssize_t-type in gfx_x11.c. I fixed it by simply including sys/types.h. | OS X Yosemite x86_64
5f8adbf | gfxlib2 wasn't allowing to use X11 on OS X. I added the option to enable X11 support by passing XQUARTZ_ENABLE=1 to the makefile. This allows to run gfxlib2-programs on OS X. However, for this to work, the installation of XQuartz is required. Since XQuartz isn't installed by default on fresh OS X installations, the XQuartz support is disabled by default. I consider this a temporary workaround until gfxlib2 gets a native Cocoa-backend. | OS X Yosemite x86_64
75ef944 | The rtlib didn't have an implementation of fb_hGetExePath for Solaris yet, so I added one using the Solaris-specific procfs. | OpenIndiana (Illumos) 5.11 i386
6f21bbb | Implementation of fb_hGetExeName for Solaris. Similar to the above commit. | OpenIndiana (Illumos) 5.11 i386
4e93bea | The makefile wasn't able to detect Solaris/SunOS automatically by using uname, so I fixed that. | OpenIndiana (Illumos) 5.11 i386
29df4d2 | For some reason, gcc on Solaris complained about the usage of alloca (something about redefinition...). After fiddling around for a while I resolved this by using __builtin_alloca instead, which seems to work. I'm not sure if this is a permanent fix (or even a good one). | OpenIndiana (Illumos) 5.11 i386
8efed13 | Implementation of fb_hGetExeName for FreeBSD. Similar to the fb_hGetExePath implementation, also uses the KERN_PROC_PATHNAME syscall. | FreeBSD 10.1-RELEASE i386
387cc47 | Implementation of fb_hGetExeName for NetBSD, similar to the fb_hGetExePath implementation. Also uses /proc/curproc/exe (NetBSD-specific procfs). | NetBSD 6.1.5 i386


Some notes:
- The OS X implementations of fb_hGetExePath and fb_hGetExecutablePath use _NSGetExecutablePath. As far as I remember, the returned path can contain symlinks, so maybe using realpath() could be a good idea. This should probably be investigated and adressed in a future commit.
- Running fbc on OS X works fine now. Unfortunately, the out-of-the-box experience on OS X still isn't very good, because "as" on OS X has problems with the flags fbc passes. See this pastebin-link for details: http://pastebin.com/emE3iF0T
- When not explicitly passing "-asm att" on OS X, gcc complains: "qbsprite.c:1:0: error: -masm=intel not supported in this configuration"
- As i wrote above, using XQuartz on OS X is not a perfect solution. I played around with Cocoa a bit, and maybe I'm able to come up with a rough prototype of a Cocoa-backend in the near future. But I can't promise anything.
- Talking about gfxlib-backends, a Wayland-backend would be nice too, although it's not really necessary right now since X11 will remain available on Linux systems in the near future.
- I wanted to implement fb_hGetExePath for OpenBSD too, but it seems that OpenBSD doesn't provide an interface for that. There is no procfs on OpenBSD by default, and it also doesn't provide a FreeBSD-like syscall for that. I already don't like this system.
- Some platforms (Solaris for example) use rather old versions of gcc (4.4 I think). These old versions seem to have problems with the C-code fbc emits. This could be a problem when there's no asm-backend available.
- Afaik the fb_hGetExeName function isn't directly available to FB-programs right now. It might be a good idea to add that, since it can differ from what command(0) tells.

And here's proof of gfxlib2 on OS X ;)
[![gfxlib on OS X](http://fs1.directupload.net/images/150715/temp/ljbjjdzx.png)](http://www.directupload.net/file/d/4049/ljbjjdzx_png.htm)