### PR TITLE
Fix #851: #line directive doesn't change source filename in debug info

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@ Version 1.06.0
 - WCHR would give the wrong result if given large number of arguments which were large constants
 - #846: Fix compiler crash on global variable initializer with type<T>(...) expression where T isn't a UDT
 - #847: Windows API binding: Fixed winnt.bi SECURITY_*_AUTHORITY initializers
+- #851: '#LINE line filename' only changed the source filename in error messages, not in debug info
 
 
 Version 1.05.0

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -393,6 +393,7 @@ declare sub fbSetLibs(byval libs as TSTRSET ptr, byval libpaths as TSTRSET ptr)
 declare sub fbGetLibs(byval libs as TSTRSET ptr, byval libpaths as TSTRSET ptr)
 declare sub fbPragmaOnce()
 declare sub fbIncludeFile(byval filename as zstring ptr, byval isonce as integer)
+declare sub fbOverrideFilename(byval filename as zstring ptr)
 
 declare function fbGetTargetId( ) as string
 declare function fbGetHostId( ) as string

--- a/src/compiler/fbint.bi
+++ b/src/compiler/fbint.bi
@@ -616,8 +616,9 @@ type FBENV
 	ppfile_num		as integer					'' -pp output file
 
 	'' include files
-	incfilehash		as THASH
-	inconcehash		as THASH
+	filenamehash		as THASH
+	incfilehash		as THASH					'' A subset of filenamehash
+	inconcehash		as THASH					'' A subset of filenamehash
 	includerec		as integer					'' >0 if parsing an include file
 
 	main			as FBMAIN

--- a/src/compiler/ir-hlc.bas
+++ b/src/compiler/ir-hlc.bas
@@ -3637,13 +3637,7 @@ private sub _emitProcBegin _
 		byval initlabel as FBSYMBOL ptr _
 	)
 
-	dim as zstring ptr incfile = any
-
-	incfile = symbGetProcIncFile( proc )
-	if( incfile = NULL ) then
-		incfile = @env.inf.name
-	end if
-	hUpdateCurrentFileName( incfile )
+	hUpdateCurrentFileName( symbGetProcIncFile( proc ) )
 
 	irhlEmitProcBegin( )
 

--- a/src/compiler/pp.bas
+++ b/src/compiler/pp.bas
@@ -377,8 +377,8 @@ private sub ppLine()
 
 		'' LIT_STR?
 		if( lexGetClass( ) = FB_TKCLASS_STRLITERAL ) then
-    		env.inf.name = *lexGetText( )
-    		lexSkipToken( )
+			fbOverrideFilename( *lexGetText( ) )
+			lexSkipToken( )
 		end if
 	end if
 end sub


### PR DESCRIPTION
Added a new hash table, env.filenamehash, for all input filenames;
env.inconcehash and env.incfilehash are now subsets of this hash.

The name of the main source file is also stored here, so env.inf.incfile
is now never NULL (allowing a little cleanup in ir-hlc.bas).
Really, env.inf.incfile is misnamed, as it is used just as an interned
copy of env.inf.name so that it can be stored in the debug info for
a procedure for use later. env.inf.name could be removed and its use
replaced with env.inf.incfile.