### PR TITLE
Fix #872 broken boolean bitfield runtime assignments from unsigned values

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -51,6 +51,7 @@ Version 1.06.0
 - Incorrect C++ mangling for BYREF parameters using built-in types
 - #844: Fix bug in -gen gcc due to duplicated type (struct) names in the main module and global namespace
 - #875: Fix bug where boolean variable to single/double conversion gives wrong sign on -gen gas x86
+- #872: Fix broken boolean bitfield runtime assignments from unsigned values 
 
 
 Version 1.05.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,7 @@ Version 1.06.0
 - #832: Fix bug allowing QB style suffixes on all keywords, regardless of -lang
 - #841: The unary negation operator gave different result signedness when used on constant instead of non-constant expression. Now the result is always signed.
 - Incorrect C++ mangling for BYREF parameters using built-in types
+- #844: Fix bug in -gen gcc due to duplicated type (struct) names in the main module and global namespace
 
 
 Version 1.05.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -50,6 +50,7 @@ Version 1.06.0
 - #841: The unary negation operator gave different result signedness when used on constant instead of non-constant expression. Now the result is always signed.
 - Incorrect C++ mangling for BYREF parameters using built-in types
 - #844: Fix bug in -gen gcc due to duplicated type (struct) names in the main module and global namespace
+- #875: Fix bug where boolean variable to single/double conversion gives wrong sign on -gen gas x86
 
 
 Version 1.05.0

--- a/src/compiler/ast-node-misc.bas
+++ b/src/compiler/ast-node-misc.bas
@@ -431,7 +431,7 @@ private function astSetBitfield _
 
 	'' boolean bitfield? - do a bool conversion before the bitfield store
 	if( symbGetType( bitfield ) = FB_DATATYPE_BOOLEAN ) then
-		if( r->class <> AST_NODECLASS_CONV ) then
+		if( (r->class <> AST_NODECLASS_CONV) orelse (astGetFullType( r ) <> FB_DATATYPE_BOOLEAN) ) then
 			r = astNewCONV( FB_DATATYPE_BOOLEAN, NULL, r )
 		end if
 		r = astNewCONV( FB_DATATYPE_UINT, NULL, r )

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -6335,7 +6335,6 @@ private sub _emitLOADB2F( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 
 		hPUSH aux
 		outp "fild dword ptr [esp]"
-		outp "fchs"
 		outp "add esp, 4"
 
 		if( isfree = FALSE ) then

--- a/src/compiler/ir-hlc.bas
+++ b/src/compiler/ir-hlc.bas
@@ -674,6 +674,11 @@ private sub hEmitUDT( byval s as FBSYMBOL ptr, byval is_ptr as integer )
 		'' see main's locals from elsewhere)
 		if( symbGetScope( s ) = FB_MAINSCOPE ) then
 			section += 1
+
+		'' global namespace due the implicit MAIN?
+		elseif( symbGetNamespace( s ) = @symbGetGlobalNamespc( ) ) then
+			section += 1
+
 		end if
 
 		'' Switching from a parent to a child scope isn't allowed,

--- a/tests/boolean/boolean-conversions.bas
+++ b/tests/boolean/boolean-conversions.bas
@@ -382,12 +382,8 @@ SUITE( fbc_tests.boolean_.conversions )
 		ull  = boolvar : CU_ASSERT( ull = culngint(boolvar) )
 		i    = boolvar : CU_ASSERT( i = cint(boolvar) )
 		ui   = boolvar : CU_ASSERT( ui = cuint(boolvar) )
-#if ENABLE_CHECK_BUGS
-		#print enable check for #875 boolean to float conversion gives wrong sign
-		#print see bug #875 at https://sourceforge.net/p/fbc/bugs/875/
 		f    = boolvar : CU_ASSERT( f = csng(boolvar) )
 		d    = boolvar : CU_ASSERT( d = cdbl(boolvar) )
-#endif
 		bool = boolvar : CU_ASSERT( bool = cbool(boolvar) )
 
 	END_TEST

--- a/tests/boolean/boolean_bitfield.bas
+++ b/tests/boolean/boolean_bitfield.bas
@@ -120,10 +120,6 @@ SUITE( fbc_tests.boolean_.bitfield )
 
 	END_TEST
 
-#if ENABLE_CHECK_BUGS
-	#print enable check for #872 broken boolean bitfield runtime assignments from unsigned values
-	#print see bug #872 at https://sourceforge.net/p/fbc/bugs/872/
-
 	TEST( assignment_unsigned_variable )
 
 		dim value as uinteger = 1
@@ -209,7 +205,5 @@ SUITE( fbc_tests.boolean_.bitfield )
 		end scope
 
 	END_TEST
-
-#endif
 
 END_SUITE

--- a/tests/scopes/module-level.bas
+++ b/tests/scopes/module-level.bas
@@ -1,0 +1,88 @@
+' TEST_MODE : COMPILE_ONLY_OK
+
+'' test for sf bug #844
+'' in -gen gcc, this would have caused a duplicate struct names to be emitted
+
+scope
+  type udt
+	dim as integer i
+  end type
+  dim as udt u1
+end scope
+
+scope
+  type udt
+	dim as integer i
+  end type
+  dim as udt u2
+end scope
+
+scope
+  scope
+    dim as integer array1()
+  end scope
+end scope
+
+scope
+  scope
+    dim as integer array2()
+  end scope
+end scope
+
+scope
+	scope
+	  type udt
+		dim as integer i
+	  end type
+	  dim as udt u1
+	end scope
+	
+	scope
+	  type udt
+		dim as integer i
+	  end type
+	  dim as udt u2
+	end scope
+	
+	scope
+	  scope
+	    dim as integer array1()
+	  end scope
+	end scope
+	
+	scope
+	  scope
+	    dim as integer array2()
+	  end scope
+	end scope
+end scope
+
+scope
+	scope
+		scope
+		  type udt
+			dim as integer i
+		  end type
+		  dim as udt u1
+		end scope
+		
+		scope
+		  type udt
+			dim as integer i
+		  end type
+		  dim as udt u2
+		end scope
+		
+		scope
+		  scope
+		    dim as integer array1()
+		  end scope
+		end scope
+		
+		scope
+		  scope
+		    dim as integer array2()
+		  end scope
+		end scope
+	end scope
+end scope


### PR DESCRIPTION
#872: Fix broken boolean bitfield runtime assignments from unsigned values
See https://sourceforge.net/p/fbc/bugs/872/
