### PR TITLE
fbgfx: oGLfbGFX - add constants for 2d render mode

### DIFF
--- a/inc/fbgfx.bi
+++ b/inc/fbgfx.bi
@@ -46,8 +46,9 @@ namespace FB
 					 GFX_MULTISAMPLE			= &h40000
 
 	'Constants for OpenGL 2D render
-	const as integer OGL_MANUAL_SYNC 			= 1, _
-                     OGL_AUTO_SYNC 				= 2
+	const as integer OGL_2D_NONE        		= 0, _
+					 OGL_2D_MANUAL_SYNC			= 1, _
+                     OGL_2D_AUTO_SYNC			= 2
 					 
 	'' Constants accepted by ScreenControl
 	''
@@ -87,7 +88,9 @@ namespace FB
 					 SET_GL_ACCUM_GREEN_BITS	= 114	, _
 					 SET_GL_ACCUM_BLUE_BITS		= 115	, _
 					 SET_GL_ACCUM_ALPHA_BITS	= 116	, _
-					 SET_GL_NUM_SAMPLES			= 117
+					 SET_GL_NUM_SAMPLES			= 117	, _
+					 SET_GL_2D_MODE				= 150	, _
+					 SET_GL_SCALE				= 151
 	'' Commands:
 	const as integer POLL_EVENTS				= 200
 	

--- a/src/gfxlib2/fb_gfx.h
+++ b/src/gfxlib2/fb_gfx.h
@@ -64,6 +64,11 @@
 #define DEFAULT_COLOR_2			0x40000000
 #define VIEW_SCREEN				0x00000001
 
+#define DRIVER_OGL_2D_NONE          0
+#define DRIVER_OGL_2D_MANUAL_SYNC   1
+#define DRIVER_OGL_2D_AUTO_SYNC     2
+
+
 #define LINE_TYPE_LINE		0
 #define LINE_TYPE_B		1
 #define LINE_TYPE_BF		2
@@ -147,9 +152,9 @@
 #define SET_GL_ACCUM_GREEN_BITS		114
 #define SET_GL_ACCUM_BLUE_BITS		115
 #define SET_GL_ACCUM_ALPHA_BITS		116
-#define SET_GL_NUM_SAMPLES		117
-#define SET_GL_2D_MODE			150
-#define SET_GL_SCALE			151
+#define SET_GL_NUM_SAMPLES			117
+#define SET_GL_2D_MODE				150
+#define SET_GL_SCALE				151
 
 #define POLL_EVENTS					200
 

--- a/src/gfxlib2/gfx_page.c
+++ b/src/gfxlib2/gfx_page.c
@@ -18,7 +18,7 @@ FBCALL int fb_GfxFlip(int from_page, int to_page)
 	}
 
 #ifndef DISABLE_OPENGL
-	if (__fb_gfx->driver->flip && __fb_gl_params.mode_2d!=2) {
+	if (__fb_gfx->driver->flip && (__fb_gl_params.mode_2d != DRIVER_OGL_2D_AUTO_SYNC)) {
 #else
 	if (__fb_gfx->driver->flip) {
 #endif

--- a/src/gfxlib2/win32/gfx_driver_opengl.c
+++ b/src/gfxlib2/win32/gfx_driver_opengl.c
@@ -422,7 +422,7 @@ static int driver_init(char *title, int w, int h, int depth_arg, int refresh_rat
 	if (fb_hWin32Init(title, w, h, depth, refresh_rate, flags)){
 		return -1;
 	}
-	if (__fb_gl_params.mode_2d==2){
+	if (__fb_gl_params.mode_2d == DRIVER_OGL_2D_AUTO_SYNC){
 		fb_wgl.MakeCurrent(NULL, NULL);
 #ifdef HOST_MINGW
 		/* Note: _beginthreadex()'s last parameter cannot be NULL,
@@ -521,7 +521,7 @@ static int driver_init(char *title, int w, int h, int depth_arg, int refresh_rat
 	if ((samples_attrib) && (*samples_attrib > 0)){
 		__fb_gl.Enable(GL_MULTISAMPLE_ARB);
 	}
-	if (__fb_gl_params.mode_2d!=0){
+	if (__fb_gl_params.mode_2d != DRIVER_OGL_2D_NONE){
 		fb_hGL_ScreenCreate();
 	}
 	return 0;
@@ -556,7 +556,7 @@ static void driver_unlock(void)
 
 static void driver_flip(void)
 {
-	if (__fb_gl_params.mode_2d==1){
+	if (__fb_gl_params.mode_2d == DRIVER_OGL_2D_MANUAL_SYNC){
 		fb_hGL_SetupProjection();
 	}
 	SwapBuffers(hdc);


### PR DESCRIPTION
this change adds constants to fbgfx source code for the OpenGL 2D render modes.  Previously was constant integers only and not obvious as to the meaning of each usage.