### PR TITLE
Macros invoked without parentheses and new builtin macros

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 1.06.0
 [changed]
 - Adjusted warning text for "mixed bool/nonbool operands" warning
 - test-suite uses libfbcunit for unit testing framework
+- macros and defines with parameters can now be invoked without using parentheses around the arguments
 
 [added]
 - -noobjinfo option to disable the writing/reading of compile-time library and other linking options from/to .o and .a files. This also disables the use of fbextra.x (the supplemental linker script) for discarding the .fbctinf sections, which is useful when using the gold linker that doesn't support this kind of linker script.
@@ -11,6 +12,7 @@ Version 1.06.0
 - Windows API binding updated to additionally support _WIN32_WINNT &h0501, &h0600, &h0601
 - Under X11, ScreenControl GET_WINDOW_HANDLE places the Display ptr in param2
 - Updated bindings: SDL2 2.0.6, SDL2_image 2.0.1, SDL2_mixer 2.0.1, SDL2_net 2.0.1, SDL2_ttf 2.0.14
+- the __FB_UNIQUEID_PUSH__(), __FB_UNIQUEID__(), __FB_UNIQUEID_POP__(), __FB_ARG_LEFTOF__(), __FB_ARG_RIGHTOF__(), __FB_JOIN__() builtin macros
 
 [fixed]
 - win/d3dx9.bi no longer has a hard-coded #inclib "d3dx9d". d3dx9d.dll is apparently not a generally valid choice. In practice programs have to be linked against d3dx9_33.dll or d3dx9_39.dll, etc.

--- a/examples/misc/generics/list.bi
+++ b/examples/misc/generics/list.bi
@@ -1,0 +1,66 @@
+#macro list(T)
+	__fb_join__(list_,__fb_arg_rightof__(T,OF))
+#endmacro
+
+#macro list_of(T)
+	list_##T
+#endmacro
+
+#macro imp_list_of(T)
+#if not defined(list_##T)	
+	type list_item_##T
+		value as T
+		next_ as list_item_##T ptr
+	end type
+
+	type list_##T
+		declare constructor(initial as integer = 0)
+		declare destructor()
+		declare sub add(v as T)
+		declare operator[](idx as integer) as T
+	private:
+		head as list_item_##T ptr
+		tail as list_item_##T ptr
+	end type
+
+	constructor list_##T(initial as integer)
+		this.head = 0
+		this.tail = 0
+	end constructor
+	
+	destructor list_##T()
+		do while head <> 0
+			var next_ = head->next_
+			deallocate(head)
+			head = next_
+		loop
+	end destructor
+	
+	sub list_##T.add(v as T)
+		dim as list_item_##T ptr node = allocate(len(list_item_##T))
+		node->value = v
+		if tail <> 0 then
+			tail->next_ = node
+		else
+			head = node
+		end if
+		node->next_ = 0
+		tail = node
+	end sub
+	
+	operator list_##T.[](idx as integer) as T
+		var i = 0
+		var node = head
+		do while node <> 0
+			if i = idx then
+				return node->value
+			end if
+			node = node->next_
+			i += 1
+		loop
+		'return default(T)
+	end operator
+#endif
+#endmacro
+
+

--- a/examples/misc/generics/test.bas
+++ b/examples/misc/generics/test.bas
@@ -1,0 +1,29 @@
+#include once "list.bi"
+
+	type foo
+		bar as integer
+	end type
+
+	imp_list_of integer
+	imp_list_of string
+	imp_list_of foo
+
+	var li = new list of integer(10) '' ok
+	li->add(123): li->add(456): li->add(789)
+	print (*li)[2]
+	delete li
+
+	'dim li2 as list of integer = list of integer(10) -- this won't work because macros called w/o parentheses will read all chars until the newline
+	dim li2 as list_of(integer) = list of integer(10)
+	li2.add(123): li2.add(456): li2.add(789)
+	print li2[1]
+	
+	dim lf as list of foo
+	lf.add(type<foo>(1337))
+	print lf[0].bar
+	
+	dim ls as list of string		 '' ok
+	ls.add("aaa"): ls.add("bbb"): ls.add("ccc")
+	print ls[1]
+	
+	

--- a/examples/misc/trycatch/test.bas
+++ b/examples/misc/trycatch/test.bas
@@ -1,0 +1,94 @@
+#include once "trycatch.bi"
+
+''to compile: fbc test.bas trycatch.bas
+
+type MyException extends Exception
+	declare constructor()
+	something as integer = 1234
+	declare operator cast() as string
+end type
+
+constructor MyException
+	base("myexception")
+end constructor
+
+operator MyException.cast() as string
+	operator = base.toString()
+end operator
+
+sub fun3()
+	print "begin fun3"
+	try
+		print "Begin try3.1"
+		try
+			print "Begin try3.2"
+			throw "bleh"
+			print "End try3.2"
+		catch ex as Exception
+			print "fun3.2:" & *ex
+			dim as integer ptr p = 0
+			*p = 2
+			throw "never executed"
+		end_try
+		print "End try3.1"
+	catch ex as Exception
+		print "fun3.1:" & *ex
+	end_try
+	
+	print "end fun3"
+end sub
+
+sub fun2()
+	print "begin fun2"
+	try
+		print "Begin try2"
+		fun3()
+		dim as integer ptr p = 0
+		*p = 2
+		print "End try2"
+	catch ex as Exception
+		print "fun2:" & *ex
+		return
+	end_try
+	
+	print "end fun2"
+end sub
+
+
+sub fun1()	
+	print "begin fun1"
+
+	try
+		print "Begin try1"
+		fun2()
+		throw new MyException 
+		throw "never executed"
+		print "End try1"
+	catch ex as MyException
+		print "fun1:" & *ex
+	catch ex as Exception
+		print "fun1:" & *ex
+	end_try
+
+	print "end fun1"
+end sub
+
+fun1()
+
+type foo
+	declare destructor
+	bar as byte
+end type
+
+destructor foo
+	print "foo:desctructor"
+end destructor
+
+	try
+		dim f as foo
+		dim as integer ptr p = 0
+		*p = 2
+		'' NOTE: without proper stack unwinding the foo's destructor will never be called :/
+	catch ex as exception
+		print *ex
+	end_try

--- a/examples/misc/trycatch/trycatch.bas
+++ b/examples/misc/trycatch/trycatch.bas
@@ -1,0 +1,170 @@
+#include once "trycatch.bi"
+
+#define	SIGINT		2	'' Interactive attention
+#define	SIGILL		4	'' Illegal instruction
+#define	SIGFPE		8	'' Floating point error
+#define	SIGSEGV		11	'' Segmentation violation
+#define	SIGTERM		15	'' Termination request
+#define SIGBREAK	21	'' Control-break
+#define	SIGABRT		22	'' Abnormal termination (abort)
+
+extern "C"
+	type __p_sig_fn_t as sub(byval as integer)
+	declare function signal(byval as integer, byval as __p_sig_fn_t) as __p_sig_fn_t
+end extern
+
+type TryCatchCtx
+	cur 		as TryCatch ptr
+	oldsigabrt  as __p_sig_fn_t
+	oldsigsegv  as __p_sig_fn_t
+	oldsigfpe	as __p_sig_fn_t
+	oldsigill	as __p_sig_fn_t
+	oldsigterm	as __p_sig_fn_t
+	oldsigint	as __p_sig_fn_t
+end type
+
+	dim shared ctx as TryCatchCtx
+	dim shared messages(0 to 31) as zstring * 32
+	
+private sub handler cdecl(byval sig as integer)
+	if ctx.cur = 0 then
+		error sig
+	end if
+	
+	signal(sig, @handler)
+	
+	ctx.cur->ex = new Exception(messages(sig))
+	
+	var buf = @ctx.cur->buf
+	
+	ctx.cur = ctx.cur->prev
+	
+	crt.longjmp(buf, sig)
+end sub
+
+private sub __construc() constructor
+	messages(SIGINT)	= "Interactive attention"
+	messages(SIGILL) 	= "Illegal instruction"
+	messages(SIGFPE) 	= "Floating point error"
+	messages(SIGSEGV)	= "Segmentation violation"
+	messages(SIGTERM)	= "Termination request"
+	messages(SIGBREAK)	= "Control-break"
+	messages(SIGABRT)	= "Abnormal termination"
+	
+	ctx.oldsigabrt = signal(SIGABRT, @handler)
+	ctx.oldsigsegv = signal(SIGSEGV, @handler)
+	ctx.oldsigfpe = signal(SIGFPE, @handler)
+	ctx.oldsigill = signal(SIGILL, @handler)
+	ctx.oldsigterm = signal(SIGTERM, @handler)
+	ctx.oldsigint = signal(SIGINT, @handler)
+end sub
+
+private sub __destruc() destructor
+	signal(SIGABRT, ctx.oldsigabrt)
+	signal(SIGSEGV, ctx.oldsigsegv)
+	signal(SIGFPE, ctx.oldsigfpe)
+	signal(SIGILL, ctx.oldsigill)
+	signal(SIGTERM, ctx.oldsigterm)
+	signal(SIGINT, ctx.oldsigint)
+end sub
+		
+''
+'' TryCatch
+''
+constructor TryCatch()
+	this.prev = ctx.cur
+	ctx.cur = @this
+end constructor
+
+destructor TryCatch()
+	if( ctx.cur = @this ) then
+		ctx.cur = this.prev
+	end if
+	if this.ex <> 0 then
+		delete this.ex
+	end if
+end destructor
+
+sub TryCatch.throw_(file as zstring ptr, func as zstring ptr, line_ as integer)
+	if ctx.cur = 0 then
+		error 1
+	end if
+	
+	this.ex->file = file
+	this.ex->func = func
+	this.ex->line = line_
+	var buf = @ctx.cur->buf
+	ctx.cur = ctx.cur->prev
+	crt.longjmp(buf, 1)
+end sub
+
+sub TryCatch.throw_(ex as Exception ptr, file as zstring ptr, func as zstring ptr, line_ as integer)
+	this.ex = ex
+	throw_(file, func, line_)
+end sub
+
+sub TryCatch.throw_(msg as zstring ptr, file as zstring ptr, func as zstring ptr, line_ as integer)
+	this.ex = new Exception(msg)
+	throw_(file, func, line_)
+end sub
+
+''
+'' Exception
+''
+constructor Exception()
+end constructor
+
+constructor Exception(msg as zstring ptr)
+	this.msg = allocate(len(*msg) + 1)
+	*this.msg = *msg
+end constructor
+
+destructor Exception()
+	if this.msg <> 0 then
+		deallocate(this.msg)
+	end if
+	if this.file_ <> 0 then
+		deallocate(this.file_)
+	end if
+	if this.func_ <> 0 then
+		deallocate(this.func_)
+	end if
+end destructor
+
+property Exception.message() as string
+	return *this.msg
+end property
+
+property Exception.file() as string
+	return iif(this.file_ <> 0, *this.file_, "")
+end property
+
+property Exception.file(file_ as zstring ptr)
+	this.file_ = allocate(len(*file_) + 1)
+	*this.file_ = *file_
+end property
+
+property Exception.func() as string
+	return iif(this.func_ <> 0, *this.func_, "")
+end property
+
+property Exception.func(func_ as zstring ptr)
+	this.func_ = allocate(len(*func_) + 1)
+	*this.func_ = *func_
+end property
+
+property Exception.line() as integer
+	return this.line_
+end property
+
+property Exception.line(line_ as integer)
+	this.line_ = line_
+end property
+
+operator Exception.cast() as string
+	operator = this.toString()
+end operator
+
+function Exception.toString() as string
+	function = this.message & " exception threw at " & this.file & "(" & this.line & "):" & this.func & "()"
+end function

--- a/examples/misc/trycatch/trycatch.bi
+++ b/examples/misc/trycatch/trycatch.bi
@@ -1,0 +1,59 @@
+namespace crt
+#include once "crt/setjmp.bi"
+end namespace
+
+'' example how to implement a try/catch using the C runtime setjmp()/longjmp(), plus the __FB_UNIQUEID_###__() and __FB_ARG_###__() builtin macros
+
+#macro TRY 
+	scope
+		__FB_UNIQUEID_PUSH__(__tc__)
+		dim __FB_UNIQUEID__(__tc__) as TryCatch
+		if crt.setjmp(@__FB_UNIQUEID__(__tc__).buf) = 0 then
+#endmacro
+
+#macro CATCH(x) 
+		elseif *cast(object ptr, __FB_UNIQUEID__(__tc__).ex) is __FB_ARG_RIGHTOF__(x, AS) then
+			var __FB_ARG_LEFTOF__(x, AS) = cast(__FB_ARG_RIGHTOF__(x, AS) ptr, __FB_UNIQUEID__(__tc__).ex)
+#endmacro
+
+#macro THROW(x) 
+		__FB_UNIQUEID__(__tc__).throw_(x, __FILE__, __FUNCTION__, __LINE__)
+#endmacro
+
+#macro END_TRY 
+		end if 
+		__FB_UNIQUEID_POP__(__tc__)
+	end scope
+#endmacro
+
+type Exception extends Object
+	declare constructor()
+	declare constructor(msg as zstring ptr)
+	declare destructor()
+	declare property message() as string
+	declare property file() as string
+	declare property file(file as zstring ptr)
+	declare property func() as string
+	declare property func(func as zstring ptr)
+	declare property line() as integer
+	declare property line(line as integer)
+	declare operator cast() as string
+	declare function toString() as string
+private:	
+	msg			as zstring ptr
+	file_ 		as zstring ptr
+	func_ 		as zstring ptr
+	line_ 		as integer
+end type
+
+type TryCatch
+	declare constructor()
+	declare destructor()
+	declare sub throw_(file as zstring ptr, func as zstring ptr, line_ as integer)
+	declare sub throw_(msg as zstring ptr, file as zstring ptr, func as zstring ptr, line_ as integer)
+	declare sub throw_(ex as Exception ptr, file as zstring ptr, func as zstring ptr, line_ as integer)
+	buf			as crt.jmp_buf = any
+	ex			as Exception ptr
+	prev		as TryCatch ptr
+end type
+

--- a/src/compiler/hlp-str.bas
+++ b/src/compiler/hlp-str.bas
@@ -1255,3 +1255,43 @@ function hIsValidHexDigit( byval ch as integer ) as integer
 	           ((ch >= asc( "a" )) and (ch <= asc( "f" ))) or _
 	           ((ch >= asc( "A" )) and (ch <= asc( "F" )))
 end function
+
+sub hSplitStr(byref txt as string, byref del as string, res() as string)
+
+	var items = 10
+	redim dpos(0 to items-1) as integer
+	
+	var dellen = len(del)
+	
+	var x = 1
+	var p = 0
+	do 
+		x = instr(x, txt, del)
+		if( x > 0 ) then
+			if( p >= items ) then
+				items += 10
+				redim preserve dpos(0 to items-1)
+			end if
+			dpos(p) = x
+			x += dellen
+		end if
+		p += 1
+	loop until x = 0
+	
+	var cnt = p - 1
+	if( cnt = 0 ) then
+		redim res(0 to 0)
+		res(0) = txt
+		return
+	end if
+	
+	redim res(0 to cnt)
+	res(0) = Left(txt, dpos(0) - 1 )
+	p = 1
+	do until p = cnt
+		res(p) = mid(txt, dpos(p - 1) + dellen, dpos(p) - dpos(p - 1) - dellen )
+		p += 1
+	loop
+	res(cnt) = mid(txt, dpos(cnt - 1) + dellen)
+   
+end sub

--- a/src/compiler/hlp-str.bas
+++ b/src/compiler/hlp-str.bas
@@ -1256,6 +1256,7 @@ function hIsValidHexDigit( byval ch as integer ) as integer
 	           ((ch >= asc( "A" )) and (ch <= asc( "F" )))
 end function
 
+'':::::
 sub hSplitStr(byref txt as string, byref del as string, res() as string)
 
 	var items = 10
@@ -1263,22 +1264,22 @@ sub hSplitStr(byref txt as string, byref del as string, res() as string)
 	
 	var dellen = len(del)
 	
-	var x = 1
-	var p = 0
+	var cnt = 0
+	var p = 1
 	do 
-		x = instr(x, txt, del)
-		if( x > 0 ) then
-			if( p >= items ) then
+		p = instr(p, txt, del)
+		if( p > 0 ) then
+			if( cnt >= items ) then
 				items += 10
 				redim preserve dpos(0 to items-1)
 			end if
-			dpos(p) = x
-			x += dellen
+			dpos(cnt) = p
+			p += dellen
 		end if
-		p += 1
-	loop until x = 0
+		cnt += 1
+	loop until( p = 0 )
 	
-	var cnt = p - 1
+	cnt -= 1
 	if( cnt = 0 ) then
 		redim res(0 to 0)
 		res(0) = txt
@@ -1288,10 +1289,71 @@ sub hSplitStr(byref txt as string, byref del as string, res() as string)
 	redim res(0 to cnt)
 	res(0) = Left(txt, dpos(0) - 1 )
 	p = 1
-	do until p = cnt
+	do until( p = cnt )
 		res(p) = mid(txt, dpos(p - 1) + dellen, dpos(p) - dpos(p - 1) - dellen )
 		p += 1
 	loop
 	res(cnt) = mid(txt, dpos(cnt - 1) + dellen)
    
 end sub
+
+'':::::
+function hStr2Tok(byval txt as const zstring ptr, res() as string) as integer
+
+	var items = 10
+	
+	var t = 0
+	var lc = 32UL
+	var s = cast(const ubyte ptr, txt)	
+	do while( *s <> 0 )
+		var c = cast(uinteger, *s)
+		
+		if( c = 7 ) then
+			c = 32
+		end if
+		
+		if( c = 32 ) then
+			if( lc <> 32 ) then
+				t += 1
+			end if
+		end if
+		
+		lc = c
+		s += 1
+	loop
+
+	if( lc <> 32 ) then
+		t += 1
+	end if
+	
+	if( t = 0 ) then
+		return 0
+	end if
+	
+	redim res(0 to t-1)
+	
+	t = 0
+	lc = 32
+	s = cast(const ubyte ptr, txt)	
+	do while( *s <> 0 )
+		var c = cast(uinteger, *s)
+		
+		if( c = 7 ) then
+			c = 32
+		end if
+		
+		if( c = 32 ) then
+			if( lc <> 32 ) then
+				t += 1
+			end if
+		else
+			res(t) += chr(c)
+		end if
+		
+		lc = c
+		s += 1
+	loop
+	
+	function = iif(lc <> 32, t + 1, t)
+	
+end function

--- a/src/compiler/hlp-str.bi
+++ b/src/compiler/hlp-str.bi
@@ -134,6 +134,8 @@ declare function hIsValidHexDigit( byval ch as integer ) as integer
 
 declare sub hSplitStr(byref txt as string, byref del as string, res() as string)
 
+declare function hStr2Tok(byval txt as const zstring ptr, res() as string) as integer
+
 '':::::
 #define ZstrAllocate(chars) xallocate( chars + 1 )
 

--- a/src/compiler/hlp-str.bi
+++ b/src/compiler/hlp-str.bi
@@ -132,6 +132,8 @@ declare function hCharNeedsEscaping _
 
 declare function hIsValidHexDigit( byval ch as integer ) as integer
 
+declare sub hSplitStr(byref txt as string, byref del as string, res() as string)
+
 '':::::
 #define ZstrAllocate(chars) xallocate( chars + 1 )
 

--- a/src/compiler/lex.bi
+++ b/src/compiler/lex.bi
@@ -134,6 +134,19 @@ type LEX_CTX
 	insidemacro 	as integer
 end type
 
+
+type LEXPP_ARG
+	union
+		text		as DZSTRING
+		textw		as DWSTRING
+	end union
+end type
+
+type LEXPP_ARGTB
+	tb(0 to FB_MAXDEFINEARGS-1) as LEXPP_ARG
+end type
+
+
 declare sub lexInit _
 	( _
 		byval isinclude as integer _

--- a/src/compiler/pp-define.bas
+++ b/src/compiler/pp-define.bas
@@ -68,7 +68,7 @@ private function hLoadMacro _
 
     dim as FB_DEFPARAM ptr param = any, nextparam = any
     dim as FB_DEFTOK ptr dt = any
-    dim as FBTOKEN t = any
+	dim as FBTOKEN t = any
     dim as LEXPP_ARGTB ptr argtb = any
 	dim as integer prntcnt = any, num = any, reached_vararg = any, is_variadic = any
     dim as zstring ptr argtext = any
@@ -76,17 +76,26 @@ private function hLoadMacro _
 
 	function = -1
 
+	var isParentLess = false
+	
 	'' '('?
 	if( lexCurrentChar( TRUE ) <> CHAR_LPRNT ) then
-		'' not an error, macro can be passed as param to other macros
-		exit function
+		isParentLess = true
+		if( pp.invoking > 0 ) then
+			'' not an error, macro can be passed as param to other macros
+			exit function
+		end if
 	end if
 
 	if (isMacroAllowed(s) = FALSE) then
 		exit function
 	end if
+	
+	pp.invoking += 1
 
-	lexEatChar( )
+	if( not isParentLess ) then
+		lexEatChar( )
+	end if
 
 	'' allocate a new arg list (support recursion)
 	param = symbGetDefineHeadParam( s )
@@ -101,6 +110,8 @@ private function hLoadMacro _
 
     '' Variadic macro?
     is_variadic = ((s->def.flags and FB_DEFINE_FLAGS_VARIADIC) <> 0)
+	
+	var readdchar = -1
 
 	'' for each arg
 	num = 0   '' num represents the current last cleared/used entry in the argtb
@@ -131,10 +142,12 @@ private function hLoadMacro _
 
 			'' )
 			case CHAR_RPRNT
-				prntcnt -= 1
-				'' Closing ')'?
-				if( prntcnt = 0 ) then
-					exit do
+				if( prntcnt > 0 ) then
+					prntcnt -= 1
+					'' Closing ')'?
+					if( prntcnt = 0 ) then
+						exit do
+					end if
 				end if
 
 			'' ,
@@ -149,13 +162,24 @@ private function hLoadMacro _
 					end if
 				end if
 
+			case FB_TK_STMTSEP
+				if( isParentLess ) then
+					readdchar = CHAR_COLON
+					prntcnt = 0
+					exit do
+				end if
+			
 			case FB_TK_EOL, FB_TK_EOF
-				hReportMacroError( s, FB_ERRMSG_EXPECTEDRPRNT )
-				'' Recovery: pretend to be at the closing ')'
+				if( not isParentLess ) then
+					hReportMacroError( s, FB_ERRMSG_EXPECTEDRPRNT )
+				else
+					readdchar = iif(t.id = FB_TK_EOF, 0, CHAR_LF)
+				end if
 				prntcnt = 0
 				exit do
+			
 			end select
-
+			
 			if( argtb <> NULL ) then
 	   			if( t.dtype <> FB_DATATYPE_WCHAR ) then
 	    			DZstrConcatAssign( argtb->tb(num).text, t.text )
@@ -269,13 +293,19 @@ private function hLoadMacro _
 
 		listDelNode( @pp.argtblist, argtb )
 	end if
+	
+	if( readdchar <> -1 ) then
+		text += chr(readdchar)
+	end if
 
 	if( lex.ctx->deflen = 0 ) then
 		DZstrAssign( lex.ctx->deftext, text )
 	else
 		DZstrAssign( lex.ctx->deftext, text + *lex.ctx->defptr )
 	end if
-
+	
+	pp.invoking -= 1
+	
 	function = len( text )
 
 end function
@@ -324,18 +354,25 @@ private function hLoadDefine _
 
 			'' arg-less macro?
 			if( symbGetDefineIsArgless( s ) ) then
+				var isParentLess = false
 				'' '('?
 				if( lexCurrentChar( TRUE ) <> CHAR_LPRNT ) then
+					isParentLess = true
 					'' not an error, macro can be passed as param to other macros
-					exit function
+					if( pp.invoking > 0 ) then
+						exit function
+					end if
 				end if
-				lexEatChar( )
-
-				'' ')'
-				if( lexCurrentChar( TRUE ) <> CHAR_RPRNT ) then
-					errReport( FB_ERRMSG_EXPECTEDRPRNT )
-				else
+				
+				if( not isParentLess ) then
 					lexEatChar( )
+
+					'' ')'
+					if( lexCurrentChar( TRUE ) <> CHAR_RPRNT ) then
+						errReport( FB_ERRMSG_EXPECTEDRPRNT )
+					else
+						lexEatChar( )
+					end if
 				end if
 			end if
 
@@ -387,17 +424,26 @@ private function hLoadMacroW _
 
 	function = -1
 
+	var isParentLess = false
+	
 	'' '('?
 	if( lexCurrentChar( TRUE ) <> CHAR_LPRNT ) then
-		'' not an error, macro can be passed as param to other macros
-		exit function
+		isParentLess = true
+		if( pp.invoking > 0 ) then
+			'' not an error, macro can be passed as param to other macros
+			exit function
+		end if
 	end if
 
 	if (isMacroAllowed(s) = FALSE) then
 		exit function
 	end if
 
-	lexEatChar( )
+	pp.invoking += 1
+
+	if( not isParentLess ) then
+		lexEatChar( )
+	end if
 
 	'' allocate a new arg list (because the recursivity)
 	param = symbGetDefineHeadParam( s )
@@ -413,6 +459,8 @@ private function hLoadMacroW _
     '' Variadic macro?
     is_variadic = ((s->def.flags and FB_DEFINE_FLAGS_VARIADIC) <> 0)
 
+	var readdchar = -1
+	
 	'' for each arg
 	num = 0    '' num represents the current last cleared/used entry in the argtb
 	do
@@ -442,10 +490,12 @@ private function hLoadMacroW _
 
 			'' )
 			case CHAR_RPRNT
-				prntcnt -= 1
-				'' Closing ')'?
-				if( prntcnt = 0 ) then
-					exit do
+				if( prntcnt > 0 ) then
+					prntcnt -= 1
+					'' Closing ')'?
+					if( prntcnt = 0 ) then
+						exit do
+					end if
 				end if
 
 			'' ,
@@ -460,10 +510,19 @@ private function hLoadMacroW _
 					end if
 				end if
 
-			''
+			case FB_TK_STMTSEP
+				if( isParentLess ) then
+					readdchar = CHAR_COLON
+					prntcnt = 0
+					exit do
+				end if
+			
 			case FB_TK_EOL, FB_TK_EOF
-				hReportMacroError( s, FB_ERRMSG_EXPECTEDRPRNT )
-				'' Recovery: pretend to be at the closing ')'
+				if( not isParentLess ) then
+					hReportMacroError( s, FB_ERRMSG_EXPECTEDRPRNT )
+				else
+					readdchar = iif(t.id = FB_TK_EOF, 0, CHAR_LF)
+				end if
 				prntcnt = 0
 				exit do
 			end select
@@ -580,12 +639,18 @@ private function hLoadMacroW _
 		listDelNode( @pp.argtblist, argtb )
 	end if
 
+	if( readdchar <> -1 ) then
+		DWstrConcatAssignA( text, chr(readdchar) )
+	end if
+
 	if( lex.ctx->deflen = 0 ) then
 		DWstrAssign( lex.ctx->deftextw, text.data )
 	else
 		DWstrAssign( lex.ctx->deftextw, *text.data + *lex.ctx->defptrw )
 	end if
 
+	pp.invoking -= 1
+	
 	function = len( *text.data )
 
 end function
@@ -633,18 +698,25 @@ private function hLoadDefineW _
 		else
 			'' arg-less macro?
 			if( symbGetDefineIsArgless( s ) ) then
+				var isParentLess = false
 				'' '('?
 				if( lexCurrentChar( TRUE ) <> CHAR_LPRNT ) then
+					isParentLess = true
 					'' not an error, macro can be passed as param to other macros
-					exit function
+					if( pp.invoking > 0 ) then
+						exit function
+					end if
 				end if
-				lexEatChar( )
-
-				'' ')'
-				if( lexCurrentChar( TRUE ) <> CHAR_RPRNT ) then
-					errReport( FB_ERRMSG_EXPECTEDRPRNT )
-				else
+				
+				if( not isParentLess ) then
 					lexEatChar( )
+
+					'' ')'
+					if( lexCurrentChar( TRUE ) <> CHAR_RPRNT ) then
+						errReport( FB_ERRMSG_EXPECTEDRPRNT )
+					else
+						lexEatChar( )
+					end if
 				end if
 			end if
 

--- a/src/compiler/pp.bi
+++ b/src/compiler/pp.bi
@@ -30,6 +30,7 @@ type PP_CTX
 	argtblist	as TLIST
 	level 		as integer
 	skipping	as integer
+	invoking	as integer		'' to let macros passed to other macros by name
 end type
 
 declare sub ppInit _

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -331,10 +331,27 @@ private function hDefArgRight_cb( byval argtb as LEXPP_ARGTB ptr, byval errnum a
 	if( len(res) = 0 ) then
 		*errnum = FB_ERRMSG_SYNTAXERROR
 	end if
-	return res
+	
+	function =  res
 	
 end function
 
+private function hDefJoin_cb( byval argtb as LEXPP_ARGTB ptr, byval errnum as integer ptr) as string
+	var l = hMacro_getArg( argtb, 0 )
+	var r = hMacro_getArg( argtb, 1 )
+	if( l = null or r = null ) then
+		*errnum = FB_ERRMSG_ARGCNTMISMATCH
+		return ""
+	end if
+	
+	var res = *l + *r
+
+	ZstrFree(l)
+	ZstrFree(r)
+	
+	function = res
+	
+end function
 
 '' Intrinsic #defines which are always defined
 dim shared defTb(0 to ...) as SYMBDEF => _
@@ -389,7 +406,8 @@ dim shared macroTb(0 to ...) as SYMBMACRO => _
 	(@"__FB_UNIQUEID__"       , @hDefUniqueId_cb 		, 1, { (@"ID") } ), _
 	(@"__FB_UNIQUEID_POP__"   , @hDefUniqueIdPop_cb		, 1, { (@"ID") } ), _
 	(@"__FB_ARG_LEFTOF__"     , @hDefArgLeft_cb			, 2, { (@"ARG"), (@"SEP") } ), _
-	(@"__FB_ARG_RIGHTOF__"    , @hDefArgRight_cb		, 2, { (@"ARG"), (@"SEP") } ) _
+	(@"__FB_ARG_RIGHTOF__"    , @hDefArgRight_cb		, 2, { (@"ARG"), (@"SEP") } ), _
+	(@"__FB_JOIN__"    		  , @hDefJoin_cb			, 2, { (@"L"), (@"R") } ) _
 }
 
 sub symbDefineInit _

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -210,7 +210,7 @@ private function hDefUniqueIdPush_cb( byval argtb as LEXPP_ARGTB ptr, byval errn
 
 	var elm = cast(SYMB_DEF_UniqueId_Elm ptr, allocate(len(SYMB_DEF_UniqueId_Elm)))
 	
-	var uid = symbUniqueId()
+	var uid = symbUniqueId(true)
 	elm->name = allocate(len(*uid)+1)
 	*elm->name = *uid
 	elm->prev = stk->top

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -388,8 +388,8 @@ dim shared macroTb(0 to ...) as SYMBMACRO => _
 	(@"__FB_UNIQUEID_PUSH__"  , @hDefUniqueIdPush_cb	, 1, { (@"ID") } ),  _
 	(@"__FB_UNIQUEID__"       , @hDefUniqueId_cb 		, 1, { (@"ID") } ), _
 	(@"__FB_UNIQUEID_POP__"   , @hDefUniqueIdPop_cb		, 1, { (@"ID") } ), _
-	(@"__FB_ARG_LEFT__"   	  , @hDefArgLeft_cb			, 2, { (@"ARG"), (@"SEP") } ), _
-	(@"__FB_ARG_RIGHT__"   	  , @hDefArgRight_cb		, 2, { (@"ARG"), (@"SEP") } ) _
+	(@"__FB_ARG_LEFTOF__"     , @hDefArgLeft_cb			, 2, { (@"ARG"), (@"SEP") } ), _
+	(@"__FB_ARG_RIGHTOF__"    , @hDefArgRight_cb		, 2, { (@"ARG"), (@"SEP") } ) _
 }
 
 sub symbDefineInit _

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -62,8 +62,8 @@ sub symbMangleEnd( )
 	flistEnd( @ctx.flist  )
 end sub
 
-function symbUniqueId( ) as zstring ptr
-	if( env.clopt.backend = FB_BACKEND_GCC ) then
+function symbUniqueId( byval validfbname as boolean ) as zstring ptr
+	if( env.clopt.backend = FB_BACKEND_GCC and not validfbname ) then
 		ctx.tempstr = "tmp$"
 		ctx.tempstr += str( ctx.uniqueidcount )
 	else

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -1743,7 +1743,7 @@ declare function symbCanDuplicate _
 		byval s as FBSYMBOL ptr _
 	) as integer
 
-declare function symbUniqueId( ) as zstring ptr
+declare function symbUniqueId( byval validfbname as boolean = false ) as zstring ptr
 declare function symbUniqueLabel( ) as zstring ptr
 declare function symbMakeProfileLabelName( ) as zstring ptr
 declare function symbGetMangledName( byval sym as FBSYMBOL ptr ) as zstring ptr

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -362,8 +362,10 @@ enum FB_DEFINE_FLAGS
 	FB_DEFINE_FLAGS_VARIADIC	= &h00000004
 end enum
 
+type LEXPP_ARGTB_ as LEXPP_ARGTB ptr
+
 type FBS_DEFINE_PROC as function( ) as string
-type FBS_MACRO_PROC as function( byval argtb as any /'LEXPP_ARGTB'/ ptr, byval errnum as integer ptr ) as string
+type FBS_MACRO_PROC as function( byval argtb as LEXPP_ARGTB_, byval errnum as integer ptr ) as string
 
 type FBS_DEFINE
 	params			as integer

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -5,6 +5,7 @@
 #include once "list.bi"
 #include once "pool.bi"
 #include once "ast-op.bi"
+#include once "stack.bi"
 
 ''
 enum FB_DATACLASS
@@ -730,9 +731,19 @@ type SYMB_DEF_PARAM
 	index			as uinteger
 end type
 
+type SYMB_DEF_UniqueId_Elm
+	name			as zstring ptr
+end type
+
+type SYMB_DEF_UniqueId
+	stack			as TSTACK					'' of SYMB_DEF_UniqueId_Elm
+	name			as zstring ptr				'' current unique id
+end type
+
 type SYMB_DEF_CTX
 	paramlist		as TLIST					'' define parameters
 	toklist			as TLIST					'' define tokens
+	uniqueid		as SYMB_DEF_UniqueId
 
 	'' macros only..
 	param			as integer					'' param count

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -363,6 +363,7 @@ enum FB_DEFINE_FLAGS
 end enum
 
 type FBS_DEFINE_PROC as function( ) as string
+type FBS_MACRO_PROC as function( byval argtb as any /'LEXPP_ARGTB'/ ptr, byval errnum as integer ptr ) as string
 
 type FBS_DEFINE
 	params			as integer
@@ -376,7 +377,10 @@ type FBS_DEFINE
 
 	isargless		as integer
     flags           as FB_DEFINE_FLAGS			'' bit 0: 1=numeric, 0=string
-	proc			as FBS_DEFINE_PROC
+	union
+		dproc			as FBS_DEFINE_PROC
+		mproc			as FBS_MACRO_PROC
+	end union
 end type
 
 '' forward definition
@@ -733,11 +737,15 @@ end type
 
 type SYMB_DEF_UniqueId_Elm
 	name			as zstring ptr
+	prev			as SYMB_DEF_UniqueId_Elm ptr
+end type
+
+type SYMB_DEF_UniqueId_Stack
+	top				as SYMB_DEF_UniqueId_Elm ptr
 end type
 
 type SYMB_DEF_UniqueId
-	stack			as TSTACK					'' of SYMB_DEF_UniqueId_Elm
-	name			as zstring ptr				'' current unique id
+	dict			as THASH					'' of SYMB_DEF_UniqueId_Stack
 end type
 
 type SYMB_DEF_CTX
@@ -2138,7 +2146,9 @@ declare function symbGetUDTBaseLevel _
 
 #define symbGetDefParamNum(a) a->num
 
-#define symbGetDefineCallback(d) d->def.proc
+#define symbGetDefineCallback(d) d->def.dproc
+
+#define symbGetMacroCallback(d) d->def.mproc
 
 #define symbGetDefineIsArgless(d) d->def.isargless
 

--- a/tests/fbcunit/inc/fbcunit.bi
+++ b/tests/fbcunit/inc/fbcunit.bi
@@ -373,7 +373,7 @@
 	#undef TMP_FBCUNIT_SUITE_IN_CLEANUP
 #endmacro
 
-#macro TEST( test_name )
+#macro INI_TEST( test_name )
 	#if defined( TMP_FBCUNIT_TEST_NAME )
 		#error FBCUNIT: tests can not be nested or missing "END_TEST"
 	#elseif defined( TMP_FBCUNIT_SUITE_IN_INIT )

--- a/tests/pp/macro_no_parentheses.bas
+++ b/tests/pp/macro_no_parentheses.bas
@@ -1,0 +1,25 @@
+# include "fbcu.bi"
+
+# macro m1( foo, bar )
+	foo + bar
+# endmacro
+
+namespace fbc_tests.macros.macro_no_parentheses
+
+sub withArgTest cdecl ()
+
+  var hello = m1 "hello", "!"
+  var world = m1 "world", "!"
+  
+  CU_ASSERT_EQUAL( hello + world, "hello!world!" ) 
+
+end sub
+
+private sub ctor () constructor
+
+	fbcu.add_suite("fbc_tests.pp.macro_no_parentheses")
+	fbcu.add_test("withArgTest", @withArgTest)
+
+end sub
+
+end namespace

--- a/tests/warnings/op-result-types.bas
+++ b/tests/warnings/op-result-types.bas
@@ -61,7 +61,7 @@ end enum
 	#print typeof( A mod B )
 
 	#print
-	#print bit ops (A, B):
+	#print "bit" ops (A, B):
 	#print
 
 	#print A shl B = non-float =

--- a/tests/warnings/op-result-types.bas
+++ b/tests/warnings/op-result-types.bas
@@ -61,7 +61,7 @@ end enum
 	#print typeof( A mod B )
 
 	#print
-	#print "bit" ops (A, B):
+	#print bitops (A, B):
 	#print
 
 	#print A shl B = non-float =


### PR DESCRIPTION
Added the builtin macros: __FB_UNIQUEID_PUSH__(), __FB_UNIQUEID__(), __FB_UNIQUEID_POP__(), __FB_ARG_LEFTOF__(), __FB_ARG_RIGHTOF__(), __FB_JOIN__(). They make it easier to create complex macros and syntax sugars.

Added option to call macros without using parentheses, allowing a more BASICish syntax with some macros.

Check the examples/misc/trycatch and examples/misc/generics to see how they could be used.