### PR TITLE
Fix #884: FORMATing dates can deadlock under Unix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -61,6 +61,7 @@ Version 1.06.0
 - Fixed inline asm procedure name mangling bug (missing underscore prefix) with -gen gcc -asm intel on dos/win32
 - #878: Fix fbc-64bit hangs on 'Case True' + 'Case False' inside 'Select Case As const'
 - Fix SELECT CASE AS CONST to allow both signed & unsigned case range values
+- #884: FORMATing dates can deadlock under Unix
 
 
 Version 1.05.0

--- a/src/rtlib/fb.h
+++ b/src/rtlib/fb.h
@@ -112,10 +112,14 @@
 	FBCALL void fb_StrUnlock( void );
 	FBCALL void fb_GraphicsLock  ( void );
 	FBCALL void fb_GraphicsUnlock( void );
+	/* NOTE: if both locks are acquired, FB_LOCK() must be called before
+           FB_STRLOCK() in order to avoid deadlocking */
 	#define FB_LOCK()      fb_Lock()
 	#define FB_UNLOCK()    fb_Unlock()
 	#define FB_STRLOCK()   fb_StrLock()
 	#define FB_STRUNLOCK() fb_StrUnlock()
+	/* FIXME: consistent locking order of FB_LOCK and FB_GRAPHICS_LOCK is
+           required. See bug #885 */
 	#define FB_GRAPHICS_LOCK()   fb_GraphicsLock()
 	#define FB_GRAPHICS_UNLOCK() fb_GraphicsUnlock()
 #else

--- a/src/rtlib/str_format.c
+++ b/src/rtlib/str_format.c
@@ -142,7 +142,7 @@ FBSTRING *fb_hBuildDouble
     LenTotal = LenSign + LenFix + LenDecPoint + LenFrac;
 
 	/* alloc temp string */
-    dst = fb_hStrAllocTemp_NoLock( NULL, LenTotal );
+    dst = fb_hStrAllocTemp( NULL, LenTotal );
 	if( dst != NULL )
 	{
         if( LenSign!=0 ) {
@@ -1154,6 +1154,7 @@ FBCALL FBSTRING *fb_hStrFormat
 
     fb_ErrorSetNum( FB_RTERROR_OK );
 
+    /* Lock to prevent inconsistent results if fb_I18nSet() called? */
     FB_LOCK();
     pszIntlResult = fb_IntlGet( eFIL_NumDecimalPoint, FALSE );
     chDecimalPoint = (( pszIntlResult==NULL ) ? '.' : *pszIntlResult );
@@ -1170,8 +1171,6 @@ FBCALL FBSTRING *fb_hStrFormat
     if( chThousandsSep==0 )
         chThousandsSep = ',';
 
-    FB_STRLOCK();
-
     if( mask == NULL || mask_length==0 ) 
     {
         dst = fb_hBuildDouble( value, chDecimalPoint, 0 );
@@ -1187,7 +1186,7 @@ FBCALL FBSTRING *fb_hStrFormat
                               chThousandsSep, chDecimalPoint,
                               chDateSep, chTimeSep ) ) 
         {
-            dst = fb_hStrAllocTemp_NoLock( NULL, info.length_min + info.length_opt );
+            dst = fb_hStrAllocTemp( NULL, info.length_min + info.length_opt );
             if( dst == NULL ) 
             {
                 fb_ErrorSetNum( FB_RTERROR_OUTOFMEM );
@@ -1204,8 +1203,6 @@ FBCALL FBSTRING *fb_hStrFormat
             }
         }
     }
-
-    FB_STRUNLOCK();
 
     return dst;
 }


### PR DESCRIPTION
Don't acquire FB_STRLOCK in fb_StrFormat, because it can call
fb_DrvIntlGetMonthName and fb_DrvIntlGetWeekdayName which under Unix acquire
FB_LOCK.

This reverses part of r3440/8b2da10