### PR TITLE
Under X11, expose Display* via ScreenControl GET_WINDOW_HANDLE param2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Version 1.06.0
 - Linux console Inkey() now recognizes F11 and F12
 - 2D render through OpenGL on Windows and Linux via screencontrol (angros47)
 - Windows API binding updated to additionally support _WIN32_WINNT &h0501, &h0600, &h0601
+- Under X11, ScreenControl GET_WINDOW_HANDLE places the Display ptr in param2
 
 [fixed]
 - win/d3dx9.bi no longer has a hard-coded #inclib "d3dx9d". d3dx9d.dll is apparently not a generally valid choice. In practice programs have to be linked against d3dx9_33.dll or d3dx9_39.dll, etc.

--- a/src/gfxlib2/dos/gfx_dos.c
+++ b/src/gfxlib2/dos/gfx_dos.c
@@ -683,3 +683,8 @@ ssize_t fb_hGetWindowHandle(void)
 {
 	return 0;
 }
+
+ssize_t fb_hGetDisplayHandle(void)
+{
+	return 0;
+}

--- a/src/gfxlib2/fb_gfx.h
+++ b/src/gfxlib2/fb_gfx.h
@@ -464,6 +464,7 @@ extern void fb_hSoftCursorPaletteChanged(void);
 extern int fb_hColorDistance(int index, int r, int g, int b);
 extern void *fb_hPixelSetAlpha4(void *dest, int color, size_t size);
 extern ssize_t fb_hGetWindowHandle(void);
+extern ssize_t fb_hGetDisplayHandle(void);
 
 
 /* Public API */

--- a/src/gfxlib2/gfx_control.c
+++ b/src/gfxlib2/gfx_control.c
@@ -80,8 +80,10 @@ FBCALL void fb_GfxControl_i( int what, ssize_t *param1, ssize_t *param2, ssize_t
 		break;
 
 	case GET_WINDOW_HANDLE:
-		if (__fb_gfx)
+		if (__fb_gfx) {
 			res1 = fb_hGetWindowHandle();
+			res2 = fb_hGetDisplayHandle();
+		}
 		break;
 
 	case GET_DESKTOP_SIZE:

--- a/src/gfxlib2/unix/gfx_x11.c
+++ b/src/gfxlib2/unix/gfx_x11.c
@@ -880,9 +880,19 @@ ssize_t fb_hGetWindowHandle(void)
 	return (fb_x11.display ? fb_x11.window : 0);
 }
 
+ssize_t fb_hGetDisplayHandle(void)
+{
+	return (ssize_t)fb_x11.display;
+}
+
 #else
 
 ssize_t fb_hGetWindowHandle(void)
+{
+	return 0;
+}
+
+ssize_t fb_hGetDisplayHandle(void)
 {
 	return 0;
 }

--- a/src/gfxlib2/win32/gfx_win32.c
+++ b/src/gfxlib2/win32/gfx_win32.c
@@ -783,6 +783,11 @@ ssize_t fb_hGetWindowHandle(void)
 	return (ssize_t)fb_win32.wnd;
 }
 
+ssize_t fb_hGetDisplayHandle(void)
+{
+	return 0;
+}
+
 static void keyconv_clear( KEYCONVINFO *k )
 {
 	if( k->v ) {


### PR DESCRIPTION
There doesn't appear to be a way to get the *Display from the Window handle,
and opening a new Display creates a new connection to the X server, which
can't be used for many things.