### PR TITLE
Fix proc name mangling in inline asm under -gen gcc -asm intel

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -53,6 +53,7 @@ Version 1.06.0
 - #844: Fix bug in -gen gcc due to duplicated type (struct) names in the main module and global namespace
 - #875: Fix bug where boolean variable to single/double conversion gives wrong sign on -gen gas x86
 - #872: Fix broken boolean bitfield runtime assignments from unsigned values 
+- Fixed inline asm procedure name mangling bug (missing underscore prefix) with -gen gcc -asm intel on dos/win32
 
 
 Version 1.05.0


### PR DESCRIPTION
This should fix tests/quirk/inline-asm.bas to build for win32. @jayrm, could you give it a try?