### PR TITLE
Fix wstring bugs in [L|R]TRIM functions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@ Version 1.07.0
 - sf.net #897: length of literal wstring is miscalculated at compile time.  Compile time evaluation of len(!"\u1234") was using the internal escaped string length instead of the actual codepoint length
 - github #137: Final -Wl flag takes precedence over previous.  fbc now passes down all options from all -Wa, -Wc, and -Wl flags (William Breathitt Gray)
 - github #138: rtlib: freebsd: Fix deprecated use of VM_METER to use VM_TOTAL (William Breathitt Gray)
+- sf.net #899: trim( wstring ) causes crash if string is single space
 
 
 Version 1.06.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,8 @@ Version 1.07.0
 - sf.net #897: length of literal wstring is miscalculated at compile time.  Compile time evaluation of len(!"\u1234") was using the internal escaped string length instead of the actual codepoint length
 - github #137: Final -Wl flag takes precedence over previous.  fbc now passes down all options from all -Wa, -Wc, and -Wl flags (William Breathitt Gray)
 - github #138: rtlib: freebsd: Fix deprecated use of VM_METER to use VM_TOTAL (William Breathitt Gray)
-- sf.net #899: trim( wstring ) causes crash if string is single space
+- sf.net #899: TRIM( wstring ) causes crash if string is single space
+- sf.net #900: LTRIM( wstring, filter ) and TRIM( wstring, filter ) truncate result if filter is zero length string
 
 
 Version 1.06.0

--- a/src/rtlib/fb_unicode.h
+++ b/src/rtlib/fb_unicode.h
@@ -220,12 +220,12 @@ static __inline__ const FB_WCHAR *fb_wstr_SkipCharRev( const FB_WCHAR *s, ssize_
 		return s;
 
 	/* fixed-len's are filled with null's as in PB, strip them too */
-	const FB_WCHAR *p = &s[chars-1];
+	const FB_WCHAR *p = &s[chars];
 	while( chars > 0 )
 	{
-		if( *p != c )
-			return p;
 		--p;
+		if( *p != c )
+			return ++p;
 		--chars;
 	}
 

--- a/src/rtlib/fb_unicode.h
+++ b/src/rtlib/fb_unicode.h
@@ -126,7 +126,7 @@ typedef uint8_t  UTF_8;
 /* Calculate the number of characters between two pointers. */
 static __inline__ ssize_t fb_wstr_CalcDiff( const FB_WCHAR *ini, const FB_WCHAR *end )
 {
-	return ((intptr_t)end - (intptr_t)ini) / sizeof( FB_WCHAR );
+	return end - ini;
 }
 
 static __inline__ FB_WCHAR *fb_wstr_AllocTemp( ssize_t chars )

--- a/src/rtlib/strw_ltrim.c
+++ b/src/rtlib/strw_ltrim.c
@@ -19,7 +19,7 @@ FBCALL FB_WCHAR *fb_WstrLTrim ( const FB_WCHAR *src )
 		return NULL;
 
 	/* alloc temp string */
-    dst = fb_wstr_AllocTemp( len );
+	dst = fb_wstr_AllocTemp( len );
 	if( dst != NULL )
 		fb_wstr_Copy( dst, p, len );
 

--- a/src/rtlib/strw_ltrimex.c
+++ b/src/rtlib/strw_ltrimex.c
@@ -6,7 +6,7 @@ FBCALL FB_WCHAR *fb_WstrLTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 {
 	FB_WCHAR 	*dst;
 	ssize_t len;
-	const FB_WCHAR *p = NULL;
+	const FB_WCHAR *p = src;
 
     if( src == NULL ) {
         return NULL;

--- a/src/rtlib/strw_ltrimex.c
+++ b/src/rtlib/strw_ltrimex.c
@@ -20,7 +20,7 @@ FBCALL FB_WCHAR *fb_WstrLTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
                 p = fb_wstr_SkipChar( src,
                                       len,
                                       *pattern );
-                len = len - (ssize_t)(p - src);
+                len -= fb_wstr_CalcDiff( src, p );
 
             } else if( len_pattern != 0 ) {
                 p = src;

--- a/src/rtlib/strw_ltrimex.c
+++ b/src/rtlib/strw_ltrimex.c
@@ -4,40 +4,40 @@
 
 FBCALL FB_WCHAR *fb_WstrLTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 {
-	FB_WCHAR 	*dst;
+	FB_WCHAR *dst;
 	ssize_t len;
 	const FB_WCHAR *p = src;
 
-    if( src == NULL ) {
-        return NULL;
-    }
+	if( src == NULL ) {
+		return NULL;
+	}
 
-    {
-        ssize_t len_pattern = fb_wstr_Len( pattern );
-        len = fb_wstr_Len( src );
-        if( len >= len_pattern ) {
-            if( len_pattern==1 ) {
-                p = fb_wstr_SkipChar( src,
-                                      len,
-                                      *pattern );
-                len -= fb_wstr_CalcDiff( src, p );
+	{
+		ssize_t len_pattern = fb_wstr_Len( pattern );
+		len = fb_wstr_Len( src );
+		if( len >= len_pattern ) {
+			if( len_pattern==1 ) {
+				p = fb_wstr_SkipChar( src,
+				                      len,
+				                      *pattern );
+				len -= fb_wstr_CalcDiff( src, p );
 
-            } else if( len_pattern != 0 ) {
-                p = src;
-                while (len >= len_pattern ) {
-                    if( fb_wstr_Compare( p, pattern, len_pattern )!=0 )
-                        break;
-                    p += len_pattern;
-                    len -= len_pattern;
-                }
-            }
-        }
+			} else if( len_pattern != 0 ) {
+				p = src;
+				while (len >= len_pattern ) {
+					if( fb_wstr_Compare( p, pattern, len_pattern )!=0 )
+						break;
+					p += len_pattern;
+					len -= len_pattern;
+				}
+			}
+		}
 	}
 
 	if( len > 0 )
 	{
 		/* alloc temp string */
-        dst = fb_wstr_AllocTemp( len );
+		dst = fb_wstr_AllocTemp( len );
 		if( dst != NULL )
 		{
 			/* simple copy */
@@ -45,7 +45,7 @@ FBCALL FB_WCHAR *fb_WstrLTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 		}
 		else
 			dst = NULL;
-    }
+	}
 	else
 		dst = NULL;
 

--- a/src/rtlib/strw_rtrim.c
+++ b/src/rtlib/strw_rtrim.c
@@ -21,7 +21,7 @@ FBCALL FB_WCHAR *fb_WstrRTrim ( const FB_WCHAR *src )
 		return NULL;
 
 	/* alloc temp string */
-    dst = fb_wstr_AllocTemp( chars );
+	dst = fb_wstr_AllocTemp( chars );
 	if( dst != NULL )
 	{
 		/* simple copy */

--- a/src/rtlib/strw_rtrim.c
+++ b/src/rtlib/strw_rtrim.c
@@ -16,7 +16,7 @@ FBCALL FB_WCHAR *fb_WstrRTrim ( const FB_WCHAR *src )
 		return NULL;
 
 	p = fb_wstr_SkipCharRev( src, chars, _LC(' ') );
-	chars = fb_wstr_CalcDiff( src, p ) + 1;
+	chars = fb_wstr_CalcDiff( src, p );
 	if( chars <= 0 )
 		return NULL;
 

--- a/src/rtlib/strw_rtrimex.c
+++ b/src/rtlib/strw_rtrimex.c
@@ -4,44 +4,44 @@
 
 FBCALL FB_WCHAR *fb_WstrRTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 {
-	FB_WCHAR 	*dst;
+	FB_WCHAR *dst;
 	ssize_t len;
 	const FB_WCHAR *p = src;
 
-    if( src == NULL ) {
-        return NULL;
-    }
+	if( src == NULL ) {
+		return NULL;
+	}
 
 	{
 		ssize_t len_pattern = fb_wstr_Len( pattern );
 		len = fb_wstr_Len( src );
 		if( len >= len_pattern )
 		{
-            if( len_pattern==1 ) {
-                p = fb_wstr_SkipCharRev( src,
-                                         len,
-                                         *pattern );
-                len = fb_wstr_CalcDiff( src, p );
+			if( len_pattern==1 ) {
+				p = fb_wstr_SkipCharRev( src,
+				                         len,
+				                         *pattern );
+				len = fb_wstr_CalcDiff( src, p );
 
-            } else if( len_pattern != 0 ) {
-                ssize_t test_index = len - len_pattern;
-                p = src;
-                while (len >= len_pattern ) {
-                    if( fb_wstr_Compare( p + test_index,
-                                         pattern,
-                                         len_pattern )!=0 )
-                        break;
-                    test_index -= len_pattern;
-                }
-                len = test_index + len_pattern;
-            }
+			} else if( len_pattern != 0 ) {
+				ssize_t test_index = len - len_pattern;
+				p = src;
+				while (len >= len_pattern ) {
+					if( fb_wstr_Compare( p + test_index,
+					                     pattern,
+					                     len_pattern )!=0 )
+						break;
+					test_index -= len_pattern;
+				}
+				len = test_index + len_pattern;
+			}
 		}
-    }
+	}
 
 	if( len > 0 )
 	{
 		/* alloc temp string */
-        dst = fb_wstr_AllocTemp( len );
+		dst = fb_wstr_AllocTemp( len );
 		if( dst != NULL )
 		{
 			/* simple copy */
@@ -49,9 +49,9 @@ FBCALL FB_WCHAR *fb_WstrRTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 		}
 		else
 			dst = NULL;
-    }
+	}
 	else
 		dst = NULL;
 
-    return dst;
+	return dst;
 }

--- a/src/rtlib/strw_rtrimex.c
+++ b/src/rtlib/strw_rtrimex.c
@@ -21,7 +21,7 @@ FBCALL FB_WCHAR *fb_WstrRTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
                 p = fb_wstr_SkipCharRev( src,
                                          len,
                                          *pattern );
-                len = (ssize_t)(p - src) + 1;
+                len = fb_wstr_CalcDiff( src, p );
 
             } else if( len_pattern != 0 ) {
                 ssize_t test_index = len - len_pattern;

--- a/src/rtlib/strw_rtrimex.c
+++ b/src/rtlib/strw_rtrimex.c
@@ -6,7 +6,7 @@ FBCALL FB_WCHAR *fb_WstrRTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 {
 	FB_WCHAR 	*dst;
 	ssize_t len;
-	const FB_WCHAR *p = NULL;
+	const FB_WCHAR *p = src;
 
     if( src == NULL ) {
         return NULL;

--- a/src/rtlib/strw_trim.c
+++ b/src/rtlib/strw_trim.c
@@ -16,7 +16,7 @@ FBCALL FB_WCHAR *fb_WstrTrim ( const FB_WCHAR *src )
 		return NULL;
 
 	p = fb_wstr_SkipCharRev( src, chars, _LC(' ') );
-	chars = fb_wstr_CalcDiff( src, p ) + 1;
+	chars = fb_wstr_CalcDiff( src, p );
 	if( chars <= 0 )
 		return NULL;
 
@@ -26,7 +26,7 @@ FBCALL FB_WCHAR *fb_WstrTrim ( const FB_WCHAR *src )
 		return NULL;
 
 	/* alloc temp string */
-    dst = fb_wstr_AllocTemp( chars );
+	dst = fb_wstr_AllocTemp( chars );
 	if( dst != NULL )
 	{
 		/* simple copy */

--- a/src/rtlib/strw_trimex.c
+++ b/src/rtlib/strw_trimex.c
@@ -4,61 +4,61 @@
 
 FBCALL FB_WCHAR *fb_WstrTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 {
-	FB_WCHAR 	*dst;
+	FB_WCHAR *dst;
 	ssize_t len;
 	const FB_WCHAR *p = src;
 
-    if( src == NULL ) {
-        return NULL;
-    }
+	if( src == NULL ) {
+		return NULL;
+	}
 
-    {
-        ssize_t len_pattern = fb_wstr_Len( pattern );
-        len = fb_wstr_Len( src );
-        if( len >= len_pattern ) {
-            if( len_pattern==1 ) {
-                p = fb_wstr_SkipChar( src,
-                                      len,
-                                      *pattern );
-                len -= fb_wstr_CalcDiff( src, p );
+	{
+		ssize_t len_pattern = fb_wstr_Len( pattern );
+		len = fb_wstr_Len( src );
+		if( len >= len_pattern ) {
+			if( len_pattern==1 ) {
+				p = fb_wstr_SkipChar( src,
+				                      len,
+				                      *pattern );
+				len -= fb_wstr_CalcDiff( src, p );
 
-            } else if( len_pattern != 0 ) {
-                p = src;
-                while (len >= len_pattern ) {
-                    if( fb_wstr_Compare( p, pattern, len_pattern )!=0 )
-                        break;
-                    p += len_pattern;
-                    len -= len_pattern;
-                }
-            }
-        }
-        if( len >= len_pattern ) {
-            if( len_pattern==1 ) {
-                const FB_WCHAR *p_tmp =
-                    fb_wstr_SkipCharRev( p,
-                                         len,
-                                         *pattern );
-                len = fb_wstr_CalcDiff( p, p_tmp );
+			} else if( len_pattern != 0 ) {
+				p = src;
+				while (len >= len_pattern ) {
+					if( fb_wstr_Compare( p, pattern, len_pattern )!=0 )
+						break;
+					p += len_pattern;
+					len -= len_pattern;
+				}
+			}
+		}
+		if( len >= len_pattern ) {
+			if( len_pattern==1 ) {
+				const FB_WCHAR *p_tmp =
+					fb_wstr_SkipCharRev( p,
+					                     len,
+					                     *pattern );
+				len = fb_wstr_CalcDiff( p, p_tmp );
 
-            } else if( len_pattern != 0 ) {
-                ssize_t test_index = len - len_pattern;
-                while (len >= len_pattern ) {
-                    if( fb_wstr_Compare( p + test_index,
-                                         pattern,
-                                         len_pattern )!=0 )
-                        break;
-                    test_index -= len_pattern;
-                }
-                len = test_index + len_pattern;
+			} else if( len_pattern != 0 ) {
+				ssize_t test_index = len - len_pattern;
+				while (len >= len_pattern ) {
+					if( fb_wstr_Compare( p + test_index,
+					                     pattern,
+					                     len_pattern )!=0 )
+						break;
+					test_index -= len_pattern;
+				}
+				len = test_index + len_pattern;
 
-            }
-        }
+			}
+		}
 	}
 
 	if( len > 0 )
 	{
 		/* alloc temp string */
-        dst = fb_wstr_AllocTemp( len );
+		dst = fb_wstr_AllocTemp( len );
 		if( dst != NULL )
 		{
 			/* simple copy */
@@ -66,7 +66,7 @@ FBCALL FB_WCHAR *fb_WstrTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 		}
 		else
 			dst = NULL;
-    }
+	}
 	else
 		dst = NULL;
 

--- a/src/rtlib/strw_trimex.c
+++ b/src/rtlib/strw_trimex.c
@@ -6,7 +6,7 @@ FBCALL FB_WCHAR *fb_WstrTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 {
 	FB_WCHAR 	*dst;
 	ssize_t len;
-	const FB_WCHAR *p = NULL;
+	const FB_WCHAR *p = src;
 
     if( src == NULL ) {
         return NULL;

--- a/src/rtlib/strw_trimex.c
+++ b/src/rtlib/strw_trimex.c
@@ -20,7 +20,7 @@ FBCALL FB_WCHAR *fb_WstrTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
                 p = fb_wstr_SkipChar( src,
                                       len,
                                       *pattern );
-                len = len - (ssize_t)(p - src);
+                len -= fb_wstr_CalcDiff( src, p );
 
             } else if( len_pattern != 0 ) {
                 p = src;
@@ -38,7 +38,7 @@ FBCALL FB_WCHAR *fb_WstrTrimEx ( const FB_WCHAR *src, const FB_WCHAR *pattern )
                     fb_wstr_SkipCharRev( p,
                                          len,
                                          *pattern );
-                len = (ssize_t)(p_tmp - p) + 1;
+                len = fb_wstr_CalcDiff( p, p_tmp );
 
             } else if( len_pattern != 0 ) {
                 ssize_t test_index = len - len_pattern;

--- a/tests/wstring/chk-wstring.bi
+++ b/tests/wstring/chk-wstring.bi
@@ -1,0 +1,26 @@
+#pragma once
+
+#macro CU_ASSERT_WSTRING_EQUAL( a, b )
+
+	'' length check
+	CU_ASSERT( len(a) = len(b) )
+
+	'' comparison check
+	CU_ASSERT_EQUAL(a, b)
+
+	'' byte-by-byte check
+	scope
+		if(len(a) = len(b)) then
+			do
+				for i as integer = 0 to len(a) - 1
+					if(a[i] <> b[i]) then
+						CU_FAIL()
+						exit do
+					end if
+				next
+				CU_PASS()
+			loop until true
+		end if
+	end scope
+
+#endmacro

--- a/tests/wstring/ltrim.bas
+++ b/tests/wstring/ltrim.bas
@@ -1,132 +1,258 @@
 #include "fbcunit.bi"
+#include once "chk-wstring.bi"
 
 SUITE( fbc_tests.wstring_.ltrim_ )
 
-	dim shared result as integer
-	dim shared str_ret as wstring*32
+	#macro check( a, length, expected )
+		scope
+			dim wr as wstring * 50 = ltrim( wstr(a) )
+			dim we as wstring * 50 = wstr( expected )
 
-	TEST( test1 )
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
 
-		str_ret = ltrim(wstr("asd"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		scope
+			dim wa as wstring * 50 = wstr(a)
+			dim we as wstring * 50 = wstr( expected )
+			dim wr as wstring * 50 = ltrim( wa )
 
-		str_ret = ltrim(wstr(" asd"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
 
-		str_ret = ltrim(wstr("  asd"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+	#macro check_filter( a, filter, length, expected )
+		scope
+			dim wr as wstring * 50 = ltrim( wstr(a), wstr(filter) )
+			dim we as wstring * 50 = wstr( expected )
 
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+
+		scope
+			dim wa as wstring * 50 = wstr(a)
+			dim wf as wstring * 50 = wstr(filter)
+			dim wr as wstring * 50 = ltrim( wa, wf )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
+
+	#macro check_filter_any( a, filter, length, expected )
+		scope
+			dim wr as wstring * 50 = ltrim( wstr(a), any wstr(filter) )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+
+		scope
+			dim wa as wstring * 50 = wstr(a)
+			dim wf as wstring * 50 = wstr(filter)
+			dim wr as wstring * 50 = ltrim( wa, any wf )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
+
+	TEST( default )
+		check( ""       , 0, "" )
+		check( " "      , 0, "" )
+		check( "  "     , 0, "" )
+		check( "asd"    , 3, "asd" )
+		check( "asd "   , 4, "asd " )
+		check( "asd  "  , 5, "asd  " )
+		check( " asd"   , 3, "asd" )
+		check( "  asd"  , 3, "asd" )
+		check( " asd "  , 4, "asd " )
+		check( "  asd  ", 5, "asd  " )
 	END_TEST
 
-	TEST( test2 )
+	TEST( filter )
+		check_filter( ""       , ""  , 0, "" )
+		check_filter( ""       , " " , 0, "" )
+		check_filter( ""       , "  ", 0, "" )
+		check_filter( " "      , ""  , 1, " " )
+		check_filter( " "      , " " , 0, "" )
+		check_filter( " "      , "  ", 1, " " )
+		check_filter( "  "     , ""  , 2, "  " )
+		check_filter( "  "     , " " , 0, "" )
+		check_filter( "  "     , "  ", 0, "" )
 
-		str_ret = ltrim(wstr("asd"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( "asd"    , " ", 3, "asd" )
+		check_filter( "asd "   , " ", 4, "asd " )
+		check_filter( "asd  "  , " ", 5, "asd  " )
+		check_filter( " asd"   , " ", 3, "asd" )
+		check_filter( "  asd"  , " ", 3, "asd" )
+		check_filter( " asd "  , " ", 4, "asd " )
+		check_filter( "  asd  ", " ", 5, "asd  " )
+		
+		check_filter( ""       , "x", 0, "" )
+		check_filter( " "      , "x", 1, " " )
+		check_filter( "x"      , "x", 0, "" )
+		check_filter( "xx"     , "x", 0, "" )
+		check_filter( "asd"    , "x", 3, "asd" )
+		check_filter( "asdx"   , "x", 4, "asdx" )
+		check_filter( "asdxx"  , "x", 5, "asdxx" )
+		check_filter( "xasd"   , "x", 3, "asd" )
+		check_filter( "xxasd"  , "x", 3, "asd" )
+		check_filter( "xasdx"  , "x", 4, "asdx" )
+		check_filter( "xxasdxx", "x", 5, "asdxx" )
 
-		str_ret = ltrim(wstr("xasd"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( ""       , "xy", 0, "" )
+		check_filter( "xy"     , "xy", 0, "" )
+		check_filter( "xyxy"   , "xy", 0, "" )
+		check_filter( "xyxyx"  , "xy", 1, "x" )
+		check_filter( "yxyxy"  , "xy", 5, "yxyxy" )
 
-		str_ret = ltrim(wstr("xxasd"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( "asd"    , "xy", 3, "asd" )
+		check_filter( "asdx"   , "xy", 4, "asdx" )
+		check_filter( "asdxy"  , "xy", 5, "asdxy" )
+		check_filter( "asdxy"  , "yx", 5, "asdxy" )
+		check_filter( "asdyy"  , "yx", 5, "asdyy" )
 
+		check_filter( "xasd"   , "xy", 4, "xasd" )
+		check_filter( "xyasd"  , "xy", 3, "asd" )
+		check_filter( "xyasd"  , "yx", 5, "xyasd" )
+		check_filter( "yyasd"  , "yx", 5, "yyasd" )
+
+		check_filter( "xasdx"  , "xy", 5, "xasdx" )
+		check_filter( "xyasdxy", "xy", 5, "asdxy" )
+		check_filter( "xyasdxy", "yx", 7, "xyasdxy" )
+		check_filter( "yyasdyy", "yx", 7, "yyasdyy" )
 	END_TEST
 
-	TEST( test3 )
 
-		str_ret = ltrim(wstr("asd"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+	TEST( filter_any )
+		check_filter_any( ""       , ""  , 0, "" )
+		check_filter_any( ""       , " " , 0, "" )
+		check_filter_any( ""       , "  ", 0, "" )
+		check_filter_any( " "      , ""  , 1, " " )
+		check_filter_any( " "      , " " , 0, "" )
+		check_filter_any( " "      , "  ", 0, "" )
+		check_filter_any( "  "     , ""  , 2, "  " )
+		check_filter_any( "  "     , " " , 0, "" )
+		check_filter_any( "  "     , "  ", 0, "" )
 
-		str_ret = ltrim(wstr("xasd"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 4 )
-		result = str_ret = "xasd"
-		CU_ASSERT( result )
 
-		str_ret = ltrim(wstr("xyasd"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter_any( "asd"    , " ", 3, "asd" )
+		check_filter_any( "asd "   , " ", 4, "asd " )
+		check_filter_any( "asd  "  , " ", 5, "asd  " )
+		check_filter_any( " asd"   , " ", 3, "asd" )
+		check_filter_any( "  asd"  , " ", 3, "asd" )
+		check_filter_any( " asd "  , " ", 4, "asd " )
+		check_filter_any( "  asd  ", " ", 5, "asd  " )
+		
+		check_filter_any( ""       , "x", 0, "" )
+		check_filter_any( " "      , "x", 1, " " )
+		check_filter_any( "x"      , "x", 0, "" )
+		check_filter_any( "xx"     , "x", 0, "" )
+		check_filter_any( "asd"    , "x", 3, "asd" )
+		check_filter_any( "asdx"   , "x", 4, "asdx" )
+		check_filter_any( "asdxx"  , "x", 5, "asdxx" )
+		check_filter_any( "xasd"   , "x", 3, "asd" )
+		check_filter_any( "xxasd"  , "x", 3, "asd" )
+		check_filter_any( "xasdx"  , "x", 4, "asdx" )
+		check_filter_any( "xxasdxx", "x", 5, "asdxx" )
 
-		str_ret = ltrim(wstr("xyasd"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 5 )
-		result = str_ret = "xyasd"
-		CU_ASSERT( result )
+		check_filter_any( ""       , "xy", 0, "" )
+		check_filter_any( "x"      , "xy", 0, "" )
+		check_filter_any( "y"      , "xy", 0, "" )
+		check_filter_any( "xy"     , "xy", 0, "" )
+		check_filter_any( "xyxy"   , "xy", 0, "" )
+		check_filter_any( "xyxyx"  , "xy", 0, "" )
+		check_filter_any( "yxyxy"  , "xy", 0, "" )
 
-		str_ret = ltrim(wstr("yyasd"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 5 )
-		result = str_ret = "yyasd"
-		CU_ASSERT( result )
+		check_filter_any( "asd"    , "xy", 3, "asd" )
+		check_filter_any( "asdx"   , "xy", 4, "asdx" )
+		check_filter_any( "asdxy"  , "xy", 5, "asdxy" )
+		check_filter_any( "asdxy"  , "yx", 5, "asdxy" )
+		check_filter_any( "asdyy"  , "yx", 5, "asdyy" )
 
+		check_filter_any( "xasd"   , ""  , 4, "xasd" )
+		check_filter_any( "xyasd"  , "xy", 3, "asd" )
+		check_filter_any( "xyasd"  , "yx", 3, "asd" )
+		check_filter_any( "yyasd"  , "yx", 3, "asd" )
+
+		check_filter_any( "xasdx"  , "xy", 4, "asdx" )
+		check_filter_any( "xyasdxy", "xy", 5, "asdxy" )
+		check_filter_any( "xyasdxy", "yx", 5, "asdxy" )
+		check_filter_any( "yyasdyy", "yx", 5, "asdyy" )
+
+		check_filter_any( "asd"     , " d", 3, "asd" )
+		check_filter_any( "asd "    , " d", 4, "asd " )
+		check_filter_any( "asd  "   , " d", 5, "asd  " )
+		check_filter_any( "das"     , " d", 2, "as" )
+		check_filter_any( " das"    , " d", 2, "as" )
+		check_filter_any( "  das"   , " d", 2, "as" )
+		check_filter_any( "dasd"    , " d", 3, "asd" )
+		check_filter_any( " dasd "  , " d", 4, "asd " )
+		check_filter_any( "  dasd  ", " d", 5, "asd  " )
+		check_filter_any( "asd"     , "d ", 3, "asd" )
+		check_filter_any( "asd "    , "d ", 4, "asd " )
+		check_filter_any( "asd  "   , "d ", 5, "asd  " )
+		check_filter_any( "das"     , "d ", 2, "as" )
+		check_filter_any( " das"    , "d ", 2, "as" )
+		check_filter_any( "  das"   , "d ", 2, "as" )
+		check_filter_any( "dasd"    , "d ", 3, "asd" )
+		check_filter_any( " dasd "  , "d ", 4, "asd " )
+		check_filter_any( "  dasd  ", "d ", 5, "asd  " )
 	END_TEST
 
-	TEST( test4 )
+	TEST( escaped )
+		check( !"\u3041\u3043\u3045\u3047\u3049"    , 5, !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"  \u3041\u3043\u3045\u3047\u3049"  , 5, !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"\u3041\u3043\u3045\u3047\u3049  "  , 7, !"\u3041\u3043\u3045\u3047\u3049  " )
+		check( !"  \u3041\u3043\u3045\u3047\u3049  ", 7, !"\u3041\u3043\u3045\u3047\u3049  " )
 
-		str_ret = ltrim(wstr("asd"), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041", _
+						4, !"\u3043\u3045\u3047\u3049" )
 
-		str_ret = ltrim(wstr(" asd"), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043", _
+						3, !"\u3045\u3047\u3049" )
 
-		str_ret = ltrim(wstr("  asd"), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3041", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-	END_TEST
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-	TEST( test5 )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = ltrim(wstr("asd"), any wstr(" a"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "sd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049\u3047", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = ltrim(wstr(" asd"), any wstr(" a"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "sd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3049", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = ltrim(wstr("  asd"), any wstr(" a"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "sd"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041", _
+						4, !"\u3043\u3045\u3047\u3049" )
 
-	END_TEST
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043", _
+						3, !"\u3045\u3047\u3049" )
 
-	TEST( test6 )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3041", _
+						3, !"\u3045\u3047\u3049" )
 
-		str_ret = ltrim(wstr("asd"), any wstr("a "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "sd"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = ltrim(wstr(" asd"), any wstr("a "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "sd"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = ltrim(wstr("  asd"), any wstr("a "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "sd"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049\u3047", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3049", _
+						4, !"\u3043\u3045\u3047\u3049" )
 	END_TEST
 
 END_SUITE

--- a/tests/wstring/rtrim.bas
+++ b/tests/wstring/rtrim.bas
@@ -1,132 +1,257 @@
 #include "fbcunit.bi"
+#include once "chk-wstring.bi"
 
 SUITE( fbc_tests.wstring_.rtrim_ )
 
-	dim shared result as integer
-	dim shared str_ret as wstring*32
+	#macro check( a, length, expected )
+		scope
+			dim wr as wstring * 50 = rtrim( wstr(a) )
+			dim we as wstring * 50 = wstr( expected )
 
-	TEST( test1 )
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
 
-		str_ret = rtrim(wstr("asd"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		scope
+			dim wa as wstring * 50 = wstr(a)
+			dim we as wstring * 50 = wstr( expected )
+			dim wr as wstring * 50 = rtrim( wa )
 
-		str_ret = rtrim(wstr("asd "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
 
-		str_ret = rtrim(wstr("asd  "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+	#macro check_filter( a, filter, length, expected )
+		scope
+			dim wr as wstring * 50 = rtrim( wstr(a), wstr(filter) )
+			dim we as wstring * 50 = wstr( expected )
 
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+
+		scope
+			dim wa as wstring * 50 = wstr(a)
+			dim wf as wstring * 50 = wstr(filter)
+			dim wr as wstring * 50 = rtrim( wa, wf )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
+
+	#macro check_filter_any( a, filter, length, expected )
+		scope
+			dim wr as wstring * 50 = rtrim( wstr(a), any wstr(filter) )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+
+		scope
+			dim wa as wstring * 50 = wstr(a)
+			dim wf as wstring * 50 = wstr(filter)
+			dim wr as wstring * 50 = rtrim( wa, any wf )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
+
+	TEST( default )
+		check( ""       , 0, "" )
+		check( " "      , 0, "" )
+		check( "  "     , 0, "" )
+		check( "asd"    , 3, "asd" )
+		check( "asd "   , 3, "asd" )
+		check( "asd  "  , 3, "asd" )
+		check( " asd"   , 4, " asd" )
+		check( "  asd"  , 5, "  asd" )
+		check( " asd "  , 4, " asd" )
+		check( "  asd  ", 5, "  asd" )
 	END_TEST
 
-	TEST( test2 )
+	TEST( filter )
+		check_filter( ""       , ""  , 0, "" )
+		check_filter( ""       , " " , 0, "" )
+		check_filter( ""       , "  ", 0, "" )
+		check_filter( " "      , ""  , 1, " " )
+		check_filter( " "      , " " , 0, "" )
+		check_filter( " "      , "  ", 1, " " )
+		check_filter( "  "     , ""  , 2, "  " )
+		check_filter( "  "     , " " , 0, "" )
+		check_filter( "  "     , "  ", 0, "" )
 
-		str_ret = rtrim(wstr("asd"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( "asd"    , " ", 3, "asd" )
+		check_filter( "asd "   , " ", 3, "asd" )
+		check_filter( "asd  "  , " ", 3, "asd" )
+		check_filter( " asd"   , " ", 4, " asd" )
+		check_filter( "  asd"  , " ", 5, "  asd" )
+		check_filter( " asd "  , " ", 4, " asd" )
+		check_filter( "  asd  ", " ", 5, "  asd" )
+		
+		check_filter( ""       , "x", 0, "" )
+		check_filter( " "      , "x", 1, " " )
+		check_filter( "x"      , "x", 0, "" )
+		check_filter( "xx"     , "x", 0, "" )
+		check_filter( "asd"    , "x", 3, "asd" )
+		check_filter( "asdx"   , "x", 3, "asd" )
+		check_filter( "asdxx"  , "x", 3, "asd" )
+		check_filter( "xasd"   , "x", 4, "xasd" )
+		check_filter( "xxasd"  , "x", 5, "xxasd" )
+		check_filter( "xasdx"  , "x", 4, "xasd" )
+		check_filter( "xxasdxx", "x", 5, "xxasd" )
 
-		str_ret = rtrim(wstr("asdx"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( ""       , "xy", 0, "" )
+		check_filter( "xy"     , "xy", 0, "" )
+		check_filter( "xyxy"   , "xy", 0, "" )
+		check_filter( "xyxyx"  , "xy", 5, "xyxyx" )
+		check_filter( "yxyxy"  , "xy", 1, "y" )
 
-		str_ret = rtrim(wstr("asdxx"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( "asd"    , "xy", 3, "asd" )
+		check_filter( "asdx"   , "xy", 4, "asdx" )
+		check_filter( "asdxy"  , "xy", 3, "asd" )
+		check_filter( "asdxy"  , "yx", 5, "asdxy" )
+		check_filter( "asdyy"  , "yx", 5, "asdyy" )
 
+		check_filter( "xasd"   , "xy", 4, "xasd" )
+		check_filter( "xyasd"  , "xy", 5, "xyasd" )
+		check_filter( "xyasd"  , "yx", 5, "xyasd" )
+		check_filter( "yyasd"  , "yx", 5, "yyasd" )
+
+		check_filter( "xasdx"  , "xy", 5, "xasdx" )
+		check_filter( "xyasdxy", "xy", 5, "xyasd" )
+		check_filter( "xyasdxy", "yx", 7, "xyasdxy" )
+		check_filter( "yyasdyy", "yx", 7, "yyasdyy" )
 	END_TEST
 
-	TEST( test3 )
+	TEST( filter_any )
+		check_filter_any( ""       , ""  , 0, "" )
+		check_filter_any( ""       , " " , 0, "" )
+		check_filter_any( ""       , "  ", 0, "" )
+		check_filter_any( " "      , ""  , 1, " " )
+		check_filter_any( " "      , " " , 0, "" )
+		check_filter_any( " "      , "  ", 0, "" )
+		check_filter_any( "  "     , ""  , 2, "  " )
+		check_filter_any( "  "     , " " , 0, "" )
+		check_filter_any( "  "     , "  ", 0, "" )
 
-		str_ret = rtrim(wstr("asd"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
 
-		str_ret = rtrim(wstr("asdx"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 4 )
-		result = str_ret = "asdx"
-		CU_ASSERT( result )
+		check_filter_any( "asd"    , " ", 3, "asd" )
+		check_filter_any( "asd "   , " ", 3, "asd" )
+		check_filter_any( "asd  "  , " ", 3, "asd" )
+		check_filter_any( " asd"   , " ", 4, " asd" )
+		check_filter_any( "  asd"  , " ", 5, "  asd" )
+		check_filter_any( " asd "  , " ", 4, " asd" )
+		check_filter_any( "  asd  ", " ", 5, "  asd" )
+		
+		check_filter_any( ""       , "x", 0, "" )
+		check_filter_any( " "      , "x", 1, " " )
+		check_filter_any( "x"      , "x", 0, "" )
+		check_filter_any( "xx"     , "x", 0, "" )
+		check_filter_any( "asd"    , "x", 3, "asd" )
+		check_filter_any( "asdx"   , "x", 3, "asd" )
+		check_filter_any( "asdxx"  , "x", 3, "asd" )
+		check_filter_any( "xasd"   , "x", 4, "xasd" )
+		check_filter_any( "xxasd"  , "x", 5, "xxasd" )
+		check_filter_any( "xasdx"  , "x", 4, "xasd" )
+		check_filter_any( "xxasdxx", "x", 5, "xxasd" )
 
-		str_ret = rtrim(wstr("asdxy"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter_any( ""       , "xy", 0, "" )
+		check_filter_any( "x"      , "xy", 0, "" )
+		check_filter_any( "y"      , "xy", 0, "" )
+		check_filter_any( "xy"     , "xy", 0, "" )
+		check_filter_any( "xyxy"   , "xy", 0, "" )
+		check_filter_any( "xyxyx"  , "xy", 0, "" )
+		check_filter_any( "yxyxy"  , "xy", 0, "" )
 
-		str_ret = rtrim(wstr("asdxy"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 5 )
-		result = str_ret = "asdxy"
-		CU_ASSERT( result )
+		check_filter_any( "asd"    , "xy", 3, "asd" )
+		check_filter_any( "asdx"   , "xy", 3, "asd" )
+		check_filter_any( "asdxy"  , "xy", 3, "asd" )
+		check_filter_any( "asdxy"  , "yx", 3, "asd" )
+		check_filter_any( "asdyy"  , "yx", 3, "asd" )
 
-		str_ret = rtrim(wstr("asdyy"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 5 )
-		result = str_ret = "asdyy"
-		CU_ASSERT( result )
+		check_filter_any( "xasd"   , ""  , 4, "xasd" )
+		check_filter_any( "xyasd"  , "xy", 5, "xyasd" )
+		check_filter_any( "xyasd"  , "yx", 5, "xyasd" )
+		check_filter_any( "yyasd"  , "yx", 5, "yyasd" )
 
+		check_filter_any( "xasdx"  , "xy", 4, "xasd" )
+		check_filter_any( "xyasdxy", "xy", 5, "xyasd" )
+		check_filter_any( "xyasdxy", "yx", 5, "xyasd" )
+		check_filter_any( "yyasdyy", "yx", 5, "yyasd" )
+
+		check_filter_any( "asd"     , " d", 2, "as" )
+		check_filter_any( "asd "    , " d", 2, "as" )
+		check_filter_any( "asd  "   , " d", 2, "as" )
+		check_filter_any( "das"     , " d", 3, "das" )
+		check_filter_any( " das"    , " d", 4, " das" )
+		check_filter_any( "  das"   , " d", 5, "  das" )
+		check_filter_any( "dasd"    , " d", 3, "das" )
+		check_filter_any( " dasd "  , " d", 4, " das" )
+		check_filter_any( "  dasd  ", " d", 5, "  das" )
+		check_filter_any( "asd"     , "d ", 2, "as" )
+		check_filter_any( "asd "    , "d ", 2, "as" )
+		check_filter_any( "asd  "   , "d ", 2, "as" )
+		check_filter_any( "das"     , "d ", 3, "das" )
+		check_filter_any( " das"    , "d ", 4, " das" )
+		check_filter_any( "  das"   , "d ", 5, "  das" )
+		check_filter_any( "dasd"    , "d ", 3, "das" )
+		check_filter_any( " dasd "  , "d ", 4, " das" )
+		check_filter_any( "  dasd  ", "d ", 5, "  das" )
 	END_TEST
 
-	TEST( test4 )
+	TEST( escaped )
+		check( !"\u3041\u3043\u3045\u3047\u3049"    , 5, !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"  \u3041\u3043\u3045\u3047\u3049"  , 7, !"  \u3041\u3043\u3045\u3047\u3049" )
+		check( !"\u3041\u3043\u3045\u3047\u3049  "  , 5, !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"  \u3041\u3043\u3045\u3047\u3049  ", 7, !"  \u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = rtrim(wstr("asd"), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = rtrim(wstr("asd "), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = rtrim(wstr("asd  "), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3041", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-	END_TEST
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049", _
+						4, !"\u3041\u3043\u3045\u3047" )
 
-	TEST( test5 )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049", _
+						3, !"\u3041\u3043\u3045" )
 
-		str_ret = rtrim(wstr("asd"), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049\u3047", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = rtrim(wstr("asd "), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3049", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = rtrim(wstr("asd  "), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-	END_TEST
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-	TEST( test6 )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3041", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = rtrim(wstr("asd"), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049", _
+						4, !"\u3041\u3043\u3045\u3047" )
 
-		str_ret = rtrim(wstr("asd "), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049", _
+						3, !"\u3041\u3043\u3045" )
 
-		str_ret = rtrim(wstr("asd  "), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049\u3047", _
+						3, !"\u3041\u3043\u3045" )
 
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3049", _
+						4, !"\u3041\u3043\u3045\u3047" )
 	END_TEST
 
 END_SUITE

--- a/tests/wstring/trim.bas
+++ b/tests/wstring/trim.bas
@@ -1,292 +1,258 @@
 #include "fbcunit.bi"
+#include once "chk-wstring.bi"
 
 SUITE( fbc_tests.wstring_.trim_ )
 
-	dim shared result as integer
-	dim shared str_ret as string
+	#macro check( a, length, expected )
+		scope
+			dim wr as wstring * 50 = trim( wstr(a) )
+			dim we as wstring * 50 = wstr( expected )
 
-	TEST( test1 )
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
 
-		str_ret = trim(wstr("asd"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		scope
+			dim wa as wstring * 50 = wstr(a)
+			dim we as wstring * 50 = wstr( expected )
+			dim wr as wstring * 50 = trim( wa )
 
-		str_ret = trim(wstr("asd "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
 
-		str_ret = trim(wstr("asd  "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+	#macro check_filter( a, filter, length, expected )
+		scope
+			dim wr as wstring * 50 = trim( wstr(a), wstr(filter) )
+			dim we as wstring * 50 = wstr( expected )
 
-		str_ret = trim(wstr(" asd"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
 
-		str_ret = trim(wstr("  asd"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		scope
+			dim wa as wstring * 50 = wstr(a)
+			dim wf as wstring * 50 = wstr(filter)
+			dim wr as wstring * 50 = trim( wa, wf )
+			dim we as wstring * 50 = wstr( expected )
 
-		str_ret = trim(wstr(" asd "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
 
-		str_ret = trim(wstr("  asd  "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+	#macro check_filter_any( a, filter, length, expected )
+		scope
+			dim wr as wstring * 50 = trim( wstr(a), any wstr(filter) )
+			dim we as wstring * 50 = wstr( expected )
 
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+
+		scope
+			dim wa as wstring * 50 = wstr(a)
+			dim wf as wstring * 50 = wstr(filter)
+			dim wr as wstring * 50 = trim( wa, any wf )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
+
+	TEST( default )
+		check( ""       , 0, "" )
+		check( " "      , 0, "" )
+		check( "  "     , 0, "" )
+		check( "asd"    , 3, "asd" )
+		check( "asd "   , 3, "asd" )
+		check( "asd  "  , 3, "asd" )
+		check( " asd"   , 3, "asd" )
+		check( "  asd"  , 3, "asd" )
+		check( " asd "  , 3, "asd" )
+		check( "  asd  ", 3, "asd" )
 	END_TEST
 
-	TEST( test2 )
+	TEST( filter )
+		check_filter( ""       , ""  , 0, "" )
+		check_filter( ""       , " " , 0, "" )
+		check_filter( ""       , "  ", 0, "" )
+		check_filter( " "      , ""  , 1, " " )
+		check_filter( " "      , " " , 0, "" )
+		check_filter( " "      , "  ", 1, " " )
+		check_filter( "  "     , ""  , 2, "  " )
+		check_filter( "  "     , " " , 0, "" )
+		check_filter( "  "     , "  ", 0, "" )
 
-		str_ret = trim(wstr("asd"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( "asd"    , " ", 3, "asd" )
+		check_filter( "asd "   , " ", 3, "asd" )
+		check_filter( "asd  "  , " ", 3, "asd" )
+		check_filter( " asd"   , " ", 3, "asd" )
+		check_filter( "  asd"  , " ", 3, "asd" )
+		check_filter( " asd "  , " ", 3, "asd" )
+		check_filter( "  asd  ", " ", 3, "asd" )
+		
+		check_filter( ""       , "x", 0, "" )
+		check_filter( " "      , "x", 1, " " )
+		check_filter( "x"      , "x", 0, "" )
+		check_filter( "xx"     , "x", 0, "" )
+		check_filter( "asd"    , "x", 3, "asd" )
+		check_filter( "asdx"   , "x", 3, "asd" )
+		check_filter( "asdxx"  , "x", 3, "asd" )
+		check_filter( "xasd"   , "x", 3, "asd" )
+		check_filter( "xxasd"  , "x", 3, "asd" )
+		check_filter( "xasdx"  , "x", 3, "asd" )
+		check_filter( "xxasdxx", "x", 3, "asd" )
 
-		str_ret = trim(wstr("asdx"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( ""       , "xy", 0, "" )
+		check_filter( "xy"     , "xy", 0, "" )
+		check_filter( "xyxy"   , "xy", 0, "" )
+		check_filter( "xyxyx"  , "xy", 1, "x" )
+		check_filter( "yxyxy"  , "xy", 1, "y" )
 
-		str_ret = trim(wstr("asdxx"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( "asd"    , "xy", 3, "asd" )
+		check_filter( "asdx"   , "xy", 4, "asdx" )
+		check_filter( "asdxy"  , "xy", 3, "asd" )
+		check_filter( "asdxy"  , "yx", 5, "asdxy" )
+		check_filter( "asdyy"  , "yx", 5, "asdyy" )
 
-		str_ret = trim(wstr("xasd"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( "xasd"   , "xy", 4, "xasd" )
+		check_filter( "xyasd"  , "xy", 3, "asd" )
+		check_filter( "xyasd"  , "yx", 5, "xyasd" )
+		check_filter( "yyasd"  , "yx", 5, "yyasd" )
 
-		str_ret = trim(wstr("xxasd"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("xasdx"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("xxasdxx"), wstr("x"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
-
+		check_filter( "xasdx"  , "xy", 5, "xasdx" )
+		check_filter( "xyasdxy", "xy", 3, "asd" )
+		check_filter( "xyasdxy", "yx", 7, "xyasdxy" )
+		check_filter( "yyasdyy", "yx", 7, "yyasdyy" )
 	END_TEST
 
-	TEST( test3 )
 
-		str_ret = trim(wstr("asd"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+	TEST( filter_any )
+		check_filter_any( ""       , ""  , 0, "" )
+		check_filter_any( ""       , " " , 0, "" )
+		check_filter_any( ""       , "  ", 0, "" )
+		check_filter_any( " "      , ""  , 1, " " )
+		check_filter_any( " "      , " " , 0, "" )
+		check_filter_any( " "      , "  ", 0, "" )
+		check_filter_any( "  "     , ""  , 2, "  " )
+		check_filter_any( "  "     , " " , 0, "" )
+		check_filter_any( "  "     , "  ", 0, "" )
 
-		str_ret = trim(wstr("asdx"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 4 )
-		result = str_ret = "asdx"
-		CU_ASSERT( result )
 
-		str_ret = trim(wstr("asdxy"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter_any( "asd"    , " ", 3, "asd" )
+		check_filter_any( "asd "   , " ", 3, "asd" )
+		check_filter_any( "asd  "  , " ", 3, "asd" )
+		check_filter_any( " asd"   , " ", 3, "asd" )
+		check_filter_any( "  asd"  , " ", 3, "asd" )
+		check_filter_any( " asd "  , " ", 3, "asd" )
+		check_filter_any( "  asd  ", " ", 3, "asd" )
+		
+		check_filter_any( ""       , "x", 0, "" )
+		check_filter_any( " "      , "x", 1, " " )
+		check_filter_any( "x"      , "x", 0, "" )
+		check_filter_any( "xx"     , "x", 0, "" )
+		check_filter_any( "asd"    , "x", 3, "asd" )
+		check_filter_any( "asdx"   , "x", 3, "asd" )
+		check_filter_any( "asdxx"  , "x", 3, "asd" )
+		check_filter_any( "xasd"   , "x", 3, "asd" )
+		check_filter_any( "xxasd"  , "x", 3, "asd" )
+		check_filter_any( "xasdx"  , "x", 3, "asd" )
+		check_filter_any( "xxasdxx", "x", 3, "asd" )
 
-		str_ret = trim(wstr("asdxy"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 5 )
-		result = str_ret = "asdxy"
-		CU_ASSERT( result )
+		check_filter_any( ""       , "xy", 0, "" )
+		check_filter_any( "x"      , "xy", 0, "" )
+		check_filter_any( "y"      , "xy", 0, "" )
+		check_filter_any( "xy"     , "xy", 0, "" )
+		check_filter_any( "xyxy"   , "xy", 0, "" )
+		check_filter_any( "xyxyx"  , "xy", 0, "" )
+		check_filter_any( "yxyxy"  , "xy", 0, "" )
 
-		str_ret = trim(wstr("asdyy"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 5 )
-		result = str_ret = "asdyy"
-		CU_ASSERT( result )
+		check_filter_any( "asd"    , "xy", 3, "asd" )
+		check_filter_any( "asdx"   , "xy", 3, "asd" )
+		check_filter_any( "asdxy"  , "xy", 3, "asd" )
+		check_filter_any( "asdxy"  , "yx", 3, "asd" )
+		check_filter_any( "asdyy"  , "yx", 3, "asd" )
 
-		str_ret = trim(wstr("xasd"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 4 )
-		result = str_ret = "xasd"
-		CU_ASSERT( result )
+		check_filter_any( "xasd"   , ""  , 4, "xasd" )
+		check_filter_any( "xyasd"  , "xy", 3, "asd" )
+		check_filter_any( "xyasd"  , "yx", 3, "asd" )
+		check_filter_any( "yyasd"  , "yx", 3, "asd" )
 
-		str_ret = trim(wstr("xyasd"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter_any( "xasdx"  , "xy", 3, "asd" )
+		check_filter_any( "xyasdxy", "xy", 3, "asd" )
+		check_filter_any( "xyasdxy", "yx", 3, "asd" )
+		check_filter_any( "yyasdyy", "yx", 3, "asd" )
 
-		str_ret = trim(wstr("xyasd"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 5 )
-		result = str_ret = "xyasd"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("yyasd"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 5 )
-		result = str_ret = "yyasd"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("xasdx"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 5 )
-		result = str_ret = "xasdx"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("xyasdxy"), wstr("xy"))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("xyasdxy"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 7 )
-		result = str_ret = "xyasdxy"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("yyasdyy"), wstr("yx"))
-		CU_ASSERT( len(str_ret) = 7 )
-		result = str_ret = "yyasdyy"
-		CU_ASSERT( result )
-
+		check_filter_any( "asd"     , " d", 2, "as" )
+		check_filter_any( "asd "    , " d", 2, "as" )
+		check_filter_any( "asd  "   , " d", 2, "as" )
+		check_filter_any( "das"     , " d", 2, "as" )
+		check_filter_any( " das"    , " d", 2, "as" )
+		check_filter_any( "  das"   , " d", 2, "as" )
+		check_filter_any( "dasd"    , " d", 2, "as" )
+		check_filter_any( " dasd "  , " d", 2, "as" )
+		check_filter_any( "  dasd  ", " d", 2, "as" )
+		check_filter_any( "asd"     , "d ", 2, "as" )
+		check_filter_any( "asd "    , "d ", 2, "as" )
+		check_filter_any( "asd  "   , "d ", 2, "as" )
+		check_filter_any( "das"     , "d ", 2, "as" )
+		check_filter_any( " das"    , "d ", 2, "as" )
+		check_filter_any( "  das"   , "d ", 2, "as" )
+		check_filter_any( "dasd"    , "d ", 2, "as" )
+		check_filter_any( " dasd "  , "d ", 2, "as" )
+		check_filter_any( "  dasd  ", "d ", 2, "as" )
 	END_TEST
 
-	TEST( test4 )
+	TEST( escaped )
+		check( !"\u3041\u3043\u3045\u3047\u3049"    , 5, !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"  \u3041\u3043\u3045\u3047\u3049"  , 5, !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"\u3041\u3043\u3045\u3047\u3049  "  , 5, !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"  \u3041\u3043\u3045\u3047\u3049  ", 5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = trim(wstr("asd"), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041", _
+						4, !"\u3043\u3045\u3047\u3049" )
 
-		str_ret = trim(wstr("asd "), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043", _
+						3, !"\u3045\u3047\u3049" )
 
-		str_ret = trim(wstr("asd  "), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3041", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = trim(wstr(" asd"), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049", _
+						4, !"\u3041\u3043\u3045\u3047" )
 
-		str_ret = trim(wstr("  asd"), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049", _
+						3, !"\u3041\u3043\u3045" )
 
-		str_ret = trim(wstr(" asd "), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049\u3047", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-		str_ret = trim(wstr("  asd  "), any wstr(" "))
-		CU_ASSERT( len(str_ret) = 3 )
-		result = str_ret = "asd"
-		CU_ASSERT( result )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3049", _
+						5, !"\u3041\u3043\u3045\u3047\u3049" )
 
-	END_TEST
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041", _
+						4, !"\u3043\u3045\u3047\u3049" )
 
-	TEST( test5 )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043", _
+						3, !"\u3045\u3047\u3049" )
 
-		str_ret = trim(wstr("asd"), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3041", _
+						3, !"\u3045\u3047\u3049" )
 
-		str_ret = trim(wstr("asd "), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049", _
+						4, !"\u3041\u3043\u3045\u3047" )
 
-		str_ret = trim(wstr("asd  "), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049", _
+						3, !"\u3041\u3043\u3045" )
 
-		str_ret = trim(wstr("das"), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049\u3047", _
+						3, !"\u3041\u3043\u3045" )
 
-		str_ret = trim(wstr(" das"), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("  das"), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("dasd"), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr(" dasd "), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("  dasd  "), any wstr(" d"))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-	END_TEST
-
-	TEST( test6 )
-
-		str_ret = trim(wstr("asd"), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("asd "), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("asd  "), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("das"), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr(" das"), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("  das"), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("dasd"), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr(" dasd "), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
-		str_ret = trim(wstr("  dasd  "), any wstr("d "))
-		CU_ASSERT( len(str_ret) = 2 )
-		result = str_ret = "as"
-		CU_ASSERT( result )
-
+		check_filter_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3049", _
+						3, !"\u3043\u3045\u3047" )
 	END_TEST
 
 END_SUITE


### PR DESCRIPTION
**bugfix: [sf.net #899](https://sourceforge.net/p/fbc/bugs/899/) trim( wstring ) causes crash if string is single space**
- In fb_wstr_CalcDiff() the original expression is optimized with a SHR expression due the divide by unsigned power of 2.  This doesn't work for negative values.
- Casting to intptr_t should not be needed as the pointer arithmetic alone should be sufficient to calculate distance betwee related pointers
- avoid returning a pointer before the first element in fb_wstr_SkipCharRev(), &s[-1] is undefined behaviour
- also then avoids passing start > end pointers to fb_wstr_CalcDiff()
- fb_wstr_SkipCharRev() now returns a pointer to the start of all skipped chars, or the end marker if no chars are skipped

**bugfix: [sf.net #900](https://sourceforge.net/p/fbc/bugs/900/) LTRIM and TRIM truncate result if filter is zero length string**
- [L]TRIM( wstring, filter ) will return a zero length string if the filter is also a zero length string