### PR TITLE
Fix #875 boolean to float conversion gives wrong sign 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,7 @@ Version 1.06.0
 - #832: Fix bug allowing QB style suffixes on all keywords, regardless of -lang
 - #841: The unary negation operator gave different result signedness when used on constant instead of non-constant expression. Now the result is always signed.
 - Incorrect C++ mangling for BYREF parameters using built-in types
+- #844: Fix bug in -gen gcc due to duplicated type (struct) names in the main module and global namespace
 
 
 Version 1.05.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -50,6 +50,7 @@ Version 1.06.0
 - #841: The unary negation operator gave different result signedness when used on constant instead of non-constant expression. Now the result is always signed.
 - Incorrect C++ mangling for BYREF parameters using built-in types
 - #844: Fix bug in -gen gcc due to duplicated type (struct) names in the main module and global namespace
+- #875: Fix bug where boolean variable to single/double conversion gives wrong sign on -gen gas x86
 
 
 Version 1.05.0

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -6335,7 +6335,6 @@ private sub _emitLOADB2F( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 
 		hPUSH aux
 		outp "fild dword ptr [esp]"
-		outp "fchs"
 		outp "add esp, 4"
 
 		if( isfree = FALSE ) then

--- a/src/compiler/ir-hlc.bas
+++ b/src/compiler/ir-hlc.bas
@@ -674,6 +674,11 @@ private sub hEmitUDT( byval s as FBSYMBOL ptr, byval is_ptr as integer )
 		'' see main's locals from elsewhere)
 		if( symbGetScope( s ) = FB_MAINSCOPE ) then
 			section += 1
+
+		'' global namespace due the implicit MAIN?
+		elseif( symbGetNamespace( s ) = @symbGetGlobalNamespc( ) ) then
+			section += 1
+
 		end if
 
 		'' Switching from a parent to a child scope isn't allowed,

--- a/tests/boolean/boolean-conversions.bas
+++ b/tests/boolean/boolean-conversions.bas
@@ -382,12 +382,8 @@ SUITE( fbc_tests.boolean_.conversions )
 		ull  = boolvar : CU_ASSERT( ull = culngint(boolvar) )
 		i    = boolvar : CU_ASSERT( i = cint(boolvar) )
 		ui   = boolvar : CU_ASSERT( ui = cuint(boolvar) )
-#if ENABLE_CHECK_BUGS
-		#print enable check for #875 boolean to float conversion gives wrong sign
-		#print see bug #875 at https://sourceforge.net/p/fbc/bugs/875/
 		f    = boolvar : CU_ASSERT( f = csng(boolvar) )
 		d    = boolvar : CU_ASSERT( d = cdbl(boolvar) )
-#endif
 		bool = boolvar : CU_ASSERT( bool = cbool(boolvar) )
 
 	END_TEST

--- a/tests/scopes/module-level.bas
+++ b/tests/scopes/module-level.bas
@@ -1,0 +1,88 @@
+' TEST_MODE : COMPILE_ONLY_OK
+
+'' test for sf bug #844
+'' in -gen gcc, this would have caused a duplicate struct names to be emitted
+
+scope
+  type udt
+	dim as integer i
+  end type
+  dim as udt u1
+end scope
+
+scope
+  type udt
+	dim as integer i
+  end type
+  dim as udt u2
+end scope
+
+scope
+  scope
+    dim as integer array1()
+  end scope
+end scope
+
+scope
+  scope
+    dim as integer array2()
+  end scope
+end scope
+
+scope
+	scope
+	  type udt
+		dim as integer i
+	  end type
+	  dim as udt u1
+	end scope
+	
+	scope
+	  type udt
+		dim as integer i
+	  end type
+	  dim as udt u2
+	end scope
+	
+	scope
+	  scope
+	    dim as integer array1()
+	  end scope
+	end scope
+	
+	scope
+	  scope
+	    dim as integer array2()
+	  end scope
+	end scope
+end scope
+
+scope
+	scope
+		scope
+		  type udt
+			dim as integer i
+		  end type
+		  dim as udt u1
+		end scope
+		
+		scope
+		  type udt
+			dim as integer i
+		  end type
+		  dim as udt u2
+		end scope
+		
+		scope
+		  scope
+		    dim as integer array1()
+		  end scope
+		end scope
+		
+		scope
+		  scope
+		    dim as integer array2()
+		  end scope
+		end scope
+	end scope
+end scope


### PR DESCRIPTION
#875: Fix bug where boolean variable to single/double conversion gives wrong sign on -gen gas x86
https://sourceforge.net/p/fbc/bugs/875/