### PR TITLE
fbc-debug: Add debug info for included files (part 2)

### DIFF
--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -214,6 +214,8 @@ sub edbgEmitHeader( byval filename as zstring ptr )
 	ctx.typecnt 	= 1
 	ctx.label 		= NULL
 	ctx.incfile 	= NULL
+
+	'' ctx.filename is never used
 	ctx.filename   = *filename
 
 	'' emit source file name
@@ -1016,6 +1018,15 @@ end sub
 
 sub edbgInclude( byval incfile as zstring ptr )
 	dim as string lname
+
+	'' NOTE: originally, fbc used STAB_TYPE_BINCL and STAB_TYPE_EINCL
+	'' to mark the beginning and end of an include file.  The purpose
+	'' for these markers is so the linker (LD) can remove duplicate
+	'' debug type information from the final EXE.  However, because
+	'' fbc only emits types actually used, the end result is that
+	'' type information from a header (.BI) is often different from
+	'' one object module to another is generally not used in the
+	'' way that BINCL/EINCL/EXCL was intented.
 
 	'' incfile is the new include file or main file name
 

--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -214,7 +214,11 @@ sub edbgEmitHeader( byval filename as zstring ptr )
 	ctx.typecnt 	= 1
 	ctx.label 		= NULL
 	ctx.incfile 	= NULL
-	ctx.filename	= *filename
+   #If defined( __FB_WIN32__ ) or defined( __FB_DOS__ )
+      ctx.filename   = UCase(*filename)
+   #Else
+      ctx.filename   = *filename
+   #EndIf
 
 	'' emit source file name
 	lname = *symbUniqueLabel( )
@@ -240,7 +244,6 @@ sub edbgEmitHeader( byval filename as zstring ptr )
 
 	emitWriteStr( "" )
 
-	hEmitSTABS( STAB_TYPE_BINCL, filename, 0, 0 )
 end sub
 
 '':::::
@@ -1018,40 +1021,22 @@ end sub
 sub edbgInclude( byval incfile as zstring ptr )
 	dim as string lname
 
-	'' incfile is the new include file for which we should open a block.
-	'' incfile can be NULL to indicate that no next include file is coming,
-	'' in which case we just want to return to the toplevel .bas file name,
-	'' if we previously opened an include file block.
+   '' incfile is the new include file or main file name
 
-	'' Already in the correct block?
-	'' (same include file, or NULL for toplevel)
-	if( incfile = ctx.incfile ) then
-		exit sub
-	end if
+   '' coming from _close incfile is null so no real need to change
+   If( incfile = NULL )Then
+      Exit Sub
+   EndIf
 
-	'' Currently in an include file block?
-	if( ctx.incfile ) then
-		'' Close it
-		hEmitSTABS( STAB_TYPE_EINCL, "", 0, 0 )
+   '' Already handling the correct name
+   if( incfile = ctx.incfile ) Then
+      exit sub
+   end If
+         
+   emitSECTION( IR_SECTION_CODE, 0 )
+   lname = *symbUniqueLabel( )
+   hEmitSTABS( STAB_TYPE_SOL, incfile, 0, 0, lname )
+   hLABEL( lname )
 
-		'' "Return" to the main filename, if no new include file block
-		'' will be opened
-		if( incfile = NULL ) then
-			emitSECTION( IR_SECTION_CODE, 0 )
-			lname = *symbUniqueLabel( )
-			hEmitSTABS( STAB_TYPE_SOL, ctx.filename, 0, 0, lname )
-			hLABEL( lname )
-		end if
-	end if
-
-	ctx.incfile = incfile
-
-	'' Open new include file block if needed
-	if( incfile ) then
-		hEmitSTABS( STAB_TYPE_BINCL, incfile, 0, 0 )
-		emitSECTION( IR_SECTION_CODE, 0 )
-		lname = *symbUniqueLabel( )
-		hEmitSTABS( STAB_TYPE_SOL, incfile, 0, 0, lname )
-		hLABEL( lname )
-	end if
+   ctx.incfile = incfile
 end sub

--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -214,11 +214,7 @@ sub edbgEmitHeader( byval filename as zstring ptr )
 	ctx.typecnt 	= 1
 	ctx.label 		= NULL
 	ctx.incfile 	= NULL
-   #If defined( __FB_WIN32__ ) or defined( __FB_DOS__ )
-      ctx.filename   = UCase(*filename)
-   #Else
-      ctx.filename   = *filename
-   #EndIf
+	ctx.filename   = *filename
 
 	'' emit source file name
 	lname = *symbUniqueLabel( )
@@ -1021,22 +1017,22 @@ end sub
 sub edbgInclude( byval incfile as zstring ptr )
 	dim as string lname
 
-   '' incfile is the new include file or main file name
+	'' incfile is the new include file or main file name
 
-   '' coming from _close incfile is null so no real need to change
-   If( incfile = NULL )Then
-      Exit Sub
-   EndIf
+	'' coming from _close incfile is null so no real need to change
+	If( incfile = NULL )Then
+		Exit Sub
+	EndIf
 
-   '' Already handling the correct name
-   if( incfile = ctx.incfile ) Then
-      exit sub
-   end If
-         
-   emitSECTION( IR_SECTION_CODE, 0 )
-   lname = *symbUniqueLabel( )
-   hEmitSTABS( STAB_TYPE_SOL, incfile, 0, 0, lname )
-   hLABEL( lname )
+	'' Already handling the correct name
+	if( incfile = ctx.incfile ) Then
+		exit sub
+	end If
 
-   ctx.incfile = incfile
+	emitSECTION( IR_SECTION_CODE, 0 )
+	lname = *symbUniqueLabel( )
+	hEmitSTABS( STAB_TYPE_SOL, incfile, 0, 0, lname )
+	hLABEL( lname )
+
+	ctx.incfile = incfile
 end sub


### PR DESCRIPTION
This is an extension to pull request #96 based on additional patch from SARG.

Original discussion at [Bug fix for debugging lines inside include files](https://www.freebasic.net/forum/viewtopic.php?t=26863)

* BINCL/EINCL appears to be intended to be used when the STAB type information is emitted for full headers.  fbc doesn't do this, it only emits the type information for types that are actually used.  In that sense, we are already emitting the least amount of type information possible.
* therefore BINCL/EINCL tags are removed as they were previously used in a way that was never intended by the STAB format

I have a feeling that this is not the last we have seen of the work on this area of the compiler.  However, I think this update gets us closer to the changes needed.
