### PR TITLE
Fix for issue #763

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Version 1.04.0
 - The FB makefile can now detect the OS when building on Solaris
 - fbc will now pass the proper parameters to "as" on OS X
 - 1.02.0 regression: NULL was declared with pointer type in updated bindings (Windows API, SDL, etc.), and is now just an integer constant again, so it can be passed to things like WPARAM/LPARAM without triggering a compiler warning.
+- format(now(), "ttttt") now works as expected under unix-like systems
 
 
 Version 1.03.0

--- a/src/rtlib/unix/drv_intl_gettimeformat.c
+++ b/src/rtlib/unix/drv_intl_gettimeformat.c
@@ -46,6 +46,10 @@ int fb_DrvIntlGetTimeFormat( char *buffer, size_t len )
                 pszAdd = "hh";
                 add_len = 2;
                 break;
+            case 'M':
+                pszAdd = "mm";
+                add_len = 2;
+                break;
             case 'p':
                 pszAdd = "tt";
                 add_len = 2;


### PR DESCRIPTION
format(now(), "ttttt") was returning a wrong string because the unix-version of  fb_DrvIntlGetTimeFormat didn't correctly parse the format string it got from nl_langinfo. This commit fixes that, it now behaves as on win32.

I tested the fix on OS X Yosemite x86_64 and Kubuntu 15.04 i386.