### PR TITLE
GCC warnings

### DIFF
--- a/src/gfxlib2/gfx_draw.c
+++ b/src/gfxlib2/gfx_draw.c
@@ -220,9 +220,9 @@ FBCALL void fb_GfxDraw(void *target, FBSTRING *command)
 				move = draw = TRUE;
 				break;
 
-			case 'F': case 'D': angle += 90;
-			case 'G': case 'L': angle += 90;
-			case 'H': case 'U': angle += 90;
+			case 'F': case 'D': angle += 90; /* fall through */
+			case 'G': case 'L': angle += 90; /* fall through */
+			case 'H': case 'U': angle += 90; /* fall through */
 			case 'E': case 'R':
 				diagonal = ((toupper(*c) >= 'E') && (toupper(*c) <= 'H'));
 				c++;

--- a/src/gfxlib2/linux/gfx_joystick.c
+++ b/src/gfxlib2/linux/gfx_joystick.c
@@ -34,7 +34,8 @@ FBCALL int fb_GfxGetJoystick(int id, ssize_t *buttons, float *a1, float *a2, flo
 	const char *device[] = { "/dev/input/js",
 							 "/dev/js",
 							 NULL };
-	char device_name[16];
+	/* overallocate device_name[] to prevent a sprintf() warning in GCC */
+	char device_name[13 + 11 + 1];
 	JOYDATA *joy;
 	JS_EVENT event;
 	int i, j, k, count = 0;

--- a/src/gfxlib2/win32/gfx_win32.c
+++ b/src/gfxlib2/win32/gfx_win32.c
@@ -322,14 +322,8 @@ LRESULT CALLBACK fb_hWin32WinProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM
 			break;
 
 		case WM_SIZE:
-		case WM_SYSKEYDOWN:
-			if (!fb_win32.is_active)
-				break;
-
-			{
-				int is_alt_enter = ((message == WM_SYSKEYDOWN) && (wParam == VK_RETURN) && (lParam & 0x20000000));
-				int is_maximize = ((message == WM_SIZE) && (wParam == SIZE_MAXIMIZED));
-				if ( is_maximize || is_alt_enter) {
+			if (fb_win32.is_active) {
+				if ( wParam == SIZE_MAXIMIZED ) {
 					if (has_focus) {
 						e.type = EVENT_MOUSE_EXIT;
 						fb_hPostEvent(&e);
@@ -337,9 +331,21 @@ LRESULT CALLBACK fb_hWin32WinProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM
 					ToggleFullScreen();
 					return FALSE;
 				}
-				if( message!=WM_SYSKEYDOWN )
-					break;
 			}
+			break;
+
+		case WM_SYSKEYDOWN:
+			if (fb_win32.is_active) {
+				if ( (wParam == VK_RETURN) && (lParam & 0x20000000) ) {
+					if (has_focus) {
+						e.type = EVENT_MOUSE_EXIT;
+						fb_hPostEvent(&e);
+					}
+					ToggleFullScreen();
+					return FALSE;
+				}
+			}
+			break;
 
 		case WM_KEYDOWN:
 		case WM_KEYUP:

--- a/src/gfxlib2/win32/gfx_win32.c
+++ b/src/gfxlib2/win32/gfx_win32.c
@@ -89,8 +89,13 @@ static void fb_hSetMouseClip( void )
 	ClipCursor(&rc);
 }
 
-static void ToggleFullScreen( void )
+static void ToggleFullScreen( EVENT *e )
 {
+	if (has_focus) {
+		e->type = EVENT_MOUSE_EXIT;
+		fb_hPostEvent(e);
+	}
+
 	if (fb_win32.flags & DRIVER_NO_SWITCH)
 		return;
 
@@ -324,11 +329,7 @@ LRESULT CALLBACK fb_hWin32WinProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM
 		case WM_SIZE:
 			if (fb_win32.is_active) {
 				if ( wParam == SIZE_MAXIMIZED ) {
-					if (has_focus) {
-						e.type = EVENT_MOUSE_EXIT;
-						fb_hPostEvent(&e);
-					}
-					ToggleFullScreen();
+					ToggleFullScreen(&e);
 					return FALSE;
 				}
 			}
@@ -337,15 +338,11 @@ LRESULT CALLBACK fb_hWin32WinProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM
 		case WM_SYSKEYDOWN:
 			if (fb_win32.is_active) {
 				if ( (wParam == VK_RETURN) && (lParam & 0x20000000) ) {
-					if (has_focus) {
-						e.type = EVENT_MOUSE_EXIT;
-						fb_hPostEvent(&e);
-					}
-					ToggleFullScreen();
+					ToggleFullScreen(&e);
 					return FALSE;
 				}
 			}
-			break;
+			/* fall through */
 
 		case WM_KEYDOWN:
 		case WM_KEYUP:

--- a/src/rtlib/dev_file_encod_read_core.c
+++ b/src/rtlib/dev_file_encod_read_core.c
@@ -36,18 +36,23 @@ static ssize_t hReadUTF8ToChar( FILE *fp, char *dst, ssize_t max_chars )
 			case 5:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 4:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 3:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 2:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 1:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 0:
 				wc += *p++;
 		}
@@ -225,18 +230,23 @@ static ssize_t hUTF8ToUTF32( FILE *fp, FB_WCHAR *dst, ssize_t max_chars )
 			case 5:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 4:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 3:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 2:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 1:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 0:
 				wc += *p++;
 		}

--- a/src/rtlib/dev_file_encod_read_core.c
+++ b/src/rtlib/dev_file_encod_read_core.c
@@ -166,18 +166,23 @@ static ssize_t hUTF8ToUTF16( FILE *fp, FB_WCHAR *dst, ssize_t max_chars )
 			case 5:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 4:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 3:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 2:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 1:
 				wc += *p++;
 				wc <<= 6;
+				/* fall through */
 			case 0:
 				wc += *p++;
 		}

--- a/src/rtlib/dos/io_cls.c
+++ b/src/rtlib/dos/io_cls.c
@@ -8,8 +8,9 @@ void fb_ConsoleClear( int mode )
 {
     int toprow, botrow;
 
-    if( mode==1 )
+    if( mode==1 ) {
         return;
+	}
 
 	if( (mode == 2) || (mode == (int)0xFFFF0000) ) {	/* same as gfxlib's DEFAULT_COLOR */
         fb_ConsoleGetView( &toprow, &botrow );

--- a/src/rtlib/file_input_tok.c
+++ b/src/rtlib/file_input_tok.c
@@ -192,6 +192,7 @@ int fb_FileInputNextToken
 					goto exit;
 				}
 			}
+			goto savechar;
 
 		default:
 savechar:

--- a/src/rtlib/file_input_tok_wstr.c
+++ b/src/rtlib/file_input_tok_wstr.c
@@ -159,6 +159,7 @@ void fb_FileInputNextTokenWstr( FB_WCHAR *buffer, ssize_t max_chars, int is_stri
 					goto exit;
 				}
 			}
+			goto savechar;
 
 		default:
 savechar:

--- a/src/rtlib/unix/io_printer.c
+++ b/src/rtlib/unix/io_printer.c
@@ -125,7 +125,7 @@ int fb_PrinterOpen( DEV_LPT_INFO *devInfo, int iPort, const char *pszDeviceRaw )
 
 	} else {
 		/* use direct port io */
-		filename = alloca( 16 );
+		filename = alloca( 7 + 11 + 1 );
 		sprintf(filename, "/dev/lp%d", (devInfo->iPort-1));
 		fp = fopen(filename, "wb");
 

--- a/src/rtlib/utf_convfrom_wchar.c
+++ b/src/rtlib/utf_convfrom_wchar.c
@@ -37,12 +37,15 @@ static void hUTF16ToUTF8( const FB_WCHAR *src, ssize_t chars, UTF_8 *dst, ssize_
 		case 4:
 			*--dst = ((c | UTF8_BYTEMARK) & UTF8_BYTEMASK);
 			c >>= 6;
+			/* fall through */
 		case 3:
 			*--dst = ((c | UTF8_BYTEMARK) & UTF8_BYTEMASK);
 			c >>= 6;
+			/* fall through */
 		case 2:
 			*--dst = ((c | UTF8_BYTEMARK) & UTF8_BYTEMASK);
 			c >>= 6;
+			/* fall through */
 		case 1:
 			*--dst = (c | __fb_utf8_bmarkTb[bytes]);
 		}

--- a/src/rtlib/utf_convfrom_wchar.c
+++ b/src/rtlib/utf_convfrom_wchar.c
@@ -78,12 +78,15 @@ static void hUTF32ToUTF8( const FB_WCHAR *src, ssize_t chars, UTF_8 *dst, ssize_
 		case 4:
 			*--dst = ((c | UTF8_BYTEMARK) & UTF8_BYTEMASK);
 			c >>= 6;
+			/* fall through */
 		case 3:
 			*--dst = ((c | UTF8_BYTEMARK) & UTF8_BYTEMASK);
 			c >>= 6;
+			/* fall through */
 		case 2:
 			*--dst = ((c | UTF8_BYTEMARK) & UTF8_BYTEMASK);
 			c >>= 6;
+			/* fall through */
 		case 1:
 			*--dst = (c | __fb_utf8_bmarkTb[bytes]);
 		}

--- a/src/rtlib/utf_convto_char.c
+++ b/src/rtlib/utf_convto_char.c
@@ -26,14 +26,19 @@ char *fb_hUTF8ToChar( const UTF_8 *src, char *dst, ssize_t *chars )
 			{
 				case 5:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 4:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 3:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 2:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 1:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 0:
 					c += *src++;
 			}
@@ -73,14 +78,19 @@ char *fb_hUTF8ToChar( const UTF_8 *src, char *dst, ssize_t *chars )
 			{
 				case 5:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 4:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 3:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 2:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 1:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 0:
 					c += *src++;
 			}

--- a/src/rtlib/utf_convto_wchar.c
+++ b/src/rtlib/utf_convto_wchar.c
@@ -93,14 +93,19 @@ static FB_WCHAR *hUTF8ToUTF16( const UTF_8 *src, FB_WCHAR *dst, ssize_t *chars )
 			{
 				case 5:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 4:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 3:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 2:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 1:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 0:
 					c += *src++;
 			}

--- a/src/rtlib/utf_convto_wchar.c
+++ b/src/rtlib/utf_convto_wchar.c
@@ -30,14 +30,19 @@ static FB_WCHAR *hUTF8ToUTF16( const UTF_8 *src, FB_WCHAR *dst, ssize_t *chars )
 			{
 				case 5:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 4:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 3:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 2:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 1:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 0:
 					c += *src++;
 			}
@@ -146,14 +151,19 @@ static FB_WCHAR *hUTF8ToUTF32( const UTF_8 *src, FB_WCHAR *dst, ssize_t *chars )
 			{
 				case 5:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 4:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 3:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 2:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 1:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 0:
 					c += *src++;
 			}
@@ -190,14 +200,19 @@ static FB_WCHAR *hUTF8ToUTF32( const UTF_8 *src, FB_WCHAR *dst, ssize_t *chars )
 			{
 				case 5:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 4:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 3:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 2:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 1:
 					c += *src++; c <<= 6;
+					/* fall through */
 				case 0:
 					c += *src++;
 			}


### PR DESCRIPTION
This is my first commit for a while.  Doing a PR seems like a nice way to go about this.
This fixes some compiler warnings I came across while making from Ubuntu 18.04 (64-bit).
Most are implicit `switch()` fall-throughs, two are `sprintf()` buffer allocation warnings.

Note that I've made one of the fall-throughs into a `goto`, to match the other cases in that block.  The fall-through worked because it was the last case in the block, but could have broken if another case were added.  The compiler should be able to optimise it out anyway.

The joystick `sprintf()` warning was difficult to make a decision about, because the problem is GCC not understanding that `j` can only be two digits.  I extended the buffer, but other approaches might involve changing the type of `j`, using character manipulation or something to write the digits, or just ignoring the warning.

With these changes, the rtlib and gfxlib compile without warnings in (my version of) Linux.