### PR TITLE
bugfix: sf.net #794 literal tabs in string literals miscompiled if fo…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,9 +6,10 @@ Version 1.07.0
 - CVA_LIST type, CVA_START(), CVA_COPY() CVA_END(), CVA_ARG() macros will map to gcc's __builtin_va_list and __builtin_va_* macros in gcc backend
 
 [fixed]
-- #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros
+- sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros
 - push/pop correct GL_PROJECTION matrix and GL_MODELVIEW matrix when setting up graphics screen (gothon)
 - fix char & wchar concatentation.  For char double byte characters (such as Chinese characters), the "wstr = char & wchar" would become "wstr = char & chrw(0) & wchar" (SkyFish)
+- sf.net #794: literal tabs in string literals miscompiled if followed by 0-9 numeric chars
 
 
 Version 1.06.0

--- a/src/compiler/hlp-str.bas
+++ b/src/compiler/hlp-str.bas
@@ -812,11 +812,15 @@ function hEscape _
 			dst += 1
 
 			if( c < 8 ) then
+				dst[0] = CHAR_0
+				dst[1] = CHAR_0
+				dst += 2
 				c += CHAR_0
 
 			elseif( c < 64 ) then
-				*dst = CHAR_0 + (c shr 3)
-				dst += 1
+				dst[0] = CHAR_0
+				dst[1] = CHAR_0 + (c shr 3)
+				dst += 2
 				c = CHAR_0 + (c and 7)
 
 			else

--- a/tests/string/literal-tab.bas
+++ b/tests/string/literal-tab.bas
@@ -1,0 +1,34 @@
+#include "fbcunit.bi"
+
+SUITE( fbc_tests.string_.literal_tab )
+
+	TEST( default)
+
+		'' test that literal tabs in the source file
+		'' are correctly escaped and emitted.
+
+		'' careful - string is 'x' chr(9) '0' 'x' chr(9) '0' '9'
+		dim as string a = "x	0x	1x"
+		dim as string b = "x" & chr(9) & "0x" & chr(9) & "1x"
+		dim as string c = !"x\t0x\t1x"
+		dim as ubyte d(0 to 6) = { asc("x"), 9, asc("0"), asc("x"), _
+			9, asc("1"), asc("x") }
+
+		CU_ASSERT( len("x	0x	1x") = 7 )
+		CU_ASSERT( len( a ) = 7 )
+		CU_ASSERT( len( b ) = 7 )
+		CU_ASSERT( len( c ) = 7 )
+
+		CU_ASSERT( a = "x	0x	1x" )
+		CU_ASSERT( b = a )
+		CU_ASSERT( c = a )
+
+		for i as integer = 0 to 6
+			CU_ASSERT( a[i] = d(i) )
+			CU_ASSERT( b[i] = d(i) )
+			CU_ASSERT( c[i] = d(i) )
+		next
+
+	END_TEST
+
+END_SUITE


### PR DESCRIPTION
…llowed by 0-9 numeric chars

- when emitting octal escapes, always write out 3 digit octal escape codes "\nnn".