### PR TITLE
Allow suffixes in comments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -78,6 +78,7 @@ Version 1.06.0
 - Fix for debugging lines in include files but not in procedures.  Filename debugging information added for module level statements in included files.
 - #699: fix new[0] causing infinite loop when calling constructor/destructor list
 - #883: when mapping 32 & 64 bit functions for PALETTE [GET] USING, check the data type pointed to and choose one of LONG PTR, LONGINT PTR, INTEGER PTR
+- #866: fbc was throwing lexer errors in comments stating with $.  Comments are lexed for directives; allow suffixes in comments
 
 
 Version 1.05.0

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -386,6 +386,12 @@ private sub hReadIdentifier _
 		byval flags as LEXCHECK _
 	)
 
+	#macro hCheckIdentifierSuffix()
+		if( (fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE) and ((flags and LEXCHECK_ALLOWSUFFIX) = 0) ) then
+			errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+		end if
+	#endmacro
+
 	dim as integer skipchar = any
 
 	'' (ALPHA | '_' )
@@ -442,24 +448,23 @@ private sub hReadIdentifier _
 
 	'' [SUFFIX]
 	dtype = FB_DATATYPE_INVALID
-
 	if( (flags and LEXCHECK_NOSUFFIX) = 0 ) then
 		select case as const lexCurrentChar( )
 		'' '%'?
 		case FB_TK_INTTYPECHAR
-			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			hCheckIdentifierSuffix()
 			dtype = env.lang.integerkeyworddtype
 			lexEatChar( )
 
 		'' '&'?
 		case FB_TK_LNGTYPECHAR
-			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			hCheckIdentifierSuffix()
 			dtype = FB_DATATYPE_LONG
 			lexEatChar( )
 
 		'' '!'?
 		case FB_TK_SGNTYPECHAR
-			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			hCheckIdentifierSuffix()
 			dtype = FB_DATATYPE_SINGLE
 			lexEatChar( )
 
@@ -467,14 +472,14 @@ private sub hReadIdentifier _
 		case FB_TK_DBLTYPECHAR
 			'' isn't it a '##'?
 			if( lexGetLookAheadChar( ) <> FB_TK_DBLTYPECHAR ) then
-				if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+				hCheckIdentifierSuffix()
 				dtype = FB_DATATYPE_DOUBLE
 				lexEatChar( )
 			end if
 
 		'' '$'?
 		case FB_TK_STRTYPECHAR
-			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			hCheckIdentifierSuffix()
 			dtype = FB_DATATYPE_STRING
 			lexEatChar( )
 		end select
@@ -1843,7 +1848,7 @@ read_char:
 		'' '/'?
 		case CHAR_SLASH
 			t->class = FB_TKCLASS_OPERATOR
-			'' in lang fb, only check for multiline comment if not inside
+			'' only check for multiline comment if not inside
 			'' a single line comment already (thanks to VonGodric for help)
 			if( (flags and LEXCHECK_NOMULTILINECOMMENT) = 0 or _
 				 fbLangIsSet( FB_LANG_FB ) = FALSE ) then

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -1850,8 +1850,7 @@ read_char:
 			t->class = FB_TKCLASS_OPERATOR
 			'' only check for multiline comment if not inside
 			'' a single line comment already (thanks to VonGodric for help)
-			if( (flags and LEXCHECK_NOMULTILINECOMMENT) = 0 or _
-				 fbLangIsSet( FB_LANG_FB ) = FALSE ) then
+			if( (flags and LEXCHECK_NOMULTILINECOMMENT) = 0 ) then
 				'' "/'"?
 				if( lexCurrentChar( ) = CHAR_APOST ) then
 					'' multi-line comment..

--- a/src/compiler/lex.bi
+++ b/src/compiler/lex.bi
@@ -40,6 +40,9 @@ enum LEXCHECK
 	
 	'' don't interpret f, u, l as type-specifier suffixes on numeric literals (used in asm blocks)
 	LEXCHECK_NOLETTERSUFFIX	= &h0400
+
+	'' allow suffix, like when reading potential directives from comments, even though the dialect prohibits suffixes
+	LEXCHECK_ALLOWSUFFIX = &h0800
 	
 end enum
 

--- a/src/compiler/parser-comment.bas
+++ b/src/compiler/parser-comment.bas
@@ -27,10 +27,9 @@ function cComment _
 		'' to the lexSkipToken() calls for '$' and from cDirective(),
 		'' when parsing a $ meta command)
 		lex.ctx->reclevel += 1
-		lexSkipToken( LEX_FLAGS )
-
+		lexSkipToken( LEX_FLAGS or LEXCHECK_ALLOWSUFFIX )
 		if( lexGetToken( LEX_FLAGS ) = FB_TK_DIRECTIVECHAR ) then
-			lexSkipToken( LEX_FLAGS )
+			lexSkipToken( LEX_FLAGS or LEXCHECK_ALLOWSUFFIX )
 			cDirective( )
 		else
 			lexSkipLine( )
@@ -171,7 +170,6 @@ private sub cDirective( ) static
 		case FB_TK_EOL, FB_TK_EOF
 			exit do
 		end select
-
-		lexSkipToken( )
+		lexSkipToken( LEX_FLAGS or LEXCHECK_ALLOWSUFFIX )
 	loop
 end sub

--- a/tests/comments/multiline.bas
+++ b/tests/comments/multiline.bas
@@ -49,3 +49,24 @@ end sub
 
 proc
 
+/'
+
+	multiline comments never check for '$' directives, 
+	so suffixes should never matter
+	
+	${f!
+	$=f# 
+	$^f$
+	$-f%
+	$@f&
+	
+	'${f!
+	'$=f# 
+	'$^f$
+	'$-f%
+	'$@f&
+	
+	$include 'does_not_matter'
+	$include "does_not_matter"
+
+'/

--- a/tests/comments/singleline.bas
+++ b/tests/comments/singleline.bas
@@ -27,24 +27,20 @@ rem comment _
 #error X1 should be defined
 #endif
 
-#if ENABLE_CHECK_BUGS
+'$=f#
+'$=f#
+'$=f#
+'$=f#
+'$=f#
 
-#print enable check for #866 fbc throws lexer errors in comments stating with $ 
-#print see bug #866 at https://sourceforge.net/p/fbc/bugs/866/
-#print introduced by #832 QB type suffixes allowed on any keywords 
-#print see bug #832 at https://sourceforge.net/p/fbc/bugs/832/
-
-
-'$=f#
-'$=f#
-'$=f#
-'$=f#
-'$=f#
+''$=f#
+''$=f#
+''$=f#
+''$=f#
+''$=f#
 
 rem ${f!
 rem $=f# 
 rem $^f$
 rem $-f%
 rem $@f&
-
-#endif


### PR DESCRIPTION
- fixes sf.net bug #866 fbc throws lexer errors in comments stating with $