### PR TITLE
Fix FileAttr return value type for x86_64 on Windows

### DIFF
--- a/src/rtlib/file_attr.c
+++ b/src/rtlib/file_attr.c
@@ -15,7 +15,7 @@ static int file_mode_map[] = { FB_FILE_ATTR_MODE_BINARY,   /* FB_FILE_MODE_BINAR
 
 FBCALL ssize_t fb_FileAttr( int handle, int returntype )
 {
-	int ret = 0;
+	ssize_t ret = 0;
 	int err = 0;
 	FB_FILE *file;
 


### PR DESCRIPTION
rtlib: The fb_FileAttr function stores its return value (type ssize_t) internally in a variable "ret" of type int. This causes problems on Windows x86_64, because int will be 32-bit and ssize_t 64-bit. This fix changes the internal "ret" variable to type ssize_t to match the return type.