### PR TITLE
C backend: struct size fixes (#858)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -80,6 +80,7 @@ Version 1.06.0
 - #699: fix new[0] causing infinite loop when calling constructor/destructor list
 - #883: when mapping 32 & 64 bit functions for PALETTE [GET] USING, check the data type pointed to and choose one of LONG PTR, LONGINT PTR, INTEGER PTR
 - #866: fbc was throwing lexer errors in comments stating with $.  Comments are lexed for directives; allow suffixes in comments
+- #858: C backend: fix internal structure size mismatch due to wrong padding when nesting packed structures
 
 
 Version 1.05.0

--- a/src/compiler/ir-hlc.bas
+++ b/src/compiler/ir-hlc.bas
@@ -1038,6 +1038,23 @@ private sub hEmitStructWithFields( byval s as FBSYMBOL ptr )
 					ln += " __attribute__((packed, aligned(" + str( align ) + ")))"
 				end if
 			end if
+			
+			'' The alignment of nested structures which are packed with a 
+			'' smaller alignment than the natural or specified alignment of the
+			'' parent structure has to be specified explicitly,
+			'' otherwise the field will be packed too.
+			if ( align <= 0 orelse skip ) then
+				if( typeGet( dtype ) = FB_DATATYPE_STRUCT ) then
+					var effectivealign = typeCalcNaturalAlign( dtype, subtype )
+					if ( align > 0 andalso align < effectivealign ) then
+						effectivealign = align
+					end if
+					var fieldudtalign = symbGetUDTAlign( subtype )
+					if( fieldudtalign > 0 andalso effectivealign > fieldudtalign ) then
+						ln += " __attribute__((aligned(" + str( effectivealign ) + ")))"
+					end if
+				end if
+			end if
 
 			ln += ";"
 			hWriteLine( ln, TRUE )

--- a/tests/structs/padding.bas
+++ b/tests/structs/padding.bas
@@ -1468,5 +1468,26 @@ SUITE( fbc_tests.structs.padding )
 		CU_ASSERT( x2.x1.i = 11 )
 		CU_ASSERT( x2.b = 22 )
 	END_TEST
+	
+	TEST( genGccUdtPackedFieldInUdt )
+		'' Regression test for -gen gcc's struct emitting
+		
+		type UDT1 field=1 '' packed UDT
+			a as byte     '' 1 byte
+			b as short    '' 2 bytes
+		end type
+		#assert sizeof( UDT1 ) = sizeof( byte ) + sizeof ( short )
+		#assert sizeof( UDT1 ) = 3
 
+		type UDT2 field=2  '' packed UDT
+			x1 as UDT1   '' UDT field, which is packed with field=1
+		end type
+		#assert sizeof( UDT2 ) = 4
+		#assert offsetof(UDT2, x1.b) = 1
+
+		dim x2 as UDT2 = ((11,22))
+		CU_ASSERT( x2.x1.a = 11 )
+		CU_ASSERT( x2.x1.b = 22 )
+	END_TEST
+	
 END_SUITE


### PR DESCRIPTION
Fixes #858: C backend: fix internal structure size mismatch due to wrong padding when nesting packed structures

The alignment of nested structures which are packed with a smaller alignment than the natural or specified alignment of the parent structure has to be specified explicitly, otherwise the field will be packed too.