### PR TITLE
Update contrib/release/build.sh for fbc 1.06

### DIFF
--- a/contrib/nsis-installer/makefile
+++ b/contrib/nsis-installer/makefile
@@ -12,7 +12,7 @@ $(FBTITLE).exe: makescript.bas template.nsi $(FBTITLE).zip \
 	$(FBTITLE)/fbc.exe -g -exx -d FBVERSION=$(FBVERSION) makescript.bas
 	find $(FBTITLE) -type f | LC_ALL=C sort | sed -e 's,^$(FBTITLE)/,,g' > files.lst
 	unix2dos files.lst
-	makescript.exe files.lst template.nsi installer.nsi
+	./makescript.exe files.lst template.nsi installer.nsi
 	rm files.lst
 	$(FBTITLE)/fbc.exe open-console.bas
 	cp installer.nsi open-console.exe fblogo.ico $(FBTITLE)

--- a/contrib/release/build.sh
+++ b/contrib/release/build.sh
@@ -219,8 +219,8 @@ win32-mingworg)
 	download_extract_mingw mpfr-3.1.2-2-mingw32-dll.tar.lzma
 
 	# Add ddraw.h and dinput.h for FB's gfxlib2
-	download dx80_mgw.zip http://alleg.sourceforge.net/files/dx80_mgw.zip
-	unzip ../input/dx80_mgw.zip include/ddraw.h include/dinput.h
+#	download dx80_mgw.zip http://alleg.sourceforge.net/files/dx80_mgw.zip
+#	unzip ../input/dx80_mgw.zip include/ddraw.h include/dinput.h
 
 	# Work around http://sourceforge.net/p/mingw/bugs/2039/
 	patch -p0 < ../mingworg-fix-wcharh.patch
@@ -482,3 +482,4 @@ dos)         dosbuild;;
 linux*)      linuxbuild   | tee log.txt 2>&1;;
 win32|win64) windowsbuild | tee log.txt 2>&1;;
 esac
+							

--- a/contrib/release/build.sh
+++ b/contrib/release/build.sh
@@ -50,7 +50,7 @@
 # 
 # TODO:
 #   - win32: fbdoc CHM
-#   - win32/win64: build libcunit too, package the libffi/libcunit builds
+#   - package libffi
 #
 set -e
 
@@ -97,6 +97,23 @@ cd build
 buildinfo=../output/buildinfo-$target.txt
 echo "fbc $fbccommit $target, build based on:" > $buildinfo
 echo >> $buildinfo
+
+copyfile() {
+	srcfile="$1"
+	dstfile="$2"
+	
+	if [ -f "$dstfile" ]; then
+		echo "cached      $dstfile"
+	else
+		if [ -f "$srcfile" ]; then
+			echo "copying $srcfile to $dstfile"
+			cp -p "$srcfile" "$dstfile"
+		else
+			echo "$srcfile not found, stopping"
+			exit 1
+		fi
+	fi
+}
 
 download() {
 	filename="$1"
@@ -150,34 +167,52 @@ dos)
 		download "DJGPP/${package}.zip" "${DJGPP_MIRROR}${dir}${package}.zip"
 	}
 
-	djver=204
-	gccver=492
-	djgppgccversiondir=4.92
-	bnuver=225
+#	djver=204
+#	gccver=492
+#	djgppgccversiondir=4.92
+#	bnuver=225
+#	gdbver=771
+#	djpkg=beta
+
+   	djver=205
+	gccver=710
+	djgppgccversiondir=7.1.0
+	bnuver=229
 	gdbver=771
+	djpkg=current
 
 	# binutils/gcc/gdb (needs updating to new versions)
-	download_djgpp beta/v2gnu/ bnu${bnuver}b
-	download_djgpp beta/v2gnu/ gcc${gccver}b
-	download_djgpp beta/v2gnu/ gpp${gccver}b
-	download_djgpp beta/v2gnu/ gdb${gdbver}b
+	download_djgpp ${djpkg}/v2gnu/ bnu${bnuver}b
+	download_djgpp ${djpkg}/v2gnu/ gcc${gccver}b
+	download_djgpp ${djpkg}/v2gnu/ gpp${gccver}b
+	download_djgpp ${djpkg}/v2gnu/ gdb${gdbver}b
 
 	# rest to complete the DJGPP install (usually no changes needed)
-	download_djgpp beta/v2/ djdev${djver}
-	download_djgpp beta/v2gnu/ fil41b
-	download_djgpp beta/v2gnu/ mak40b
-	download_djgpp beta/v2gnu/ shl2011b
+	download_djgpp ${djpkg}/v2/ djdev${djver}
+
+#	download_djgpp ${djpkg}/v2gnu/ fil41b
+#	download_djgpp ${djpkg}/v2gnu/ mak40b
+#	download_djgpp ${djpkg}/v2gnu/ shl2011b
+
+	download_djgpp ${djpkg}/v2gnu/ fil41br2
+	download_djgpp ${djpkg}/v2gnu/ mak421b
+	download_djgpp ${djpkg}/v2gnu/ shl2011br2
 
 	# Sources for stuff that goes into the FB-dos package (needs updating to new versions)
-	download_djgpp beta/v2gnu/ bnu${bnuver}s
-	download_djgpp beta/v2gnu/ gcc${gccver}s
-	download_djgpp beta/v2gnu/ gdb${gdbver}s
-	download_djgpp beta/v2/    djlsr${djver}
+	download_djgpp ${djpkg}/v2gnu/ bnu${bnuver}s
+	download_djgpp ${djpkg}/v2gnu/ gcc${gccver}s
+	download_djgpp ${djpkg}/v2gnu/ gdb${gdbver}s
+	download_djgpp ${djpkg}/v2/    djlsr${djver}
 
 	unzip -q ../input/DJGPP/djdev${djver}.zip
-	unzip -q ../input/DJGPP/shl2011b.zip
-	unzip -q ../input/DJGPP/fil41b.zip
-	unzip -q ../input/DJGPP/mak40b.zip
+	
+#	unzip -q ../input/DJGPP/shl2011b.zip
+#	unzip -q ../input/DJGPP/fil41b.zip
+#	unzip -q ../input/DJGPP/mak40b.zip
+	unzip -q ../input/DJGPP/shl2011br2.zip
+	unzip -q ../input/DJGPP/fil41br2.zip
+	unzip -q ../input/DJGPP/mak421b.zip
+	
 	unzip -q ../input/DJGPP/gdb${gdbver}b.zip
 	unzip -q ../input/DJGPP/bnu${bnuver}b.zip
 	unzip -q ../input/DJGPP/gcc${gccver}b.zip
@@ -219,8 +254,13 @@ win32-mingworg)
 	download_extract_mingw mpfr-3.1.2-2-mingw32-dll.tar.lzma
 
 	# Add ddraw.h and dinput.h for FB's gfxlib2
+#   THIS DOES NOT EXIST ANYMORE
 #	download dx80_mgw.zip http://alleg.sourceforge.net/files/dx80_mgw.zip
 #	unzip ../input/dx80_mgw.zip include/ddraw.h include/dinput.h
+
+	# Add ddraw.h and dinput.h for FB's gfxlib2
+	copyfile "../input/MinGW.org/ddraw.h" "include/ddraw.h"
+	copyfile "../input/MinGW.org/dinput.h" "include/dinput.h"
 
 	# Work around http://sourceforge.net/p/mingw/bugs/2039/
 	patch -p0 < ../mingworg-fix-wcharh.patch
@@ -482,4 +522,3 @@ dos)         dosbuild;;
 linux*)      linuxbuild   | tee log.txt 2>&1;;
 win32|win64) windowsbuild | tee log.txt 2>&1;;
 esac
-							

--- a/contrib/release/build.sh
+++ b/contrib/release/build.sh
@@ -34,17 +34,24 @@
 #       the FB makefile's uname check in order to build for 64bit instead of
 #       32bit.
 #
+# <fbc-commit-id>
+#   can be:
+#       - a SHA-1 hash to refer to a specific commit
+#       - a branch or tag name in origin remote
+#       - a remote branch or tag name, must specify "remote-name/branch".
+#
 # --offline
 #   when given, build.sh will stop with exit code 1 if the file is not already in
-#   in the download cache
+#   in the download cache.
 #
 # --repo url
 #   specify an additional repo url to fetch in to the local repo other than the 
-#   official https://github.com/freebasic/fbc.git repo
+#   official https://github.com/freebasic/fbc.git repo.
 #
 # --remote name
-#   specify the remote name to use when referring to the other repo url
-#   default is 'other'
+#   specifies the remote name to add and use when referring to the other repo url.
+#   remote name will default to 'other' if the --repo option was given.
+#   remote name will default to 'origin' if the --repo option was not given.
 #
 # Requirements:
 #   - MSYS environment on Windows with: bash, wget/curl, zip, unzip, patch, make, findutils
@@ -156,7 +163,7 @@ if [ ! -z "$repo_url" ]; then
 	git fetch "$remote_name"
 	git fetch --tags "$remote_name"
 	git remote prune "$remote_name"
-	git reset --hard "$remote_name"/"$fbccommit"
+	git reset --hard "$fbccommit"
 fi
 
 cd ../..
@@ -341,7 +348,7 @@ linux*)
 
 	# fbc sources
 	cp -R ../input/fbc .
-	cd fbc && git reset --hard "$remote_name"/"$fbccommit" && cd ..
+	cd fbc && git reset --hard "$fbccommit" && cd ..
 
 	mkdir tempinstall
 	;;
@@ -353,7 +360,7 @@ linux*)
 
 	# fbc sources
 	cp -R ../input/fbc fbc
-	cd fbc && git reset --hard "$remote_name"/"$fbccommit" && cd ..
+	cd fbc && git reset --hard "$fbccommit" && cd ..
 	echo "prefix := `pwd -W`" > fbc/config.mk
 
 	# On 64bit, we have to override the FB makefile's uname check, because MSYS uname reports 32bit still

--- a/contrib/release/build.sh
+++ b/contrib/release/build.sh
@@ -59,18 +59,30 @@ usage() {
 	exit 1
 }
 
-target="$1"
-case "$target" in
+# parse command line arguments
+while [[ $# -gt 0 ]] 
+do
+arg="$1"
+case $arg in
 dos|linux-x86|linux-x86_64|win32|win64)
-	fbtarget=$target;;
+	target="$1"
+	fbtarget=$target
+	shift
+	;;
 win32-mingworg)
-	fbtarget=win32;;
+	target="$1"
+	fbtarget=win32
+	shift
+	;;
 *)
-	usage;;
+	fbccommit="$1"
+	shift
+	;;	
 esac
+done
 
-fbccommit="$2"
-if [ -z "$fbccommit" ]; then
+# need a target and a commit id
+if [ -z "$target" -o -z "$fbccommit" ]; then
 	usage
 fi
 
@@ -167,13 +179,6 @@ dos)
 		download "DJGPP/${package}.zip" "${DJGPP_MIRROR}${dir}${package}.zip"
 	}
 
-#	djver=204
-#	gccver=492
-#	djgppgccversiondir=4.92
-#	bnuver=225
-#	gdbver=771
-#	djpkg=beta
-
    	djver=205
 	gccver=710
 	djgppgccversiondir=7.1.0
@@ -190,10 +195,6 @@ dos)
 	# rest to complete the DJGPP install (usually no changes needed)
 	download_djgpp ${djpkg}/v2/ djdev${djver}
 
-#	download_djgpp ${djpkg}/v2gnu/ fil41b
-#	download_djgpp ${djpkg}/v2gnu/ mak40b
-#	download_djgpp ${djpkg}/v2gnu/ shl2011b
-
 	download_djgpp ${djpkg}/v2gnu/ fil41br2
 	download_djgpp ${djpkg}/v2gnu/ mak421b
 	download_djgpp ${djpkg}/v2gnu/ shl2011br2
@@ -206,9 +207,6 @@ dos)
 
 	unzip -q ../input/DJGPP/djdev${djver}.zip
 	
-#	unzip -q ../input/DJGPP/shl2011b.zip
-#	unzip -q ../input/DJGPP/fil41b.zip
-#	unzip -q ../input/DJGPP/mak40b.zip
 	unzip -q ../input/DJGPP/shl2011br2.zip
 	unzip -q ../input/DJGPP/fil41br2.zip
 	unzip -q ../input/DJGPP/mak421b.zip
@@ -252,11 +250,6 @@ win32-mingworg)
 	download_extract_mingw gmp-5.1.2-1-mingw32-dll.tar.lzma
 	download_extract_mingw mpc-1.0.1-2-mingw32-dll.tar.lzma
 	download_extract_mingw mpfr-3.1.2-2-mingw32-dll.tar.lzma
-
-	# Add ddraw.h and dinput.h for FB's gfxlib2
-#   THIS DOES NOT EXIST ANYMORE
-#	download dx80_mgw.zip http://alleg.sourceforge.net/files/dx80_mgw.zip
-#	unzip ../input/dx80_mgw.zip include/ddraw.h include/dinput.h
 
 	# Add ddraw.h and dinput.h for FB's gfxlib2
 	copyfile "../input/MinGW.org/ddraw.h" "include/ddraw.h"


### PR DESCRIPTION
This updates and improves on the contrib/release/build.sh script for creating releases:
- added some command line argument parsing
- the --offline option (WIP) is intended to only use files that are locally available without connecting to internet
- the --repo url --remote name options allow building a release from an alternate repo other than freebasic/fbc
- copy the directx headers from the build system
- updated the packages needed for djgpp
- bootstrap from fbc 1.05.0

Tested:
- on win7 to build fbc win 32-bit packages
- on win7 to build fbc win 64-bit packages
- on slackware 14.1 to build fbc linux 64-bit packages

The dos version only partially tested.  I don't have a build environment that will work with.  The updates for fbc dos version are pasted in from commands manually typed in when testing on winxp & win98 VM systems.

No guarantees that this produces a valid distribution, however, the script does complete.