### PR TITLE
Fix dim shared byref initializer check

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -61,7 +61,7 @@ Version 1.06.0
 - Fixed inline asm procedure name mangling bug (missing underscore prefix) with -gen gcc -asm intel on dos/win32
 - #878: Fix fbc-64bit hangs on 'Case True' + 'Case False' inside 'Select Case As const'
 - Fix SELECT CASE AS CONST to allow both signed & unsigned case range values
-- #822, #814: Compiler crash when initializing shared reference (DIM SHARED BYREF) with non-constant initializer (e.g. another reference, or dynamic array element)
+- #822, #814, #842: Compiler crash when initializing static/shared reference (DIM SHARED/STATIC BYREF) with non-constant initializer (e.g. another reference, or dynamic array element)
 
 
 Version 1.05.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -61,7 +61,7 @@ Version 1.06.0
 - Fixed inline asm procedure name mangling bug (missing underscore prefix) with -gen gcc -asm intel on dos/win32
 - #878: Fix fbc-64bit hangs on 'Case True' + 'Case False' inside 'Select Case As const'
 - Fix SELECT CASE AS CONST to allow both signed & unsigned case range values
-- Compiler crash when initializing shared reference (DIM SHARED BYREF) from another shared reference
+- #822: Compiler crash when initializing shared reference (DIM SHARED BYREF) from another shared reference
 
 
 Version 1.05.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -61,7 +61,7 @@ Version 1.06.0
 - Fixed inline asm procedure name mangling bug (missing underscore prefix) with -gen gcc -asm intel on dos/win32
 - #878: Fix fbc-64bit hangs on 'Case True' + 'Case False' inside 'Select Case As const'
 - Fix SELECT CASE AS CONST to allow both signed & unsigned case range values
-- #822: Compiler crash when initializing shared reference (DIM SHARED BYREF) from another shared reference
+- #822, #814: Compiler crash when initializing shared reference (DIM SHARED BYREF) with non-constant initializer (e.g. another reference, or dynamic array element)
 
 
 Version 1.05.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -61,6 +61,7 @@ Version 1.06.0
 - Fixed inline asm procedure name mangling bug (missing underscore prefix) with -gen gcc -asm intel on dos/win32
 - #878: Fix fbc-64bit hangs on 'Case True' + 'Case False' inside 'Select Case As const'
 - Fix SELECT CASE AS CONST to allow both signed & unsigned case range values
+- Compiler crash when initializing shared reference (DIM SHARED BYREF) from another shared reference
 
 
 Version 1.05.0

--- a/src/compiler/ast-node-typeini.bas
+++ b/src/compiler/ast-node-typeini.bas
@@ -556,7 +556,6 @@ private sub hFlushExprStatic( byval n as ASTNODE ptr, byval basesym as FBSYMBOL 
 		end if
 	'' literal string..
 	else
-		var sdtype = symbGetType( sym )
 		'' not a wstring?
 		if( sdtype <> FB_DATATYPE_WCHAR ) then
 			'' convert?

--- a/src/compiler/ast-node-typeini.bas
+++ b/src/compiler/ast-node-typeini.bas
@@ -524,7 +524,7 @@ private sub hFlushExprStatic( byval n as ASTNODE ptr, byval basesym as FBSYMBOL 
 	end if
 
 	var sdtype = symbGetType( sym )
-	var sfulldtype = symbGetType( sym )
+	var sfulldtype = symbGetFullType( sym )
 	if( symbIsRef( sym ) ) then
 		'' Initializers for references initialize the pointer,
 		'' not an object of the symbol's type.

--- a/src/compiler/ast-node-typeini.bas
+++ b/src/compiler/ast-node-typeini.bas
@@ -522,7 +522,15 @@ private sub hFlushExprStatic( byval n as ASTNODE ptr, byval basesym as FBSYMBOL 
 	if( sym = NULL ) then
 		sym = basesym
 	end if
+
 	var sdtype = symbGetType( sym )
+	var sfulldtype = symbGetType( sym )
+	if( symbIsRef( sym ) ) then
+		'' Initializers for references initialize the pointer,
+		'' not an object of the symbol's type.
+		sdtype = typeAddrOf( sdtype )
+		sfulldtype = typeAddrOf( sfulldtype )
+	end if
 
 	'' Get rhs expression
 	var expr = n->l
@@ -543,7 +551,7 @@ private sub hFlushExprStatic( byval n as ASTNODE ptr, byval basesym as FBSYMBOL 
 		else
 			'' different types?
 			if( edtype <> sdtype ) then
-				expr = astNewCONV( symbGetFullType( sym ), symbGetSubtype( sym ), expr, AST_CONVOPT_DONTCHKPTR )
+				expr = astNewCONV( sfulldtype, symbGetSubtype( sym ), expr, AST_CONVOPT_DONTCHKPTR )
 				assert( expr <> NULL )
 			end if
 

--- a/src/compiler/ir-tac.bas
+++ b/src/compiler/ir-tac.bas
@@ -725,11 +725,17 @@ private sub _emitVarIniEnd( byval sym as FBSYMBOL ptr )
 end sub
 
 private sub _emitVarIniI( byval sym as FBSYMBOL ptr, byval value as longint )
-	emitVARINIi( symbGetType( sym ), value )
+	dim realtype as integer
+	dim realsubtype as FBSYMBOL ptr
+	symbGetRealType( sym, realtype, realsubtype )
+	emitVARINIi( realtype, value )
 end sub
 
 private sub _emitVarIniF( byval sym as FBSYMBOL ptr, byval value as double )
-	emitVARINIf( symbGetType( sym ), value )
+	dim realtype as integer
+	dim realsubtype as FBSYMBOL ptr
+	symbGetRealType( sym, realtype, realsubtype )
+	emitVARINIf( realtype, value )
 end sub
 
 private sub _emitVarIniOfs _

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -824,7 +824,7 @@ private sub hValidateGlobalVarInit( byval sym as FBSYMBOL ptr, byref initree as 
 
 	'' Disallow initialization of global dynamic strings
 	'' (not implemented - requires executing code)
-	if( symbGetType( sym ) = FB_DATATYPE_STRING ) then
+	if( (symbGetType( sym ) = FB_DATATYPE_STRING) and (not symbIsRef( sym )) ) then
 		errReport( FB_ERRMSG_CANTINITDYNAMICSTRINGS, TRUE )
 		astDelTree( initree )
 		initree = NULL
@@ -833,7 +833,7 @@ private sub hValidateGlobalVarInit( byval sym as FBSYMBOL ptr, byref initree as 
 
 	'' Check for constant initializer?
 	'' (doing this check first, it results in a nicer error message)
-	if( symbHasCtor( sym ) = FALSE ) then
+	if( (not symbHasCtor( sym )) or symbIsRef( sym ) ) then
 		if( astTypeIniIsConst( initree ) = FALSE ) then
 			errReport( FB_ERRMSG_EXPECTEDCONST )
 			astDelTree( initree )
@@ -877,9 +877,7 @@ private function hCheckAndBuildByrefInitializer( byval sym as FBSYMBOL ptr, byre
 	astTypeIniAddAssign( initree, astNewADDROF( expr ), sym, ptrdtype, ptrsubtype )
 	astTypeIniEnd( initree, TRUE )
 
-	if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or FB_SYMBATTRIB_SHARED)) <> 0 ) then
-		hCheckVarsUsedInGlobalInit( sym, initree )
-	end if
+	hValidateGlobalVarInit( sym, initree )
 
 	function = initree
 end function

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -174,7 +174,7 @@ enum FB_SYMBATTRIB
 	FB_SYMBATTRIB_TEMP			= &h00400000
     FB_SYMBATTRIB_DESCRIPTOR	= &h00800000
 	FB_SYMBATTRIB_FUNCRESULT	= &h01000000
-	FB_SYMBATTRIB_REF               = &h02000000    '' procedures returning BYREF
+	FB_SYMBATTRIB_REF               = &h02000000    '' VARs/FIELDs (if declared with BYREF), PROCs (functions/function pointers returning BYREF)
 	FB_SYMBATTRIB_VIS_PRIVATE	= &h04000000    '' UDT members only
 	FB_SYMBATTRIB_VIS_PROTECTED	= &h08000000    '' ditto
 	FB_SYMBATTRIB_NAKED         = &h10000000  '' procedures only

--- a/tests/dim/byref-shared-from-global-dynamic-array-element.bas
+++ b/tests/dim/byref-shared-from-global-dynamic-array-element.bas
@@ -1,0 +1,4 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+redim shared as integer array(10)
+public dim shared byref as integer r = array(5)

--- a/tests/dim/byref-shared-from-shared-ref.bas
+++ b/tests/dim/byref-shared-from-shared-ref.bas
@@ -1,0 +1,5 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+public dim shared a as integer = 5
+public dim shared byref as integer b = a
+public dim shared byref as integer c = b

--- a/tests/dim/byref-static-from-static-field.bas
+++ b/tests/dim/byref-static-from-static-field.bas
@@ -1,0 +1,10 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+Type UDT
+  Dim As Integer I = 123
+End Type
+
+Static As UDT u
+
+Static Byref As Integer RI = u.I
+Print RI

--- a/tests/dim/byref-static-member-from-local.bas
+++ b/tests/dim/byref-static-member-from-local.bas
@@ -1,0 +1,14 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+Type UDT1
+  Dim As Integer I1
+End Type
+
+Type UDT2
+  Dim As Integer I2
+  Static Byref As UDT1 ru1
+End Type
+
+Dim As UDT1 u1
+
+Dim Byref As UDT1 UDT2.ru1 = u1

--- a/tests/dim/byref.bas
+++ b/tests/dim/byref.bas
@@ -608,4 +608,25 @@ SUITE( fbc_tests.dim_.byref_ )
 		externs.globalExterns_proc
 	END_TEST
 
+	TEST_GROUP( globalConstantInitWithoutOffset )
+		type UDT1
+			dummy as integer
+		end type
+
+		type UDT2
+			dummy as integer
+			static byref r1 as UDT1
+			static byref r2 as UDT1
+		end type
+
+		'' Initializer for global ref var using a constant that is not an offset
+		dim byref UDT2.r1 as UDT1 = *cptr(UDT1 ptr, 0)
+		dim byref UDT2.r2 as UDT1 = *cptr(UDT1 ptr, 123)
+
+		TEST( default )
+			CU_ASSERT( @UDT2.r1 = 0 )
+			CU_ASSERT( @UDT2.r2 = 123 )
+		END_TEST
+	END_TEST_GROUP
+
 END_SUITE


### PR DESCRIPTION
global ref initializers were not checked for being non-constant, but that can actually matter. For example when trying to initialize a ref from another ref, the second ref will try to copy the first ref's value, which is a non-constant initializer that isn't possible without generating a global constructor.

So for now I think the best solution is to disallow the case - at least fbc doesn't crash anymore.