### PR TITLE
Fbdoc fixes: wiki URL and HTML character escaping

### DIFF
--- a/doc/fbchkdoc/fbchkdoc.org
+++ b/doc/fbchkdoc/fbchkdoc.org
@@ -16,4 +16,3 @@ dev_wiki_url =
 ' dev_certificate = path/filename.pem"
 dev_username = 
 dev_password = 
-

--- a/doc/libfbdoc/CWakka2Html.bas
+++ b/doc/libfbdoc/CWakka2Html.bas
@@ -758,7 +758,7 @@ namespace fb.fbdoc
 
 		res = _closeList( ctx )
 		
-		cellData = paramsTb->GetParam( "cells" )
+		cellData = UnescapeHtml( paramsTb->GetParam( "cells" ) )
 		strCols = paramsTb->GetParam( "columns" )
 
 		n = _index_cells( cellData, @cellTb )
@@ -781,7 +781,7 @@ namespace fb.fbdoc
 			if( cell = "###" ) then
 				res += "<td>&nbsp;</td>"
 			else
-				res += "<td>" + Text2Html( CellUnescapeCodes( cell ) ) + "</td>"
+				res += "<td>" + Text2Html( cell ) + "</td>"
 			end if
 			col += 1
 			if( col > cols ) then

--- a/doc/libfbdoc/CWakka2fbhelp.bas
+++ b/doc/libfbdoc/CWakka2fbhelp.bas
@@ -1178,7 +1178,7 @@ namespace fb.fbdoc
 
 		_closeList( ctx )
 		
-		cellData = paramsTb->GetParam( "cells" )
+		cellData = UnescapeHtml( paramsTb->GetParam( "cells" ) )
 		strCols =  paramsTb->GetParam( "columns" )
 
 		if( len( strCols ) > 0 ) then
@@ -1207,10 +1207,6 @@ namespace fb.fbdoc
 					if( *cellTb[i] = "###" ) then
 						cells( col, row ) = cell_space
 					else
-						'' hack: remove escape codes in table text
-						'' relies on the text returned being no longer than the original
-						*cellTb[i] = CellUnescapeCodes( *cellTb[i] )
-
 						cells( col, row ) = cellTb[i]
 					end if
 					if( len( *cells( col, row ) ) > sizes( col ) ) then

--- a/doc/libfbdoc/CWakka2texinfo.bas
+++ b/doc/libfbdoc/CWakka2texinfo.bas
@@ -818,7 +818,7 @@ namespace fb.fbdoc
 
 		_closeList( ctx )
 		
-		cellData = paramsTb->GetParam( "cells" )
+		cellData = UnescapeHtml( paramsTb->GetParam( "cells" ) )
 		strCols =  paramsTb->GetParam( "columns" )
 
 		if( len( strCols ) > 0 ) then
@@ -847,10 +847,6 @@ namespace fb.fbdoc
 					if( *cellTb[i] = "###" ) then
 						cells( col, row ) = cell_space
 					else
-						'' hack: remove escape codes in table text
-						'' relies on the text returned being no longer than the original
-						*cellTb[i] = CellUnescapeCodes( *cellTb[i] )
-
 						cells( col, row ) = cellTb[i]
 					end if
 					if( len( *cells( col, row ) ) > sizes( col ) ) then

--- a/doc/libfbdoc/CWiki.bas
+++ b/doc/libfbdoc/CWiki.bas
@@ -39,8 +39,7 @@ namespace fb.fbdoc
 							actionre, _
 							action2re, _
 							indentre, _
-							actionparamre, _
-							quotere
+							actionparamre
 
 		as CList ptr 		tokenlist
 		as CList ptr		actparamlist
@@ -280,12 +279,6 @@ namespace fb.fbdoc
 			exit function
 		end if
 
-		ctx->quotere = new CRegex( $"(&quot)", REGEX_OPT_CASELESS)
-		if( ctx->quotere = NULL ) then	
-			exit function
-		end if
-
-		
 
 		function = TRUE
 
@@ -296,11 +289,6 @@ namespace fb.fbdoc
  		( _
 			byval ctx as CWikiCtx ptr _
 		) 
-
-		if( ctx->quotere <> NULL ) then
-			delete ctx->quotere
-			ctx->quotere = NULL
-		end if
 
 		if( ctx->actionparamre <> NULL ) then
 			delete ctx->actionparamre
@@ -488,22 +476,7 @@ namespace fb.fbdoc
 				
 				param->name = *ctx->actionparamre->GetStr( 1 )
 				match = ctx->actionparamre->GetStr( 2 )
-
-				param->value = ""
-
-				if( ctx->quotere->Search( match ) ) then
-					dim as integer ofs = 0
-					do
-						dim as integer mofs = ctx->quotere->GetOfs( 0 )
-						param->value += mid( *match, 1+ofs, mofs-ofs ) + chr(34)
-						ofs = mofs + ctx->quotere->GetLen( 0 )
-					loop while ctx->quotere->SearchNext()
-					if( ofs < len( *match  ) ) then
-						param->value += mid( *match, 1+ofs )
-					end if
-				else
-					param->value = *match
-				end if
+				param->value = *match
 
 				last = param
 

--- a/doc/libfbdoc/CWiki.bas
+++ b/doc/libfbdoc/CWiki.bas
@@ -176,7 +176,11 @@ namespace fb.fbdoc
 			t += "%%"
 		case WIKI_TOKEN_LINK
 			if( token->text > "" ) then
-				t = "[[" + token->link->url + " " + token->text + "]]"
+				if( token->link->pipechar ) then
+					t = "[[" + token->link->url + "|" + token->text + "]]"
+				else
+					t = "[[" + token->link->url + " " + token->text + "]]"
+				end if
 			else
 				t = "[[" + token->link->url + "]]"
 			end if
@@ -622,10 +626,11 @@ namespace fb.fbdoc
 			token->link->url = *ctx->linkre->GetStr( 1 )
 			token->text = trim( *ctx->linkre->GetStr( 2 ) )
 
-			' !!! FIXME
-			' if( token->text = "" ) then
-			' 	token->text = token->link->url
-			' end if
+			if( token->text = "" ) then
+				token->link->pipechar = FALSE
+			else
+				token->link->pipechar = TRUE
+			end if
 
 			exit sub
 		end if

--- a/doc/libfbdoc/CWiki.bi
+++ b/doc/libfbdoc/CWiki.bi
@@ -108,7 +108,8 @@ namespace fb.fbdoc
 
 	type WikiToken_Link
 		as string 				url
-		as integer        linkclass
+		as integer				linkclass
+		as integer				pipechar
 	end type
 
 	type WikiToken_Code

--- a/doc/libfbdoc/CWiki2Chm.bas
+++ b/doc/libfbdoc/CWiki2Chm.bas
@@ -268,7 +268,7 @@ namespace fb.fbdoc
 			end if
 
 			sBodyHtml +=  DBG_INDENT + "<li><object type=""text/sitemap"">"
-			sBodyHtml +=  "<param name=""Name"" value=""" + page->GetFormattedTitle() + """>"
+			sBodyHtml +=  "<param name=""Name"" value=""" + Text2Html( page->GetFormattedTitle() ) + """>"
 			if( len( page->GetName()) > 0 ) then
 				sBodyHtml +=  "<param name=""Local"" value=""" + page->GetName() + ".html"">"
 			end if
@@ -364,7 +364,7 @@ namespace fb.fbdoc
 
 			'' If( page->GetEmitted() ) then
 				sBodyHtml +=  "<li><object type=""text/sitemap"">"
-				sBodyHtml +=  "<param name=""Name"" value=""" + page->GetFormattedTitle() + """>"
+				sBodyHtml +=  "<param name=""Name"" value=""" + Text2Html( page->GetFormattedTitle() ) + """>"
 				sBodyHtml +=  "<param name=""Local"" value=""" + page->GetName() + ".html"">"
 				sBodyHtml +=  "</object>" + crlf
 			'' end if

--- a/doc/libfbdoc/fbdoc_string.bas
+++ b/doc/libfbdoc/fbdoc_string.bas
@@ -156,28 +156,24 @@ namespace fb.fbdoc
 	end function
 
 	'':::::
-	function CellUnescapeCodes _
+	function UnescapeHtml _
 		( _
 			byref celltext as const string _
 		) as string
 
 		'' Unescape HTML-like codes (eg &amp, &#...) which may be
-		'' found in {{table}} blocks.  Note the lack of ';' terminator.
+		'' found in {{table}} blocks.  Note that the ';' terminator is optional for backward compatibility.
+		dim as string HtmlCodes(0 to ...) = { "amp", "&", "quot", """", "lt", "<", "gt", ">" }
 
-		dim i as integer = 1, ret as string 
+		dim i as integer = 1, ret as string
+		dim j as integer
 		ret = celltext
 		do
 
 			i = instr(i, ret, "&") 
 			if i = 0 then exit do
 
-			if( mid( ret, i + 1, 3 ) = "amp" ) then
-				ret = left(ret, i - 1) + "&" + mid(ret, i + 3 + 1) 
-				i += 3
-			elseif( mid( ret, i + 1, 4 ) = "quot" ) then
-				ret = left(ret, i - 1) + """" + mid(ret, i + 4 + 1) 
-				i += 4
-			elseif( asc( ret , i + 1 ) = asc( "#" ) ) then
+			if( asc( ret , i + 1 ) = asc( "#" ) ) then
 				dim as integer j = i + 2
 				dim as integer c = 0
 				do
@@ -190,9 +186,19 @@ namespace fb.fbdoc
 					j += 1
 				loop
 				if( c > 0 and c <= 255 ) then
+					if( mid( ret, j, 1) = ";" ) then j += 1
 					ret = left(ret, i - 1) + chr(c) + mid(ret, j)
 				end if
-				i = j - 1
+			else
+				for q as integer = 0 to ubound(HtmlCodes) step 2
+					if( mid( ret, i + 1, len( HtmlCodes(q) )) = HtmlCodes(q) ) then
+						j = i + len( HtmlCodes(q) ) + 1
+						if( mid( ret, j, 1) = ";" ) then j += 1
+						ret = left(ret, i - 1) + HtmlCodes(q+1) + mid(ret, j)
+						i += len( HtmlCodes(q+1) ) - 1
+						exit for
+					end if
+				next
 			end if
 
 			i += 1
@@ -217,6 +223,7 @@ namespace fb.fbdoc
 		dim as string res
 		dim as integer i
 		dim as integer lastcr
+		dim as string HtmlCodes(0 to ...) = { "amp", "&", "quot", """", "lt", "<", "gt", ">" }
 
 		res = ""
 		lastcr = FALSE
@@ -229,12 +236,6 @@ namespace fb.fbdoc
 				else
 					res += mid( text, i, 1)
 				end if
-			case "<"
-				res += "&lt;"
-			case ">"
-				res += "&gt;"
-			case "&"
-				res += "&amp;"
 			case chr(13)
 				if( br ) then
 					res += "<br />"
@@ -249,6 +250,12 @@ namespace fb.fbdoc
 				end if
 				res += mid( text, i, 1)
 			case else
+				for q as integer = 1 to ubound(HtmlCodes) step 2
+					if( mid( text, i, 1) = HtmlCodes(q) ) then
+						res += "&" + HtmlCodes(q-1) + ";"
+						exit select
+					end if
+				next
 				res += mid( text, i, 1)
 			end select
 

--- a/doc/libfbdoc/fbdoc_string.bi
+++ b/doc/libfbdoc/fbdoc_string.bi
@@ -43,7 +43,7 @@ namespace fb.fbdoc
 
 	declare function CapFirstLetter( byref a as string ) as string
 
-	declare function CellUnescapeCodes _
+	declare function UnescapeHtml _
 		( _
 			byref celltext as const string _
 		) as string

--- a/doc/manual/templates/default/code/chm_def.tpl.html
+++ b/doc/manual/templates/default/code/chm_def.tpl.html
@@ -2,6 +2,7 @@
 <head>
 <title>{$pg_title}</title>
 <link rel="stylesheet" type="text/css" href="style.css">
+<meta charset="UTF-8">
 </head>
 <body>
 <div id="fb_body_wrapper">

--- a/doc/manual/templates/default/code/chm_doctoc.tpl.html
+++ b/doc/manual/templates/default/code/chm_doctoc.tpl.html
@@ -2,6 +2,7 @@
 <head>
 <title>{$pg_title}</title>
 <link rel="stylesheet" type="text/css" href="style.css">
+<meta charset="UTF-8">
 </head>
 <body>
 <div id="fb_body_wrapper">

--- a/doc/manual/templates/default/code/chm_idx.tpl.html
+++ b/doc/manual/templates/default/code/chm_idx.tpl.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 	<title>{$pg_title}</title>
+    <meta charset="UTF-8">
 </head>
 <body>
 <object type="text/site properties">

--- a/doc/manual/templates/default/code/chm_toc.tpl.html
+++ b/doc/manual/templates/default/code/chm_toc.tpl.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
+<meta charset="UTF-8">
 </head>
 <body>
 <object type="text/site properties">

--- a/doc/manual/templates/default/code/htm_toc.tpl.html
+++ b/doc/manual/templates/default/code/htm_toc.tpl.html
@@ -2,6 +2,7 @@
 <head>
 <title>{#fb_chm_title}</title>
 <link rel="stylesheet" type="text/css" href="style.css">
+<meta charset="UTF-8">
 </head>
 <body>
 <div id="fb_body_wrapper">

--- a/doc/manual/templates/default/lang/en/common.ini
+++ b/doc/manual/templates/default/lang/en/common.ini
@@ -17,7 +17,7 @@ fb_sect_back="Back"
 
 fb_toc_title="Table of Contents"
 
-fb_docinfo_homepage="http://www.freebasic.net/"
-fb_docinfo_wiki="http://www.freebasic.net/wiki/"
+fb_docinfo_homepage="https://www.freebasic.net/"
+fb_docinfo_wiki="https://www.freebasic.net/wiki/"
 fb_docinfo_dateformat="yyyy/mm/dd"
 fb_docinfo_timeformat="hh:mm:ss"


### PR DESCRIPTION
The commits in this PR aim to fix the character escaping issue discussed here:
https://freebasic.net/forum/viewtopic.php?f=9&t=25972

It allows the following HTML character escape sequences:
```
&gt;
&lt;
&amp;
&quot;
&#xxx; (where xxx represents a number between 0 and 255)
```

In tables the sequence `&#59;` (semicolon) is not allowed, because semicolon is used as a table cell separator.


Additionally it changes the Wiki URL to use https:// instead of http://
The issue is mentioned here:
https://freebasic.net/forum/viewtopic.php?p=235627#p235627
