### PR TITLE
gfxlib: palette [get] using

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -74,6 +74,7 @@ Version 1.06.0
 - #880: Overload binary operators now support covariant arguments, overloaded procedure resolution changed especially with respect to CONST and non-CONST parameters
 - Fix for debugging lines in include files but not in procedures.  Filename debugging information added for module level statements in included files.
 - #699: fix new[0] causing infinite loop when calling constructor/destructor list
+- #883: when mapping 32 & 64 bit functions for PALETTE [GET] USING, check the data type pointed to and choose one of LONG PTR, LONGINT PTR, INTEGER PTR
 
 
 Version 1.05.0

--- a/src/compiler/parser-quirk-gfx.bas
+++ b/src/compiler/parser-quirk-gfx.bas
@@ -879,7 +879,7 @@ end function
 ''
 function cGfxPalette as integer
     dim as ASTNODE ptr arrayexpr, attexpr, rexpr, gexpr, bexpr
-	dim as integer isget
+	dim as integer isget, dptrsize
 
 	function = FALSE
 
@@ -892,7 +892,19 @@ function cGfxPalette as integer
 			errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
 			exit function
 		end if
-		function = rtlGfxPaletteUsing( arrayexpr, isget )
+
+		'' Choose either the 32 or 64-bit version
+
+		assert( typeIsPtr( astGetDataType( arrayexpr ) ) )
+
+		'' get the size of the data pointed to
+		dptrsize = typeGetSize( typeDeref( astGetDataType( arrayexpr ) ) )
+
+		if( dptrsize <> typeGetSize( FB_DATATYPE_LONG ) and dptrsize <> typeGetSize( FB_DATATYPE_LONGINT ) ) then
+			dptrsize = typeGetSize( FB_DATATYPE_INTEGER )
+		end if
+
+		function = rtlGfxPaletteUsing( arrayexpr, isget, (dptrsize = typeGetSize( FB_DATATYPE_LONGINT )) )
 	else
 		attexpr = NULL
 		rexpr = NULL

--- a/src/compiler/rtl-gfx.bas
+++ b/src/compiler/rtl-gfx.bas
@@ -2015,7 +2015,8 @@ end function
 function rtlGfxPaletteUsing  _
 	( _
 		byval arrayexpr as ASTNODE ptr, _
-		byval isget as integer _
+		byval isget as integer, _
+		byval is64bit as integer _
 	) as integer
 
     dim as ASTNODE ptr proc = any
@@ -2023,7 +2024,7 @@ function rtlGfxPaletteUsing  _
 
 	function = FALSE
 
-	if( typeGetSize( astGetDataType( arrayexpr ) ) = 8 ) then
+	if( is64bit ) then
 		if( isget ) then
 			f = PROCLOOKUP( GFXPALETTEGETUSING64 )
 		else

--- a/src/compiler/rtl.bi
+++ b/src/compiler/rtl.bi
@@ -1655,7 +1655,8 @@ declare function rtlGfxPalette _
 declare function rtlGfxPaletteUsing _
 	( _
 		byval arrayexpr as ASTNODE ptr, _
-		byval isget as integer _
+		byval isget as integer, _
+		byval is64bit as integer _
 	) as integer
 
 declare function rtlGfxPut _

--- a/tests/gfx/image-expr.bas
+++ b/tests/gfx/image-expr.bas
@@ -125,7 +125,7 @@ SUITE( fbc_tests.gfx.image_expr )
 		CU_ASSERT( hImageIsFilledWithColor( a, rgb(255,0,0) ) )
 		hResetImageToBlack( a )
 
-		'' TODO: Palette Using
+		'' Palette Get Using is in tests/gfx/palette.bas
 
 		CU_ASSERT( hImageIsFilledWithColor( b, rgb(255,0,0) ) )
 		put a, (0, 0), b, pset
@@ -212,6 +212,12 @@ SUITE( fbc_tests.gfx.image_expr )
 			'' @array(0)
 			line @array(0), (0, 0) - (SCREEN_W-1, SCREEN_H-1), rgb(255,0,0), bf
 			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(255,0,0) ) )
+
+			'' byref pointer = @array(0)
+			var array0idx = @array(0)
+			var byref array0 = array0idx
+			line array0, (0, 0) - (SCREEN_W-1, SCREEN_H-1), rgb(0,0,255), bf
+			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,0,255) ) )
 		end scope
 
 		'' array on heap:
@@ -235,6 +241,12 @@ SUITE( fbc_tests.gfx.image_expr )
 			'' @array(0)
 			line @array(0), (0, 0) - (SCREEN_W-1, SCREEN_H-1), rgb(255,0,0), bf
 			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(255,0,0) ) )
+
+			'' byref pointer = @array(0)
+			var array0idx = @array(0)
+			var byref array0 = array0idx
+			line array0, (0, 0) - (SCREEN_W-1, SCREEN_H-1), rgb(0,0,255), bf
+			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,0,255) ) )
 		end scope
 
 		'' dynamic array, descriptor on stack:
@@ -258,6 +270,12 @@ SUITE( fbc_tests.gfx.image_expr )
 			'' @array(0)
 			line @array(0), (0, 0) - (SCREEN_W-1, SCREEN_H-1), rgb(255,0,0), bf
 			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(255,0,0) ) )
+
+			'' byref pointer = @array(0)
+			var array0idx = @array(0)
+			var byref array0 = array0idx
+			line array0, (0, 0) - (SCREEN_W-1, SCREEN_H-1), rgb(0,0,255), bf
+			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,0,255) ) )
 		end scope
 
 		'' array field:
@@ -302,6 +320,11 @@ SUITE( fbc_tests.gfx.image_expr )
 
 			'' GET into pointer from array access
 			get (0, 0) - (SCREEN_W-1, SCREEN_H-1), array(0)
+			CU_ASSERT( hImageIsFilledWithColor( array(0), rgb(0,255,0) ) )
+
+			'' GET into pointer from byref array access
+			var byref array0 = array(0)
+			get (0, 0) - (SCREEN_W-1, SCREEN_H-1), array0
 			CU_ASSERT( hImageIsFilledWithColor( array(0), rgb(0,255,0) ) )
 
 			imagedestroy( array(0) )
@@ -365,6 +388,12 @@ SUITE( fbc_tests.gfx.image_expr )
 		'' @array(0)
 		get (0, 0) - (SCREEN_W-1, SCREEN_H-1), @array(0)
 		CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,255,0) ) )
+
+		'' byref pointer = @array(0)
+		var array0idx = @array(0)
+		var byref array0 = array0idx
+		get (0, 0) - (SCREEN_W-1, SCREEN_H-1), array0
+		CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,255,0) ) )
 	end sub
 
 	private sub hTestUdtWithMatchingCastArrayTarget( )
@@ -376,9 +405,20 @@ SUITE( fbc_tests.gfx.image_expr )
 		get (0, 0) - (SCREEN_W-1, SCREEN_H-1), array
 		CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,255,0) ) )
 
+		'' array(0)
+		'' not tested, cast() is known to be used in this case
+
 		'' @array(0)
 		get (0, 0) - (SCREEN_W-1, SCREEN_H-1), @array(0)
 		CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,255,0) ) )
+
+		'' byref pointer = @array(0)
+		var array0idx = @array(0)
+		var byref array0 = array0idx
+		get (0, 0) - (SCREEN_W-1, SCREEN_H-1), array0
+		CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,255,0) ) )
+
+	
 	end sub
 
 	'' GET from screen into some array...
@@ -430,6 +470,15 @@ SUITE( fbc_tests.gfx.image_expr )
 		scope
 			dim array(0 to IMAGE_BUFFER_SIZE-1) as ubyte
 			get (0, 0) - (SCREEN_W-1, SCREEN_H-1), @array(0)
+			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,255,0) ) )
+		end scope
+
+		'' byref pointer = @array(0)
+		scope
+			dim array(0 to IMAGE_BUFFER_SIZE-1) as ubyte
+			var array0idx = @array(0)
+			var byref array0 = array0idx
+			get (0, 0) - (SCREEN_W-1, SCREEN_H-1), array0
 			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,255,0) ) )
 		end scope
 
@@ -537,6 +586,15 @@ SUITE( fbc_tests.gfx.image_expr )
 		scope
 			dim array(0 to (IMAGE_BUFFER_SIZE\4)-1) as ulong
 			get (0, 0) - (SCREEN_W-1, SCREEN_H-1), array(0)
+			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,255,0) ) )
+		end scope
+
+		'' byref pointer = @array(0)
+		scope
+			dim array(0 to (IMAGE_BUFFER_SIZE\4)-1) as ulong
+			var array0idx = @array(0)
+			var byref array0 = array0idx
+			get (0, 0) - (SCREEN_W-1, SCREEN_H-1), array0
 			CU_ASSERT( hImageIsFilledWithColor( @array(0), rgb(0,255,0) ) )
 		end scope
 

--- a/tests/gfx/palette.bas
+++ b/tests/gfx/palette.bas
@@ -1,0 +1,266 @@
+#include "fbcunit.bi"
+#include once "fbgfx.bi"
+
+SUITE( fbc_tests.gfx.palette_ )
+
+	const SCREEN_W = 16
+	const SCREEN_H = 16
+
+	'' Tests:
+	''   PALETTE GET index, qb_value
+	''   PALETTE GET index, r, g, b
+	''   PALETTE GET USING array
+	''   PALETTE GET USING array(index)
+	''   PALETTE GET USING @array(index)
+	''   PALETTE GET USING pointer
+	''   PALETTE GET USING UDT
+	''   PALETTE GET USING byref-variable
+	
+	'' The palette values we are comparing with come from gfxlib.   If the fbgfx default
+	'' palette ever changes, these values must be updated to match.
+
+	dim shared def_qb_pal1(0 to ...) as long = _
+		{ _
+			&h00000000, &h002A0000, &h00002A00, &h002A2A00, _
+			&h0000002A, &h002A002A, &h0000152A, &h002A2A2A, _
+			&h00151515, &h003F1515, &h00153F15, &h003F3F15, _
+			&h0015153F, &h003F153F, &h00153F3F, &h003F3F3F _
+		}
+
+	type RGBVALUE
+		r as integer
+		g as integer
+		b as integer
+	end type
+
+	dim shared def_rgb_pal1(0 to ...) as RGBVALUE = _
+		{ _
+			(&h00, &h00, &h00), (&h00, &h00, &hAA), (&h00, &hAA, &h00), (&h00, &hAA, &hAA), _
+			(&hAA, &h00, &h00), (&hAA, &h00, &hAA), (&hAA, &h55, &h00), (&hAA, &hAA, &hAA), _
+			(&h55, &h55, &h55), (&h55, &h55, &hFF), (&h55, &hFF, &h55), (&h55, &hFF, &hFF), _
+			(&hFF, &h55, &h55), (&hFF, &h55, &hFF), (&hFF, &hFF, &h55), (&hFF, &hFF, &hFF) _
+		}
+
+	sub hInitNullGfx()
+		'' 8-bit screen mode
+		CU_ASSERT( screenres( SCREEN_W, SCREEN_H, 8, , fb.GFX_NULL ) = 0 )
+	end sub
+
+	#macro assert_pal( expr )
+		for i as integer = 0 to 15
+			CU_ASSERT_EQUAL( expr, def_qb_pal1(i) )
+		next
+	#endmacro
+
+	#macro do_test( T, expr1 )
+		scope
+			dim p(0 To 255) As T
+			palette get using expr1
+			assert_pal( p(i) )
+		end scope
+	#endmacro
+
+	#macro do_test_at_N( N, T, expr1 )
+		scope
+			dim p(N To N+255) As T
+			palette get using expr1
+			assert_pal( p(i+N) )
+		end scope
+	#endmacro
+
+	TEST( paletteGetArrayByName )
+		hInitNullGfx()
+		do_test( long, p )
+		do_test( ulong, p )
+		do_test( integer, p )
+		do_test( uinteger, p )
+		do_test( longint, p )
+		do_test( ulongint, p )
+
+		do_test_at_N( 5, long, p )
+		do_test_at_N( 5, ulong, p )
+		do_test_at_N( 5, integer, p )
+		do_test_at_N( 5, uinteger, p )
+		do_test_at_N( 5, longint, p )
+		do_test_at_N( 5, ulongint, p )
+	END_TEST
+
+	TEST( paletteGetArrayByIndex )
+		hInitNullGfx()
+		do_test( integer, p(0) )
+		do_test( uinteger, p(0) )
+		do_test( long, p(0) )
+		do_test( ulong, p(0) )
+		do_test( longint, p(0) )
+		do_test( ulongint, p(0) )
+
+		do_test_at_N( 5, integer, p(5) )
+		do_test_at_N( 5, uinteger, p(5) )
+		do_test_at_N( 5, long, p(5) )
+		do_test_at_N( 5, ulong, p(5) )
+		do_test_at_N( 5, longint, p(5) )
+		do_test_at_N( 5, ulongint, p(5) )
+	END_TEST
+
+	TEST( paletteGetPtrToArrayIndex )
+		hInitNullGfx()
+		do_test( integer, @p(0) )
+		do_test( uinteger, @p(0) )
+		do_test( long, @p(0) )
+		do_test( ulong, @p(0) )
+		do_test( longint, @p(0) )
+		do_test( ulongint, @p(0) )
+		do_test( integer, cast(any ptr, @p(0) ) )
+
+		do_test_at_N( 5, integer, @p(5) )
+		do_test_at_N( 5, uinteger, @p(5) )
+		do_test_at_N( 5, long, @p(5) )
+		do_test_at_N( 5, ulong, @p(5) )
+		do_test_at_N( 5, longint, @p(5) )
+		do_test_at_N( 5, ulongint, @p(5) )
+		do_test_at_N( 5, integer, cast(any ptr, @p(5) ) )
+	END_TEST
+
+	#macro do_test_ptr( T, expr1 )
+		scope
+			dim p(0 To 255) As T
+			dim x as T ptr = @p(0)
+			palette get using expr1
+			assert_pal( p(i) )
+		end scope
+	#endmacro
+
+	TEST( paletteGetPtrToArray )
+		hInitNullGfx()
+
+		do_test_ptr( long, x )
+		do_test_ptr( ulong, x )
+		do_test_ptr( integer, x )
+		do_test_ptr( uinteger, x )
+		do_test_ptr( longint, x )
+		do_test_ptr( ulongint, x )
+
+		do_test_ptr( long, @x[0] )
+		do_test_ptr( ulong, @x[0] )
+		do_test_ptr( integer, @x[0] )
+		do_test_ptr( uinteger, @x[0] )
+		do_test_ptr( longint, @x[0] )
+		do_test_ptr( ulongint, @x[0] )
+
+	END_TEST
+
+	#macro defn_PAL_UDT( T )
+
+		type PAL_##T
+			pal as T ptr
+			declare constructor
+			declare destructor
+			declare operator cast() as T ptr
+			declare operator []( index as integer ) as T
+		end type
+
+		constructor PAL_##T
+			pal = new T[256] 
+		end constructor
+
+		destructor PAL_##t
+			delete[] pal
+		end destructor
+
+		operator PAL_##T.cast() as T ptr
+			operator = pal
+		end operator
+
+		operator PAL_##T.[]( index as integer ) as T
+			operator = pal[index]
+		end operator
+
+	#endmacro
+
+	defn_PAL_UDT( long )
+	defn_PAL_UDT( ulong )
+	defn_PAL_UDT( integer )
+	defn_PAL_UDT( uinteger )
+	defn_PAL_UDT( longint )
+	defn_PAL_UDT( ulongint )
+
+	#macro test_UDTptrCast( T )
+		scope
+			dim p as PAL_##T
+			palette get using p
+			for i as integer = 0 to 15
+				CU_ASSERT( p[i] = def_qb_pal1(i) )
+			next
+		end scope
+	#endmacro
+
+	TEST( paletteGetUDTPtr )
+		hInitNullGfx()
+		test_UDTptrCast( long )
+		test_UDTptrCast( ulong )
+		test_UDTptrCast( integer )
+		test_UDTptrCast( uinteger )
+		test_UDTptrCast( longint )
+		test_UDTptrCast( ulongint )
+	END_TEST
+
+	#macro test_qb_pal_value( T )
+		for i as integer = 0 to 15
+			dim value as T
+			palette get i, value
+			CU_ASSERT( value = def_qb_pal1(i) )
+		next
+	#endmacro
+
+	TEST( paletteGetQbValue )
+		hInitNullGfx()
+		test_qb_pal_value( long )
+		test_qb_pal_value( ulong )
+		test_qb_pal_value( integer )
+		test_qb_pal_value( uinteger )
+		test_qb_pal_value( longint )
+		test_qb_pal_value( ulongint )
+	END_TEST
+
+	#macro test_rgb_pal_value( T )
+		for i as integer = 0 to 15
+			dim as integer r, g, b
+			palette get i, r, g, b
+			CU_ASSERT( r = def_rgb_pal1(i).r )
+			CU_ASSERT( g = def_rgb_pal1(i).g )
+			CU_ASSERT( b = def_rgb_pal1(i).b )
+		next
+	#endmacro
+
+	TEST( paletteGetRgbValue )
+		hInitNullGfx()
+		test_rgb_pal_value( long )
+		test_rgb_pal_value( ulong )
+		test_rgb_pal_value( integer )
+		test_rgb_pal_value( uinteger )
+		test_rgb_pal_value( longint )
+		test_rgb_pal_value( ulongint )
+	END_TEST
+
+	#macro do_test_byref( T, expr1 )
+		scope
+			dim p(0 To 255) As T
+			dim byref x as T = p(0)
+			palette get using expr1
+			assert_pal( p(i) )
+		end scope
+	#endmacro
+
+	TEST( paletteGetByrefPointer )
+		hInitNullGfx()
+
+		do_test_byref( long, @x )
+		do_test_byref( ulong, @x )
+		do_test_byref( integer, @x )
+		do_test_byref( uinteger, @x )
+		do_test_byref( longint, @x )
+		do_test_byref( ulongint, @x )
+
+	END_TEST
+
+END_SUITE


### PR DESCRIPTION
- when mapping 32 & 64 bit functions for PALETTE [GET] USING, check the data type pointed to choose one of LONG PTR, LONGINT PTR, INTEGER PTR
- tests/gfx/palette.bas added to test PALETTE GET [USING]
- add tests for BYREF pointer variables for palettes and image buffers

sf.net bug report [#883 PALETTE [GET] USING failes using [u]long[int] types depending on platform ](https://sourceforge.net/p/fbc/bugs/883/)
fb.net forum discussion [FB palette array datatypes](https://www.freebasic.net/forum/viewtopic.php?t=26789)