### PR TITLE
fix internal declaration of lbound() & ubound() rtl to accept const arrays

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -81,6 +81,7 @@ Version 1.06.0
 - #883: when mapping 32 & 64 bit functions for PALETTE [GET] USING, check the data type pointed to and choose one of LONG PTR, LONGINT PTR, INTEGER PTR
 - #866: fbc was throwing lexer errors in comments stating with $.  Comments are lexed for directives; allow suffixes in comments
 - #858: C backend: fix internal structure size mismatch due to wrong padding when nesting packed structures
+- C backend: fix array descriptor mangling to avoid naming conflicts where array data types differ only by const
 
 
 Version 1.05.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -82,6 +82,7 @@ Version 1.06.0
 - #866: fbc was throwing lexer errors in comments stating with $.  Comments are lexed for directives; allow suffixes in comments
 - #858: C backend: fix internal structure size mismatch due to wrong padding when nesting packed structures
 - C backend: fix array descriptor mangling to avoid naming conflicts where array data types differ only by const
+- #823: Function overload resolution for [const] array() and passing non-const array argument to const array parameter
 
 
 Version 1.05.0

--- a/src/compiler/parser-expr-variable.bas
+++ b/src/compiler/parser-expr-variable.bas
@@ -179,7 +179,7 @@ private function hFieldAccess _
 			'' Dynamic array field; access the descriptor field (same offset)
 			desc = symbGetArrayDescriptor( fld )
 			varexpr = astNewBOP( AST_OP_ADD, varexpr, offsetexpr )
-			varexpr = astNewCONV( typeAddrOf( symbGetFullType( desc ) ), symbGetSubtype( desc ), varexpr, AST_CONVOPT_DONTCHKPTR )
+			varexpr = astNewCONV( typeAddrOf( symbGetFullType( desc ) ), symbGetSubtype( desc ), varexpr, AST_CONVOPT_DONTCHKPTR or AST_CONVOPT_DONTWARNCONST )
 
 			tree = NULL
 			if( astHasSideFx( varexpr ) ) then
@@ -190,7 +190,7 @@ private function hFieldAccess _
 
 			'' *cptr( dtype ptr, var->descriptor.data + index )
 			varexpr = astNewBOP( AST_OP_ADD, varexpr, astNewCONSTi( symb.fbarray_data ) )
-			varexpr = astNewCONV( typeMultAddrOf( dtype, 2 ), subtype, varexpr, AST_CONVOPT_DONTCHKPTR )
+			varexpr = astNewCONV( typeMultAddrOf( dtype, 2 ), subtype, varexpr, AST_CONVOPT_DONTCHKPTR or AST_CONVOPT_DONTWARNCONST )
 			varexpr = astNewDEREF( varexpr )
 			varexpr = astNewBOP( AST_OP_ADD, varexpr, indexexpr )
 			varexpr = astNewDEREF( varexpr )

--- a/src/compiler/rtl-array.bas
+++ b/src/compiler/rtl-array.bas
@@ -213,7 +213,7 @@
 			NULL, FB_RTL_OPT_NONE, _
 			2, _
 			{ _
-				( FB_DATATYPE_VOID, FB_PARAMMODE_BYDESC, FALSE ), _
+				( typeSetIsConst( FB_DATATYPE_VOID ), FB_PARAMMODE_BYDESC, FALSE ), _
 				( typeSetIsConst( FB_DATATYPE_INTEGER ), FB_PARAMMODE_BYVAL, FALSE ) _
 			} _
 		), _
@@ -224,7 +224,7 @@
 			NULL, FB_RTL_OPT_NONE, _
 			2, _
 			{ _
-				( FB_DATATYPE_VOID, FB_PARAMMODE_BYDESC, FALSE ), _
+				( typeSetIsConst( FB_DATATYPE_VOID ), FB_PARAMMODE_BYDESC, FALSE ), _
 				( typeSetIsConst( FB_DATATYPE_INTEGER ), FB_PARAMMODE_BYVAL, FALSE ) _
 			} _
 		), _

--- a/src/compiler/symb-proc.bas
+++ b/src/compiler/symb-proc.bas
@@ -1883,18 +1883,17 @@ private function hCheckOvlParam _
 			return FB_OVLPROC_NO_MATCH
 		end if
 
-		'' not a full match?
-        if( param_dtype <> arg_dtype ) then
-        	return FB_OVLPROC_NO_MATCH
-        end if
+		var match = typeCalcMatch( param_dtype, param_subtype, symbGetParamMode( param ), arg_dtype, arg_subtype )
 
-        if( param_subtype <> arg_subtype ) then
-        	return FB_OVLPROC_NO_MATCH
-        end if
-
+		'' not same type?
+		if( match < FB_OVLPROC_TYPEMATCH ) then
+			return FB_OVLPROC_NO_MATCH
+		end if
+	
 		assert( astIsVAR( arg_expr ) or astIsFIELD( arg_expr ) )
 		array = arg_expr->sym
 		assert( symbIsArray( array ) )
+
 
 		'' If the BYDESC parameter has unknown dimensions, any array can be passed.
 		'' Otherwise, only arrays with unknown or matching dimensions can be passed.
@@ -1905,7 +1904,7 @@ private function hCheckOvlParam _
 			end if
 		end if
 
-		return FB_OVLPROC_FULLMATCH
+		return match
 
 	'' byref param?
 	case FB_PARAMMODE_BYREF

--- a/src/compiler/symb-var.bas
+++ b/src/compiler/symb-var.bas
@@ -77,7 +77,7 @@ sub symbGetDescTypeArrayDtype _
 	fld = symbUdtGetFirstField( desctype )
 	assert( typeIsPtr( symbGetType( fld ) ) )
 
-	arraydtype = typeDeref( symbGetType( fld ) )
+	arraydtype = typeDeref( symbGetFullType( fld ) )
 	arraysubtype = fld->subtype
 
 end sub
@@ -157,19 +157,14 @@ function symbAddArrayDescriptorType _
 		aliasid &= dimensions
 	end if
 
-	'' top level const will be ignored in symbMangleType(), so use an alternate 
-	'' alias for const array descriptor dtypes to avoid alias conflicts
-	if( typeIsConst( arraydtype ) ) then
-		aliasid &= "K"
-	end if
-
 	'' Some unique internal id that allows this descriptor type to be looked
 	'' up later when we need one with the same dimensions & array dtype
 	'' again. '$' prefix ensures that there are no collisions with user's
-	'' ids.
+	'' ids.  Always keep the top-level const for array datatypes to avoid
+	'' conflicts between types differing only by const.
 	id = "$" + aliasid
 	id += "<"
-	symbMangleType( id, arraydtype, arraysubtype )
+	symbMangleType( id, arraydtype, arraysubtype, FB_MANGLEOPT_KEEPTOPCONST )
 	symbMangleResetAbbrev( )
 	id += ">"
 

--- a/src/compiler/symb-var.bas
+++ b/src/compiler/symb-var.bas
@@ -157,6 +157,12 @@ function symbAddArrayDescriptorType _
 		aliasid &= dimensions
 	end if
 
+	'' top level const will be ignored in symbMangleType(), so use an alternate 
+	'' alias for const array descriptor dtypes to avoid alias conflicts
+	if( typeIsConst( arraydtype ) ) then
+		aliasid &= "K"
+	end if
+
 	'' Some unique internal id that allows this descriptor type to be looked
 	'' up later when we need one with the same dimensions & array dtype
 	'' again. '$' prefix ensures that there are no collisions with user's

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -249,6 +249,12 @@ enum FB_MANGLING
 	FB_MANGLING_PASCAL
 end enum
 
+''
+enum FB_MANGLEOPT
+	FB_MANGLEOPT_NONE = 0          '' no special options
+	FB_MANGLEOPT_KEEPTOPCONST = 1  '' keep the top-level const when mangling
+end enum
+
 type FBSYMBOL_ as FBSYMBOL
 
 #ifndef ASTNODE_
@@ -1747,7 +1753,8 @@ declare sub symbMangleType _
 	( _
 		byref mangled as string, _
 		byval dtype as integer, _
-		byval subtype as FBSYMBOL ptr _
+		byval subtype as FBSYMBOL ptr, _
+		byval options as FB_MANGLEOPT = FB_MANGLEOPT_NONE _
 	)
 declare sub symbMangleParam( byref mangled as string, byval param as FBSYMBOL ptr )
 

--- a/tests/cpp/cpp-mangle.cpp
+++ b/tests/cpp/cpp-mangle.cpp
@@ -163,7 +163,7 @@ namespace cpp_mangle
 		return *a;
 	}
 
-	double cpp_byval_double_const_ptr( double *const a )
+	double cpp_byval_double_const_ptr( double* const a )
 	{
 		return *a;
 	}
@@ -200,7 +200,7 @@ namespace cpp_mangle
 		return a;
 	}
 
-	double cpp_byref_double_ptr( double* &a )
+	double cpp_byref_double_ptr( double*& a )
 	{
 		return *a;
 	}

--- a/tests/cpp/cpp-mangle.cpp
+++ b/tests/cpp/cpp-mangle.cpp
@@ -146,4 +146,98 @@ namespace cpp_mangle
 		return a;
 	} 
 
+	/* byval const, pointer, reference */
+
+	double cpp_byval_const_double( const double a )
+	{
+		return a;
+	}
+
+	double cpp_byval_double_ptr( double* a )
+	{
+		return *a;
+	}
+
+	double cpp_byval_const_double_ptr( double const* a )
+	{
+		return *a;
+	}
+
+	double cpp_byval_double_const_ptr( double *const a )
+	{
+		return *a;
+	}
+
+	double cpp_byval_const_double_const_ptr( double const* const a )
+	{
+		return *a;
+	}
+
+	double cpp_byval_double_ptr_ptr( double** a )
+	{
+		return **a;
+	}
+
+	double cpp_byval_const_double_ptr_ptr( double const** a )
+	{
+		return **a;
+	}
+
+	double cpp_byval_double_const_ptr_ptr( double* const* a )
+	{
+		return **a;
+	}
+
+	double cpp_byval_double_ptr_const_ptr( double** const a )
+	{
+		return **a;
+	}
+
+	/* byval const, pointer, reference */
+
+	double cpp_byref_const_double( double const& a )
+	{
+		return a;
+	}
+
+	double cpp_byref_double_ptr( double* &a )
+	{
+		return *a;
+	}
+
+	double cpp_byref_const_double_ptr( double const*& a )
+	{
+		return *a;
+	}
+
+	double cpp_byref_double_const_ptr( double* const& a )
+	{
+		return *a;
+	}
+
+	double cpp_byref_const_double_const_ptr( double const* const& a )
+	{
+		return *a;
+	}
+
+	double cpp_byref_double_ptr_ptr( double**& a )
+	{
+		return **a;
+	}
+
+	double cpp_byref_const_double_ptr_ptr( double const**& a )
+	{
+		return **a;
+	}
+
+	double cpp_byref_double_const_ptr_ptr( double* const*& a )
+	{
+		return **a;
+	}
+
+	double cpp_byref_double_ptr_const_ptr( double** const& a )
+	{
+		return **a;
+	}
+
 }

--- a/tests/cpp/fbc-mangle.bas
+++ b/tests/cpp/fbc-mangle.bas
@@ -59,6 +59,26 @@ namespace cpp_mangle
 	declare function cpp_byref_ulonglongint( byref a as unsigned longint ) as unsigned longint 
 	declare function cpp_byref_slonglongint( byref a as longint ) as longint
 
+	declare function cpp_byval_const_double( byval a as const double ) as double
+	declare function cpp_byval_double_ptr( byval a as double ptr ) as double
+	declare function cpp_byval_const_double_ptr( byval a as const double ptr ) as double
+	declare function cpp_byval_double_const_ptr( byval a as double const ptr ) as double
+	declare function cpp_byval_const_double_const_ptr( byval a as const double const ptr ) as double
+	declare function cpp_byval_double_ptr_ptr( byval a as double ptr ptr ) as double
+	declare function cpp_byval_const_double_ptr_ptr( byval a as const double ptr ptr ) as double
+	declare function cpp_byval_double_const_ptr_ptr( byval a as double const ptr ptr ) as double
+	declare function cpp_byval_double_ptr_const_ptr( byval a as double ptr const ptr ) as double
+
+	declare function cpp_byref_const_double( byref a as const double ) as double
+	declare function cpp_byref_double_ptr( byref a as double ptr ) as double
+	declare function cpp_byref_const_double_ptr( byref a as const double ptr ) as double
+	declare function cpp_byref_double_const_ptr( byref a as double const ptr ) as double
+	declare function cpp_byref_const_double_const_ptr( byref a as const double const ptr ) as double
+	declare function cpp_byref_double_ptr_ptr( byref a as double ptr ptr ) as double
+	declare function cpp_byref_const_double_ptr_ptr( byref a as const double ptr ptr ) as double
+	declare function cpp_byref_double_const_ptr_ptr( byref a as double const ptr ptr ) as double
+	declare function cpp_byref_double_ptr_const_ptr( byref a as double ptr const ptr ) as double
+
 end namespace
 
 end extern
@@ -207,5 +227,39 @@ scope
 	sll = &h7fffffffffffffff
 	ASSERT( cpp_byref_ulonglongint(ull) = &h7fffffffffffffff )
 	ASSERT( cpp_byref_slonglongint(sll) = &h7fffffffffffffff )
+
+end scope
+
+scope
+	'' [const] pointers and references
+
+	dim d as double = 1
+	dim dp as double ptr = @d
+	dim dpp as double ptr ptr = @dp
+
+	ASSERT( cpp_byval_double( d ) = d )
+	ASSERT( cpp_byval_const_double( d ) = d )
+	ASSERT( cpp_byval_double_ptr( dp ) = d )
+	ASSERT( cpp_byval_const_double_ptr( dp ) = d )
+	ASSERT( cpp_byval_double_const_ptr( dp ) = d )
+	ASSERT( cpp_byval_const_double_const_ptr( dp ) = d )
+
+	ASSERT( cpp_byval_double_ptr_ptr( dpp ) = d )
+	ASSERT( cpp_byval_const_double_ptr_ptr( dpp ) = d )
+	ASSERT( cpp_byval_double_const_ptr_ptr( dpp ) = d )
+	ASSERT( cpp_byval_double_ptr_const_ptr( dpp ) = d )
+
+	ASSERT( cpp_byref_double( d ) = d )
+	ASSERT( cpp_byref_const_double( d ) = d )
+	ASSERT( cpp_byref_double_ptr( dp ) = d )
+	ASSERT( cpp_byref_const_double_ptr( dp ) = d )
+	ASSERT( cpp_byref_double_const_ptr( dp ) = d )
+	ASSERT( cpp_byref_const_double_const_ptr( dp ) = d )
+
+	ASSERT( cpp_byref_double_ptr_ptr( dpp ) = d )
+	ASSERT( cpp_byref_const_double_ptr_ptr( dpp ) = d )
+	ASSERT( cpp_byref_double_const_ptr_ptr( dpp ) = d )
+	ASSERT( cpp_byref_double_ptr_const_ptr( dpp ) = d )
+
 
 end scope

--- a/tests/overload/const.bas
+++ b/tests/overload/const.bas
@@ -50,4 +50,136 @@ SUITE( fbc_tests.overload_.const_ )
 		END_TEST
 	END_TEST_GROUP
 
+	dim shared axlong(1 to ...) as long = {1, 2}
+	dim shared axlongint(1 to ...) as longint = {1, 2}
+	dim shared axinteger(1 to ...) as integer = {1, 2}
+	dim shared axsingle(1 to ...) as single = {1.0f, 2.0f}
+	dim shared axdouble(1 to ...) as double = {1.0, 2.0}
+
+	dim shared axconstlong(1 to ...) as const long = {1, 2}
+	dim shared axconstlongint(1 to ...) as const longint = {1, 2}
+	dim shared axconstinteger(1 to ...) as const integer = {1, 2}
+	dim shared axconstsingle(1 to ...) as const single = {1.0f, 2.0f}
+	dim shared axconstdouble(1 to ...) as const double = {1.0, 2.0}
+
+	dim shared axconstbyte(1 to ...) as const byte = {1, 2}
+
+	TEST_GROUP( array )
+
+		function f overload( x() as integer ) as string : function = "integer" : end function
+		function f overload( x() as longint ) as string : function = "longint" : end function
+		function f overload( x() as single  ) as string : function = "single"  : end function
+		function f overload( x() as double  ) as string : function = "double"  : end function
+		function f overload( x() as long    ) as string : function = "long"    : end function
+
+		TEST( non_const_array )
+			CU_ASSERT( f( axlong()    ) = "long"    )
+			CU_ASSERT( f( axlongint() ) = "longint" )
+			CU_ASSERT( f( axinteger() ) = "integer" )
+			CU_ASSERT( f( axsingle()  ) = "single"  )
+			CU_ASSERT( f( axdouble()  ) = "double"  )
+		END_TEST
+
+		function fc overload( x() as const integer ) as string : function = "integer" : end function
+		function fc overload( x() as const longint ) as string : function = "longint" : end function
+		function fc overload( x() as const single  ) as string : function = "single"  : end function
+		function fc overload( x() as const double  ) as string : function = "double"  : end function
+		function fc overload( x() as const long    ) as string : function = "long"    : end function
+
+		TEST( const_array )
+			CU_ASSERT( fc( axlong()    ) = "long"    )
+			CU_ASSERT( fc( axlongint() ) = "longint" )
+			CU_ASSERT( fc( axinteger() ) = "integer" )
+			CU_ASSERT( fc( axsingle()  ) = "single"  )
+			CU_ASSERT( fc( axdouble()  ) = "double"  )
+			CU_ASSERT( fc( axconstlong()    ) = "long"    )
+			CU_ASSERT( fc( axconstlongint() ) = "longint" )
+			CU_ASSERT( fc( axconstinteger() ) = "integer" )
+			CU_ASSERT( fc( axconstsingle()  ) = "single"  )
+			CU_ASSERT( fc( axconstdouble()  ) = "double"  )
+		END_TEST
+
+	END_TEST_GROUP
+
+	TEST_GROUP( array )
+
+		'' base test using scalars
+		function f0 overload( byref a as integer, byval x as integer ) as string
+			function = "integer, integer"
+		end function
+		function f0 overload( byref a as integer, byval x as double ) as string
+			function = "integer, double"
+		end function
+
+		function f1 overload( byref a as const integer, byval x as integer ) as string
+			function = "const integer, integer"
+		end function
+		function f1 overload( byref a as const integer, byval x as double ) as string
+			function = "const integer, double"
+		end function
+
+		'' array() tests
+		function f2 overload( a() as integer, byval x as integer ) as string
+			function = "() const integer, integer"
+		end function
+		function f2 overload( a() as integer, byval x as double ) as string
+			function = "() const integer, double"
+		end function
+
+		function f3 overload( a() as const integer, byval x as integer ) as string
+			function = "() const integer, integer"
+		end function
+		function f3 overload( a() as const integer, byval x as double ) as string
+			function = "() const integer, double"
+		end function
+
+		function f4 overload( a() as integer, byval x as integer ) as string
+			function = "() integer, integer"
+		end function
+		function f4 overload( a() as const integer, byval x as double ) as string
+			function = "() const integer, double"
+		end function
+
+		function f5 overload( a() as const integer, byval x as integer ) as string
+			function = "() const integer, integer"
+		end function
+		function f5 overload( a() as integer, byval x as double ) as string
+			function = "() integer, double"
+		end function
+
+		TEST( array_number )
+
+			dim a(1 to ... ) as integer = {1, 2}
+			dim ca( 1 to ...) as const integer = {1, 2}
+			dim i as integer, ci as const integer = 1
+			dim d as double
+
+			CU_ASSERT( f0( i, i ) = "integer, integer" )
+			CU_ASSERT( f0( i, d ) = "integer, double" )
+			
+			CU_ASSERT( f1( ci, i ) = "const integer, integer" )
+			CU_ASSERT( f1( ci, d ) = "const integer, double" )
+
+			CU_ASSERT( f2(  a(), i ) = "() const integer, integer" )
+			CU_ASSERT( f2(  a(), d ) = "() const integer, double" )
+
+			CU_ASSERT( f3(  a(), i ) = "() const integer, integer" )
+			CU_ASSERT( f3( ca(), i ) = "() const integer, integer" )
+			CU_ASSERT( f3(  a(), d ) = "() const integer, double" )
+			CU_ASSERT( f3( ca(), d ) = "() const integer, double" )
+
+			CU_ASSERT( f4(  a(), i ) = "() integer, integer" )
+			CU_ASSERT( f4( ca(), i ) = "() const integer, double" )
+			CU_ASSERT( f4(  a(), d ) = "() const integer, double" )
+			CU_ASSERT( f4( ca(), d ) = "() const integer, double" )
+
+			CU_ASSERT( f5(  a(), i ) = "() const integer, integer" )
+			CU_ASSERT( f5( ca(), i ) = "() const integer, integer" )
+			CU_ASSERT( f5(  a(), d ) = "() integer, double" )
+			CU_ASSERT( f5( ca(), d ) = "() const integer, integer" )
+
+		END_TEST
+
+	END_TEST_GROUP
+
 END_SUITE

--- a/tests/quirk/lubound.bas
+++ b/tests/quirk/lubound.bas
@@ -160,4 +160,58 @@ SUITE( fbc_tests.quirk.lubound )
 		hCheckBydesc( array10(), 31, 33 )
 	END_TEST
 
+	sub hCheckConstBydesc _
+		( _
+			array() as const integer, _
+			byval expectedlbound as integer, _
+			byval expectedubound as integer _
+		)
+
+		CU_ASSERT( lbound( array ) = expectedlbound )
+		CU_ASSERT( ubound( array ) = expectedubound )
+
+	end sub
+
+	dim shared const_array1(0 to 1) as const integer = {1, 2}
+	dim shared const_array2(123 to 127) as const integer = {3, 4, 5, 6, 7}
+	dim shared const_array9(11 to ...) as const integer = { 1, lbound( const_array9 ), 3 }
+
+	TEST( const_array_bound )
+
+		hCheckConstBydesc( const_array1(), 0, 1 )
+		hCheckConstBydesc( const_array2(), 123, 127 )
+		hCheckConstBydesc( const_array9(), 11, 13 )
+
+	END_TEST
+
+	type point
+		x as single
+		y as single
+	end type
+
+	type shape
+		points(any) as point
+	end type
+
+	sub const_udt_test (byref s as const shape)
+		CU_ASSERT( lbound(s.points) = 0 )
+		CU_ASSERT( ubound(s.points) = -1 )
+	end sub
+
+	TEST( const_UDT_array )
+
+		dim as shape s0
+		CU_ASSERT( lbound(s0.points) = 0 )
+		CU_ASSERT( ubound(s0.points) = -1 )
+
+		dim as const shape s = s0
+		CU_ASSERT( lbound(s.points) = 0 )
+		CU_ASSERT( ubound(s.points) = -1 )
+
+		const_udt_test( s0 )
+		const_udt_test( s )
+
+	END_TEST
+
+
 END_SUITE

--- a/tests/warnings/const-discard.bas
+++ b/tests/warnings/const-discard.bas
@@ -1014,3 +1014,29 @@ scope
 	WARN(0)
 	memcpy( x + i, xc, 5 )
 end scope
+
+'' --------------------------------------------------------
+
+'' from https://www.freebasic.net/forum/viewtopic.php?p=254288#p254288
+
+#print "---- Array in Const UDT"
+
+type point
+	x as single
+	y as single
+end type
+
+type shape
+	points(any) as point
+end type
+
+sub const_udt_array( byref s as const shape )
+	WARN(0)
+	print lbound(s.points)
+	WARN(0)
+	print ubound(s.points)
+	WARN(0)
+	print @s.points(0)
+	WARN(0)
+	print s.points(0).x
+end sub

--- a/tests/warnings/r/dos/const-discard.txt
+++ b/tests/warnings/r/dos/const-discard.txt
@@ -415,3 +415,8 @@ none expected
 none expected
 none expected
 none expected
+---- Array in Const UDT
+none expected
+none expected
+none expected
+none expected

--- a/tests/warnings/r/linux-x86/const-discard.txt
+++ b/tests/warnings/r/linux-x86/const-discard.txt
@@ -415,3 +415,8 @@ none expected
 none expected
 none expected
 none expected
+---- Array in Const UDT
+none expected
+none expected
+none expected
+none expected

--- a/tests/warnings/r/linux-x86_64/const-discard.txt
+++ b/tests/warnings/r/linux-x86_64/const-discard.txt
@@ -415,3 +415,8 @@ none expected
 none expected
 none expected
 none expected
+---- Array in Const UDT
+none expected
+none expected
+none expected
+none expected

--- a/tests/warnings/r/win32/const-discard.txt
+++ b/tests/warnings/r/win32/const-discard.txt
@@ -415,3 +415,8 @@ none expected
 none expected
 none expected
 none expected
+---- Array in Const UDT
+none expected
+none expected
+none expected
+none expected

--- a/tests/warnings/r/win64/const-discard.txt
+++ b/tests/warnings/r/win64/const-discard.txt
@@ -415,3 +415,8 @@ none expected
 none expected
 none expected
 none expected
+---- Array in Const UDT
+none expected
+none expected
+none expected
+none expected


### PR DESCRIPTION
- rtl-const: lbound() & ubound() rtl functions should accept const arrays
- internal lbound() and ubound() run-time functions were being declared expecting non-const bydesc array() as any.
- added regression test
- reference: https://www.freebasic.net/forum/viewtopic.php?p=254260#p254260

While investigating the lbound & ubound bug, found an unrelated bug where internal mangling of the array descriptor was conflicting between const & non-const types
- mangling: mangle top-level const in to internal array descriptor structs