### PR TITLE
fbc-debug: Add debug info for included files

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -72,6 +72,7 @@ Version 1.06.0
 - #642, #886: CASTs involving CONST qualifiers solved out too early allowing invalid statements to be compiled
 - #801: *@(expr) solved to (expr) did not cleanly remove null ptr checks allowing invalid datatype assignment with -exx.  *PTRCHK(@expr) solves to (expr).
 - #880: Overload binary operators now support covariant arguments, overloaded procedure resolution changed especially with respect to CONST and non-CONST parameters
+- Fix for debugging lines in include files but not in procedures.  Filename debugging information added for module level statements in included files.
 
 
 Version 1.05.0

--- a/src/compiler/ast-node-misc.bas
+++ b/src/compiler/ast-node-misc.bas
@@ -152,7 +152,8 @@ end function
 function astNewDBG _
 	( _
 		byval op as integer, _
-		byval ex as integer _
+      byval ex As Integer, _
+      byval filename As ZString Ptr _
 	) as ASTNODE ptr
 
 	dim as ASTNODE ptr n = any
@@ -165,13 +166,14 @@ function astNewDBG _
 
 	n->dbg.op = op
 	n->dbg.ex = ex
+   n->dbg.filename = filename
 
 	function = n
 end function
 
 function astLoadDBG( byval n as ASTNODE ptr ) as IRVREG ptr
 	if( ast.doemit ) then
-		irEmitDBG( n->dbg.op, astGetProc( )->sym, n->dbg.ex )
+      irEmitDBG( n->dbg.op, astGetProc( )->sym, n->dbg.ex, n->dbg.filename )
 	end if
 
 	function = NULL

--- a/src/compiler/ast-node-misc.bas
+++ b/src/compiler/ast-node-misc.bas
@@ -152,8 +152,8 @@ end function
 function astNewDBG _
 	( _
 		byval op as integer, _
-      byval ex As Integer, _
-      byval filename As ZString Ptr _
+		byval ex as integer, _
+		byval filename As ZString Ptr _
 	) as ASTNODE ptr
 
 	dim as ASTNODE ptr n = any
@@ -166,14 +166,14 @@ function astNewDBG _
 
 	n->dbg.op = op
 	n->dbg.ex = ex
-   n->dbg.filename = filename
+	n->dbg.filename = filename
 
 	function = n
 end function
 
 function astLoadDBG( byval n as ASTNODE ptr ) as IRVREG ptr
 	if( ast.doemit ) then
-      irEmitDBG( n->dbg.op, astGetProc( )->sym, n->dbg.ex, n->dbg.filename )
+		irEmitDBG( n->dbg.op, astGetProc( )->sym, n->dbg.ex, n->dbg.filename )
 	end if
 
 	function = NULL

--- a/src/compiler/ast.bi
+++ b/src/compiler/ast.bi
@@ -172,9 +172,9 @@ type AST_NODE_JMPTB
 end type
 
 type AST_NODE_DBG
-   ex          as integer
-   filename    as ZString Ptr
-   op          as integer
+	ex				as integer
+	filename		as zstring ptr
+	op				as integer
 end type
 
 type AST_NODE_MEM
@@ -794,9 +794,9 @@ declare function astNewASM( byval asmtokhead as ASTASMTOK ptr ) as ASTNODE ptr
 
 declare function astNewDBG _
 	( _
-      byval op       As integer, _
-      byval ex       as integer = 0, _
-      byval filename As ZString Ptr = 0 _
+		byval op as integer, _
+		byval ex as integer = 0, _
+		byval filename as zstring ptr = 0 _
 	) as ASTNODE ptr
 
 declare function astNewMEM _

--- a/src/compiler/ast.bi
+++ b/src/compiler/ast.bi
@@ -172,8 +172,9 @@ type AST_NODE_JMPTB
 end type
 
 type AST_NODE_DBG
-	ex				as integer
-	op				as integer
+   ex          as integer
+   filename    as ZString Ptr
+   op          as integer
 end type
 
 type AST_NODE_MEM
@@ -793,8 +794,9 @@ declare function astNewASM( byval asmtokhead as ASTASMTOK ptr ) as ASTNODE ptr
 
 declare function astNewDBG _
 	( _
-		byval op as integer, _
-		byval ex as integer = 0 _
+      byval op       As integer, _
+      byval ex       as integer = 0, _
+      byval filename As ZString Ptr = 0 _
 	) as ASTNODE ptr
 
 declare function astNewMEM _

--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -266,13 +266,13 @@ sub edbgLineBegin _
 	( _
 		byval proc as FBSYMBOL ptr, _
 		byval lnum as integer, _
-      byval pos_ as Integer, _
-      ByVal filename As ZString Ptr _
+		byval pos_ as integer, _
+		ByVal filename As zstring ptr _
 	)
 
 	if( env.clopt.debuginfo = FALSE ) then
     	exit sub
-   end If
+	end if
 
     if( ctx.lnum > 0 ) then
     	ctx.pos = pos_ - ctx.pos
@@ -282,7 +282,7 @@ sub edbgLineBegin _
     	end if
     end if
 
-    edbgInclude(filename)
+    edbgInclude( filename )
    
     ctx.pos = pos_
     ctx.lnum = lnum
@@ -533,7 +533,7 @@ sub edbgEmitProcHeader _
 
 	''
 	ctx.isnewline = TRUE
-   ctx.lnum        = 0
+	ctx.lnum      = 0
 	ctx.pos	  	  = 0
 	ctx.label	  = NULL
 
@@ -648,7 +648,7 @@ sub edbgEmitProcFooter _
 
 	''
 	ctx.isnewline = TRUE
-   ctx.lnum      = 0
+	ctx.lnum      = 0
 	ctx.pos	  	  = 0
 	ctx.label	  = NULL
 

--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -266,12 +266,13 @@ sub edbgLineBegin _
 	( _
 		byval proc as FBSYMBOL ptr, _
 		byval lnum as integer, _
-		byval pos_ as integer _
+      byval pos_ as Integer, _
+      ByVal filename As ZString Ptr _
 	)
 
 	if( env.clopt.debuginfo = FALSE ) then
     	exit sub
-    end if
+   end If
 
     if( ctx.lnum > 0 ) then
     	ctx.pos = pos_ - ctx.pos
@@ -281,6 +282,8 @@ sub edbgLineBegin _
     	end if
     end if
 
+    edbgInclude(filename)
+   
     ctx.pos = pos_
     ctx.lnum = lnum
     if( ctx.isnewline ) then
@@ -530,7 +533,7 @@ sub edbgEmitProcHeader _
 
 	''
 	ctx.isnewline = TRUE
-	ctx.lnum	  = 0
+   ctx.lnum        = 0
 	ctx.pos	  	  = 0
 	ctx.label	  = NULL
 
@@ -645,7 +648,7 @@ sub edbgEmitProcFooter _
 
 	''
 	ctx.isnewline = TRUE
-	ctx.lnum	  = 0
+   ctx.lnum      = 0
 	ctx.pos	  	  = 0
 	ctx.label	  = NULL
 

--- a/src/compiler/emit.bas
+++ b/src/compiler/emit.bas
@@ -204,7 +204,8 @@ sub emitFlush( )
 		case EMIT_NODECLASS_DBG
 			cast( EMIT_DBGCB, emit.opFnTb[n->dbg.op] )( n->dbg.sym, _
 												   		n->dbg.lnum, _
-												   		n->dbg.pos )
+                                             n->dbg.pos, _
+                                             n->dbg.filename )
 
 		end select
 
@@ -456,7 +457,8 @@ private function hNewDBG _
 		byval op as integer, _
 		byval sym as FBSYMBOL ptr, _
 		byval lnum as integer = 0, _
-		byval pos_ as integer = 0 _
+      byval pos_ as integer = 0, _
+      ByVal filename As ZString Ptr =0  _
 	) as EMIT_NODE ptr static
 
 	dim as EMIT_NODE ptr n
@@ -466,6 +468,7 @@ private function hNewDBG _
 	n->dbg.op = op
 	n->dbg.sym = sym
 	n->dbg.lnum = lnum
+   n->dbg.filename = filename
 	n->dbg.pos = pos_
 
 	function = n
@@ -1632,10 +1635,11 @@ end function
 function emitDBGLineBegin _
 	( _
 		byval proc as FBSYMBOL ptr, _
-		byval lnum as integer _
+      byval lnum as Integer, _
+      ByVal filename As ZString Ptr _
 	) as EMIT_NODE ptr
 
-	function = hNewDBG( EMIT_OP_LINEINI, proc, lnum, emit.pos )
+   function = hNewDBG( EMIT_OP_LINEINI, proc, lnum, emit.pos, filename )
 
 end function
 

--- a/src/compiler/emit.bas
+++ b/src/compiler/emit.bas
@@ -204,8 +204,8 @@ sub emitFlush( )
 		case EMIT_NODECLASS_DBG
 			cast( EMIT_DBGCB, emit.opFnTb[n->dbg.op] )( n->dbg.sym, _
 												   		n->dbg.lnum, _
-                                             n->dbg.pos, _
-                                             n->dbg.filename )
+												   		n->dbg.pos, _
+												   		n->dbg.filename )
 
 		end select
 
@@ -457,8 +457,8 @@ private function hNewDBG _
 		byval op as integer, _
 		byval sym as FBSYMBOL ptr, _
 		byval lnum as integer = 0, _
-      byval pos_ as integer = 0, _
-      ByVal filename As ZString Ptr =0  _
+		byval pos_ as integer = 0, _
+		byval filename As zstring ptr = 0  _
 	) as EMIT_NODE ptr static
 
 	dim as EMIT_NODE ptr n
@@ -468,7 +468,7 @@ private function hNewDBG _
 	n->dbg.op = op
 	n->dbg.sym = sym
 	n->dbg.lnum = lnum
-   n->dbg.filename = filename
+	n->dbg.filename = filename
 	n->dbg.pos = pos_
 
 	function = n
@@ -1635,11 +1635,11 @@ end function
 function emitDBGLineBegin _
 	( _
 		byval proc as FBSYMBOL ptr, _
-      byval lnum as Integer, _
-      ByVal filename As ZString Ptr _
+		byval lnum as integer, _
+		byval filename As zstring ptr _
 	) as EMIT_NODE ptr
 
-   function = hNewDBG( EMIT_OP_LINEINI, proc, lnum, emit.pos, filename )
+	function = hNewDBG( EMIT_OP_LINEINI, proc, lnum, emit.pos, filename )
 
 end function
 

--- a/src/compiler/emit.bi
+++ b/src/compiler/emit.bi
@@ -199,6 +199,7 @@ type EMIT_DBGNODE
 	op			as integer
 	sym			as FBSYMBOL ptr
 	lnum		as integer
+   filename As ZString Ptr
 	pos			as integer
 end type
 
@@ -261,7 +262,8 @@ type EMIT_MEMCB as sub( byval dvreg as IRVREG ptr, _
 
 type EMIT_DBGCB as sub( byval sym as FBSYMBOL ptr, _
 						byval lnum as integer, _
-						byval pos as integer )
+                  byval pos as Integer, _
+                  ByVal filename As ZString Ptr =0 )
 
 '' if changed, update the _vtbl symbols at emit_*.bas::*_ctor
 type EMIT_VTBL
@@ -790,7 +792,8 @@ declare function emitSTKCLEAR _
 declare function emitDBGLineBegin _
 	( _
 		byval proc as FBSYMBOL ptr, _
-		byval ex as integer _
+      byval ex as Integer, _
+      ByVal filename As ZString Ptr _
 	) as EMIT_NODE ptr
 
 declare function emitDBGLineEnd _

--- a/src/compiler/emit.bi
+++ b/src/compiler/emit.bi
@@ -199,7 +199,7 @@ type EMIT_DBGNODE
 	op			as integer
 	sym			as FBSYMBOL ptr
 	lnum		as integer
-   filename As ZString Ptr
+	filename 	as zstring ptr
 	pos			as integer
 end type
 

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -6049,11 +6049,11 @@ private sub _emitLINEINI _
 	( _
 		byval proc as FBSYMBOL ptr, _
 		byval lnum as integer, _
-      byval pos_ as Integer, _
-      ByVal filename As ZString Ptr _
+		byval pos_ as integer, _
+		byval filename As zstring ptr _
 	)
 
-   edbgLineBegin( proc, lnum, pos_, filename )
+	edbgLineBegin( proc, lnum, pos_, filename )
 
 end sub
 

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -6049,10 +6049,11 @@ private sub _emitLINEINI _
 	( _
 		byval proc as FBSYMBOL ptr, _
 		byval lnum as integer, _
-		byval pos_ as integer _
+      byval pos_ as Integer, _
+      ByVal filename As ZString Ptr _
 	)
 
-	edbgLineBegin( proc, lnum, pos_ )
+   edbgLineBegin( proc, lnum, pos_, filename )
 
 end sub
 

--- a/src/compiler/emitdbg.bi
+++ b/src/compiler/emitdbg.bi
@@ -9,8 +9,8 @@ declare sub edbgLineBegin _
 	( _
 		byval proc as FBSYMBOL ptr, _
 		byval lnum as integer, _
-      byval pos as Integer, _
-      ByVal filename as ZString Ptr _
+		byval pos as integer, _
+		byval filename as zstring ptr _
 	)
 
 declare sub edbgLineEnd _

--- a/src/compiler/emitdbg.bi
+++ b/src/compiler/emitdbg.bi
@@ -9,7 +9,8 @@ declare sub edbgLineBegin _
 	( _
 		byval proc as FBSYMBOL ptr, _
 		byval lnum as integer, _
-		byval pos as integer _
+      byval pos as Integer, _
+      ByVal filename as ZString Ptr _
 	)
 
 declare sub edbgLineEnd _

--- a/src/compiler/ir-hlc.bas
+++ b/src/compiler/ir-hlc.bas
@@ -192,7 +192,7 @@ type IRHLCCTX
 	section				as integer '' Current section to write to
 	sectiongosublevel		as integer
 
-	linenum				as integer
+   lnum            as integer
 	escapedinputfilename		as string
 	usedbuiltins			as uinteger  '' BUILTIN_*
 
@@ -223,7 +223,8 @@ declare sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-		byval ex as integer _
+      byval lnum as Integer, _
+      ByVal filename As ZString Ptr = 0 _
 	)
 
 declare sub exprFreeNode( byval n as EXPRNODE ptr )
@@ -385,7 +386,7 @@ private sub hWriteLine( byref s as string, byval noline as integer = FALSE )
 	static as string ln
 
 	if( env.clopt.debuginfo and (noline = FALSE) ) then
-		ln = "#line " + str( ctx.linenum )
+      ln = "#line " + str( ctx.lnum )
 		ln += " """ + ctx.escapedinputfilename + """"
 		sectionWriteLine( ln )
 	end if
@@ -1249,7 +1250,7 @@ private function _emitBegin( ) as integer
 
 	ctx.section = -1
 	ctx.sectiongosublevel = 0
-	ctx.linenum = 0
+   ctx.lnum = 0
 	ctx.usedbuiltins = 0
 	ctx.globalvarpass = 0
 	hUpdateCurrentFileName( env.inf.name )
@@ -3158,11 +3159,13 @@ private sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-		byval ex as integer _
+      byval lnum as Integer, _
+      ByVal filename As ZString Ptr _
 	)
 
 	if( op = AST_OP_DBG_LINEINI ) then
-		ctx.linenum = ex
+      ctx.lnum = lnum
+      If filename<>0 Then hUpdateCurrentFileName(filename)
 	end if
 
 end sub

--- a/src/compiler/ir-hlc.bas
+++ b/src/compiler/ir-hlc.bas
@@ -192,7 +192,7 @@ type IRHLCCTX
 	section				as integer '' Current section to write to
 	sectiongosublevel		as integer
 
-   lnum            as integer
+	linenum				as integer
 	escapedinputfilename		as string
 	usedbuiltins			as uinteger  '' BUILTIN_*
 
@@ -223,8 +223,8 @@ declare sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-      byval lnum as Integer, _
-      ByVal filename As ZString Ptr = 0 _
+		byval lnum as integer, _
+		ByVal filename As zstring ptr = 0 _
 	)
 
 declare sub exprFreeNode( byval n as EXPRNODE ptr )
@@ -386,7 +386,7 @@ private sub hWriteLine( byref s as string, byval noline as integer = FALSE )
 	static as string ln
 
 	if( env.clopt.debuginfo and (noline = FALSE) ) then
-      ln = "#line " + str( ctx.lnum )
+		ln = "#line " + str( ctx.linenum )
 		ln += " """ + ctx.escapedinputfilename + """"
 		sectionWriteLine( ln )
 	end if
@@ -1250,7 +1250,7 @@ private function _emitBegin( ) as integer
 
 	ctx.section = -1
 	ctx.sectiongosublevel = 0
-   ctx.lnum = 0
+	ctx.linenum = 0
 	ctx.usedbuiltins = 0
 	ctx.globalvarpass = 0
 	hUpdateCurrentFileName( env.inf.name )
@@ -3159,13 +3159,15 @@ private sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-      byval lnum as Integer, _
-      ByVal filename As ZString Ptr _
+		byval lnum as integer, _
+		ByVal filename As zstring ptr _
 	)
 
 	if( op = AST_OP_DBG_LINEINI ) then
-      ctx.lnum = lnum
-      If filename<>0 Then hUpdateCurrentFileName(filename)
+		ctx.linenum = lnum
+		if( filename <> NULL ) then
+			hUpdateCurrentFileName( filename )
+		end if
 	end if
 
 end sub

--- a/src/compiler/ir-llvm.bas
+++ b/src/compiler/ir-llvm.bas
@@ -155,7 +155,7 @@ const MAXVARINISCOPES = 128
 
 type IRLLVMCONTEXT
 	indent				as integer  '' current indentation used by hWriteLine()
-	linenum				as integer
+   lnum            as integer
 
 	varini				as string
 	variniscopelevel		as integer
@@ -185,7 +185,8 @@ declare sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-		byval ex as integer _
+      byval lnum as Integer, _
+      ByVal filename As ZString Ptr = 0 _
 	)
 declare function hVregToStr( byval vreg as IRVREG ptr ) as string
 declare sub hEmitConvert( byval v1 as IRVREG ptr, byval v2 as IRVREG ptr )
@@ -885,7 +886,7 @@ private function _emitBegin( ) as integer
 	ctx.head_txt = ""
 	ctx.body_txt = ""
 	ctx.foot_txt = ""
-	ctx.linenum = 0
+   ctx.lnum = 0
 	ctx.section = SECTION_HEAD
 
 	for i as integer = 0 to BUILTIN__COUNT-1
@@ -2080,13 +2081,18 @@ private sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-		byval ex as integer _
+      byval lnum as Integer, _
+      ByVal filename As ZString Ptr _
 	)
 
-	if( op = AST_OP_DBG_LINEINI ) then
-		hWriteLine( "#line " & ex & " """ & hReplace( env.inf.name, "\", $"\\" ) & """" )
-		ctx.linenum = ex
-	end if
+   if( op = AST_OP_DBG_LINEINI ) Then
+      If filename<>0 Then
+         hWriteLine( "#line " & lnum & " """ & hReplace( filename, "\", $"\\" ) & """" )
+      Else
+         hWriteLine( "#line " & lnum & " """ & hReplace( env.inf.name, "\", $"\\" ) & """" )
+      End If
+      ctx.lnum = lnum
+   end If
 
 end sub
 

--- a/src/compiler/ir-llvm.bas
+++ b/src/compiler/ir-llvm.bas
@@ -155,7 +155,7 @@ const MAXVARINISCOPES = 128
 
 type IRLLVMCONTEXT
 	indent				as integer  '' current indentation used by hWriteLine()
-   lnum            as integer
+	linenum				as integer
 
 	varini				as string
 	variniscopelevel		as integer
@@ -185,8 +185,8 @@ declare sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-      byval lnum as Integer, _
-      ByVal filename As ZString Ptr = 0 _
+		byval lnum as integer, _
+		ByVal filename As zstring ptr = 0 _
 	)
 declare function hVregToStr( byval vreg as IRVREG ptr ) as string
 declare sub hEmitConvert( byval v1 as IRVREG ptr, byval v2 as IRVREG ptr )
@@ -886,7 +886,7 @@ private function _emitBegin( ) as integer
 	ctx.head_txt = ""
 	ctx.body_txt = ""
 	ctx.foot_txt = ""
-   ctx.lnum = 0
+	ctx.linenum = 0
 	ctx.section = SECTION_HEAD
 
 	for i as integer = 0 to BUILTIN__COUNT-1
@@ -2081,18 +2081,18 @@ private sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-      byval lnum as Integer, _
-      ByVal filename As ZString Ptr _
+		byval lnum as integer, _
+		ByVal filename As zstring ptr _
 	)
 
-   if( op = AST_OP_DBG_LINEINI ) Then
-      If filename<>0 Then
-         hWriteLine( "#line " & lnum & " """ & hReplace( filename, "\", $"\\" ) & """" )
-      Else
-         hWriteLine( "#line " & lnum & " """ & hReplace( env.inf.name, "\", $"\\" ) & """" )
-      End If
-      ctx.lnum = lnum
-   end If
+	if( op = AST_OP_DBG_LINEINI ) Then
+		if( filename <> NULL ) then
+			hWriteLine( "#line " & lnum & " """ & hReplace( filename, "\", $"\\" ) & """" )
+		else
+			hWriteLine( "#line " & lnum & " """ & hReplace( env.inf.name, "\", $"\\" ) & """" )
+		end if
+		ctx.linenum = lnum
+	end If
 
 end sub
 

--- a/src/compiler/ir-tac.bas
+++ b/src/compiler/ir-tac.bas
@@ -106,8 +106,8 @@ declare sub hFlushDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-      byval ex as Integer, _
-      ByVal filename As ZString Ptr _
+		byval ex as integer, _
+		ByVal filename As zstring ptr _
 	)
 
 declare sub hFlushLIT( byval op as integer, byval text as zstring ptr )
@@ -295,8 +295,8 @@ private sub _emit _
 		byval v2 as IRVREG ptr, _
 		byval vr as IRVREG ptr, _
 		byval ex1 as FBSYMBOL ptr = NULL, _
-      byval ex2 as integer = 0, _
-      byval ex3 as ZString Ptr = 0 _
+		byval ex2 as integer = 0, _
+		byval ex3 as zstring ptr = 0 _
 	) static
 
     dim as IRTAC ptr t
@@ -682,11 +682,11 @@ private sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-      byval ex       As Integer, _
-      ByVal filename As ZString Ptr _
+		byval ex as integer, _
+		byval filename as zstring ptr _
 	)
 
-   _emit( op, NULL, NULL, NULL, proc, ex, filename )
+	_emit( op, NULL, NULL, NULL, proc, ex, filename )
 
 end sub
 
@@ -1365,7 +1365,7 @@ private sub _flush static
 			hFlushMEM( op, v1, v2, t->ex2, t->ex1 )
 
 		case AST_NODECLASS_DBG
-         hFlushDBG( op, t->ex1, t->ex2, t->ex3 )
+			hFlushDBG( op, t->ex1, t->ex2, t->ex3 )
 
 		case AST_NODECLASS_LIT
 			hFlushLIT( op, cast( any ptr, t->ex1 ) )
@@ -2401,13 +2401,13 @@ private sub hFlushDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-      byval ex as Integer, _
-      ByVal filename As ZString Ptr _
+		byval ex as integer, _
+		ByVal filename As zstring ptr _
 	)
 
 	select case as const op
 	case AST_OP_DBG_LINEINI
-      emitDBGLineBegin( proc, ex, filename )
+		emitDBGLineBegin( proc, ex, filename )
 
 	case AST_OP_DBG_LINEEND
 		emitDBGLineEnd( proc, ex )

--- a/src/compiler/ir-tac.bas
+++ b/src/compiler/ir-tac.bas
@@ -106,7 +106,8 @@ declare sub hFlushDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-		byval ex as integer _
+      byval ex as Integer, _
+      ByVal filename As ZString Ptr _
 	)
 
 declare sub hFlushLIT( byval op as integer, byval text as zstring ptr )
@@ -294,7 +295,8 @@ private sub _emit _
 		byval v2 as IRVREG ptr, _
 		byval vr as IRVREG ptr, _
 		byval ex1 as FBSYMBOL ptr = NULL, _
-		byval ex2 as integer = 0 _
+      byval ex2 as integer = 0, _
+      byval ex3 as ZString Ptr = 0 _
 	) static
 
     dim as IRTAC ptr t
@@ -317,7 +319,8 @@ private sub _emit _
 
     t->ex1 = ex1
     t->ex2 = ex2
-
+    t->ex3 = ex3
+   
     ctx.taccnt += 1
 
 end sub
@@ -679,10 +682,11 @@ private sub _emitDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-		byval ex as integer _
+      byval ex       As Integer, _
+      ByVal filename As ZString Ptr _
 	)
 
-	_emit( op, NULL, NULL, NULL, proc, ex )
+   _emit( op, NULL, NULL, NULL, proc, ex, filename )
 
 end sub
 
@@ -1361,7 +1365,7 @@ private sub _flush static
 			hFlushMEM( op, v1, v2, t->ex2, t->ex1 )
 
 		case AST_NODECLASS_DBG
-			hFlushDBG( op, t->ex1, t->ex2 )
+         hFlushDBG( op, t->ex1, t->ex2, t->ex3 )
 
 		case AST_NODECLASS_LIT
 			hFlushLIT( op, cast( any ptr, t->ex1 ) )
@@ -2397,12 +2401,13 @@ private sub hFlushDBG _
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-		byval ex as integer _
+      byval ex as Integer, _
+      ByVal filename As ZString Ptr _
 	)
 
 	select case as const op
 	case AST_OP_DBG_LINEINI
-		emitDBGLineBegin( proc, ex )
+      emitDBGLineBegin( proc, ex, filename )
 
 	case AST_OP_DBG_LINEEND
 		emitDBGLineEnd( proc, ex )

--- a/src/compiler/ir.bi
+++ b/src/compiler/ir.bi
@@ -67,7 +67,7 @@ type IRTAC
 
 	ex1			as FBSYMBOL ptr					'' extra field, used by call/jmp
 	ex2			as integer						'' /
-   ex3         As ZString Ptr
+	ex3			as zstring ptr					'' filename, used by DBG
 end type
 
 type IRVREG
@@ -320,8 +320,8 @@ type IR_VTBL
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-      byval ex       as Integer, _
-      ByVal filename As ZString Ptr = 0 _
+		byval ex as integer, _
+		byval filename As zstring ptr = 0 _
 	)
 
 	emitVarIniBegin as sub( byval sym as FBSYMBOL ptr )

--- a/src/compiler/ir.bi
+++ b/src/compiler/ir.bi
@@ -67,6 +67,7 @@ type IRTAC
 
 	ex1			as FBSYMBOL ptr					'' extra field, used by call/jmp
 	ex2			as integer						'' /
+   ex3         As ZString Ptr
 end type
 
 type IRVREG
@@ -319,7 +320,8 @@ type IR_VTBL
 	( _
 		byval op as integer, _
 		byval proc as FBSYMBOL ptr, _
-		byval ex as integer _
+      byval ex       as Integer, _
+      ByVal filename As ZString Ptr = 0 _
 	)
 
 	emitVarIniBegin as sub( byval sym as FBSYMBOL ptr )
@@ -598,7 +600,7 @@ declare function vregDump( byval v as IRVREG ptr ) as string
 
 #define irEmitSCOPEEND(s) ir.vtbl.emitScopeEnd( s )
 
-#define irEmitDBG(op, proc, ex) ir.vtbl.emitDBG( op, proc, ex )
+#define irEmitDBG(op, proc, ex, filename) ir.vtbl.emitDBG( op, proc, ex, filename )
 
 #define irEmitDECL( sym ) ir.vtbl.emitDECL( sym )
 

--- a/src/compiler/parser-inlineasm.bas
+++ b/src/compiler/parser-inlineasm.bas
@@ -319,7 +319,7 @@ function cAsmBlock as integer
 	'' (AsmCode Comment? NewLine)+
 	do
 		if( issingleline = FALSE ) then
-         astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ),env.inf.incfile ))
+         astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ), env.inf.incfile ))
 		end if
 
 		cAsmCode( )

--- a/src/compiler/parser-inlineasm.bas
+++ b/src/compiler/parser-inlineasm.bas
@@ -319,7 +319,7 @@ function cAsmBlock as integer
 	'' (AsmCode Comment? NewLine)+
 	do
 		if( issingleline = FALSE ) then
-			astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ) ) )
+         astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ),env.inf.incfile ))
 		end if
 
 		cAsmCode( )

--- a/src/compiler/parser-toplevel.bas
+++ b/src/compiler/parser-toplevel.bas
@@ -110,7 +110,7 @@ sub cProgram()
 	'' For each line...
 	do
 		'' line begin
-		astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ) ) )
+      astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ),env.inf.incfile ) )
 
 		'' Label?
 		cLabel( )

--- a/src/compiler/parser-toplevel.bas
+++ b/src/compiler/parser-toplevel.bas
@@ -110,7 +110,7 @@ sub cProgram()
 	'' For each line...
 	do
 		'' line begin
-      astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ),env.inf.incfile ) )
+		astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ), env.inf.incfile ) )
 
 		'' Label?
 		cLabel( )


### PR DESCRIPTION
This update from SARG and St_W adds filename debug information for included files.  
* This patch adds debug file name information for included files to allow the debugger to determine the filename origin of module-level statements, which may be in both the main file and included files
* Previously, only the top level file name was emitted to the debug information

Original discussion at [Bug fix for debugging lines inside include files](https://www.freebasic.net/forum/viewtopic.php?t=26863)

Results are comparable on 32-bit and 64-bit and gdb appears to generate a meaningful backtrace.