### PR TITLE
Fix C++ mangling for BYREF parameters with built-in types

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ Version 1.06.0
 - #851: '#LINE line filename' only changed the source filename in error messages, not in debug info
 - #832: Fix bug allowing QB style suffixes on all keywords, regardless of -lang
 - #841: The unary negation operator gave different result signedness when used on constant instead of non-constant expression. Now the result is always signed.
+- Incorrect C++ mangling for BYREF parameters using built-in types
 
 
 Version 1.05.0

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -247,15 +247,6 @@ private function hAbbrevFind _
 		return -1
 	end if
 
-	'' builtin?
-	if( subtype = NULL ) then
-		if( typeIsPtr( dtype ) = FALSE ) then
-			if( typeGet( dtype ) <> FB_DATATYPE_STRING ) then
-				return -1
-			end if
-		end if
-	end if
-
 	'' for each item..
 	n = flistGetHead( @ctx.flist )
 	do while( n <> NULL )
@@ -272,6 +263,8 @@ private function hAbbrevFind _
 	function = -1
 end function
 
+'' Add qualified/non-built-in type to lookup table for substitution/compression
+'' according to Itanium C++ ABI.
 private function hAbbrevAdd _
 	( _
 		byval dtype as integer, _
@@ -329,15 +322,8 @@ function hMangleBuiltInType _
 	assert( dtype = typeGetDtOnly( dtype ) )
 
 	''
-	'' According to the Itanium C++ ABI, C++ built-in type aren't considered
-	'' for abbreviation, while other types are.
-	''
-	'' For FB this means that some of FB built-ins can be mangled as C++
-	'' built-ins without having to do hAbbrevAdd(), while others (e.g.
-	'' FBSTRING) must be mangled as UDT or custom/vendor-specific types for
-	'' which we must do hAbbrevAdd().
-	''
-	'' This way our abbreviations stay compatible to GCC and demanglers.
+	'' Plain unqualified C++ built-in types are not considered for abbreviation.
+	'' However, custom/vendor-specific types still are.
 	''
 	'' This only matters when hMangleBuiltInType() is called from
 	'' symbMangleType(), but it does not matter when hMangleBuiltInType() is


### PR DESCRIPTION
hAbbrevFind() skipped the lookup for reference-to-built-in types. (and potentially even more)

However, references are considered for compression too by the Itanium C++ ABI. We already do hAbbrevAdd() for such cases too.