### PR TITLE
Fixed mismatched matrix mode of matrix stack push/pop calls

### DIFF
--- a/src/gfxlib2/gfx_opengl.c
+++ b/src/gfxlib2/gfx_opengl.c
@@ -266,6 +266,7 @@ void fb_hGL_SetupProjection(void)
 
 	__fb_gl.Ortho(-1, 1, -1, 1, -1, 1);
 	__fb_gl.MatrixMode(GL_MODELVIEW);
+	__fb_gl.PushMatrix();
 	__fb_gl.LoadIdentity();
 	__fb_gl.ShadeModel(GL_FLAT);
 	__fb_gl.Disable(GL_DEPTH_TEST);
@@ -307,6 +308,8 @@ void fb_hGL_SetupProjection(void)
 	__fb_gl.Enable(GL_TEXTURE_2D);
 	__fb_gl.DrawArrays(GL_TRIANGLE_FAN,0,4);
 
+	__fb_gl.PopMatrix(); /* GL_MODELVIEW */
+	__fb_gl.MatrixMode(GL_PROJECTION);
 	__fb_gl.PopMatrix();
 	__fb_gl.PopAttrib();
 	__fb_gl.PopClientAttrib();


### PR DESCRIPTION
Since each OpenGL matrix has is own stack, we need to ensure the correct stack is active before popping its stack.  I added calls to handle both GL_PROJECTION and GL_MODELVIEW matrix stacks in addition to ensuring that the MatrixMode() of the PopMatrix() call match the PushMatrix() call.