### PR TITLE
Implement the '-strip' compiler option

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,9 @@ Version 1.07.0
 [added]
 - CVA_LIST type, CVA_START(), CVA_COPY() CVA_END(), CVA_ARG() macros will map to gcc's __builtin_va_list and __builtin_va_* macros in gcc backend
 - github #133: fbc makefile supports bootstrap-minimal target to build a bootstrap fbc with only the minimal features necessary to build another fbc. (William Breathitt Gray)
+- github #141: introduced '-strip'/'-nostrip' options to control symbol stripping of output files (William Breathitt Gray)
+- github #141: fbc will default to stripping symbols if '-d ENABLE_STRIPALL' is passed in FBCFLAGS (William Breathitt Gray)
+- github #141: makefile option 'ENABLE_STRIPALL=1' introduced to pass '-d ENABLE_STRIPALL' via FBCFLAGS by default for dos/win32 targets (William Breathitt Gray)
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/makefile
+++ b/makefile
@@ -81,6 +81,7 @@
 #   ENABLE_SUFFIX=-0.24    append a string like "-0.24" to fbc/FB dir names,
 #                          and use "-d ENABLE_SUFFIX=$(ENABLE_SUFFIX)" (non-standalone only)
 #   ENABLE_LIB64=1         use prefix/lib64/ instead of prefix/lib/ for 64bit libs (non-standalone only)
+#   ENABLE_STRIPALL=1      use "-d ENABLE_STRIPALL" with select targets
 #   FBPACKAGE     bindist: The package/archive file name without path or extension
 #   FBPACKSUFFIX  bindist: Allows adding a custom suffix to the normal package name (and the toplevel dir in the archive)
 #   FBMANIFEST    bindist: The manifest file name without path or extension
@@ -92,6 +93,7 @@
 #   -d ENABLE_SUFFIX=-0.24   assume FB's lib dir uses the given suffix (non-standalone only)
 #   -d ENABLE_PREFIX=/some/path   hard-code specific $(prefix) into fbc
 #   -d ENABLE_LIB64          use prefix/lib64/ instead of prefix/lib/ for 64bit libs (non-standalone only)
+#   -d ENABLE_STRIPALL       configure fbc to pass down '--strip-all' to linker by default
 #
 # rtlib/gfxlib2 source code configuration (CFLAGS):
 #   -DDISABLE_X11    build without X11 headers (disables X11 gfx driver)
@@ -429,6 +431,12 @@ endif
 ifdef ENABLE_LIB64
   ALLFBCFLAGS += -d ENABLE_LIB64
 endif
+ifdef ENABLE_STRIPALL
+  ifneq ($(filter dos win32,$(TARGET_OS)),)
+    ALLFBCFLAGS += -d ENABLE_STRIPALL
+  endif
+endif
+
 
 ALLFBCFLAGS += $(FBCFLAGS) $(FBFLAGS)
 ALLFBLFLAGS += $(FBLFLAGS) $(FBFLAGS)


### PR DESCRIPTION
This change allows users to choose whether or not to strip symbol
information from the output file. The fbc '-strip' option is analogous
to the ld '--strip-all' option.

This fixes issue #140.