### PR TITLE
fixed linker warnings on OS X

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ Version 1.05.0
 - Type<Foo>(...) expressions couldn't be used at the begin of a statement (because the Type keyword was treated as begin of a Type declaration)
 - FileAttr() was still broken for 64bit - the result value was truncated to 32bit
 - 1.04.0 regression: Under -gen gcc -asm att, support for gcc-style inline asm was broken
+- ld was warning about unsupported linker options on OS X
 
 
 Version 1.04.0

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -664,8 +664,10 @@ private function hLinkFiles( ) as integer
 		'' (needed until binutils' default DJGPP ldscripts are fixed)
 		ldcline += " -T """ + fbc.libpath + (FB_HOST_PATHDIV + "i386go32.x""")
 	else
-		'' Supplementary ld script to drop the fbctinf objinfo section
-		ldcline += " """ + fbc.libpath + (FB_HOST_PATHDIV + "fbextra.x""")
+		if( fbGetOption( FB_COMPOPT_TARGET ) <> FB_COMPTARGET_DARWIN ) then
+			'' Supplementary ld script to drop the fbctinf objinfo section
+			ldcline += " """ + fbc.libpath + (FB_HOST_PATHDIV + "fbextra.x""")
+		end if
 	end if
 
 	select case as const fbGetOption( FB_COMPOPT_TARGET )
@@ -703,7 +705,9 @@ private function hLinkFiles( ) as integer
 
 	if( fbGetOption( FB_COMPOPT_DEBUG ) = FALSE ) then
 		if( fbGetOption( FB_COMPOPT_PROFILE ) = FALSE ) then
-			ldcline += " -s"
+			if( fbGetOption( FB_COMPOPT_TARGET ) <> FB_COMPTARGET_DARWIN ) then
+				ldcline += " -s"
+			end if
 		end if
 	end if
 
@@ -863,6 +867,10 @@ private function hLinkFiles( ) as integer
 		ldcline += hFindLib( "crtend.o" )
 
 	end select
+	
+	if( fbGetOption( FB_COMPOPT_TARGET ) = FB_COMPTARGET_DARWIN ) then
+		ldcline += " -macosx_version_min 10.6"
+	end if
 
 	'' extra options
 	ldcline += " " + fbc.extopt.ld


### PR DESCRIPTION
Just a quick adjustment to the parameters that fbc passes to ld. Similar to the changes in the emscripten branch, but I also added "-macosx_version_min 10.6" because it's expected on OS X.
fbc requires at least OS X 10.6 Snow Leopard, but since 10.6 was assumed by default the requirements don't change.

Tested on OS X 10.10.5 Yosemite.