### PR TITLE
Updated zlib.bi to use the 3 common library names

### DIFF
--- a/inc/zlib.bi
+++ b/inc/zlib.bi
@@ -35,7 +35,22 @@
 
 #pragma once
 
+#ifdef ZLIB_USE_ZLIB1
+#define NAMEDEF 
+#inclib "zlib1"
+#endif
+#ifdef ZLIB_USE_Z
+#define NAMEDEF
 #inclib "z"
+#endif
+#ifdef ZLIB_USE_LIBZLIB
+#define NAMEDEF
+#inclib "libzlib"
+#endif
+
+#ifndef NAMEDEF
+#inclib "z"
+#endif
 
 #include once "crt/long.bi"
 #include once "crt/stdarg.bi"


### PR DESCRIPTION
now zlib.bi can use either
* zlib1
* z
* libzlib 

to include the library. This fixes issues when trying to include zlib in projects.

to use a specific library name:
* for "zlib1"   : `#define ZLIB_USE_ZLIB1`
* for "z"         : `#define ZLIB_USE_Z`
* for "libzlib" : `#define ZLIB_USE_LIBZLIB`

If none of them are defined, the default choice is "z"
The `#define` has to be done before `#include "zlib.bi"`