### PR TITLE
rtlib: freebsd: Fix deprecated use of VM_METER

### DIFF
--- a/src/rtlib/freebsd/sys_fmem.c
+++ b/src/rtlib/freebsd/sys_fmem.c
@@ -7,7 +7,7 @@
 
 FBCALL size_t fb_GetMemAvail( int mode )
 {
-	int mib[2] = { CTL_VM, VM_METER };
+	int mib[2] = { CTL_VM, VM_TOTAL };
 	struct vmtotal vmt;
 	size_t size = sizeof(struct vmtotal);
 


### PR DESCRIPTION
VM_METER has been deprecated for over 15 years; VM_TOTAL should be used
to request the population of a struct vmtotal.