### PR TITLE
 rtlib: optimization of [L/R]TrimAny function code 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Version 1.07.0
 - github #138: rtlib: freebsd: Fix deprecated use of VM_METER to use VM_TOTAL (William Breathitt Gray)
 - sf.net #899: TRIM( wstring ) causes crash if string is single space
 - sf.net #900: LTRIM( wstring, filter ) and TRIM( wstring, filter ) truncate result if filter is zero length string
+- github #116: Fix optimizations in [L/R]TrimAny rtlib functions (SkyFish)
 
 
 Version 1.06.0

--- a/src/rtlib/str_ltrimany.c
+++ b/src/rtlib/str_ltrimany.c
@@ -30,15 +30,8 @@ FBCALL FBSTRING *fb_LTrimAny
 		{
 			while ( len != 0 )
 	        {
-			ssize_t i;
-	            for( i=0; i!=len_pattern; ++i ) 
-	            {
-	                if( FB_MEMCHR( pattern->data, *pachText, len_pattern )!=NULL )
-	                    break;
-	            }
-	            
-	            if( i==len_pattern )
-	                break;
+	           if( FB_MEMCHR( pattern->data, *pachText, len_pattern )==NULL )
+	              break;
 
 	            --len;
 	            ++pachText;

--- a/src/rtlib/str_ltrimany.c
+++ b/src/rtlib/str_ltrimany.c
@@ -4,37 +4,37 @@
 
 FBCALL FBSTRING *fb_LTrimAny 
 	( 
-		FBSTRING *src, 
+		FBSTRING *src,
 		FBSTRING *pattern 
 	)
 {
-    const char *pachText = NULL;
+	const char *pachText = NULL;
 	FBSTRING *dst;
 	ssize_t len;
 
-    if( src == NULL ) 
-    {
-        fb_hStrDelTemp( pattern );
-        return &__fb_ctx.null_desc;
-    }
+	if( src == NULL )
+	{
+		fb_hStrDelTemp( pattern );
+		return &__fb_ctx.null_desc;
+	}
 
-   	FB_STRLOCK();
+	FB_STRLOCK();
 
 	len = 0;
 	if( src->data != NULL )
-    {
-        ssize_t len_pattern = ((pattern != NULL) && (pattern->data != NULL)? FB_STRSIZE( pattern ) : 0);
-        pachText = src->data;
-        len = FB_STRSIZE( src );
+	{
+		ssize_t len_pattern = ((pattern != NULL) && (pattern->data != NULL)? FB_STRSIZE( pattern ) : 0);
+		pachText = src->data;
+		len = FB_STRSIZE( src );
 		if( len_pattern != 0 )
 		{
 			while ( len != 0 )
-	        {
-	           if( FB_MEMCHR( pattern->data, *pachText, len_pattern )==NULL )
-	              break;
+			{
+				if( FB_MEMCHR( pattern->data, *pachText, len_pattern ) == NULL )
+					break;
 
-	            --len;
-	            ++pachText;
+				--len;
+				++pachText;
 			}
 		}
 	}
@@ -42,7 +42,7 @@ FBCALL FBSTRING *fb_LTrimAny
 	if( len > 0 )
 	{
 		/* alloc temp string */
-        dst = fb_hStrAllocTemp_NoLock( NULL, len );
+		dst = fb_hStrAllocTemp_NoLock( NULL, len );
 		if( dst != NULL )
 		{
 			/* simple copy */
@@ -50,15 +50,15 @@ FBCALL FBSTRING *fb_LTrimAny
 		}
 		else
 			dst = &__fb_ctx.null_desc;
-    }
+	}
 	else
 		dst = &__fb_ctx.null_desc;
 
 	/* del if temp */
 	fb_hStrDelTemp_NoLock( src );
-    fb_hStrDelTemp_NoLock( pattern );
+	fb_hStrDelTemp_NoLock( pattern );
 
-   	FB_STRUNLOCK();
+	FB_STRUNLOCK();
 
 	return dst;
 }

--- a/src/rtlib/str_rtrimany.c
+++ b/src/rtlib/str_rtrimany.c
@@ -25,15 +25,8 @@ FBCALL FBSTRING *fb_RTrimAny( FBSTRING *src, FBSTRING *pattern )
 		{
 			while ( len != 0 )
 	        {
-			ssize_t i;
 	            --len;
-	            for( i=0; i!=len_pattern; ++i ) 
-	            {
-	                if( FB_MEMCHR( pattern->data, pachText[len], len_pattern )!=NULL )
-	                    break;
-	            }
-	            
-	            if( i==len_pattern ) 
+	            if( FB_MEMCHR( pattern->data, pachText[len], len_pattern )==NULL ) 
 	            {
 	                ++len;
 	                break;

--- a/src/rtlib/str_rtrimany.c
+++ b/src/rtlib/str_rtrimany.c
@@ -7,30 +7,30 @@ FBCALL FBSTRING *fb_RTrimAny( FBSTRING *src, FBSTRING *pattern )
 	FBSTRING *dst;
 	ssize_t len;
 
-    if( src == NULL ) 
-    {
-        fb_hStrDelTemp( pattern );
-        return &__fb_ctx.null_desc;
-    }
+	if( src == NULL )
+	{
+		fb_hStrDelTemp( pattern );
+		return &__fb_ctx.null_desc;
+	}
 
-   	FB_STRLOCK();
+	FB_STRLOCK();
 
 	len = 0;
 	if( src->data != NULL )
-    {
-        const char *pachText = src->data;
+	{
+		const char *pachText = src->data;
 		ssize_t len_pattern = ((pattern != NULL) && (pattern->data != NULL)? FB_STRSIZE( pattern ) : 0);
-        len = FB_STRSIZE( src );
+		len = FB_STRSIZE( src );
 		if( len_pattern != 0 )
 		{
 			while ( len != 0 )
-	        {
-	            --len;
-	            if( FB_MEMCHR( pattern->data, pachText[len], len_pattern )==NULL ) 
-	            {
-	                ++len;
-	                break;
-	            }
+			{
+				--len;
+				if( FB_MEMCHR( pattern->data, pachText[len], len_pattern ) == NULL )
+				{
+					++len;
+					break;
+				}
 			}
 		}
 	}
@@ -38,7 +38,7 @@ FBCALL FBSTRING *fb_RTrimAny( FBSTRING *src, FBSTRING *pattern )
 	if( len > 0 )
 	{
 		/* alloc temp string */
-        dst = fb_hStrAllocTemp_NoLock( NULL, len );
+		dst = fb_hStrAllocTemp_NoLock( NULL, len );
 		if( dst != NULL )
 		{
 			/* simple copy */
@@ -46,7 +46,7 @@ FBCALL FBSTRING *fb_RTrimAny( FBSTRING *src, FBSTRING *pattern )
 		}
 		else
 			dst = &__fb_ctx.null_desc;
-    }
+	}
 	else
 		dst = &__fb_ctx.null_desc;
 
@@ -54,7 +54,7 @@ FBCALL FBSTRING *fb_RTrimAny( FBSTRING *src, FBSTRING *pattern )
 	fb_hStrDelTemp_NoLock( src );
 	fb_hStrDelTemp_NoLock( pattern );
 
-   	FB_STRUNLOCK();
+	FB_STRUNLOCK();
 
 	return dst;
 }

--- a/src/rtlib/str_trimany.c
+++ b/src/rtlib/str_trimany.c
@@ -26,14 +26,7 @@ FBCALL FBSTRING *fb_TrimAny( FBSTRING *src, FBSTRING *pattern )
 		{
 			while ( len != 0 )
 	        {
-	            ssize_t i;
-	            for( i=0; i!=len_pattern; ++i ) 
-	            {
-	                if( FB_MEMCHR( pattern->data, *pachText, len_pattern )!=NULL )
-	                    break;
-	            }
-	            
-	            if( i==len_pattern )
+	            if( FB_MEMCHR( pattern->data, *pachText, len_pattern )==NULL )
 	                break;
 
 	            --len;
@@ -41,15 +34,8 @@ FBCALL FBSTRING *fb_TrimAny( FBSTRING *src, FBSTRING *pattern )
 			}
 			while ( len != 0 )
 	        {
-	            ssize_t i;
 	            --len;
-	            for( i=0; i!=len_pattern; ++i ) 
-	            {
-	                if( FB_MEMCHR( pattern->data, pachText[len], len_pattern )!=NULL )
-	                    break;
-	            }
-	            
-	            if( i==len_pattern ) 
+	            if( FB_MEMCHR( pattern->data, pachText[len], len_pattern )==NULL ) 
 	            {
 	                ++len;
 	                break;

--- a/src/rtlib/str_trimany.c
+++ b/src/rtlib/str_trimany.c
@@ -4,42 +4,42 @@
 
 FBCALL FBSTRING *fb_TrimAny( FBSTRING *src, FBSTRING *pattern )
 {
-    const char *pachText = NULL;
+	const char *pachText = NULL;
 	FBSTRING *dst;
 	ssize_t len;
 
-    if( src == NULL ) 
-    {
-        fb_hStrDelTemp( pattern );
-        return &__fb_ctx.null_desc;
-    }
+	if( src == NULL ) 
+	{
+		fb_hStrDelTemp( pattern );
+		return &__fb_ctx.null_desc;
+	}
 
-   	FB_STRLOCK();
+	FB_STRLOCK();
 
 	len = 0;
 	if( src->data != NULL )
-    {
-        ssize_t len_pattern = ((pattern != NULL) && (pattern->data != NULL)? FB_STRSIZE( pattern ) : 0);
-        pachText = src->data;
-        len = FB_STRSIZE( src );
+	{
+		ssize_t len_pattern = ((pattern != NULL) && (pattern->data != NULL)? FB_STRSIZE( pattern ) : 0);
+		pachText = src->data;
+		len = FB_STRSIZE( src );
 		if( len_pattern != 0 )
 		{
 			while ( len != 0 )
-	        {
-	            if( FB_MEMCHR( pattern->data, *pachText, len_pattern )==NULL )
-	                break;
+			{
+				if( FB_MEMCHR( pattern->data, *pachText, len_pattern ) == NULL )
+					break;
 
-	            --len;
-	            ++pachText;
+				--len;
+				++pachText;
 			}
 			while ( len != 0 )
-	        {
-	            --len;
-	            if( FB_MEMCHR( pattern->data, pachText[len], len_pattern )==NULL ) 
-	            {
-	                ++len;
-	                break;
-	            }
+			{
+				--len;
+				if( FB_MEMCHR( pattern->data, pachText[len], len_pattern ) == NULL ) 
+				{
+					++len;
+					break;
+				}
 			}
 		}
 	}
@@ -47,7 +47,7 @@ FBCALL FBSTRING *fb_TrimAny( FBSTRING *src, FBSTRING *pattern )
 	if( len > 0 )
 	{
 		/* alloc temp string */
-        dst = fb_hStrAllocTemp_NoLock( NULL, len );
+		dst = fb_hStrAllocTemp_NoLock( NULL, len );
 		if( dst != NULL )
 		{
 			/* simple copy */
@@ -55,15 +55,15 @@ FBCALL FBSTRING *fb_TrimAny( FBSTRING *src, FBSTRING *pattern )
 		}
 		else
 			dst = &__fb_ctx.null_desc;
-    }
+	}
 	else
 		dst = &__fb_ctx.null_desc;
 
 	/* del if temp */
 	fb_hStrDelTemp_NoLock( src );
-    fb_hStrDelTemp_NoLock( pattern );
+	fb_hStrDelTemp_NoLock( pattern );
 
-   	FB_STRUNLOCK();
+	FB_STRUNLOCK();
 
 	return dst;
 }

--- a/src/rtlib/strw_ltrimany.c
+++ b/src/rtlib/strw_ltrimany.c
@@ -4,35 +4,35 @@
 
 FBCALL FB_WCHAR *fb_WstrLTrimAny ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 {
-    const FB_WCHAR *pachText;
-	FB_WCHAR 	*dst;
+	const FB_WCHAR *pachText;
+	FB_WCHAR *dst;
 	ssize_t len;
 
-    if( src == NULL ) {
-        return NULL;
-    }
+	if( src == NULL ) {
+		return NULL;
+	}
 
 	len = fb_wstr_Len( src );
-    {
-        ssize_t len_pattern = fb_wstr_Len( pattern );
-        pachText = src;
-				if( len_pattern != 0 )
-				{
-					while ( len != 0 )
-							{
-									if( wcschr( pattern, *pachText )==NULL ) {
-											break;
-									}
-									--len;
-									++pachText;
-					}
+	{
+		ssize_t len_pattern = fb_wstr_Len( pattern );
+		pachText = src;
+		if( len_pattern != 0 )
+		{
+			while ( len != 0 )
+			{
+				if( wcschr( pattern, *pachText )==NULL ) {
+					break;
 				}
+				--len;
+				++pachText;
+			}
+		}
 	}
 
 	if( len > 0 )
 	{
 		/* alloc temp string */
-        dst = fb_wstr_AllocTemp( len );
+		dst = fb_wstr_AllocTemp( len );
 		if( dst != NULL )
 		{
 			/* simple copy */
@@ -40,7 +40,7 @@ FBCALL FB_WCHAR *fb_WstrLTrimAny ( const FB_WCHAR *src, const FB_WCHAR *pattern 
 		}
 		else
 			dst = NULL;
-    }
+	}
 	else
 		dst = NULL;
 

--- a/src/rtlib/strw_ltrimany.c
+++ b/src/rtlib/strw_ltrimany.c
@@ -16,20 +16,17 @@ FBCALL FB_WCHAR *fb_WstrLTrimAny ( const FB_WCHAR *src, const FB_WCHAR *pattern 
     {
         ssize_t len_pattern = fb_wstr_Len( pattern );
         pachText = src;
-		while ( len != 0 )
-        {
-            ssize_t i;
-            for( i=0; i!=len_pattern; ++i ) {
-                if( wcschr( pattern, *pachText )!=NULL ) {
-                    break;
-                }
-            }
-            if( i==len_pattern ) {
-                break;
-            }
-            --len;
-            ++pachText;
-		}
+				if( len_pattern != 0 )
+				{
+					while ( len != 0 )
+							{
+									if( wcschr( pattern, *pachText )==NULL ) {
+											break;
+									}
+									--len;
+									++pachText;
+					}
+				}
 	}
 
 	if( len > 0 )

--- a/src/rtlib/strw_rtrimany.c
+++ b/src/rtlib/strw_rtrimany.c
@@ -4,35 +4,35 @@
 
 FBCALL FB_WCHAR *fb_WstrRTrimAny ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 {
-    const FB_WCHAR *pachText;
-	FB_WCHAR 	*dst;
+	const FB_WCHAR *pachText;
+	FB_WCHAR *dst;
 	ssize_t len;
 
-    if( src == NULL ) {
-        return NULL;
-    }
+	if( src == NULL ) {
+		return NULL;
+	}
 
 	len = fb_wstr_Len( src );
-    {
-        ssize_t len_pattern = fb_wstr_Len( pattern );
-        pachText = src;
-		    if( len_pattern != 0 )
-		    {
-		        while ( len != 0 )
-            {
-                --len;
-                if( wcschr( pattern, pachText[len] )==NULL ) {
-                    ++len;
-                    break;
-                }
-		        }
-		    }
+	{
+		ssize_t len_pattern = fb_wstr_Len( pattern );
+		pachText = src;
+		if( len_pattern != 0 )
+		{
+			while ( len != 0 )
+			{
+				--len;
+				if( wcschr( pattern, pachText[len] ) == NULL ) {
+					++len;
+					break;
+				}
+			}
+		}
 	}
 
 	if( len > 0 )
 	{
 		/* alloc temp string */
-        dst = fb_wstr_AllocTemp( len );
+		dst = fb_wstr_AllocTemp( len );
 		if( dst != NULL )
 		{
 			/* simple copy */
@@ -40,7 +40,7 @@ FBCALL FB_WCHAR *fb_WstrRTrimAny ( const FB_WCHAR *src, const FB_WCHAR *pattern 
 		}
 		else
 			dst = NULL;
-    }
+	}
 	else
 		dst = NULL;
 

--- a/src/rtlib/strw_rtrimany.c
+++ b/src/rtlib/strw_rtrimany.c
@@ -16,20 +16,17 @@ FBCALL FB_WCHAR *fb_WstrRTrimAny ( const FB_WCHAR *src, const FB_WCHAR *pattern 
     {
         ssize_t len_pattern = fb_wstr_Len( pattern );
         pachText = src;
-		while ( len != 0 )
-        {
-            ssize_t i;
-            --len;
-            for( i=0; i!=len_pattern; ++i ) {
-                if( wcschr( pattern, pachText[len] )!=NULL ) {
+		    if( len_pattern != 0 )
+		    {
+		        while ( len != 0 )
+            {
+                --len;
+                if( wcschr( pattern, pachText[len] )==NULL ) {
+                    ++len;
                     break;
                 }
-            }
-            if( i==len_pattern ) {
-                ++len;
-                break;
-            }
-		}
+		        }
+		    }
 	}
 
 	if( len > 0 )

--- a/src/rtlib/strw_trimany.c
+++ b/src/rtlib/strw_trimany.c
@@ -4,44 +4,44 @@
 
 FBCALL FB_WCHAR *fb_WstrTrimAny ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 {
-    const FB_WCHAR *pachText = NULL;
-	FB_WCHAR 	*dst;
+	const FB_WCHAR *pachText = NULL;
+	FB_WCHAR	*dst;
 	ssize_t len;
 
-    if( src == NULL ) {
-        return NULL;
-    }
+	if( src == NULL ) {
+		return NULL;
+	}
 
 	len = 0;
-    {
-        ssize_t len_pattern = fb_wstr_Len( pattern );
-        pachText = src;
-        len = fb_wstr_Len( src );
-		    if( len_pattern != 0 )
-		    {
-					while ( len != 0 )
-							{
-									if( wcschr( pattern, *pachText )==NULL ) {
-											break;
-									}
-									--len;
-									++pachText;
-					}
-					while ( len != 0 )
-							{
-									--len;
-									if( wcschr( pattern, pachText[len] )==NULL ) {
-											++len;
-											break;
-									}
-					}
+	{
+		ssize_t len_pattern = fb_wstr_Len( pattern );
+		pachText = src;
+		len = fb_wstr_Len( src );
+		if( len_pattern != 0 )
+		{
+			while ( len != 0 )
+			{
+				if( wcschr( pattern, *pachText )==NULL ) {
+					break;
 				}
+				--len;
+				++pachText;
+			}
+			while ( len != 0 )
+			{
+				--len;
+				if( wcschr( pattern, pachText[len] )==NULL ) {
+					++len;
+					break;
+				}
+			}
+		}
 	}
 
 	if( len > 0 )
 	{
 		/* alloc temp string */
-        dst = fb_wstr_AllocTemp( len );
+		dst = fb_wstr_AllocTemp( len );
 		if( dst != NULL )
 		{
 			/* simple copy */
@@ -49,7 +49,7 @@ FBCALL FB_WCHAR *fb_WstrTrimAny ( const FB_WCHAR *src, const FB_WCHAR *pattern )
 		}
 		else
 			dst = NULL;
-    }
+	}
 	else
 		dst = NULL;
 

--- a/src/rtlib/strw_trimany.c
+++ b/src/rtlib/strw_trimany.c
@@ -17,34 +17,25 @@ FBCALL FB_WCHAR *fb_WstrTrimAny ( const FB_WCHAR *src, const FB_WCHAR *pattern )
         ssize_t len_pattern = fb_wstr_Len( pattern );
         pachText = src;
         len = fb_wstr_Len( src );
-		while ( len != 0 )
-        {
-            ssize_t i;
-            for( i=0; i!=len_pattern; ++i ) {
-                if( wcschr( pattern, *pachText )!=NULL ) {
-                    break;
-                }
-            }
-            if( i==len_pattern ) {
-                break;
-            }
-            --len;
-            ++pachText;
-		}
-		while ( len != 0 )
-        {
-            ssize_t i;
-            --len;
-            for( i=0; i!=len_pattern; ++i ) {
-                if( wcschr( pattern, pachText[len] )!=NULL ) {
-                    break;
-                }
-            }
-            if( i==len_pattern ) {
-                ++len;
-                break;
-            }
-		}
+		    if( len_pattern != 0 )
+		    {
+					while ( len != 0 )
+							{
+									if( wcschr( pattern, *pachText )==NULL ) {
+											break;
+									}
+									--len;
+									++pachText;
+					}
+					while ( len != 0 )
+							{
+									--len;
+									if( wcschr( pattern, pachText[len] )==NULL ) {
+											++len;
+											break;
+									}
+					}
+				}
 	}
 
 	if( len > 0 )


### PR DESCRIPTION
Removes unnecessary looping for pattern matching in run time library functions:
- LTRIM( [w]str, any [w]str )
- TRIM( [w]str, any [w]str )
- RTRIM( [w]str, any [w]str )

Fixes #116 
