### PR TITLE
832Fix - Fix bug allowing QB style suffixes on all keywords

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ Version 1.06.0
 - #846: Fix compiler crash on global variable initializer with type<T>(...) expression where T isn't a UDT
 - #847: Windows API binding: Fixed winnt.bi SECURITY_*_AUTHORITY initializers
 - #851: '#LINE line filename' only changed the source filename in error messages, not in debug info
+- #832: Fix bug allowing QB style suffixes on all keywords, regardless of -lang
 
 
 Version 1.05.0

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -456,19 +456,19 @@ private sub hReadIdentifier _
 		select case as const lexCurrentChar( )
 		'' '%'?
 		case FB_TK_INTTYPECHAR
-			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = env.lang.integerkeyworddtype
 			c = lexEatChar( )
 
 		'' '&'?
 		case FB_TK_LNGTYPECHAR
-			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = FB_DATATYPE_LONG
 			c = lexEatChar( )
 
 		'' '!'?
 		case FB_TK_SGNTYPECHAR
-			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = FB_DATATYPE_SINGLE
 			c = lexEatChar( )
 
@@ -476,14 +476,14 @@ private sub hReadIdentifier _
 		case FB_TK_DBLTYPECHAR
 			'' isn't it a '##'?
 			if( lexGetLookAheadChar( ) <> FB_TK_DBLTYPECHAR ) then
-				if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+				if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 				dtype = FB_DATATYPE_DOUBLE
 				c = lexEatChar( )
 			end if
 
 		'' '$'?
 		case FB_TK_STRTYPECHAR
-			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = FB_DATATYPE_STRING
 			c = lexEatChar( )
 		end select

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -456,19 +456,19 @@ private sub hReadIdentifier _
 		select case as const lexCurrentChar( )
 		'' '%'?
 		case FB_TK_INTTYPECHAR
-			if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = env.lang.integerkeyworddtype
 			c = lexEatChar( )
 
 		'' '&'?
 		case FB_TK_LNGTYPECHAR
-			if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = FB_DATATYPE_LONG
 			c = lexEatChar( )
 
 		'' '!'?
 		case FB_TK_SGNTYPECHAR
-			if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = FB_DATATYPE_SINGLE
 			c = lexEatChar( )
 
@@ -476,14 +476,14 @@ private sub hReadIdentifier _
 		case FB_TK_DBLTYPECHAR
 			'' isn't it a '##'?
 			if( lexGetLookAheadChar( ) <> FB_TK_DBLTYPECHAR ) then
-				if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+				if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 				dtype = FB_DATATYPE_DOUBLE
 				c = lexEatChar( )
 			end if
 
 		'' '$'?
 		case FB_TK_STRTYPECHAR
-			if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = FB_DATATYPE_STRING
 			c = lexEatChar( )
 		end select

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -456,16 +456,19 @@ private sub hReadIdentifier _
 		select case as const lexCurrentChar( )
 		'' '%'?
 		case FB_TK_INTTYPECHAR
+			if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = env.lang.integerkeyworddtype
 			c = lexEatChar( )
 
 		'' '&'?
 		case FB_TK_LNGTYPECHAR
+			if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = FB_DATATYPE_LONG
 			c = lexEatChar( )
 
 		'' '!'?
 		case FB_TK_SGNTYPECHAR
+			if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = FB_DATATYPE_SINGLE
 			c = lexEatChar( )
 
@@ -473,12 +476,14 @@ private sub hReadIdentifier _
 		case FB_TK_DBLTYPECHAR
 			'' isn't it a '##'?
 			if( lexGetLookAheadChar( ) <> FB_TK_DBLTYPECHAR ) then
+				if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 				dtype = FB_DATATYPE_DOUBLE
 				c = lexEatChar( )
 			end if
 
 		'' '$'?
 		case FB_TK_STRTYPECHAR
+			if ( env.clopt.lang <> FB_LANG_QB and env.clopt.lang <> FB_LANG_FB_DEPRECATED ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
 			dtype = FB_DATATYPE_STRING
 			c = lexEatChar( )
 		end select

--- a/tests/quirk/keyword-suffix.bas
+++ b/tests/quirk/keyword-suffix.bas
@@ -1,0 +1,4 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+if$ 1 then
+end if


### PR DESCRIPTION
832Fix - Fix bug allowing QB style suffixes on all keywords, regardless of -lang