### PR TITLE
Separate internal flags for debuginfo and assertions

### DIFF
--- a/src/compiler/ast-node-misc.bas
+++ b/src/compiler/ast-node-misc.bas
@@ -157,7 +157,7 @@ function astNewDBG _
 
 	dim as ASTNODE ptr n = any
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		return NULL
 	end if
 

--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -207,7 +207,7 @@ end sub
 sub edbgEmitHeader( byval filename as zstring ptr )
 	dim as string lname
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
 	end if
 
@@ -247,7 +247,7 @@ end sub
 sub edbgEmitFooter( ) static
 	dim as string lname
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
 	end if
 
@@ -269,7 +269,7 @@ sub edbgLineBegin _
 		byval pos_ as integer _
 	)
 
-    if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
     	exit sub
     end if
 
@@ -299,7 +299,7 @@ sub edbgLineEnd _
 		byval pos_ as integer _
 	)
 
-    if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
     	exit sub
     end if
 
@@ -324,7 +324,7 @@ sub edbgEmitLine _
 
     dim as zstring ptr s
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
 	end if
 
@@ -352,7 +352,7 @@ sub edbgEmitLineFlush _
 		byval label as FBSYMBOL ptr _
 	) static
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
 	end if
 
@@ -371,7 +371,7 @@ sub edbgScopeBegin _
 
 	'' called by ir->ast
 
-    if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
     	exit sub
     end if
 
@@ -388,7 +388,7 @@ sub edbgScopeEnd _
 
 	'' called by ir->ast
 
-    if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
     	exit sub
     end if
 
@@ -403,7 +403,7 @@ sub edbgEmitScopeINI _
 		byval s as FBSYMBOL ptr _
 	) static
 
-    if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
     	exit sub
     end if
 
@@ -417,7 +417,7 @@ sub edbgEmitScopeEND _
 		byval s as FBSYMBOL ptr _
 	) static
 
-    if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
     	exit sub
     end if
 
@@ -483,7 +483,7 @@ sub edbgEmitProcHeader _
 
     dim as string desc, procname
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
 	end if
 
@@ -627,7 +627,7 @@ sub edbgEmitProcFooter _
 
     dim as string procname, lname
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
 	end if
 
@@ -889,7 +889,7 @@ sub edbgEmitGlobalVar _
 	dim as integer t = any, attrib = any
 	dim as string desc
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
 	end if
 
@@ -952,7 +952,7 @@ sub edbgEmitLocalVar _
 	dim as integer t = any
 	dim as string desc, value
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
 	end if
 
@@ -992,7 +992,7 @@ end sub
 sub edbgEmitProcArg( byval sym as FBSYMBOL ptr )
 	dim as string desc
 
-	if( env.clopt.debug = FALSE ) then
+	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
 	end if
 

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -512,7 +512,7 @@ sub outp _
 
     static as string ostr
 
-	if( env.clopt.debug ) then
+	if( env.clopt.debuginfo ) then
 		ostr = TABCHAR
 		ostr += *s
 	else
@@ -1100,7 +1100,7 @@ private sub hCreateFrame _
     	if( (bytestoalloc <> 0) or _
     		(proc->proc.ext->stk.argofs <> EMIT_ARGSTART) or _
         	symbGetIsMainProc( proc ) or _
-        	env.clopt.debug or _
+			env.clopt.debuginfo or _
 			env.clopt.profile ) then
 
     		hPUSH( "ebp" )
@@ -1181,7 +1181,7 @@ private sub hDestroyFrame _
     	if( (bytestoalloc <> 0) or _
     		(proc->proc.ext->stk.argofs <> EMIT_ARGSTART) or _
         	symbGetIsMainProc( proc ) or _
-        	env.clopt.debug or _
+			env.clopt.debuginfo or _
 			env.clopt.profile ) then
     		outp( "mov esp, ebp" )
     		hPOP( "ebp" )

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -459,7 +459,7 @@ sub fbGlobalInit()
 	env.clopt.lang          = FB_DEFAULT_LANG
 	env.clopt.forcelang     = FALSE
 
-	env.clopt.debug         = FALSE
+	env.clopt.debuginfo     = FALSE
 	env.clopt.errorcheck    = FALSE
 	env.clopt.extraerrchk   = FALSE
 	env.clopt.resumeerr     = FALSE
@@ -527,8 +527,8 @@ sub fbSetOption( byval opt as integer, byval value as integer )
 	case FB_COMPOPT_FORCELANG
 		env.clopt.forcelang = value
 
-	case FB_COMPOPT_DEBUG
-		env.clopt.debug = value
+	case FB_COMPOPT_DEBUGINFO
+		env.clopt.debuginfo = value
 	case FB_COMPOPT_ERRORCHECK
 		env.clopt.errorcheck = value
 	case FB_COMPOPT_RESUMEERROR
@@ -600,8 +600,8 @@ function fbGetOption( byval opt as integer ) as integer
 	case FB_COMPOPT_FORCELANG
 		function = env.clopt.forcelang
 
-	case FB_COMPOPT_DEBUG
-		function = env.clopt.debug
+	case FB_COMPOPT_DEBUGINFO
+		function = env.clopt.debuginfo
 	case FB_COMPOPT_ERRORCHECK
 		function = env.clopt.errorcheck
 	case FB_COMPOPT_RESUMEERROR

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -460,6 +460,7 @@ sub fbGlobalInit()
 	env.clopt.forcelang     = FALSE
 
 	env.clopt.debuginfo     = FALSE
+	env.clopt.assertions    = FALSE
 	env.clopt.errorcheck    = FALSE
 	env.clopt.extraerrchk   = FALSE
 	env.clopt.resumeerr     = FALSE
@@ -529,6 +530,8 @@ sub fbSetOption( byval opt as integer, byval value as integer )
 
 	case FB_COMPOPT_DEBUGINFO
 		env.clopt.debuginfo = value
+	case FB_COMPOPT_ASSERTIONS
+		env.clopt.assertions = value
 	case FB_COMPOPT_ERRORCHECK
 		env.clopt.errorcheck = value
 	case FB_COMPOPT_RESUMEERROR
@@ -602,6 +605,8 @@ function fbGetOption( byval opt as integer ) as integer
 
 	case FB_COMPOPT_DEBUGINFO
 		function = env.clopt.debuginfo
+	case FB_COMPOPT_ASSERTIONS
+		function = env.clopt.assertions
 	case FB_COMPOPT_ERRORCHECK
 		function = env.clopt.errorcheck
 	case FB_COMPOPT_RESUMEERROR

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -69,7 +69,7 @@ enum FB_COMPOPT
 	FB_COMPOPT_FORCELANG            '' boolean: TRUE if -forcelang was specified
 
 	'' debugging/error checking
-	FB_COMPOPT_DEBUG                '' boolean: -g
+	FB_COMPOPT_DEBUGINFO            '' boolean: debugging info (affects code generation)
 	FB_COMPOPT_ERRORCHECK           '' boolean: runtime error checks
 	FB_COMPOPT_RESUMEERROR          '' boolean: RESUME support
 	FB_COMPOPT_EXTRAERRCHECK        '' boolean: NULL pointer/array bounds checks
@@ -239,7 +239,7 @@ type FBCMMLINEOPT
 	forcelang       as integer              '' TRUE if -forcelang was specified
 
 	'' debugging/error checking
-	debug           as integer              '' true = add debug info (default = false)
+	debuginfo       as integer              '' true = add debug info (default = false)
 	errorcheck      as integer              '' enable runtime error checks?
 	resumeerr       as integer              '' enable RESUME support?
 	extraerrchk     as integer              '' enable NULL pointer/array bounds checks?

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -70,6 +70,7 @@ enum FB_COMPOPT
 
 	'' debugging/error checking
 	FB_COMPOPT_DEBUGINFO            '' boolean: debugging info (affects code generation)
+	FB_COMPOPT_ASSERTIONS           '' boolean: enable assert() and __FB_DEBUG__
 	FB_COMPOPT_ERRORCHECK           '' boolean: runtime error checks
 	FB_COMPOPT_RESUMEERROR          '' boolean: RESUME support
 	FB_COMPOPT_EXTRAERRCHECK        '' boolean: NULL pointer/array bounds checks
@@ -240,6 +241,7 @@ type FBCMMLINEOPT
 
 	'' debugging/error checking
 	debuginfo       as integer              '' true = add debug info (default = false)
+	assertions      as integer              '' true = enable assert() and __FB_DEBUG__ (default = false)
 	errorcheck      as integer              '' enable runtime error checks?
 	resumeerr       as integer              '' enable RESUME support?
 	extraerrchk     as integer              '' enable NULL pointer/array bounds checks?

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -760,7 +760,7 @@ private function hLinkFiles( ) as integer
 		ldcline += " -Map " + fbc.mapfile
 	end if
 
-	if( fbGetOption( FB_COMPOPT_DEBUG ) = FALSE ) then
+	if( fbGetOption( FB_COMPOPT_DEBUGINFO ) = FALSE ) then
 		if( fbGetOption( FB_COMPOPT_PROFILE ) = FALSE ) then
 			if( fbGetOption( FB_COMPOPT_TARGET ) <> FB_COMPTARGET_DARWIN ) then
 				ldcline += " -s"
@@ -1020,7 +1020,7 @@ private function hLinkFiles( ) as integer
 
 		cxbecline = "-TITLE:" + QUOTE + fbc.xbe_title + (QUOTE + " ")
 
-		if( fbGetOption( FB_COMPOPT_DEBUG ) ) then
+		if( fbGetOption( FB_COMPOPT_DEBUGINFO ) ) then
 			cxbecline += "-DUMPINFO:" + QUOTE + hStripExt(fbc.outname) + (".cxbe" + QUOTE)
 		end if
 
@@ -1603,7 +1603,7 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 		fbSetOption( FB_COMPOPT_FPUTYPE, value )
 
 	case OPT_G
-		fbSetOption( FB_COMPOPT_DEBUG, TRUE )
+		fbSetOption( FB_COMPOPT_DEBUGINFO, TRUE )
 
 	case OPT_GEN
 		select case( lcase( arg ) )
@@ -2859,7 +2859,7 @@ private function hCompileStage2Module( byval module as FBCIOFILE ptr ) as intege
 		'' Avoid gcc exception handling bloat
 		ln += "-fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables "
 
-		if( fbGetOption( FB_COMPOPT_DEBUG ) ) then
+		if( fbGetOption( FB_COMPOPT_DEBUGINFO ) ) then
 			ln += "-g "
 		end if
 
@@ -2941,7 +2941,7 @@ private function hAssembleModule( byval module as FBCIOFILE ptr ) as integer
 		endif
 	end select
 
-	if( fbGetOption( FB_COMPOPT_DEBUG ) = FALSE ) then
+	if( fbGetOption( FB_COMPOPT_DEBUGINFO ) = FALSE ) then
 		if (fbGetOption( FB_COMPOPT_TARGET ) <> FB_COMPTARGET_DARWIN) then
 			ln += "--strip-local-absolute "
 		endif

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -1604,6 +1604,7 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 
 	case OPT_G
 		fbSetOption( FB_COMPOPT_DEBUGINFO, TRUE )
+		fbSetOption( FB_COMPOPT_ASSERTIONS, TRUE )
 
 	case OPT_GEN
 		select case( lcase( arg ) )

--- a/src/compiler/ir-hlc.bas
+++ b/src/compiler/ir-hlc.bas
@@ -384,7 +384,7 @@ end sub
 private sub hWriteLine( byref s as string, byval noline as integer = FALSE )
 	static as string ln
 
-	if( env.clopt.debug and (noline = FALSE) ) then
+	if( env.clopt.debuginfo and (noline = FALSE) ) then
 		ln = "#line " + str( ctx.linenum )
 		ln += " """ + ctx.escapedinputfilename + """"
 		sectionWriteLine( ln )
@@ -1252,7 +1252,7 @@ private function _emitBegin( ) as integer
 	'' header
 	sectionBegin( )
 
-	if( env.clopt.debug ) then
+	if( env.clopt.debuginfo ) then
 		_emitDBG( AST_OP_DBG_LINEINI, NULL, 0 )
 	end if
 
@@ -3648,7 +3648,7 @@ private sub _emitProcBegin _
 
 	hWriteLine( "", TRUE )
 
-	if( env.clopt.debug ) then
+	if( env.clopt.debuginfo ) then
 		_emitDBG( AST_OP_DBG_LINEINI, proc, proc->proc.ext->dbg.iniline )
 	end if
 

--- a/src/compiler/ir-llvm.bas
+++ b/src/compiler/ir-llvm.bas
@@ -892,7 +892,7 @@ private function _emitBegin( ) as integer
 		builtins(i).used = FALSE
 	next
 
-	if( env.clopt.debug ) then
+	if( env.clopt.debuginfo ) then
 		_emitDBG( AST_OP_DBG_LINEINI, NULL, 0 )
 	end if
 

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -191,7 +191,7 @@ private function hReadChar _
 		end if
 
 		'' update current line text (if not parsing an inc file)
-		if( env.clopt.debug ) then
+		if( env.clopt.debuginfo ) then
 			if( env.includerec = 0 ) then
 				if( lex.insidemacro = FALSE ) then
 					lex.insidemacro = TRUE
@@ -249,7 +249,7 @@ private function hReadChar _
 		end if
 
 		'' update current line text (if not parsing an inc file)
-		if( env.clopt.debug ) then
+		if( env.clopt.debuginfo ) then
 			if( env.includerec = 0 ) then
 				if( lex.insidemacro ) then
 					lex.insidemacro = FALSE

--- a/src/compiler/parser-toplevel.bas
+++ b/src/compiler/parser-toplevel.bas
@@ -126,7 +126,7 @@ sub cProgram()
 		end if
 
 		'' Emit the current line in text form, for debugging purposes
-		if( env.clopt.debug ) then
+		if( env.clopt.debuginfo ) then
 			if( env.includerec = 0 ) then
 				hEmitCurrentLineText( )
 			end if

--- a/src/compiler/parser.bi
+++ b/src/compiler/parser.bi
@@ -944,7 +944,7 @@ declare function hIntegerTypeFromBitSize _
 
 '':::::
 #macro hEmitCurrLine( )
-	if( env.clopt.debug ) then
+	if( env.clopt.debuginfo ) then
 		if( env.includerec = 0 ) then
 			astAdd( astNewLIT( lexCurrLineGet( ) ) )
 			lexCurrLineReset( )

--- a/src/compiler/rtl-macro.bas
+++ b/src/compiler/rtl-macro.bas
@@ -592,7 +592,7 @@ private sub hAddMacro( byval macdef as FB_RTL_MACRODEF ptr )
 
 	'' only if debugging?
 	if( (macdef->options and FB_RTL_OPT_DBGONLY) <> 0 ) then
-		if( env.clopt.debug = FALSE ) then
+		if( env.clopt.debuginfo = FALSE ) then
 			addbody = FALSE
 		end if
 	end if

--- a/src/compiler/rtl-macro.bas
+++ b/src/compiler/rtl-macro.bas
@@ -590,9 +590,9 @@ private sub hAddMacro( byval macdef as FB_RTL_MACRODEF ptr )
 		end if
 	next
 
-	'' only if debugging?
+	'' Only add the assert[warn]() macros in debug builds
 	if( (macdef->options and FB_RTL_OPT_DBGONLY) <> 0 ) then
-		if( env.clopt.debuginfo = FALSE ) then
+		if( env.clopt.assertions = FALSE ) then
 			addbody = FALSE
 		end if
 	end if

--- a/src/compiler/rtl.bi
+++ b/src/compiler/rtl.bi
@@ -828,7 +828,7 @@ enum FB_RTL_OPT
 	FB_RTL_OPT_ERROR	  = &h00000002					'' returns an error
 	FB_RTL_OPT_MT		  = &h00000004					'' needs the multithreaded rtlib
 
-	FB_RTL_OPT_DBGONLY	  = &h00000010                  '' -g only
+	FB_RTL_OPT_DBGONLY	  = &h00000010                  '' Debug-build only (assertions/__FB_DEBUG__)
 				''= &h00000020
 	FB_RTL_OPT_STRSUFFIX  = &h00000040                  '' has a $ suffix (-lang qb only)
 	FB_RTL_OPT_NOQB		  = &h00000080                  '' anything but -lang qb

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -103,7 +103,7 @@ private function hDefOutObj_cb ( ) as string
 end function
 
 private function hDefDebug_cb ( ) as string
-	function = str( env.clopt.debuginfo )
+	function = str( env.clopt.assertions )
 end function
 
 private function hDefErr_cb ( ) as string

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -103,7 +103,7 @@ private function hDefOutObj_cb ( ) as string
 end function
 
 private function hDefDebug_cb ( ) as string
-	function = str( env.clopt.debug )
+	function = str( env.clopt.debuginfo )
 end function
 
 private function hDefErr_cb ( ) as string


### PR DESCRIPTION
Previously there was only a single "debug" flag internally, but it seems better to have separate ones for debug symbols/info and assertions, which would potentially allow adding separate fbc command line options for them in the future.