### PR TITLE
#857: fix PAINT used in a VIEWport causing segfault

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,7 @@ Version 1.06.0
 - #846: Fix compiler crash on global variable initializer with type<T>(...) expression where T isn't a UDT
 - #847: Windows API binding: Fixed winnt.bi SECURITY_*_AUTHORITY initializers
 - #851: '#LINE line filename' only changed the source filename in error messages, not in debug info
+- #857: PAINT used in a VIEWport and without delimitation border induces segmentation violation when ending code
 - #832: Fix bug allowing QB style suffixes on all keywords, regardless of -lang
 - #841: The unary negation operator gave different result signedness when used on constant instead of non-constant expression. Now the result is always signed.
 - Incorrect C++ mangling for BYREF parameters using built-in types

--- a/src/gfxlib2/gfx_paint.c
+++ b/src/gfxlib2/gfx_paint.c
@@ -149,7 +149,7 @@ FBCALL void fb_GfxPaint(void *target, float fx, float fy, unsigned int color, un
 			}
 
 			if (__fb_gfx->framebuffer == context->line[0])
-				__fb_gfx->dirty[context->view_y + y] = TRUE;
+				__fb_gfx->dirty[y] = TRUE;
 		}
 	}
 	free(span);


### PR DESCRIPTION
- PAINT used in a VIEWport and without delimitation border induces segmentation violation when ending code
- was caused by wrong calculation to update fbgfx "dirty" array