### PR TITLE
adding dependency

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -61,7 +61,7 @@
           gcc libncurses5-dev libffi-dev libgl1-mesa-dev
           libx11-dev libxext-dev libxrender-dev libxrandr-dev libxpm-dev
         Fedora:
-          gcc ncurses-devel libffi-devel mesa-libGL-devel
+          gcc ncurses-devel ncurses-compat-libs libffi-devel mesa-libGL-devel
           libX11-devel libXext-devel libXrender-devel libXrandr-devel
           libXpm-devel
       If you want to use the 32bit version of FB on a 64bit system, it is


### PR DESCRIPTION
at fedora 26, if installed to fedora, ncurses-compat-libs is needed.