### PR TITLE
Fix two WINDOW scaling problems (GitHub Issue #113):

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -83,6 +83,7 @@ Version 1.06.0
 - #858: C backend: fix internal structure size mismatch due to wrong padding when nesting packed structures
 - C backend: fix array descriptor mangling to avoid naming conflicts where array data types differ only by const
 - #823: Function overload resolution for [const] array() and passing non-const array argument to const array parameter
+- Github #113: When a WINDOW was active, the top/right edges (bottom/right for WINDOW SCREEN) were transformed out of the viewport.
 
 
 Version 1.05.0

--- a/src/gfxlib2/gfx_core.c
+++ b/src/gfxlib2/gfx_core.c
@@ -126,8 +126,8 @@ void fb_hSetPixelTransfer(FB_GFXCTX *context, unsigned int color)
 void fb_hTranslateCoord(FB_GFXCTX *context, float fx, float fy, int *x, int *y)
 {
 	if (context->flags & CTX_WINDOW_ACTIVE) {
-		fx = ((fx - context->win_x) * context->view_w) / context->win_w;
-		fy = ((fy - context->win_y) * context->view_h) / context->win_h;
+		fx = ((fx - context->win_x) * (context->view_w - 1)) / context->win_w;
+		fy = ((fy - context->win_y) * (context->view_h - 1)) / context->win_h;
 	}
 	
 	*x = CINT(fx);

--- a/src/rtlib/fb.h
+++ b/src/rtlib/fb.h
@@ -86,7 +86,7 @@
 #define MIN(a,b)		((a) < (b) ? (a) : (b))
 #define MAX(a,b)		((a) > (b) ? (a) : (b))
 #define MID(a,b,c)		MIN(MAX((a), (b)), (c))
-#define CINT(x)			((x) > 0.0 ? (int)(x) + 0.5 : (int)(x - 0.5))
+#define CINT(x)			((x) > 0.0 ? (int)((x) + 0.5) : (int)((x) - 0.5))
 
 #define SWAP(a,b)		((a) ^= (b), (b) ^= (a), (a) ^= (b))
 


### PR DESCRIPTION
- coordinates should be multiplied by e.g. 'width - 1', not just 'width'.
- CINT() macro was not rounding positive values properly

Note: CINT() is also used in https://github.com/freebasic/fbc/blob/master/src/gfxlib2/gfx_circle.c#L96 and https://github.com/freebasic/fbc/blob/master/src/gfxlib2/gfx_draw.c#L247, so we need to make sure that they were not relying on the buggy rounding.