### PR TITLE
log test for PR#62 -- Fix C++ mangling for BYREF parameters with built-in types

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,7 @@ Version 1.06.0
 - #851: '#LINE line filename' only changed the source filename in error messages, not in debug info
 - #832: Fix bug allowing QB style suffixes on all keywords, regardless of -lang
 - #841: The unary negation operator gave different result signedness when used on constant instead of non-constant expression. Now the result is always signed.
+- Incorrect C++ mangling for BYREF parameters using built-in types
 
 
 Version 1.05.0

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -247,15 +247,6 @@ private function hAbbrevFind _
 		return -1
 	end if
 
-	'' builtin?
-	if( subtype = NULL ) then
-		if( typeIsPtr( dtype ) = FALSE ) then
-			if( typeGet( dtype ) <> FB_DATATYPE_STRING ) then
-				return -1
-			end if
-		end if
-	end if
-
 	'' for each item..
 	n = flistGetHead( @ctx.flist )
 	do while( n <> NULL )
@@ -272,6 +263,8 @@ private function hAbbrevFind _
 	function = -1
 end function
 
+'' Add qualified/non-built-in type to lookup table for substitution/compression
+'' according to Itanium C++ ABI.
 private function hAbbrevAdd _
 	( _
 		byval dtype as integer, _
@@ -329,15 +322,8 @@ function hMangleBuiltInType _
 	assert( dtype = typeGetDtOnly( dtype ) )
 
 	''
-	'' According to the Itanium C++ ABI, C++ built-in type aren't considered
-	'' for abbreviation, while other types are.
-	''
-	'' For FB this means that some of FB built-ins can be mangled as C++
-	'' built-ins without having to do hAbbrevAdd(), while others (e.g.
-	'' FBSTRING) must be mangled as UDT or custom/vendor-specific types for
-	'' which we must do hAbbrevAdd().
-	''
-	'' This way our abbreviations stay compatible to GCC and demanglers.
+	'' Plain unqualified C++ built-in types are not considered for abbreviation.
+	'' However, custom/vendor-specific types still are.
 	''
 	'' This only matters when hMangleBuiltInType() is called from
 	'' symbMangleType(), but it does not matter when hMangleBuiltInType() is

--- a/tests/cpp/cpp-mangle.cpp
+++ b/tests/cpp/cpp-mangle.cpp
@@ -82,22 +82,22 @@ namespace cpp_mangle
 
 	// long = 32 bit
 
-	unsigned long cpp_byval_u32( unsigned long a )
+	unsigned int cpp_byval_u32( unsigned int a )
 	{
 		return a;
 	}
 	
-	signed long cpp_byval_s32( signed long a )
+	signed int cpp_byval_s32( signed int a )
 	{
 		return a;
 	}
 	
-	unsigned long cpp_byref_u32( unsigned long &a )
+	unsigned int cpp_byref_u32( unsigned int &a )
 	{
 		return a;
 	} 
 
-	signed long cpp_byref_s32( signed long &a )
+	signed int cpp_byref_s32( signed int &a )
 	{
 		return a;
 	} 

--- a/tests/cpp/cpp-mangle.cpp
+++ b/tests/cpp/cpp-mangle.cpp
@@ -1,6 +1,6 @@
 namespace cpp_mangle 
 {
-	// boolean
+	// bool
 
 	bool cpp_byval_bool( bool a )
 	{
@@ -36,90 +36,112 @@ namespace cpp_mangle
 		return a;
 	} 
 
-	// byte = 8 bit
+	// char = 8 bit
 
-	unsigned char cpp_byval_u8( unsigned char a )
+	unsigned char cpp_byval_uchar( unsigned char a )
 	{
 		return a;
 	}
 
-	signed char cpp_byval_s8( signed char a )
-	{
-		return a;
-	}
-	
-	unsigned char cpp_byref_u8( unsigned char &a )
-	{
-		return a;
-	} 
-
-   	signed char cpp_byref_s8( signed char &a )
-	{
-		return a;
-	} 
-
-	// short = 16 bit
-
-	unsigned short cpp_byval_u16( unsigned short a )
+	signed char cpp_byval_schar( signed char a )
 	{
 		return a;
 	}
 	
-	signed short cpp_byval_s16( signed short a )
-	{
-		return a;
-	}
-	
-	unsigned short cpp_byref_u16( unsigned short &a )
+	unsigned char cpp_byref_uchar( unsigned char &a )
 	{
 		return a;
 	} 
 
-	signed short cpp_byref_s16( signed short &a )
+   	signed char cpp_byref_schar( signed char &a )
 	{
 		return a;
 	} 
 
-	// long = 32 bit
+	// short int = 16 bit
 
-	unsigned int cpp_byval_u32( unsigned int a )
+	unsigned short cpp_byval_ushort( unsigned short int a )
 	{
 		return a;
 	}
 	
-	signed int cpp_byval_s32( signed int a )
+	signed short cpp_byval_sshort( signed short int a )
 	{
 		return a;
 	}
 	
-	unsigned int cpp_byref_u32( unsigned int &a )
+	unsigned short cpp_byref_ushort( unsigned short int &a )
 	{
 		return a;
 	} 
 
-	signed int cpp_byref_s32( signed int &a )
+	signed short cpp_byref_sshort( signed short int &a )
 	{
 		return a;
 	} 
 
-	// long long = 64 bit
+	// int
 
-	unsigned long long cpp_byval_u64( unsigned long long a )
+	unsigned int cpp_byval_uint( unsigned int a )
 	{
 		return a;
 	}
 	
-	signed long long cpp_byval_s64( signed long long a )
+	signed int cpp_byval_sint( signed int a )
 	{
 		return a;
 	}
 	
-	unsigned long long cpp_byref_u64( unsigned long long &a )
+	unsigned int cpp_byref_uint( unsigned int &a )
 	{
 		return a;
 	} 
 
-	signed long long cpp_byref_s64( signed long long &a )
+	signed int cpp_byref_sint( signed int &a )
+	{
+		return a;
+	} 
+
+	// long int
+
+	unsigned long int cpp_byval_ulongint( unsigned long int a )
+	{
+		return a;
+	}
+	
+	signed long int cpp_byval_slongint( signed long int a )
+	{
+		return a;
+	}
+	
+	unsigned long int cpp_byref_ulongint( unsigned long int &a )
+	{
+		return a;
+	} 
+
+	signed long int cpp_byref_slongint( signed long int &a )
+	{
+		return a;
+	} 
+
+	// long long int = 64 bit
+
+	unsigned long long int cpp_byval_ulonglongint( unsigned long long int a )
+	{
+		return a;
+	}
+	
+	signed long long int cpp_byval_slonglongint( signed long long int a )
+	{
+		return a;
+	}
+	
+	unsigned long long int cpp_byref_ulonglongint( unsigned long long int &a )
+	{
+		return a;
+	} 
+
+	signed long long int cpp_byref_slonglongint( signed long long int &a )
 	{
 		return a;
 	} 

--- a/tests/cpp/cpp-mangle.cpp
+++ b/tests/cpp/cpp-mangle.cpp
@@ -1,0 +1,127 @@
+namespace cpp_mangle 
+{
+	// boolean
+
+	bool cpp_byval_bool( bool a )
+	{
+		return a;
+	}
+	
+	bool cpp_byref_bool( bool &a )
+	{
+		return a;
+	} 
+
+    // float
+
+	float cpp_byval_float( float a )
+	{
+		return a;
+	}
+	
+	float cpp_byref_float( float &a )
+	{
+		return a;
+	} 
+
+   	// double
+
+	double cpp_byval_double( double a )
+	{
+		return a;
+	}
+	
+	double cpp_byref_double( double &a )
+	{
+		return a;
+	} 
+
+	// byte = 8 bit
+
+	unsigned char cpp_byval_u8( unsigned char a )
+	{
+		return a;
+	}
+
+	signed char cpp_byval_s8( signed char a )
+	{
+		return a;
+	}
+	
+	unsigned char cpp_byref_u8( unsigned char &a )
+	{
+		return a;
+	} 
+
+   	signed char cpp_byref_s8( signed char &a )
+	{
+		return a;
+	} 
+
+	// short = 16 bit
+
+	unsigned short cpp_byval_u16( unsigned short a )
+	{
+		return a;
+	}
+	
+	signed short cpp_byval_s16( signed short a )
+	{
+		return a;
+	}
+	
+	unsigned short cpp_byref_u16( unsigned short &a )
+	{
+		return a;
+	} 
+
+	signed short cpp_byref_s16( signed short &a )
+	{
+		return a;
+	} 
+
+	// long = 32 bit
+
+	unsigned long cpp_byval_u32( unsigned long a )
+	{
+		return a;
+	}
+	
+	signed long cpp_byval_s32( signed long a )
+	{
+		return a;
+	}
+	
+	unsigned long cpp_byref_u32( unsigned long &a )
+	{
+		return a;
+	} 
+
+	signed long cpp_byref_s32( signed long &a )
+	{
+		return a;
+	} 
+
+	// long long = 64 bit
+
+	unsigned long long cpp_byval_u64( unsigned long long a )
+	{
+		return a;
+	}
+	
+	signed long long cpp_byval_s64( signed long long a )
+	{
+		return a;
+	}
+	
+	unsigned long long cpp_byref_u64( unsigned long long &a )
+	{
+		return a;
+	} 
+
+	signed long long cpp_byref_s64( signed long long &a )
+	{
+		return a;
+	} 
+
+}

--- a/tests/cpp/fbc-mangle.bas
+++ b/tests/cpp/fbc-mangle.bas
@@ -9,8 +9,12 @@
 	type cxxlongint as integer
 
 	/' !!!
-		cxxlongint will never work on win64, fbc custom mangles INTEGER and there is 
+		cxxlongint will currently fail on win64, fbc custom mangles INTEGER and there is 
 		no other data type that will return the "m" and "l" suffixes for c's long int.
+		The specific test that fails is skipped over using and and #ifdef.  To have a basic
+		datatype on win64 that can map to g++ long int, one possible solution would be
+		change the overloading allowed for the c++ mangled names onlym what would have to
+		be added to fbc.
 	'/
 
 #else
@@ -167,8 +171,12 @@ scope
 
 end scope
 
+#if (not defined(__FB_64BIT__)) or defined(__FB_UNIX__)
+
 /' !!! there is no name mangling on win64 that can
-       map to g++ long int
+       map to g++ long int, only allow the test on
+	   32-bit or unix
+'/
 
 scope
 
@@ -191,7 +199,7 @@ scope
 
 end scope
 
-'/
+#endif
 
 scope
 

--- a/tests/cpp/fbc-mangle.bas
+++ b/tests/cpp/fbc-mangle.bas
@@ -1,5 +1,22 @@
 ' TEST_MODE : MULTI_MODULE_TEST
 
+#ifdef __FB_64BIT__
+
+	type cxxint as long
+	
+	/' !!!
+	this will never work on win64, fbc custom mangles INTEGER and there is no other 
+	data type that will return the "m" and "l" suffixes for C's long int.
+	'/
+	type cxxlongint as integer
+
+#else
+
+	type cxxint as integer
+	type cxxlongint as long
+
+#endif
+
 extern "c++"
 
 namespace cpp_mangle
@@ -13,25 +30,30 @@ namespace cpp_mangle
 	declare function cpp_byval_double( byval a as double ) as double
 	declare function cpp_byref_double( byref a as double ) as double
 	
-	declare function cpp_byval_u8( byval a as unsigned byte ) as unsigned byte
-	declare function cpp_byval_s8( byval a as byte ) as byte
-	declare function cpp_byref_u8( byref a as unsigned byte ) as unsigned byte
-	declare function cpp_byref_s8( byref a as byte ) as byte
+	declare function cpp_byval_uchar( byval a as unsigned byte ) as unsigned byte
+	declare function cpp_byval_schar( byval a as byte ) as byte
+	declare function cpp_byref_uchar( byref a as unsigned byte ) as unsigned byte
+	declare function cpp_byref_schar( byref a as byte ) as byte
 
-   	declare function cpp_byval_u16( byval a as unsigned short ) as unsigned short
-	declare function cpp_byval_s16( byval a as short ) as short
-	declare function cpp_byref_u16( byref a as unsigned short ) as unsigned short
-	declare function cpp_byref_s16( byref a as short ) as short
+   	declare function cpp_byval_ushort( byval a as unsigned short ) as unsigned short
+	declare function cpp_byval_sshort( byval a as short ) as short
+	declare function cpp_byref_ushort( byref a as unsigned short ) as unsigned short
+	declare function cpp_byref_sshort( byref a as short ) as short
 
-   	declare function cpp_byval_u32( byval a as unsigned long ) as unsigned long
-	declare function cpp_byval_s32( byval a as long ) as long
-	declare function cpp_byref_u32( byref a as unsigned long ) as unsigned long
-	declare function cpp_byref_s32( byref a as long ) as long
+   	declare function cpp_byval_uint( byval a as unsigned cxxint ) as unsigned cxxint
+	declare function cpp_byval_sint( byval a as cxxint ) as cxxint
+	declare function cpp_byref_uint( byref a as unsigned cxxint ) as unsigned cxxint
+	declare function cpp_byref_sint( byref a as cxxint ) as cxxint
 
-   	declare function cpp_byval_u64( byval a as unsigned longint ) as unsigned longint
-	declare function cpp_byval_s64( byval a as longint ) as longint
-	declare function cpp_byref_u64( byref a as unsigned longint ) as unsigned longint 
-	declare function cpp_byref_s64( byref a as longint ) as longint
+   	declare function cpp_byval_ulongint( byval a as unsigned cxxlongint ) as unsigned cxxlongint
+	declare function cpp_byval_slongint( byval a as cxxlongint ) as cxxlongint
+	declare function cpp_byref_ulongint( byref a as unsigned cxxlongint ) as unsigned cxxlongint
+	declare function cpp_byref_slongint( byref a as cxxlongint ) as cxxlongint
+
+   	declare function cpp_byval_ulonglongint( byval a as unsigned longint ) as unsigned longint
+	declare function cpp_byval_slonglongint( byval a as longint ) as longint
+	declare function cpp_byref_ulonglongint( byref a as unsigned longint ) as unsigned longint 
+	declare function cpp_byref_slonglongint( byref a as longint ) as longint
 
 end namespace
 
@@ -39,79 +61,151 @@ end extern
 
 using cpp_mangle
 
-'' boolean
-dim b as boolean
-ASSERT( cpp_byval_bool(false) = 0 )
-ASSERT( cpp_byval_bool(true) = true )
-b = false: ASSERT( cpp_byref_bool(b) = false )
-b = true : ASSERT( cpp_byref_bool(b) = true )
+scope
 
-'' single
-dim s as single
-ASSERT( cpp_byval_float(s) = 0 )
-ASSERT( cpp_byval_float(s) = 0 )
-s = 0: ASSERT( cpp_byref_float(s) = 0 )
-s = 10 : ASSERT( cpp_byref_float(s) = 10 )
+	''  c = bool
+	'' fb = boolean
 
-'' double
-dim d as double
-ASSERT( cpp_byval_double(d) = 0 )
-ASSERT( cpp_byval_double(d) = 0 )
-d = 0: ASSERT( cpp_byref_double(d) = 0 )
-d = 10 : ASSERT( cpp_byref_double(d) = 10 )
-			 
-'' signed|unsigned byte
-ASSERT( cpp_byval_u8(0) = 0 )
-ASSERT( cpp_byval_s8(0) = 0 )
-ASSERT( cpp_byval_u8(&h7f) = &h7f )
-ASSERT( cpp_byval_s8(&h7f) = &h7f )
-dim ub as unsigned byte = 0
-dim sb as byte = 0
-ASSERT( cpp_byval_u8(ub) = 0 )
-ASSERT( cpp_byval_s8(sb) = 0 )
-ub = &h7f
-sb = &h7f
-ASSERT( cpp_byval_u8(ub) = &h7f )
-ASSERT( cpp_byval_s8(sb) = &h7f )
+	dim b as boolean
+	ASSERT( cpp_byval_bool(false) = 0 )
+	ASSERT( cpp_byval_bool(true) = true )
+	b = false: ASSERT( cpp_byref_bool(b) = false )
+	b = true : ASSERT( cpp_byref_bool(b) = true )
 
-'' signed|unsigned short
-ASSERT( cpp_byval_u16(0) = 0 )
-ASSERT( cpp_byval_s16(0) = 0 )
-ASSERT( cpp_byval_u16(&h7fff) = &h7fff )
-ASSERT( cpp_byval_s16(&h7fff) = &h7fff )
-dim us as unsigned short = 0
-dim ss as short = 0
-ASSERT( cpp_byval_u16(us) = 0 )
-ASSERT( cpp_byval_s16(ss) = 0 )
-us = &h7fff
-ss = &h7fff
-ASSERT( cpp_byval_u16(us) = &h7fff )
-ASSERT( cpp_byval_s16(ss) = &h7fff )
+end scope
 
-'' signed|unsigned long
-ASSERT( cpp_byval_u32(0) = 0 )
-ASSERT( cpp_byval_s32(0) = 0 )
-ASSERT( cpp_byval_u32(&h7fffffff) = &h7fffffff )
-ASSERT( cpp_byval_s32(&h7fffffff) = &h7fffffff )
-dim ul as unsigned long = 0
-dim sl as long = 0
-ASSERT( cpp_byval_u32(ul) = 0 )
-ASSERT( cpp_byval_s32(sl) = 0 )
-ul = &h7fffffff
-sl = &h7fffffff
-ASSERT( cpp_byval_u32(ul) = &h7fffffff )
-ASSERT( cpp_byval_s32(sl) = &h7fffffff )
+scope
 
-'' signed|unsigned longint
-ASSERT( cpp_byval_u64(0) = 0 )
-ASSERT( cpp_byval_s64(0) = 0 )
-ASSERT( cpp_byval_u64(&h7fffffffffffffff) = &h7fffffffffffffff )
-ASSERT( cpp_byval_s64(&h7fffffffffffffff) = &h7fffffffffffffff )
-dim ull as unsigned longint = 0
-dim sll as longint = 0
-ASSERT( cpp_byval_u64(ull) = 0 )
-ASSERT( cpp_byval_s64(sll) = 0 )
-ull = &h7fffffffffffffff
-sll = &h7fffffffffffffff
-ASSERT( cpp_byval_u64(ull) = &h7fffffffffffffff )
-ASSERT( cpp_byval_s64(sll) = &h7fffffffffffffff )
+	''  c = float
+	'' fb = single
+
+	dim s as single
+	ASSERT( cpp_byval_float(s) = 0 )
+	ASSERT( cpp_byval_float(s) = 0 )
+	s = 0: ASSERT( cpp_byref_float(s) = 0 )
+	s = 10 : ASSERT( cpp_byref_float(s) = 10 )
+
+end scope
+
+scope
+
+	''  c = double
+	'' fb = double
+
+	dim d as double
+	ASSERT( cpp_byval_double(d) = 0 )
+	ASSERT( cpp_byval_double(d) = 0 )
+	d = 0: ASSERT( cpp_byref_double(d) = 0 )
+	d = 10 : ASSERT( cpp_byref_double(d) = 10 )
+
+end scope
+
+scope
+				 
+	''  c = signed|unsigned char
+	'' fb = [unsigned] byte
+
+	ASSERT( cpp_byval_uchar(0) = 0 )
+	ASSERT( cpp_byval_schar(0) = 0 )
+	ASSERT( cpp_byval_uchar(&h7f) = &h7f )
+	ASSERT( cpp_byval_schar(&h7f) = &h7f )
+
+	dim ub as unsigned byte = 0
+	dim sb as byte = 0
+	ASSERT( cpp_byref_uchar(ub) = 0 )
+	ASSERT( cpp_byref_schar(sb) = 0 )
+	ub = &h7f
+	sb = &h7f
+	ASSERT( cpp_byref_uchar(ub) = &h7f )
+	ASSERT( cpp_byref_schar(sb) = &h7f )
+
+end scope
+
+scope
+
+	''  c = signed|unsigned short int
+	'' fb = [unsigned] short
+
+	ASSERT( cpp_byval_ushort(0) = 0 )
+	ASSERT( cpp_byval_sshort(0) = 0 )
+	ASSERT( cpp_byval_ushort(&h7fff) = &h7fff )
+	ASSERT( cpp_byval_sshort(&h7fff) = &h7fff )
+
+	dim us as unsigned short = 0
+	dim ss as short = 0
+	ASSERT( cpp_byref_ushort(us) = 0 )
+	ASSERT( cpp_byref_sshort(ss) = 0 )
+	us = &h7fff
+	ss = &h7fff
+	ASSERT( cpp_byref_ushort(us) = &h7fff )
+	ASSERT( cpp_byref_sshort(ss) = &h7fff )
+
+end scope
+'/
+scope
+
+	''  c = signed|unsigned int
+	'' fb = [unsigned] long|integer
+
+	ASSERT( cpp_byval_uint(0) = 0 )
+	ASSERT( cpp_byval_sint(0) = 0 )
+	ASSERT( cpp_byval_uint(&h7fffffff) = &h7fffffff )
+	ASSERT( cpp_byval_sint(&h7fffffff) = &h7fffffff )
+
+	dim ui as unsigned cxxint = 0
+	dim si as cxxint = 0
+	ASSERT( cpp_byref_uint(ui) = 0 )
+	ASSERT( cpp_byref_sint(si) = 0 )
+	ui = &h7fffffff
+	si = &h7fffffff
+	ASSERT( cpp_byref_uint(ui) = &h7fffffff )
+	ASSERT( cpp_byref_sint(si) = &h7fffffff )
+
+end scope
+
+/' !!! there is no name mangling on win64 that can
+map to gcc long in
+
+scope
+
+	'' c = signed|unsigned long int
+	'' fb = [unsigned] long|integer
+
+	ASSERT( cpp_byval_ulongint(0) = 0 )
+	ASSERT( cpp_byval_slongint(0) = 0 )
+	ASSERT( cpp_byval_ulongint(&h7fffffff) = &h7fffffff )
+	ASSERT( cpp_byval_sint(&h7fffffff) = &h7fffffff )
+
+	dim ul as unsigned cxxlongint = 0
+	dim sl as cxxlongint = 0
+	ASSERT( cpp_byref_ulongint(ul) = 0 )
+	ASSERT( cpp_byref_slongint(sl) = 0 )
+	ul = &h7fffffff
+	sl = &h7fffffff
+	ASSERT( cpp_byref_ulongint(ul) = &h7fffffff )
+	ASSERT( cpp_byref_slongint(sl) = &h7fffffff )
+
+end scope
+
+'/
+
+scope
+
+	''  c = signed|unsigned long long int
+	'' fb = [unsigned] longint
+
+	ASSERT( cpp_byval_ulonglongint(0) = 0 )
+	ASSERT( cpp_byval_slonglongint(0) = 0 )
+	ASSERT( cpp_byval_ulonglongint(&h7fffffffffffffff) = &h7fffffffffffffff )
+	ASSERT( cpp_byval_slonglongint(&h7fffffffffffffff) = &h7fffffffffffffff )
+
+	dim ull as unsigned longint = 0
+	dim sll as longint = 0
+	ASSERT( cpp_byref_ulonglongint(ull) = 0 )
+	ASSERT( cpp_byref_slonglongint(sll) = 0 )
+	ull = &h7fffffffffffffff
+	sll = &h7fffffffffffffff
+	ASSERT( cpp_byref_ulonglongint(ull) = &h7fffffffffffffff )
+	ASSERT( cpp_byref_slonglongint(sll) = &h7fffffffffffffff )
+
+end scope

--- a/tests/cpp/fbc-mangle.bas
+++ b/tests/cpp/fbc-mangle.bas
@@ -1,0 +1,117 @@
+' TEST_MODE : MULTI_MODULE_TEST
+
+extern "c++"
+
+namespace cpp_mangle
+	
+	declare function cpp_byval_bool( byval a as boolean ) as boolean
+	declare function cpp_byref_bool( byref a as boolean ) as boolean
+
+	declare function cpp_byval_float( byval a as single ) as single
+	declare function cpp_byref_float( byref a as single ) as single
+
+	declare function cpp_byval_double( byval a as double ) as double
+	declare function cpp_byref_double( byref a as double ) as double
+	
+	declare function cpp_byval_u8( byval a as unsigned byte ) as unsigned byte
+	declare function cpp_byval_s8( byval a as byte ) as byte
+	declare function cpp_byref_u8( byref a as unsigned byte ) as unsigned byte
+	declare function cpp_byref_s8( byref a as byte ) as byte
+
+   	declare function cpp_byval_u16( byval a as unsigned short ) as unsigned short
+	declare function cpp_byval_s16( byval a as short ) as short
+	declare function cpp_byref_u16( byref a as unsigned short ) as unsigned short
+	declare function cpp_byref_s16( byref a as short ) as short
+
+   	declare function cpp_byval_u32( byval a as unsigned long ) as unsigned long
+	declare function cpp_byval_s32( byval a as long ) as long
+	declare function cpp_byref_u32( byref a as unsigned long ) as unsigned long
+	declare function cpp_byref_s32( byref a as long ) as long
+
+   	declare function cpp_byval_u64( byval a as unsigned longint ) as unsigned longint
+	declare function cpp_byval_s64( byval a as longint ) as longint
+	declare function cpp_byref_u64( byref a as unsigned longint ) as unsigned longint 
+	declare function cpp_byref_s64( byref a as longint ) as longint
+
+end namespace
+
+end extern
+
+using cpp_mangle
+
+'' boolean
+dim b as boolean
+ASSERT( cpp_byval_bool(false) = 0 )
+ASSERT( cpp_byval_bool(true) = true )
+b = false: ASSERT( cpp_byref_bool(b) = false )
+b = true : ASSERT( cpp_byref_bool(b) = true )
+
+'' single
+dim s as single
+ASSERT( cpp_byval_float(s) = 0 )
+ASSERT( cpp_byval_float(s) = 0 )
+s = 0: ASSERT( cpp_byref_float(s) = 0 )
+s = 10 : ASSERT( cpp_byref_float(s) = 10 )
+
+'' double
+dim d as double
+ASSERT( cpp_byval_double(d) = 0 )
+ASSERT( cpp_byval_double(d) = 0 )
+d = 0: ASSERT( cpp_byref_double(d) = 0 )
+d = 10 : ASSERT( cpp_byref_double(d) = 10 )
+			 
+'' signed|unsigned byte
+ASSERT( cpp_byval_u8(0) = 0 )
+ASSERT( cpp_byval_s8(0) = 0 )
+ASSERT( cpp_byval_u8(&h7f) = &h7f )
+ASSERT( cpp_byval_s8(&h7f) = &h7f )
+dim ub as unsigned byte = 0
+dim sb as byte = 0
+ASSERT( cpp_byval_u8(ub) = 0 )
+ASSERT( cpp_byval_s8(sb) = 0 )
+ub = &h7f
+sb = &h7f
+ASSERT( cpp_byval_u8(ub) = &h7f )
+ASSERT( cpp_byval_s8(sb) = &h7f )
+
+'' signed|unsigned short
+ASSERT( cpp_byval_u16(0) = 0 )
+ASSERT( cpp_byval_s16(0) = 0 )
+ASSERT( cpp_byval_u16(&h7fff) = &h7fff )
+ASSERT( cpp_byval_s16(&h7fff) = &h7fff )
+dim us as unsigned short = 0
+dim ss as short = 0
+ASSERT( cpp_byval_u16(us) = 0 )
+ASSERT( cpp_byval_s16(ss) = 0 )
+us = &h7fff
+ss = &h7fff
+ASSERT( cpp_byval_u16(us) = &h7fff )
+ASSERT( cpp_byval_s16(ss) = &h7fff )
+
+'' signed|unsigned long
+ASSERT( cpp_byval_u32(0) = 0 )
+ASSERT( cpp_byval_s32(0) = 0 )
+ASSERT( cpp_byval_u32(&h7fffffff) = &h7fffffff )
+ASSERT( cpp_byval_s32(&h7fffffff) = &h7fffffff )
+dim ul as unsigned long = 0
+dim sl as long = 0
+ASSERT( cpp_byval_u32(ul) = 0 )
+ASSERT( cpp_byval_s32(sl) = 0 )
+ul = &h7fffffff
+sl = &h7fffffff
+ASSERT( cpp_byval_u32(ul) = &h7fffffff )
+ASSERT( cpp_byval_s32(sl) = &h7fffffff )
+
+'' signed|unsigned longint
+ASSERT( cpp_byval_u64(0) = 0 )
+ASSERT( cpp_byval_s64(0) = 0 )
+ASSERT( cpp_byval_u64(&h7fffffffffffffff) = &h7fffffffffffffff )
+ASSERT( cpp_byval_s64(&h7fffffffffffffff) = &h7fffffffffffffff )
+dim ull as unsigned longint = 0
+dim sll as longint = 0
+ASSERT( cpp_byval_u64(ull) = 0 )
+ASSERT( cpp_byval_s64(sll) = 0 )
+ull = &h7fffffffffffffff
+sll = &h7fffffffffffffff
+ASSERT( cpp_byval_u64(ull) = &h7fffffffffffffff )
+ASSERT( cpp_byval_s64(sll) = &h7fffffffffffffff )

--- a/tests/cpp/fbc-mangle.bas
+++ b/tests/cpp/fbc-mangle.bas
@@ -1,17 +1,21 @@
 ' TEST_MODE : MULTI_MODULE_TEST
 
+'' test mapping of basic data types between fbc and g++
+'' with c++ name mangling
+
 #ifdef __FB_64BIT__
 
 	type cxxint as long
-	
-	/' !!!
-	this will never work on win64, fbc custom mangles INTEGER and there is no other 
-	data type that will return the "m" and "l" suffixes for C's long int.
-	'/
 	type cxxlongint as integer
 
-#else
+	/' !!!
+		cxxlongint will never work on win64, fbc custom mangles INTEGER and there is 
+		no other data type that will return the "m" and "l" suffixes for c's long int.
+	'/
 
+#else
+	
+	'' 32-bit
 	type cxxint as integer
 	type cxxlongint as long
 
@@ -141,7 +145,7 @@ scope
 	ASSERT( cpp_byref_sshort(ss) = &h7fff )
 
 end scope
-'/
+
 scope
 
 	''  c = signed|unsigned int
@@ -164,7 +168,7 @@ scope
 end scope
 
 /' !!! there is no name mangling on win64 that can
-map to gcc long in
+       map to g++ long int
 
 scope
 

--- a/tests/cpp/mangle.bmk
+++ b/tests/cpp/mangle.bmk
@@ -1,0 +1,10 @@
+# TEST_MODE : MULTI_MODULE_OK
+
+MAIN := fbc-mangle.bas
+SRCS := 
+
+EXTRA_OBJS := cpp-mangle.o
+
+$(SRCDIR)cpp-mangle.o : $(SRCDIR)cpp-mangle.cpp
+	# Pass $(CFLAGS) to get -m32 or -m64 as required
+	$(CXX) -c $(CFLAGS) -o $@ $^

--- a/tests/dirlist.mk
+++ b/tests/dirlist.mk
@@ -11,6 +11,7 @@ comments \
 compound \
 console \
 const \
+cpp \
 crt \
 data \
 datetime \


### PR DESCRIPTION
intent is to add basic testing for c++ name mangling