### PR TITLE
Added  __FB_GUI__ intrinsic define

### DIFF
--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -480,7 +480,8 @@ sub fbGlobalInit()
 	env.clopt.stacksize     = FB_DEFSTACKSIZE
 	env.clopt.objinfo       = TRUE
 	env.clopt.showincludes  = FALSE
-
+	env.clopt.modeview      = FB_DEFAULT_MODEVIEW
+				
 	hUpdateLangOptions( )
 	hUpdateTargetOptions( )
 end sub
@@ -571,6 +572,8 @@ sub fbSetOption( byval opt as integer, byval value as integer )
 		env.clopt.objinfo = value
 	case FB_COMPOPT_SHOWINCLUDES
 		env.clopt.showincludes = value
+	case FB_COMPOPT_MODEVIEW              		'***** console/gui
+		env.clopt.modeview = value         	'***** console/gui  				
 	end select
 end sub
 
@@ -643,7 +646,9 @@ function fbGetOption( byval opt as integer ) as integer
 		function = env.clopt.objinfo
 	case FB_COMPOPT_SHOWINCLUDES
 		function = env.clopt.showincludes
-
+	case FB_COMPOPT_MODEVIEW                	'***** console/gui
+		function = env.clopt.modeview        	'***** console/gui
+		
 	case else
 		function = 0
 	end select

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -480,7 +480,7 @@ sub fbGlobalInit()
 	env.clopt.stacksize     = FB_DEFSTACKSIZE
 	env.clopt.objinfo       = TRUE
 	env.clopt.showincludes  = FALSE
-	env.clopt.modeview      = FB_DEFAULT_MODEVIEW
+	env.clopt.modeview      = FB_DEFAULT_MODEVIEW  '***** console/gui
 				
 	hUpdateLangOptions( )
 	hUpdateTargetOptions( )

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -92,7 +92,7 @@ enum FB_COMPOPT
 	FB_COMPOPT_STACKSIZE            '' integer
 	FB_COMPOPT_OBJINFO              '' boolean: write/read .fbctinf sections etc.?
 	FB_COMPOPT_SHOWINCLUDES         '' boolean: -showincludes
-	FB_COMPOPT_MODEVIEW             '' new for console gui        '***** console/gui
+	FB_COMPOPT_MODEVIEW             '' new for console gui       '***** console/gui
 	
 	FB_COMPOPTIONS
 end enum

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -92,9 +92,15 @@ enum FB_COMPOPT
 	FB_COMPOPT_STACKSIZE            '' integer
 	FB_COMPOPT_OBJINFO              '' boolean: write/read .fbctinf sections etc.?
 	FB_COMPOPT_SHOWINCLUDES         '' boolean: -showincludes
-
+	FB_COMPOPT_MODEVIEW             '' new for console gui        '***** console/gui
+	
 	FB_COMPOPTIONS
 end enum
+
+enum FB_MODEVIEW                    		'***** console/gui
+	FB_MODEVIEW_ISCONSOLE = 0        	'***** console/gui
+	FB_MODEVIEW_ISGUI                	'***** console/gui
+end enum 					'***** console/gui
 
 '' pedantic checks
 enum FB_PDCHECK
@@ -265,6 +271,7 @@ type FBCMMLINEOPT
 	stacksize       as integer
 	objinfo         as integer
 	showincludes    as integer
+	modeview        as FB_MODEVIEW 
 end type
 
 '' features allowed in the selected language

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -102,6 +102,8 @@ enum FB_MODEVIEW                    		'***** console/gui
 	FB_MODEVIEW_ISGUI                	'***** console/gui
 end enum 					'***** console/gui
 
+const FB_DEFAULT_MODEVIEW   =  FB_MODEVIEW_ISCONSOLE		 '***** console/gui
+
 '' pedantic checks
 enum FB_PDCHECK
 	FB_PDCHECK_NONE         = &h00000000

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -1755,8 +1755,8 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 
 	case OPT_S
 		fbc.subsystem = arg
-		select case( arg )                                                            '***** console/gui
-      			case "gui" : fbSetOption( FB_COMPOPT_MODEVIEW, FB_MODEVIEW_ISGUI )    '***** console/gui
+		select case( arg )                                                             '***** console/gui
+      			case "gui" : fbSetOption( FB_COMPOPT_MODEVIEW, FB_MODEVIEW_ISGUI )     '***** console/gui
       		end select
 
 	case OPT_SHOWINCLUDES

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -1755,6 +1755,9 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 
 	case OPT_S
 		fbc.subsystem = arg
+		select case( arg )                                                            '***** console/gui
+      			case "gui" : fbSetOption( FB_COMPOPT_MODEVIEW, FB_MODEVIEW_ISGUI )    '***** console/gui
+      		end select
 
 	case OPT_SHOWINCLUDES
 		fbSetOption( FB_COMPOPT_SHOWINCLUDES, TRUE )

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -85,7 +85,11 @@ end function
 private function hDefOptGosub_cb ( ) as string
 	function = str( env.opt.gosub = TRUE )
 end function
-
+															
+private function hDefViewGui_cb ( ) as string            '***** console/gui
+	function = str( env.clopt.modeview = FB_MODEVIEW_ISGUI )
+end function
+																
 private function hDefOutExe_cb ( ) as string
 	function = str( env.clopt.outtype = FB_OUTTYPE_EXECUTABLE )
 end function
@@ -209,6 +213,7 @@ dim shared defTb(0 to ...) as SYMBDEF => _
 	(@"__FB_FPU__"            , NULL          , FB_DEFINE_FLAGS_STR, @hDefFpu_cb        ), _
 	(@"__FB_FPMODE__"         , NULL          , FB_DEFINE_FLAGS_STR, @hDefFpmode_cb     ), _
 	(@"__FB_GCC__"            , NULL          , 0                  , @hDefGcc_cb        )  _
+	(@"__FB_GUI__"            , NULL          , 0                  , @hDefViewGui_cb    )  _        '***** console/gui
 }
 
 sub symbDefineInit _

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -212,7 +212,7 @@ dim shared defTb(0 to ...) as SYMBDEF => _
 	(@"__FB_BACKEND__"        , NULL          , FB_DEFINE_FLAGS_STR, @hDefBackend_cb    ), _
 	(@"__FB_FPU__"            , NULL          , FB_DEFINE_FLAGS_STR, @hDefFpu_cb        ), _
 	(@"__FB_FPMODE__"         , NULL          , FB_DEFINE_FLAGS_STR, @hDefFpmode_cb     ), _
-	(@"__FB_GCC__"            , NULL          , 0                  , @hDefGcc_cb        )  _
+	(@"__FB_GCC__"            , NULL          , 0                  , @hDefGcc_cb        ), _
 	(@"__FB_GUI__"            , NULL          , 0                  , @hDefViewGui_cb    )  _  '***** console/gui
 }
 

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -213,7 +213,7 @@ dim shared defTb(0 to ...) as SYMBDEF => _
 	(@"__FB_FPU__"            , NULL          , FB_DEFINE_FLAGS_STR, @hDefFpu_cb        ), _
 	(@"__FB_FPMODE__"         , NULL          , FB_DEFINE_FLAGS_STR, @hDefFpmode_cb     ), _
 	(@"__FB_GCC__"            , NULL          , 0                  , @hDefGcc_cb        )  _
-	(@"__FB_GUI__"            , NULL          , 0                  , @hDefViewGui_cb    )  _        '***** console/gui
+	(@"__FB_GUI__"            , NULL          , 0                  , @hDefViewGui_cb    )  _  '***** console/gui
 }
 
 sub symbDefineInit _


### PR DESCRIPTION
only 1 define as console is default mode, compiled ok with 32 and 64

tested with
#if __FB_GUI__
#include "windows.bi"
messagebox(0, "Gui mode", "info",0) 
#else
print "Console mode"
print : print "Any key to close"
sleep
#endif