### PR TITLE
fbc: sf.net #699: fix new[0] causing infinite loop when calling constructor/destructor list

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -73,6 +73,7 @@ Version 1.06.0
 - #801: *@(expr) solved to (expr) did not cleanly remove null ptr checks allowing invalid datatype assignment with -exx.  *PTRCHK(@expr) solves to (expr).
 - #880: Overload binary operators now support covariant arguments, overloaded procedure resolution changed especially with respect to CONST and non-CONST parameters
 - Fix for debugging lines in include files but not in procedures.  Filename debugging information added for module level statements in included files.
+- #699: fix new[0] causing infinite loop when calling constructor/destructor list
 
 
 Version 1.05.0

--- a/src/compiler/ast-helper.bas
+++ b/src/compiler/ast-helper.bas
@@ -288,8 +288,8 @@ end function
 ''
 ''     CNT = INIVALUE
 ''     WHILE( CNT )
-''        CNT -= 1
 ''        <user code>
+''        CNT -= 1
 ''     WEND
 
 function astBuildWhileCounterBegin _

--- a/src/compiler/ast-helper.bas
+++ b/src/compiler/ast-helper.bas
@@ -284,6 +284,70 @@ end function
 '' loops
 ''
 
+'' While Counter:
+''
+''     CNT = INIVALUE
+''     WHILE( CNT )
+''        CNT -= 1
+''        <user code>
+''     WEND
+
+function astBuildWhileCounterBegin _
+	( _
+		byval tree as ASTNODE ptr, _
+		byval cnt as FBSYMBOL ptr, _
+		byval label as FBSYMBOL ptr, _
+		byval exitlabel as FBSYMBOL ptr, _
+		byval initexpr as ASTNODE ptr, _
+		byval flush_label as integer _
+	) as ASTNODE ptr
+
+	'' counter = initvalue
+	tree = astNewLINK( tree, astBuildVarAssign( cnt, initexpr ) )
+
+	'' do
+	tree = astNewLINK( tree, astNewLABEL( label, flush_label ) )
+
+	'' if( counter = 0 ) then
+	''     goto exitlabel
+	'' end if
+	tree = astNewLINK( tree, _
+		astBuildBranch( _
+			astNewBOP( AST_OP_EQ, astNewVAR( cnt ), astNewCONSTi( 0 ) ), _
+			exitlabel, TRUE ) )
+
+	function = tree
+end function
+
+function astBuildWhileCounterEnd _
+	( _
+		byval tree as ASTNODE ptr, _
+		byval cnt as FBSYMBOL ptr, _
+		byval label as FBSYMBOL ptr, _
+		byval exitlabel as FBSYMBOL ptr, _
+		byval flush_label as integer _
+	) as ASTNODE ptr
+
+	'' counter -= 1
+	tree = astNewLINK( tree, astBuildVarInc( cnt, -1 ) )
+
+	'' goto label
+	tree = astNewLINK( tree, astNewBranch( AST_OP_JMP, label ) )
+
+	'' loop
+	tree = astNewLINK( tree, astNewLABEL( exitlabel, flush_label ) )
+
+	function = tree
+end function
+
+'' For: 
+''
+''     CNT = INIVALUE
+''     DO
+''         <user code>
+''         CNT += 1
+''     LOOP UNTIL CNT=ENDVALUE
+
 function astBuildForBegin _
 	( _
 		byval tree as ASTNODE ptr, _

--- a/src/compiler/ast-node-mem.bas
+++ b/src/compiler/ast-node-mem.bas
@@ -63,7 +63,7 @@ private function hCallCtorList _
     dim as FBSYMBOL ptr cnt = any, label = any, iter = any
     dim as ASTNODE ptr tree = any
 
-	cnt = symbAddTempVar( FB_DATATYPE_INTEGER )
+	cnt = symbAddTempVar( FB_DATATYPE_UINT )
 	label = symbAddLabel( NULL )
 	iter = symbAddTempVar( typeAddrOf( dtype ), subtype )
 
@@ -199,7 +199,7 @@ function astBuildNewOp _
 		if( save_elmts ) then
 			'' length + sizeof( integer )   (to store the vector size)
 			lenexpr = astNewBOP( AST_OP_ADD, lenexpr, _
-					astNewCONSTi( typeGetSize( FB_DATATYPE_INTEGER ), FB_DATATYPE_UINT ) )
+					astNewCONSTi( typeGetSize( FB_DATATYPE_UINT ), FB_DATATYPE_UINT ) )
 		end if
 
 		newexpr = rtlMemNewOp( op, lenexpr, dtype, subtype )
@@ -216,15 +216,15 @@ function astBuildNewOp _
 		'' *tempptr = elements
 		tree = astNewLINK( tree, _
 			astNewASSIGN( _
-				astNewDEREF( astNewVAR( tmp, , typeAddrOf( FB_DATATYPE_INTEGER ) ) ), _
+				astNewDEREF( astNewVAR( tmp, , typeAddrOf( FB_DATATYPE_UINT ) ) ), _
 				hElements( elementsexpr, elementstreecount ), _
 				AST_OPOPT_ISINI ) )
 
-		'' tempptr += len( integer )
+		'' tempptr += len( uinteger )
 		tree = astNewLINK( tree, _
 			astNewSelfBOP( AST_OP_ADD_SELF, _
 				astNewVAR( tmp, , typeAddrOf( FB_DATATYPE_VOID ) ), _
-				astNewCONSTi( typeGetSize( FB_DATATYPE_INTEGER ) ), _
+				astNewCONSTi( typeGetSize( FB_DATATYPE_UINT ) ), _
 				NULL ) )
 	end if
 
@@ -271,15 +271,15 @@ private function hCallDtorList( byval ptrexpr as ASTNODE ptr ) as ASTNODE ptr
 
 	'' DELETE[]'s counter is at: cast(integer ptr, vector)[-1]
 
-	'' elmts = *cast( integer ptr, cast( any ptr, vector ) + -sizeof( integer ) )
+	'' elmts = *cast( uinteger ptr, cast( any ptr, vector ) + -sizeof( uinteger ) )
 	'' (using AST_CONVOPT_DONTCHKPTR to support derived UDT pointers)
 	tree = astBuildVarAssign( _
 		elmts, _
 		astNewDEREF( _
-			astNewCONV( typeAddrOf( FB_DATATYPE_INTEGER ), NULL, _
+			astNewCONV( typeAddrOf( FB_DATATYPE_UINT ), NULL, _
 				astNewBOP( AST_OP_ADD, _
 					astCloneTree( ptrexpr ), _
-					astNewCONSTi( -typeGetSize( FB_DATATYPE_INTEGER ) ) ), _
+					astNewCONSTi( -typeGetSize( FB_DATATYPE_UINT ) ) ), _
 				AST_CONVOPT_DONTCHKPTR ) ), _
 		AST_OPOPT_ISINI )
 

--- a/src/compiler/ast.bi
+++ b/src/compiler/ast.bi
@@ -1174,6 +1174,25 @@ declare function astBuildDtorCall _
 		byval ignore_virtual as integer = FALSE _
 	) as ASTNODE ptr
 
+declare function astBuildWhileCounterBegin _
+	( _
+		byval tree as ASTNODE ptr, _
+		byval cnt as FBSYMBOL ptr, _
+		byval label as FBSYMBOL ptr, _
+		byval exitlabel as FBSYMBOL ptr, _
+		byval initexpr as ASTNODE ptr, _
+		byval flush_label as integer = TRUE _
+	) as ASTNODE ptr
+
+declare function astBuildWhileCounterEnd _
+	( _
+		byval tree as ASTNODE ptr, _
+		byval cnt as FBSYMBOL ptr, _
+		byval label as FBSYMBOL ptr, _
+		byval exitlabel as FBSYMBOL ptr, _
+		byval flush_label as integer = TRUE _
+	) as ASTNODE ptr
+
 declare function astBuildForBegin _
 	( _
 		byval tree as ASTNODE ptr, _

--- a/src/compiler/parser-quirk-mem.bas
+++ b/src/compiler/parser-quirk-mem.bas
@@ -114,8 +114,14 @@ function cOperatorNew( ) as ASTNODE ptr
 	if( elementsexpr = NULL ) then
 		elementsexpr = astNewCONSTi( 1, FB_DATATYPE_UINT )
 	else
-		'' hack(?): make sure it's a uinteger, otherwise it may crash later, fixes bug #2533376 (counting_pine)
-		elementsexpr = astNewCONV( FB_DATATYPE_UINT, NULL, elementsexpr )
+		'' Constant?
+		if( astIsCONST( elementsexpr ) ) then
+			'' check at compile time
+			elementsexpr = astNewCONSTi( cConstIntExprRanged( elementsexpr, FB_DATATYPE_UINT ), FB_DATATYPE_UINT )
+		else
+			'' make sure it's a uinteger, otherwise it may crash later, fixes bug #2533376 (counting_pine)
+			elementsexpr = astNewCONV( FB_DATATYPE_UINT, NULL, elementsexpr, AST_CONVOPT_SIGNCONV )
+		end if
 		if( elementsexpr = NULL ) then
 			errReport( FB_ERRMSG_TYPEMISMATCH, TRUE )
 			elementsexpr = astNewCONSTi( 1, FB_DATATYPE_UINT )

--- a/tests/pointers/new-delete.bas
+++ b/tests/pointers/new-delete.bas
@@ -404,24 +404,29 @@ SUITE( fbc_tests.pointers.new_delete )
 		end type
 
 		dim shared as integer T2_ctor_count = 0
+		dim shared as integer T2_ctor_count_x = 0
 		type T2
 			as integer i
 			declare constructor( )
 		end type
 		constructor T2( )
 			T2_ctor_count += 1
+			T2_ctor_count_x += 1
 		end constructor
 
 		dim shared as integer T3_dtor_count = 0
+		dim shared as integer T3_dtor_count_x = 0
 		type T3
 			as integer i
 			declare destructor( )
 		end type
 		destructor T3( )
 			T3_dtor_count += 1
+			T3_dtor_count_x += 1
 		end destructor
 
 		dim shared as integer T4_ctor_count = 0, T4_dtor_count = 0
+		dim shared as integer T4_ctor_count_x = 0, T4_dtor_count_x = 0
 		type T4
 			as integer i
 			declare constructor( )
@@ -429,9 +434,11 @@ SUITE( fbc_tests.pointers.new_delete )
 		end type
 		constructor T4( )
 			T4_ctor_count += 1
+			T4_ctor_count_x += 1
 		end constructor
 		destructor T4( )
 			T4_dtor_count += 1
+			T4_dtor_count_x += 1
 		end destructor
 
 		TEST( default )
@@ -558,6 +565,18 @@ SUITE( fbc_tests.pointers.new_delete )
 			end scope
 
 			scope
+				var p = new T1[0]
+				CU_ASSERT( p <> NULL )
+				delete[] p
+			end scope
+
+			scope
+				var p = new T1[1]
+				CU_ASSERT( p[0].i = 0 )
+				delete[] p
+			end scope
+
+			scope
 				var p = new T1[2]
 				CU_ASSERT( p[0].i = 0 )
 				CU_ASSERT( p[1].i = 0 )
@@ -572,6 +591,14 @@ SUITE( fbc_tests.pointers.new_delete )
 				delete[] p
 			end scope
 
+			for n as integer = 0 to 2
+				var p = new T1[n]
+				CU_ASSERT( p <> NULL )
+				delete[] p
+			next
+
+			'' new T2[N]
+			CU_ASSERT( T2_ctor_count_x = 0 )
 			scope
 				CU_ASSERT( T2_ctor_count = 0 )
 				var p = new T2[2]
@@ -580,12 +607,82 @@ SUITE( fbc_tests.pointers.new_delete )
 			end scope
 
 			scope
+				T2_ctor_count_x = 0
+				var p = new T2[0]
+				CU_ASSERT( p <> NULL )
+				CU_ASSERT( T2_ctor_count_x = 0 )
+				delete[] p
+			end scope
+
+			scope
+				T2_ctor_count_x = 0
+				var p = new T2[1]
+				CU_ASSERT( T2_ctor_count_x = 1 )
+				delete[] p
+			end scope
+
+			scope
+				T2_ctor_count_x = 0
+				var p = new T2[2]
+				CU_ASSERT( T2_ctor_count_x = 2 )
+				delete[] p
+			end scope
+
+			for n as integer = 0 to 2
+				T2_ctor_count_x = 0
+				var p = new T2[n]
+				CU_ASSERT( p <> NULL )
+				CU_ASSERT( T2_ctor_count_x = n )
+				delete[] p
+			next
+
+			'' new T3[N]
+			CU_ASSERT( T3_dtor_count_x = 0 )
+
+			scope
 				CU_ASSERT( T3_dtor_count = 0 )
 				var p = new T3[2]
 				CU_ASSERT( T3_dtor_count = 0 )
 				delete[] p
 				CU_ASSERT( T3_dtor_count = 2 )
 			end scope
+
+			scope
+				T3_dtor_count_x = 0
+				var p = new T3[0]
+				CU_ASSERT( p <> NULL )
+				CU_ASSERT( T3_dtor_count_x = 0 )
+				delete[] p
+				CU_ASSERT( T3_dtor_count_x = 0 )
+			end scope
+
+			scope
+				T3_dtor_count_x = 0
+				var p = new T3[1]
+				CU_ASSERT( T3_dtor_count_x = 0 )
+				delete[] p
+				CU_ASSERT( T3_dtor_count_x = 1 )
+			end scope
+
+			scope
+				T3_dtor_count_x = 0
+				var p = new T3[2]
+				CU_ASSERT( T3_dtor_count_x = 0 )
+				delete[] p
+				CU_ASSERT( T3_dtor_count_x = 2 )
+			end scope
+
+			for n as integer = 0 to 2
+				T3_dtor_count_x = 0
+				var p = new T3[n]
+				CU_ASSERT( p <> NULL )
+				CU_ASSERT( T3_dtor_count_x = 0 )
+				delete[] p
+				CU_ASSERT( T3_dtor_count_x = n )
+			next
+
+			'' new T4[N]
+			CU_ASSERT( T4_ctor_count_x = 0 )
 
 			scope
 				CU_ASSERT( T4_ctor_count = 0 )
@@ -597,6 +694,53 @@ SUITE( fbc_tests.pointers.new_delete )
 				CU_ASSERT( T4_ctor_count = 2 )
 				CU_ASSERT( T4_dtor_count = 2 )
 			end scope
+
+			scope
+				T4_ctor_count_x = 0
+				T4_dtor_count_x = 0
+				var p = new T4[0]
+				CU_ASSERT( p <> NULL )
+				CU_ASSERT( T4_ctor_count_x = 0 )
+				CU_ASSERT( T4_dtor_count_x = 0 )
+				delete[] p
+				CU_ASSERT( T4_ctor_count_x = 0 )
+				CU_ASSERT( T4_dtor_count_x = 0 )
+			end scope
+
+			scope
+				T4_ctor_count_x = 0
+				T4_dtor_count_x = 0
+				var p = new T4[1]
+				CU_ASSERT( T4_ctor_count_x = 1 )
+				CU_ASSERT( T4_dtor_count_x = 0 )
+				delete[] p
+				CU_ASSERT( T4_ctor_count_x = 1 )
+				CU_ASSERT( T4_dtor_count_x = 1 )
+			end scope
+
+			scope
+				T4_ctor_count_x = 0
+				T4_dtor_count_x = 0
+				var p = new T4[2]
+				CU_ASSERT( T4_ctor_count_x = 2 )
+				CU_ASSERT( T4_dtor_count_x = 0 )
+				delete[] p
+				CU_ASSERT( T4_ctor_count_x = 2 )
+				CU_ASSERT( T4_dtor_count_x = 2 )
+			end scope
+
+			for n as integer = 0 to 2
+				T4_ctor_count_x = 0
+				T4_dtor_count_x = 0
+				var p = new T4[n]
+				CU_ASSERT( p <> NULL )
+				CU_ASSERT( T4_ctor_count_x = n )
+				CU_ASSERT( T4_dtor_count_x = 0 )
+				delete[] p
+				CU_ASSERT( T4_ctor_count_x = n )
+				CU_ASSERT( T4_dtor_count_x = n )
+			next
+
 		END_TEST
 	END_TEST_GROUP
 


### PR DESCRIPTION
This fixes some, but not all, of the remaining issues with [Bug on the New[] operator when attempting to allocate a negative number of elements ](https://sourceforge.net/p/fbc/bugs/699/)

- new[N] expects N to be unsigned, so internally, use the UINT type for this expression
- for new[const N], because const N is expected to be unsigned, added a warning if constant is signed and out of range (negative).  This is not fully correct; see below
- new[expr] was causing infinite loop when expr=0 because of the previous For/Next constructor iterator always starts with at least one iteration.  And 'expr' may be an expression that is only known at run-time.  Solved this by adding a While(CNT) iterator for ctor/dtor loop.
- if new[expr] fails (NULL ptr returned), added IF/ENDIF to prevent the constructor iterator loop from executing on a NULL pointer.  NULL pointer is returned from the new[] expression instead.

The last issue, not solved is the limits on NEW T[N]:
* N is expected to be unsigned integer
* practically though, (N * sizeof(T) + sizeof(integer)) should not be allowed to overflow unsigned integer otherwise we get a bad memory allocation
* misleading is the specific test case of new T[-1] where sizeof(T)=sizeof(integer), -1 is converted to UINT, and the allocation request ends up being zero (0) bytes.  That's incidental only, because, for example in 32-bit the allocation is (&hffffffff * 4 + 4) which is same case of overflow as mentioned above.
