### PR TITLE
Bug fixes for CVA_LIST PTR types

### DIFF
--- a/src/compiler/ast-node-check.bas
+++ b/src/compiler/ast-node-check.bas
@@ -177,8 +177,10 @@ function astLoadPTRCHK _
 	end if
 
 	'' assign to a temp, can't reuse the same vreg or registers could
-	'' be spilled as IR can't handle inter-blocks
-	t = astNewASSIGN( astNewVAR( n->sym ), l, AST_OPOPT_ISINI )
+	'' be spilled as IR can't handle inter-blocks.
+	'' And don't generate pointer warnings for this internal assignment; as
+	'' in the case where datatypes differ by mangle modifier only.
+	t = astNewASSIGN( astNewVAR( n->sym ), l, AST_OPOPT_ISINI or AST_OPOPT_DONTCHKPTR )
 	astLoad( t )
 	astDelNode( t )
 

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -65,6 +65,15 @@ sub hSymbolType _
 		lgt = typeGetSize( dtype )
 	end if
 
+	'' ANY alias "modifier" but no pointer level?
+	if( typeHasMangleDt( dtype ) and (typeGetDtAndPtrOnly( dtype ) = FB_DATATYPE_VOID) ) then
+		errReport( FB_ERRMSG_INVALIDDATATYPES )
+		'' error recovery: fake a type
+		dtype = typeAddrOf( dtype )
+		subtype = NULL
+		lgt = typeGetSize( dtype )
+	end if
+
 end sub
 
 function hCheckScope() as integer

--- a/tests/dim/dim-bad-datatype-1.bas
+++ b/tests/dim/dim-bad-datatype-1.bas
@@ -1,0 +1,3 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+dim x as any alias "char"

--- a/tests/functions/va_cva_api.bas
+++ b/tests/functions/va_cva_api.bas
@@ -94,8 +94,8 @@ SUITE( fbc_tests.functions.va_cva_api )
 
 		next
 
-		cva_end( x1 )
-		cva_end( x2 )
+		cva_end( y1 )
+		cva_end( y2 )
 
 	end sub
 


### PR DESCRIPTION
A few fixes for issues mentioned on freebasic.net forums:
See [variadic functions and argument lists in fbc](https://www.freebasic.net/forum/viewtopic.php?t=27194)

- disable suspicious warnings on NULL pointer checks for pointers to cva_list types
- disable -gen gcc warning of comparison of distinct pointer types lacks a cast when comparing cva_list pointer types
- disallow ANY ALIAS "modifier" unless it is also a pointer type, like ANY PTR.  Allocated data types must have non-zero size.
