### PR TITLE
Change negation UOP to always produce signed result

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,7 @@ Version 1.06.0
 - #847: Windows API binding: Fixed winnt.bi SECURITY_*_AUTHORITY initializers
 - #851: '#LINE line filename' only changed the source filename in error messages, not in debug info
 - #832: Fix bug allowing QB style suffixes on all keywords, regardless of -lang
+- #841: The unary negation operator gave different result signedness when used on constant instead of non-constant expression. Now the result is always signed.
 
 
 Version 1.05.0

--- a/tests/warnings/r/dos/op-result-types.txt
+++ b/tests/warnings/r/dos/op-result-types.txt
@@ -18561,7 +18561,7 @@ ul:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:
@@ -18697,7 +18697,7 @@ ull:
 not:
 ULONGINT
 negation:
-ULONGINT
+LONGINT
 abs:
 ULONGINT
 sgn:
@@ -18833,7 +18833,7 @@ ui:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:

--- a/tests/warnings/r/linux-x86/op-result-types.txt
+++ b/tests/warnings/r/linux-x86/op-result-types.txt
@@ -18561,7 +18561,7 @@ ul:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:
@@ -18697,7 +18697,7 @@ ull:
 not:
 ULONGINT
 negation:
-ULONGINT
+LONGINT
 abs:
 ULONGINT
 sgn:
@@ -18833,7 +18833,7 @@ ui:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:

--- a/tests/warnings/r/linux-x86_64/op-result-types.txt
+++ b/tests/warnings/r/linux-x86_64/op-result-types.txt
@@ -18697,7 +18697,7 @@ ull:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:
@@ -18833,7 +18833,7 @@ ui:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:

--- a/tests/warnings/r/win32/op-result-types.txt
+++ b/tests/warnings/r/win32/op-result-types.txt
@@ -18561,7 +18561,7 @@ ul:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:
@@ -18697,7 +18697,7 @@ ull:
 not:
 ULONGINT
 negation:
-ULONGINT
+LONGINT
 abs:
 ULONGINT
 sgn:
@@ -18833,7 +18833,7 @@ ui:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:

--- a/tests/warnings/r/win64/op-result-types.txt
+++ b/tests/warnings/r/win64/op-result-types.txt
@@ -18697,7 +18697,7 @@ ull:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:
@@ -18833,7 +18833,7 @@ ui:
 not:
 UINTEGER
 negation:
-UINTEGER
+INTEGER
 abs:
 UINTEGER
 sgn:


### PR DESCRIPTION
The unary generation now always gives a signed result. Previously it only produced a signed result in case the operand was a constant, so `-1u` gave an Integer, but `-myuintvar` gave a UInteger. (#841)

It's different from C's rules, but as far as I know it was intentionally done this way for FB. And I think it's important for constant and non-constant operations to give the same result. Obviously this change breaks backwards compatibility.