### PR TITLE
Fix #875 for -gen gas -fpu sse

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -51,7 +51,7 @@ Version 1.06.0
 - #841: The unary negation operator gave different result signedness when used on constant instead of non-constant expression. Now the result is always signed.
 - Incorrect C++ mangling for BYREF parameters using built-in types
 - #844: Fix bug in -gen gcc due to duplicated type (struct) names in the main module and global namespace
-- #875: Fix bug where boolean variable to single/double conversion gives wrong sign on -gen gas x86
+- #875: Fix bug where boolean variable to single/double conversion gives wrong sign on -gen gas -fpu x87 & sse
 - #872: Fix broken boolean bitfield runtime assignments from unsigned values 
 
 


### PR DESCRIPTION
Fix #875 for -gen gas -fpu sse where boolean variable to single/double conversion gives wrong sign.
