### PR TITLE
Make Integer/Long mangling consistent on 32bit/64bit

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 1.06.0
 
 [changed]
+- Name mangling of Integer/Long parameters was reversed on 32bit to match 64bit, so the same FB and C++ code will be compatible on both 32bit and 64bit. Integer is mangled as C++ long (except on Win64), Long is mangled as C++ int.
 - Adjusted warning text for "mixed bool/nonbool operands" warning
 - test-suite uses libfbcunit for unit testing framework
 - SELECT CASE AS CONST respects data type and will show overflow warnings on out-of-range constants

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -336,53 +336,40 @@ function hMangleBuiltInType _
 		return @"8FBSTRING"
 	end if
 
-	if( fbIs64bit( ) ) then
-		'' By default on x86 we mangle INTEGER to "int", but on 64bit
-		'' our INTEGER becomes 64bit, while int stays 32bit, so we
-		'' really shouldn't use the same mangling in that case.
-		''
-		'' Mangling the 64bit INTEGER as "long long" would conflict
-		'' with the LONGINT mangling though (we cannot allow separate
-		'' INTEGER/LONGINT overloads in code but then generate the same
-		'' mangled id for them, the assembler/linker would complain).
-		''
-		'' Besides that, our LONG stays 32bit always, but "long" on
-		'' 64bit Linux changes to 64bit, so we shouldn't mangle LONG
-		'' to "long" in that case. It would still be possible on 64bit
-		'' Windows, because there "long" stays 32bit, but it seems best
-		'' to mangle LONG to "int" on 64bit consistently, since "int"
-		'' stays 32bit on both Linux and Windows.
-		''
-		'' That allows 64bit INTEGER to be mangled as 64bit long on
-		'' Linux & co, making GCC compatibility easier, it's only Win64
-		'' where we need a custom mangling.
-		''
-		'' Itanium C++ ABI compatible mangling of non-C++ built-in
-		'' types (vendor extended types):
+	''
+	'' Integer/Long mangling:
+	''
+	''           32bit        64bit
+	'' Integer   long         long (Unix) or INTEGER (Windows)
+	'' Long      int          int
+	'' LongInt   long long    long long
+	''
+	''  - Fundamental problem: FB and C++ types are different, an exact mapping
+	''    is impossible
+	''
+	''  - mangling should match the C/C++ binding recommendations, i.e. use Long
+	''    for int and Integer for things like ssize_t. On linux-x86_64 Integer
+	''    can be mangled as long, but on win64 the only 64bit integer type is
+	''    long long and that's already used for LongInt. So it seems that we have
+	''    to use a custom mangling for that case (INTEGER).
+	''
+	''  - 32bit fbc used to mangle Integer as int and Long as long, but to match
+	''    64bit fbc it was reversed, allowing the same FB and C++ code to work
+	''    together on both 32bit and 64bit.
+	''
+	if( fbIs64bit( ) and ((env.target.options and FB_TARGETOPT_UNIX) = 0) ) then
+		'' Windows 64bit
+		'' Itanium C++ ABI compatible mangling of non-C++ built-in types (vendor extended types):
 		''    u <length-of-id> <id>
-
-		if( env.target.options and FB_TARGETOPT_UNIX ) then
-			select case( dtype )
-			case FB_DATATYPE_INTEGER : return @"l"  '' long
-			case FB_DATATYPE_UINT    : return @"m"  '' unsigned long
-			end select
-		else
-			select case( dtype )
-			case FB_DATATYPE_INTEGER : add_abbrev = TRUE : return @"u7INTEGER"  '' seems like a good choice
-			case FB_DATATYPE_UINT    : add_abbrev = TRUE : return @"u8UINTEGER"
-			end select
-		end if
-
 		select case( dtype )
-		case FB_DATATYPE_LONG    : return @"i"  '' int
-		case FB_DATATYPE_ULONG   : return @"j"  '' unsigned int
+		case FB_DATATYPE_INTEGER : add_abbrev = TRUE : return @"u7INTEGER"  '' seems like a good choice
+		case FB_DATATYPE_UINT    : add_abbrev = TRUE : return @"u8UINTEGER"
 		end select
 	else
+		'' 32bit, Unix 64bit
 		select case( dtype )
-		case FB_DATATYPE_INTEGER : return @"i"  '' int
-		case FB_DATATYPE_UINT    : return @"j"  '' unsigned int
-		case FB_DATATYPE_LONG    : return @"l"  '' long
-		case FB_DATATYPE_ULONG   : return @"m"  '' unsigned long
+		case FB_DATATYPE_INTEGER : return @"l"  '' long
+		case FB_DATATYPE_UINT    : return @"m"  '' unsigned long
 		end select
 	end if
 
@@ -390,20 +377,20 @@ function hMangleBuiltInType _
 	{ _
 		@"v", _ '' void
 		@"b", _ '' boolean
-		@"a", _ '' byte (signed char)
-		@"h", _ '' ubyte (unsigned char)
+		@"a", _ '' Byte: signed char
+		@"h", _ '' UByte: unsigned char
 		@"c", _ '' char
 		@"s", _ '' short
 		@"t", _ '' ushort
 		@"w", _ '' wchar
-		NULL, _ '' integer
-		NULL, _ '' uinteger
+		NULL, _ '' Integer
+		NULL, _ '' UInteger
 		NULL, _ '' enum
-		NULL, _ '' long
-		NULL, _ '' ulong
-		@"x", _ '' longint (long long)
-		@"y", _ '' ulongint (unsigned long long)
-		@"f", _ '' single
+		@"i", _ '' Long: int
+		@"j", _ '' ULong: unsigned int
+		@"x", _ '' LongInt: long long
+		@"y", _ '' ULongInt: unsigned long long
+		@"f", _ '' Single: float
 		@"d", _ '' double
 		NULL, _ '' var-len string
 		NULL, _ '' fix-len string

--- a/tests/cpp/fbc-mangle.bas
+++ b/tests/cpp/fbc-mangle.bas
@@ -3,11 +3,8 @@
 '' test mapping of basic data types between fbc and g++
 '' with c++ name mangling
 
-#ifdef __FB_64BIT__
-
-	type cxxint as long
-	type cxxlongint as integer
-
+type cxxint as long
+type cxxlongint as integer
 	/' !!!
 		cxxlongint will currently fail on win64, fbc custom mangles INTEGER and there is 
 		no other data type that will return the "m" and "l" suffixes for c's long int.
@@ -16,14 +13,6 @@
 		change the overloading allowed for the c++ mangled names onlym what would have to
 		be added to fbc.
 	'/
-
-#else
-	
-	'' 32-bit
-	type cxxint as integer
-	type cxxlongint as long
-
-#endif
 
 extern "c++"
 

--- a/tests/namespace/cpp/fbmod.bas
+++ b/tests/namespace/cpp/fbmod.bas
@@ -1,17 +1,11 @@
 ' TEST_MODE : MULTI_MODULE_TEST
 
-#ifdef __FB_64BIT__
-	type cxxint as long
-#else
-	type cxxint as integer
-#endif
-
 '' simple
 
 extern "c++"
 	namespace cpp
-		declare function sum( byval a as cxxint, byval b as cxxint ) as cxxint
-		declare function dec( byval a as cxxint, byval b as cxxint ) as cxxint
+		declare function sum( byval a as long, byval b as long ) as long
+		declare function dec( byval a as long, byval b as long ) as long
 	end namespace
 end extern
 
@@ -23,8 +17,8 @@ end extern
 
 extern "c++"
 	namespace cpp.foo.bar
-		declare function sum( byval a as cxxint, byval b as cxxint ) as cxxint
-		declare function dec( byval a as cxxint, byval b as cxxint ) as cxxint
+		declare function sum( byval a as long, byval b as long ) as long
+		declare function dec( byval a as long, byval b as long ) as long
 	end namespace
 end extern
 
@@ -37,11 +31,11 @@ end extern
 extern "c++"
 	namespace cpp.foo.bar
 		type udt
-			v as cxxint
+			v as long
 		end type
 	
-		declare function sum_udt( byval a as udt ptr, byval b as udt ptr ) as cxxint
-		declare function dec_udt( byval a as udt ptr, byval b as udt ptr ) as cxxint
+		declare function sum_udt( byval a as udt ptr, byval b as udt ptr ) as long
+		declare function dec_udt( byval a as udt ptr, byval b as udt ptr ) as long
 	end namespace
 end extern
 
@@ -53,24 +47,24 @@ end extern
 extern "c++"
 	namespace cpp.foo.bar
 		type baz
-			v1 as cxxint
-			v2 as cxxint
+			v1 as long
+			v2 as long
 		end type
 	
 		declare function sum_fn( byval baz as baz ptr, _
-								 byval a as function cdecl(byval as baz ptr) as cxxint, _
-								 byval b as function cdecl(byval as baz ptr) as cxxint ) as cxxint
+								 byval a as function cdecl(byval as baz ptr) as long, _
+								 byval b as function cdecl(byval as baz ptr) as long ) as long
 		declare function dec_fn( byval baz as baz ptr, _
-								 byval a as function cdecl(byval as baz ptr) as cxxint, _
-								 byval b as function cdecl(byval as baz ptr) as cxxint ) as cxxint
+								 byval a as function cdecl(byval as baz ptr) as long, _
+								 byval b as function cdecl(byval as baz ptr) as long ) as long
 	end namespace
 end extern
 
-private function fun_v1 cdecl( byval baz as cpp.foo.bar.baz ptr) as cxxint
+private function fun_v1 cdecl( byval baz as cpp.foo.bar.baz ptr) as long
 	function = baz->v1
 end function
 
-private function fun_v2 cdecl ( byval baz as cpp.foo.bar.baz ptr) as cxxint
+private function fun_v2 cdecl ( byval baz as cpp.foo.bar.baz ptr) as long
 	function = baz->v2
 end function
 


### PR DESCRIPTION
Make Integer/Long mangling consistent on 32bit/64bit

```
                old          new
32bit, Integer  int          long [long]  (now consistent with 64bit)
32bit, Long     long         int          (now consistent with 64bit)
64bit, Integer  long [long]  long [long]  (unchanged)
64bit, Long     int          int          (unchanged)
```

dkl, I rebased these commits as-is onto current master from [dkl/integer-mangling](https://github.com/dkl/fbc/tree/integer-mangling).  I have some additional changes based on your work.
