### PR TITLE
Fix UTF to wchar conversion functions

### DIFF
--- a/src/rtlib/utf_convfrom_wchar.c
+++ b/src/rtlib/utf_convfrom_wchar.c
@@ -268,6 +268,14 @@ static char *hToUTF32( const FB_WCHAR *src, ssize_t chars, char *dst, ssize_t *b
 	return dst;
 }
 
+/* chars is the length of the input in characters, with UTF16 surrogate pairs
+   counting as 2.
+   dst is an optional output buffer (which must be large enough); if NULL, one
+   is malloc'd.
+   A NUL is only appended to the output if it occurs in the input (unlike
+   fb_UTFToWChar this does NOT stop on seeing a NUL, as the length is known).
+   Returns the output buffer and sets *bytes to the number of bytes written.
+*/
 char *fb_WCharToUTF
 	(
 		FB_FILE_ENCOD encod,


### PR DESCRIPTION
I noticed that recently added UTF conversion testcases were failing; the newly rewritten conversion code was still not right.

There are completely different codepaths depending on the size of wchar, and unfortunately I don't see any simple way to run testcases against different wchar sizes. The simplest would probably be to expose all the currently private functions so that they can be accessed by tests. I tested on a 32 bit wchar machine.