### PR TITLE
#879: Literal type suffix and unary operators

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 1.06.0
 [changed]
 - Adjusted warning text for "mixed bool/nonbool operands" warning
 - test-suite uses libfbcunit for unit testing framework
+- #879: Literal type suffix and unary ops; preserve data type on numeric literals if used with unary operator and if literal is suffixed
 
 [added]
 - -noobjinfo option to disable the writing/reading of compile-time library and other linking options from/to .o and .a files. This also disables the use of fbextra.x (the supplemental linker script) for discarding the .fbctinf sections, which is useful when using the gold linker that doesn't support this kind of linker script.

--- a/src/compiler/ast-node-const.bas
+++ b/src/compiler/ast-node-const.bas
@@ -76,6 +76,7 @@ function astNewCONSTi _
 
 	n = astNewNode( AST_NODECLASS_CONST, FB_DATATYPE_LONGINT, NULL )
 	n->val.i = value
+	n->val.hassuffix = FALSE
 
 	n = astNewCONV( dtype, subtype, n, AST_CONVOPT_DONTCHKPTR )
 	assert( n )
@@ -94,6 +95,7 @@ function astNewCONSTf _
 
 	n = astNewNode( AST_NODECLASS_CONST, FB_DATATYPE_DOUBLE )
 	n->val.f = value
+	n->val.hassuffix = FALSE
 
 	function = astNewCONV( dtype, NULL, n )
 end function

--- a/src/compiler/ast-node-uop.bas
+++ b/src/compiler/ast-node-uop.bas
@@ -176,6 +176,7 @@ function astNewUOP _
 	'' see also astNewBOP()
 	''
 	'' - do nothing if operand is boolean with NOT operator
+	'' - do nothing if operand is constant and had a suffix
 	
 	do_promote = (env.clopt.lang <> FB_LANG_QB) and (typeGetClass( o->dtype ) = FB_DATACLASS_INTEGER)
 
@@ -187,6 +188,12 @@ function astNewUOP _
 		else
 			'' no other operation allowed with booleans
 			exit function
+		end if
+
+	'' if the original constant had a suffix, keep original data type
+	elseif( astIsConst( o ) ) then
+		if( o->val.hassuffix ) then
+			do_promote = FALSE
 		end if
 	end if
 

--- a/src/compiler/ast.bi
+++ b/src/compiler/ast.bi
@@ -115,6 +115,16 @@ type AST_NODE_ARG
 	lgt				as longint						'' length, used to push UDT's by value
 end type
 
+type AST_NODE_CONST '' extends FBVALUE
+	union
+		value		as FBVALUE
+		s			as FBSYMBOL_ ptr
+		i			as longint
+		f			as double
+	end union
+	hassuffix		as integer
+end type
+
 type AST_NODE_VAR
 	ofs				as longint						'' offset
 end type
@@ -260,7 +270,7 @@ type ASTNODE
 	vector			as integer					'' 0, 2, 3, or 4 (> 2 for single only)
 
 	union
-		val			as FBVALUE    '' CONST nodes
+		val			as AST_NODE_CONST
 		var_		as AST_NODE_VAR
 		idx			as AST_NODE_IDX
 		ptr			as AST_NODE_PTR
@@ -1419,7 +1429,7 @@ declare function astLoadNIDXARRAY( byval n as ASTNODE ptr ) as IRVREG ptr
 
 #define astIsCAST(n) (n->class = AST_NODECLASS_CONV)
 
-#define astConstGetVal( n ) (@(n)->val)
+#define astConstGetVal( n ) (@(n)->val.value)
 #define astConstGetFloat( n ) ((n)->val.f)
 #define astConstGetInt( n ) ((n)->val.i)
 #define astConstGetUint( n ) cunsg( (n)->val.i )

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -1035,6 +1035,7 @@ private sub hReadNumber( byref t as FBTOKEN, byval flags as LEXCHECK )
 	var pnum = @t.text[0]
 	*pnum = 0
 	t.len = 0
+	t.hassuffix = false
 
 	select case as const lexCurrentChar( )
 	'' integer part
@@ -1083,6 +1084,7 @@ private sub hReadNumber( byref t as FBTOKEN, byval flags as LEXCHECK )
 			if( (flags and LEXCHECK_NOLETTERSUFFIX) = 0 ) then
 				select case lexCurrentChar( )
 				case CHAR_UUPP, CHAR_ULOW
+					t.hassuffix = TRUE
 					lexEatChar( )
 					t.dtype = typeToUnsigned( t.dtype )
 					have_u_suffix = TRUE
@@ -1093,6 +1095,7 @@ private sub hReadNumber( byref t as FBTOKEN, byval flags as LEXCHECK )
 			'' 'L' | 'l'
 			case CHAR_LUPP, CHAR_LLOW
 				if( (flags and LEXCHECK_NOLETTERSUFFIX) = 0 ) then
+					t.hassuffix = TRUE
 					lexEatChar( )
 					'' 'LL'?
 					var c = lexCurrentChar( )
@@ -1120,6 +1123,7 @@ private sub hReadNumber( byref t as FBTOKEN, byval flags as LEXCHECK )
 				if( (flags and LEXCHECK_NOLETTERSUFFIX) = 0 ) then
 					if( have_u_suffix = FALSE ) then
 						t.dtype = FB_DATATYPE_SINGLE
+						t.hassuffix = TRUE
 						lexEatChar( )
 					end if
 				end if
@@ -1130,6 +1134,7 @@ private sub hReadNumber( byref t as FBTOKEN, byval flags as LEXCHECK )
 				if( (flags and LEXCHECK_NOLETTERSUFFIX) = 0 ) then
 					if( have_u_suffix = FALSE ) then
 						t.dtype = FB_DATATYPE_DOUBLE
+						t.hassuffix = TRUE
 						lexEatChar( )
 					end if
 				end if
@@ -1165,13 +1170,14 @@ private sub hReadNumber( byref t as FBTOKEN, byval flags as LEXCHECK )
 					end if
 				end if
 				t.dtype = FB_DATATYPE_LONG
-
+				t.hassuffix = TRUE
 				lexEatChar( )
 
 			'' '!'
 			case FB_TK_SGNTYPECHAR
 				if( have_u_suffix = FALSE ) then
 					t.dtype = FB_DATATYPE_SINGLE
+					t.hassuffix = TRUE
 					lexEatChar( )
 				end if
 
@@ -1181,6 +1187,7 @@ private sub hReadNumber( byref t as FBTOKEN, byval flags as LEXCHECK )
 					'' isn't it a '##'?
 					if( lexGetLookAheadChar( ) <> FB_TK_DBLTYPECHAR ) then
 						t.dtype = FB_DATATYPE_DOUBLE
+						t.hassuffix = TRUE
 						lexEatChar( )
 					end if
 				end if

--- a/src/compiler/lex.bi
+++ b/src/compiler/lex.bi
@@ -60,6 +60,7 @@ type FBTOKEN
 	union
 		prdpos		as integer					'' period '.' pos in symbol names
 		hasesc		as integer					'' any '\' in literals
+		hassuffix	as integer					'' numeric litteral has suffix 
 	end union
 
 	after_space		as integer
@@ -242,6 +243,8 @@ declare function lexPeekCurrentLine _
 #define lexGetPeriodPos( ) lex.ctx->head->prdpos
 
 #define lexGetHasSlash( ) lex.ctx->head->hasesc
+
+#define lexGetHasSuffix( ) lex.ctx->head->hassuffix
 
 #define lexGetHead( ) lex.ctx->head
 

--- a/src/compiler/parser-expr-constant.bas
+++ b/src/compiler/parser-expr-constant.bas
@@ -109,26 +109,32 @@ end function
 
 function cNumLiteral( byval skiptoken as integer ) as ASTNODE ptr
 	dim as integer dtype = any
+	dim as ASTNODE ptr expr = any
 
 	dtype = lexGetType( )
 
 	select case( dtype )
 	case FB_DATATYPE_DOUBLE
-		function = astNewCONSTf( val( *lexGetText( ) ), dtype )
+		expr = astNewCONSTf( val( *lexGetText( ) ), dtype )
 
 	case FB_DATATYPE_SINGLE
 		dim fval as single = val( *lexGetText( ) )
-		function = astNewCONSTf( fval , dtype )
+		expr = astNewCONSTf( fval , dtype )
 
 	case else
 		if( typeIsSigned( dtype ) ) then
-			function = astNewCONSTi( clngint( *lexGetText( ) ), dtype )
+			expr = astNewCONSTi( clngint( *lexGetText( ) ), dtype )
 		else
-			function = astNewCONSTi( culngint( *lexGetText( ) ), dtype )
+			expr = astNewCONSTi( culngint( *lexGetText( ) ), dtype )
 		end if
 	end select
+
+	'' record that it is a suffixed constant
+	expr->val.hassuffix = lexGetHasSuffix()
 
 	if( skiptoken ) then
 		lexSkipToken( )
 	end if
+
+	function = expr
 end function

--- a/src/compiler/symb-const.bas
+++ b/src/compiler/symb-const.bas
@@ -35,7 +35,8 @@ function symbAddConst _
 		exit function
 	end if
 
-	sym->val = *value
+	sym->val.value = *value
+	sym->val.hassuffix = FALSE
 
 	function = sym
 end function

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -315,11 +315,13 @@ type FBNAMESPC
     ext				as FBNAMESPC_EXT ptr
 end type
 
-union FBVALUE
-	s			as FBSYMBOL_ ptr
-	i			as longint
-	f			as double
-end union
+type FBVALUE
+	union
+		s			as FBSYMBOL_ ptr
+		i			as longint
+		f			as double
+	end union
+end type
 
 '' keyword
 type FBS_KEYWORD
@@ -634,6 +636,16 @@ type FBVAR_DATA
 	prev			as FBSYMBOL_ ptr
 end type
 
+type FBS_CONST '' extends FBVALUE
+	union
+		value		as FBVALUE
+		s			as FBSYMBOL_ ptr
+		i			as longint
+		f			as double
+	end union
+	hassuffix		as integer
+end type
+
 type FBS_VAR
 	union
 		littext		as zstring ptr
@@ -696,7 +708,7 @@ type FBSYMBOL
 
 	union
 		var_		as FBS_VAR
-		val			as FBVALUE  '' constants
+		val			as FBS_CONST  '' constants
 		udt			as FBS_STRUCT
 		enum_		as FBS_ENUM
 		proc		as FBS_PROC
@@ -2092,7 +2104,7 @@ declare function symbGetUDTBaseLevel _
 
 #define symbIsNameSpace(s) (s->class = FB_SYMBCLASS_NAMESPACE)
 
-#define symbGetConstVal( sym )   (@((sym)->val))
+#define symbGetConstVal( sym )   (@((sym)->val.value))
 #define symbGetConstStr( sym )   ((sym)->val.s)
 #define symbGetConstInt( sym )   ((sym)->val.i)
 #define symbGetConstFloat( sym ) ((sym)->val.f)

--- a/tests/warnings/r/dos/op-result-types.txt
+++ b/tests/warnings/r/dos/op-result-types.txt
@@ -18457,13 +18457,13 @@ INTEGER
 
 0l:
 not:
-INTEGER
+LONG
 negation:
-INTEGER
+LONG
 abs:
-INTEGER
+LONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:
@@ -18525,13 +18525,13 @@ INTEGER
 
 0ul:
 not:
-UINTEGER
+ULONG
 negation:
-INTEGER
+LONG
 abs:
-UINTEGER
+ULONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:

--- a/tests/warnings/r/linux-x86/op-result-types.txt
+++ b/tests/warnings/r/linux-x86/op-result-types.txt
@@ -18457,13 +18457,13 @@ INTEGER
 
 0l:
 not:
-INTEGER
+LONG
 negation:
-INTEGER
+LONG
 abs:
-INTEGER
+LONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:
@@ -18525,13 +18525,13 @@ INTEGER
 
 0ul:
 not:
-UINTEGER
+ULONG
 negation:
-INTEGER
+LONG
 abs:
-UINTEGER
+ULONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:

--- a/tests/warnings/r/linux-x86_64/op-result-types.txt
+++ b/tests/warnings/r/linux-x86_64/op-result-types.txt
@@ -18457,13 +18457,13 @@ INTEGER
 
 0l:
 not:
-INTEGER
+LONG
 negation:
-INTEGER
+LONG
 abs:
-INTEGER
+LONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:
@@ -18525,13 +18525,13 @@ INTEGER
 
 0ul:
 not:
-INTEGER
+ULONG
 negation:
-INTEGER
+LONG
 abs:
-INTEGER
+ULONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:
@@ -18593,13 +18593,13 @@ INTEGER
 
 0ll:
 not:
-INTEGER
+LONGINT
 negation:
-INTEGER
+LONGINT
 abs:
-INTEGER
+LONGINT
 sgn:
-INTEGER
+LONGINT
 sin:
 DOUBLE
 asin:
@@ -18661,13 +18661,13 @@ INTEGER
 
 0ull:
 not:
-UINTEGER
+ULONGINT
 negation:
-INTEGER
+LONGINT
 abs:
-UINTEGER
+ULONGINT
 sgn:
-INTEGER
+LONGINT
 sin:
 DOUBLE
 asin:

--- a/tests/warnings/r/win32/op-result-types.txt
+++ b/tests/warnings/r/win32/op-result-types.txt
@@ -18457,13 +18457,13 @@ INTEGER
 
 0l:
 not:
-INTEGER
+LONG
 negation:
-INTEGER
+LONG
 abs:
-INTEGER
+LONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:
@@ -18525,13 +18525,13 @@ INTEGER
 
 0ul:
 not:
-UINTEGER
+ULONG
 negation:
-INTEGER
+LONG
 abs:
-UINTEGER
+ULONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:

--- a/tests/warnings/r/win64/op-result-types.txt
+++ b/tests/warnings/r/win64/op-result-types.txt
@@ -18457,13 +18457,13 @@ INTEGER
 
 0l:
 not:
-INTEGER
+LONG
 negation:
-INTEGER
+LONG
 abs:
-INTEGER
+LONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:
@@ -18525,13 +18525,13 @@ INTEGER
 
 0ul:
 not:
-INTEGER
+ULONG
 negation:
-INTEGER
+LONG
 abs:
-INTEGER
+ULONG
 sgn:
-INTEGER
+LONG
 sin:
 DOUBLE
 asin:
@@ -18593,13 +18593,13 @@ INTEGER
 
 0ll:
 not:
-INTEGER
+LONGINT
 negation:
-INTEGER
+LONGINT
 abs:
-INTEGER
+LONGINT
 sgn:
-INTEGER
+LONGINT
 sin:
 DOUBLE
 asin:
@@ -18661,13 +18661,13 @@ INTEGER
 
 0ull:
 not:
-UINTEGER
+ULONGINT
 negation:
-INTEGER
+LONGINT
 abs:
-UINTEGER
+ULONGINT
 sgn:
-INTEGER
+LONGINT
 sin:
 DOUBLE
 asin:


### PR DESCRIPTION
- preserve data type on numeric literals if used with unary operators and if literal is suffixed