### PR TITLE
LLVM backend fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Version 1.06.0
 - #797: False-positive warnings when mixing booleans with comparisons in logic operations
 - TRE binding: Didn't compile with TRE_USE_SYSTEM_REGEX_H
 - LLVM backend: Let llc emit AT&T syntax assembly to prevent gas from failing
+- LLVM backend: Emit the new (LLVM 3.7+) load-syntax
 
 
 Version 1.05.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ Version 1.06.0
 - utf_conv.bi: In UTF8 => UTF16/32 and UTF32 => UTF16 conversions, strings longer than 8 chars could be truncated
 - #797: False-positive warnings when mixing booleans with comparisons in logic operations
 - TRE binding: Didn't compile with TRE_USE_SYSTEM_REGEX_H
+- LLVM backend: Let llc emit AT&T syntax assembly to prevent gas from failing
 
 
 Version 1.05.0

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -2829,13 +2829,6 @@ private function hCompileStage2Module( byval module as FBCIOFILE ptr ) as intege
 
 		ln += "-O" + str( fbGetOption( FB_COMPOPT_OPTIMIZELEVEL ) ) + " "
 
-		select case( fbGetCpuFamily( ) )
-		case FB_CPUFAMILY_X86, FB_CPUFAMILY_X86_64
-			if( fbGetOption( FB_COMPOPT_ASMSYNTAX ) = FB_ASMSYNTAX_INTEL ) then
-				ln += "--x86-asm-syntax=intel "
-			end if
-		end select
-
 	end select
 
 	ln += """" + hGetAsmName( module, 1 ) + """ "

--- a/src/compiler/ir-llvm.bas
+++ b/src/compiler/ir-llvm.bas
@@ -1186,7 +1186,11 @@ private sub hLoadVreg( byval v as IRVREG ptr )
 		hPrepareAddress( v )
 		assert( typeIsPtr( v->dtype ) )
 		var temp0 = irhlAllocVreg( typeDeref( v->dtype ), v->subtype )
-		hWriteLine( hVregToStr( temp0 ) + " = load " + hEmitType( v->dtype, v->subtype ) + " " + hVregToStr( v ) )
+		var s = hVregToStr( temp0 ) + " = load "
+		s += hEmitType( typeDeref( v->dtype ), v->subtype ) + ", "
+		s += hEmitType( v->dtype, v->subtype ) + " "
+		s += hVregToStr( v )
+		hWriteLine( s )
 		*v = *temp0
 	end select
 end sub


### PR DESCRIPTION
I saw that the LLVM-backend didn't work on my Arch Linux machine and decided to fix that.

Commit fca08f4 addresses the problem that llc doesn't emit ".intel_syntax noprefix" which makes gas fail. As explained in the commit message, the emitted assembly syntax doesn't really matter anyway (inline assembly is transformed by llc), so I just let llc use the AT&T syntax. I do consider this a workaround for a llc-bug, but it's doesn't hurt and does get things working.

Commit 2f0680b changes the LLVM-IR-emitter to use the new load-syntax, which was (afaik) introduced with LLVM 3.7. Since this version was released last August (and LLVM 3.8 has been released already, too), I think we shouldn't have any problems with assuming that LLVM 3.7+ is available. Well, except for Debian, but I don't think there's anything we can do about it: We either break Debian, or everything else.
This commit is the first time I actually touched any compiler internals, so please fell free to tell me if there's anything problematic in there. But since it's a relatively small change I think it's fine.

With these two changes, the LLVM-backend now works on my Arch Linux x86_64 system, but I haven't been able to test it on any other platforms yet.