### PR TITLE
Fixed debug information's error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 /doc/fbdoc/fbdoc
 /doc/makefbhelp/makefbhelp
 /doc/fbchkdoc/fbchkdoc.ini
+*.undo
+*.fbp

--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -272,6 +272,13 @@ sub edbgLineBegin _
     	exit sub
     end if
 
+	if( lnum<0 ) then
+		dim  dbg as AST_NODE_DBG ptr=-lnum
+		hEmitSTABS( STAB_TYPE_SOL,dbg->op, 0, 0,@"-1")
+		lnum=dbg->ex
+		delete dbg
+	end if
+	
     if( ctx.lnum > 0 ) then
     	ctx.pos = pos_ - ctx.pos
     	if( ctx.pos > 0 ) then

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -7036,7 +7036,9 @@ private sub _procFooter _
 	''
 	hDestroyFrame( proc, bytestopop )
 
-    edbgEmitLineFlush( proc, proc->proc.ext->dbg.endline, exitlabel )
+	if( symbIsNaked( proc ) = FALSE ) then'No need when it is Naked proc.(DestroyFrame's code is empty)
+		edbgEmitLineFlush( proc, proc->proc.ext->dbg.endline, exitlabel )
+	EndIf
 
     edbgEmitProcFooter( proc, initlabel, exitlabel )
 

--- a/src/compiler/fbint.bi
+++ b/src/compiler/fbint.bi
@@ -637,4 +637,6 @@ declare sub fbAddLibPath(byval path as zstring ptr)
 ''
 common shared as FBENV env
 
+extern infileTb( ) as FBFILE
+
 #endif ''__FBINT_BI__

--- a/tests/FixedDbgInfos/Test1.bas
+++ b/tests/FixedDbgInfos/Test1.bas
@@ -1,0 +1,11 @@
+
+
+
+
+dim as string g="ccccccccccccccccccccccc"
+dim as string h="ccccccccccccccccccccccc"
+dim as string c="ccccccccccccccccccccccc"
+
+#Include "Test2.bas"
+dim as string d="ddddddddddddddddddddddd" +c
+#Include "test3.bas"

--- a/tests/FixedDbgInfos/TestMain.bas
+++ b/tests/FixedDbgInfos/TestMain.bas
@@ -1,0 +1,29 @@
+type tX
+	d as BYTE
+	e as integer
+End Type
+
+dim ttX as tX
+with ttX
+	select case  .d
+		case 1,4,8,9
+			.e=1
+		case 2,3,5,7
+			.e=2
+		case else
+			.e=3
+	End Select
+End With
+dim as string a="aaaaaaaaaaaaaaaaaaaaaa"
+
+#Include "Test1.bas"
+dim as string b="bbbbbbbbbbbbbbbbbbbbbb" +a
+end
+
+sub ta naked()
+	asm
+		BLabel:
+		.long 12345
+		mov eax,1
+	End Asm
+End Sub

--- a/tests/FixedDbgInfos/test2.bas
+++ b/tests/FixedDbgInfos/test2.bas
@@ -1,0 +1,13 @@
+type t
+	d as integer
+End Type
+dim tt as t
+with tt 
+select case  .d
+	case 1,4,8,9
+End Select
+End With
+
+dim as string e="eeeeeeeeeeeeeeeeeeeeee"
+
+dim as string f="FFFFFFFFFFFFFFFFFFFFFFF" +f

--- a/tests/FixedDbgInfos/test3.bas
+++ b/tests/FixedDbgInfos/test3.bas
@@ -1,0 +1,9 @@
+
+
+
+dim as string g3="ccccccccccccccccccccccc"
+dim as string h3="ccccccccccccccccccccccc"
+dim as string c3="ccccccccccccccccccccccc"
+#Include "test4.bas"
+
+dim as string d3="ddddddddddddddddddddddd" +c

--- a/tests/FixedDbgInfos/test4.bas
+++ b/tests/FixedDbgInfos/test4.bas
@@ -1,0 +1,37 @@
+const AST_INITNODES				= 8192
+const AST_INITPROCNODES			= 128
+#define CL_ERROR   &HFFFFFFFF
+#define CL_ADDR1   &H10000000 '操作码中地址大小的位字段(字节)
+#define CL_ADDR2   &H20000000 '(单字)
+type td
+	d as integer
+End Type
+un:
+dim cdd as string
+
+Union ff
+Data_b(0 To 7) As Byte  ' 20 21 22 23  24 25 26 27
+Data_w(0 To 3) As Short
+Data_d(0 To 1) As Long
+Data_c(0 To 7) As byte
+Data_s(0 To 3) As Short
+Data_l(0 To 1) As Long
+End Union
+
+enum AST_OPOPT
+AST_OPOPT_NONE  		= &h00000000
+
+AST_OPOPT_ALLOCRES		= &h00000001
+AST_OPOPT_LPTRARITH		= &h00000002
+AST_OPOPT_RPTRARITH		= &h00000004
+AST_OPOPT_NOCOERCION	= &h00000008
+AST_OPOPT_DONTCHKPTR	= &h00000010
+AST_OPOPT_DONTCHKOPOVL	= &h00000020
+AST_OPOPT_ISINI			= &h00000040
+
+AST_OPOPT_DOPTRARITH	= AST_OPOPT_LPTRARITH or AST_OPOPT_RPTRARITH
+
+AST_OPOPT_DEFAULT		= AST_OPOPT_ALLOCRES
+end enum
+
+Declare function LDEXWY (ByVal StartAddress As Integer) As Integer


### PR DESCRIPTION
1, in the Asm block , the non assembly code also generate
debug information;
2, at the end of the function with  "Naked" tag, generate no actual
code's debugging information of line (Stabn);
3, when multiple file define some main function's local variables or
code, the line debugging information is wrong, which file name may be
different. So, in the main function, for each defined main function's
local variables or code of the source file add a "stabs" tag,and the
tail is "-1" .