### PR TITLE
Update SDL2 headers to 2.0.6, and also all other SDL2 libs to latest versions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ Version 1.06.0
 - 2D render through OpenGL on Windows and Linux via screencontrol (angros47)
 - Windows API binding updated to additionally support _WIN32_WINNT &h0501, &h0600, &h0601
 - Under X11, ScreenControl GET_WINDOW_HANDLE places the Display ptr in param2
+- Updated bindings: SDL2 2.0.6, SDL2_image 2.0.1, SDL2_mixer 2.0.1, SDL2_net 2.0.1, SDL2_ttf 2.0.14
 
 [fixed]
 - win/d3dx9.bi no longer has a hard-coded #inclib "d3dx9d". d3dx9d.dll is apparently not a generally valid choice. In practice programs have to be linked against d3dx9_33.dll or d3dx9_39.dll, etc.

--- a/inc/SDL2/SDL_image.bi
+++ b/inc/SDL2/SDL_image.bi
@@ -1,8 +1,8 @@
-'' FreeBASIC binding for SDL2_image-2.0.0
+'' FreeBASIC binding for SDL2_image-2.0.1
 ''
 '' based on the C header files:
 ''   SDL_image:  An example image loading library for use with SDL
-''   Copyright (C) 1997-2013 Sam Lantinga <slouken@libsdl.org>
+''   Copyright (C) 1997-2016 Sam Lantinga <slouken@libsdl.org>
 ''
 ''   This software is provided 'as-is', without any express or implied
 ''   warranty.  In no event will the authors be held liable for any damages
@@ -34,7 +34,7 @@ extern "C"
 #define _SDL_IMAGE_H
 const SDL_IMAGE_MAJOR_VERSION = 2
 const SDL_IMAGE_MINOR_VERSION = 0
-const SDL_IMAGE_PATCHLEVEL = 0
+const SDL_IMAGE_PATCHLEVEL = 1
 #macro SDL_IMAGE_VERSION(X)
 	scope
 		(X)->major = SDL_IMAGE_MAJOR_VERSION

--- a/inc/SDL2/SDL_mixer.bi
+++ b/inc/SDL2/SDL_mixer.bi
@@ -1,8 +1,8 @@
-'' FreeBASIC binding for SDL2_mixer-2.0.0
+'' FreeBASIC binding for SDL2_mixer-2.0.1
 ''
 '' based on the C header files:
 ''   SDL_mixer:  An audio mixer library based on the SDL library
-''   Copyright (C) 1997-2013 Sam Lantinga <slouken@libsdl.org>
+''   Copyright (C) 1997-2016 Sam Lantinga <slouken@libsdl.org>
 ''
 ''   This software is provided 'as-is', without any express or implied
 ''   warranty.  In no event will the authors be held liable for any damages
@@ -34,7 +34,7 @@ extern "C"
 #define _SDL_MIXER_H
 const SDL_MIXER_MAJOR_VERSION = 2
 const SDL_MIXER_MINOR_VERSION = 0
-const SDL_MIXER_PATCHLEVEL = 0
+const SDL_MIXER_PATCHLEVEL = 1
 #macro SDL_MIXER_VERSION(X)
 	scope
 		(X)->major = SDL_MIXER_MAJOR_VERSION

--- a/inc/SDL2/SDL_net.bi
+++ b/inc/SDL2/SDL_net.bi
@@ -1,8 +1,8 @@
-'' FreeBASIC binding for SDL2_net-2.0.0
+'' FreeBASIC binding for SDL2_net-2.0.1
 ''
 '' based on the C header files:
 ''   SDL_net:  An example cross-platform network library for use with SDL
-''   Copyright (C) 1997-2013 Sam Lantinga <slouken@libsdl.org>
+''   Copyright (C) 1997-2016 Sam Lantinga <slouken@libsdl.org>
 ''   Copyright (C) 2012 Simeon Maxein <smaxein@googlemail.com>
 ''
 ''   This software is provided 'as-is', without any express or implied
@@ -36,7 +36,7 @@ extern "C"
 type SDLNet_version as SDL_version
 const SDL_NET_MAJOR_VERSION = 2
 const SDL_NET_MINOR_VERSION = 0
-const SDL_NET_PATCHLEVEL = 0
+const SDL_NET_PATCHLEVEL = 1
 #macro SDL_NET_VERSION(X)
 	scope
 		(X)->major = SDL_NET_MAJOR_VERSION
@@ -158,10 +158,16 @@ declare function SDLNet_GetError() as const zstring ptr
 		return (((cast(Uint32, area[0]) shl 24) or (cast(Uint32, area[1]) shl 16)) or (cast(Uint32, area[2]) shl 8)) or cast(Uint32, area[3])
 	end function
 #else
-	#define _SDLNet_Write16(value, areap) scope : *cptr(Uint16 ptr, areap) = SDL_Swap16(value) : end sco
-	#define _SDLNet_Write32(value, areap) scope : *cptr(Uint32 ptr, areap) = SDL_Swap32(value) : end sco
-	#define _SDLNet_Read16(areap) SDL_Swap16(*cptr(const Uint16 ptr, areap))
-	#define _SDLNet_Read32(areap) SDL_Swap32(*cptr(const Uint32 ptr, areap))
+	private sub _SDLNet_Write16(byval value as Uint16, byval areap as any ptr)
+		(*cptr(Uint16 ptr, areap)) = SDL_Swap16(value)
+	end sub
+
+	private sub _SDLNet_Write32(byval value as Uint32, byval areap as any ptr)
+		(*cptr(Uint32 ptr, areap)) = SDL_Swap32(value)
+	end sub
+
+	#define _SDLNet_Read16(areap) cast(Uint16, SDL_Swap16(*cptr(const Uint16 ptr, (areap))))
+	#define _SDLNet_Read32(areap) cast(Uint32, SDL_Swap32(*cptr(const Uint32 ptr, (areap))))
 #endif
 
 end extern

--- a/inc/SDL2/SDL_ttf.bi
+++ b/inc/SDL2/SDL_ttf.bi
@@ -1,8 +1,8 @@
-'' FreeBASIC binding for SDL2_ttf-2.0.12
+'' FreeBASIC binding for SDL2_ttf-2.0.14
 ''
 '' based on the C header files:
 ''   SDL_ttf:  A companion library to SDL for working with TrueType (tm) fonts
-''   Copyright (C) 2001-2013 Sam Lantinga <slouken@libsdl.org>
+''   Copyright (C) 2001-2016 Sam Lantinga <slouken@libsdl.org>
 ''
 ''   This software is provided 'as-is', without any express or implied
 ''   warranty.  In no event will the authors be held liable for any damages
@@ -35,7 +35,7 @@ extern "C"
 #define _SDL_TTF_H
 const SDL_TTF_MAJOR_VERSION = 2
 const SDL_TTF_MINOR_VERSION = 0
-const SDL_TTF_PATCHLEVEL = 12
+const SDL_TTF_PATCHLEVEL = 14
 #macro SDL_TTF_VERSION(X)
 	scope
 		(X)->major = SDL_TTF_MAJOR_VERSION
@@ -116,6 +116,7 @@ declare sub TTF_CloseFont(byval font as TTF_Font ptr)
 declare sub TTF_Quit()
 declare function TTF_WasInit() as long
 declare function TTF_GetFontKerningSize(byval font as TTF_Font ptr, byval prev_index as long, byval index as long) as long
+declare function TTF_GetFontKerningSizeGlyphs(byval font as TTF_Font ptr, byval previous_ch as Uint16, byval ch as Uint16) as long
 declare function TTF_SetError alias "SDL_SetError"(byval fmt as const zstring ptr, ...) as long
 declare function TTF_GetError alias "SDL_GetError"() as const zstring ptr
 


### PR DESCRIPTION
Actually, aside from SDL.bi, only SDL_ttf.bi saw a non-trivial change. So maybe
not worth mentioning the new versions of other libraries in the changelog?