### PR TITLE
Fix compilation error on/for aarch64 (arm64)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -48,6 +48,7 @@ Version 1.07.0
 - github #145: WSTRING concat and assign buffer (&=) overrun
 - sf.net #893: 'Suffixes are only valid in -lang' error message showing incorrect -lang options allowed
 - fbc uses '-march=armv8-a' instead of invalid option '-march=aarch64' when passing options to gcc/LLVM (czsgaba)
+- rtlib: sys/io.h incorrectly included on systems that do not provide it.  It is used only for x86, x86_64 and is unnecessary for all other linux targets (armhf ,arm64, mips ....)
 
 
 Version 1.06.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 1.07.0
 [changed]
 - SADD/STRPTR(wstring) returns WSTRING PTR
 - '-v' be verbose command line option affects '-help' output
+- fbc aarch64 target by default maps to '-march=armv8-a' when passing options to gcc/LLVM (czsgaba)
 
 [added]
 - CVA_LIST type, CVA_START(), CVA_COPY() CVA_END(), CVA_ARG() macros will map to gcc's __builtin_va_list and __builtin_va_* macros in gcc backend
@@ -46,6 +47,7 @@ Version 1.07.0
 - github #116: Fix optimizations in [L/R]TrimAny rtlib functions (SkyFish)
 - github #145: WSTRING concat and assign buffer (&=) overrun
 - sf.net #893: 'Suffixes are only valid in -lang' error message showing incorrect -lang options allowed
+- fbc uses '-march=armv8-a' instead of invalid option '-march=aarch64' when passing options to gcc/LLVM (czsgaba)
 
 
 Version 1.06.0

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -232,7 +232,7 @@ dim shared as FBCPUTYPEINFO cputypeinfo(0 to FB_CPUTYPE__COUNT-1) = _
 	( NULL       , @"x86-64"       , FB_CPUFAMILY_X86_64 , 64 ), _ '' FB_CPUTYPE_X86_64
 	( NULL       , @"armv6"        , FB_CPUFAMILY_ARM    , 32 ), _ '' FB_CPUTYPE_ARMV6
 	( NULL       , @"armv7-a"      , FB_CPUFAMILY_ARM    , 32 ), _ '' FB_CPUTYPE_ARMV7A
-	( NULL       , @"aarch64"      , FB_CPUFAMILY_AARCH64, 64 )  _ '' FB_CPUTYPE_AARCH64
+	( @"armv8-a" , @"aarch64"      , FB_CPUFAMILY_AARCH64, 64 )  _ '' FB_CPUTYPE_AARCH64
 }
 
 ''::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -2961,7 +2961,39 @@ private function hCompileStage2Module( byval module as FBCIOFILE ptr ) as intege
 		case FB_CPUFAMILY_ARM
 			ln += "-march=arm "
 		case FB_CPUFAMILY_AARCH64
-			ln += "-march=aarch64 "
+			'' From the GCC manual:
+			'' -march=name
+			'' Specify the name of the target architecture and, 
+			'' optionally, one or more feature modifiers. This option 
+			'' has the form ‘-march=arch{+[no]feature}*’.
+			'' 
+			'' The permissible values for arch are 
+			'' 'armv8-a'
+			'' 'armv8.1-a' = 'armv8-a' + ARMv8.1-A 
+			'' 'armv8.2-a' = 'armv8.1-a' + ARMv8.2-A
+			'' 'armv8.3-a' = 'armv8.2-a' + ARMv8.3-A
+			'' 'armv8.4-a' = 'armv8.3-a' + ARMv8.4-A
+			'' 'armv8.5-a' = 'armv8.4-a' + ARMv8.5-A
+			'' 'native' = architecture of the host system
+			'' 
+			'' It enables the '+crc', '+lse', and '+rdma' features.
+			'' 
+			'' The value 'native' is available on native AArch64 
+			'' GNU/Linux and causes the compiler to pick the 
+			'' architecture of the host system. This option has no 
+			'' effect if the compiler is unable to recognize the 
+			'' architecture of the host system, The permissible 
+			'' values for feature are listed in the sub-section on 
+			'' ['-march' and '-mcpu' Feature Modifiers]. Where 
+			'' conflicting feature modifiers are specified, the 
+			'' right-most feature is used. GCC uses name to determine 
+			'' what kind of instructions it can emit when generating 
+			'' assembly code. If '-march' is specified without either 
+			'' of '-mtune' or '-mcpu' also being specified, the code
+			'' is tuned to perform well across a range of target 
+			'' processors implementing the target architecture.
+
+			ln += "-march=armv8-a "
 		end select
 
 		if( fbGetOption( FB_COMPOPT_PIC ) ) then

--- a/src/rtlib/unix/hinit.c
+++ b/src/rtlib/unix/hinit.c
@@ -8,9 +8,21 @@
 #include "../fb_private_thread.h"
 #include <signal.h>
 #include <termcap.h>
-#ifdef HOST_LINUX
-#include <sys/io.h>
+
+#if defined HOST_LINUX && (defined HOST_X86 || defined HOST_X86_64)
+	/*
+	The sys/ headers are architecture and OS dependent. They 
+	do not exist across all targets and io.h in particular 
+	is intended for very low-level non-portable uses often 
+	in coordination with the kernel. The only targets that 
+	provide sys/io.h are x86*, Alpha, IA64, and 32-bit ARM.
+	No other systems provide it.
+	From https://bugzilla.redhat.com/show_bug.cgi?id=1116162
+	or http://www.hep.by/gnu/gnulib/ioperm.html#ioperm
+	*/
+	#include <sys/io.h>
 #endif
+
 #include <sys/ioctl.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
aarch64 is not a permissible value for -march

From the GCC manual:
-march=name
Specify the name of the target architecture and, optionally, one or more feature
modifiers. This option has the form ‘-march=arch{+[no]feature}*’.
The permissible values for arch are ‘armv8-a’, ‘armv8.1-a’, ‘armv8.2-a’,
‘armv8.3-a’, ‘armv8.4-a’, ‘armv8.5-a’ or native.
The value ‘armv8.5-a’ implies ‘armv8.4-a’ and enables compiler support for
the ARMv8.5-A architecture extensions.
The value ‘armv8.4-a’ implies ‘armv8.3-a’ and enables compiler support for
the ARMv8.4-A architecture extensions.
The value ‘armv8.3-a’ implies ‘armv8.2-a’ and enables compiler support for
the ARMv8.3-A architecture extensions.
The value ‘armv8.2-a’ implies ‘armv8.1-a’ and enables compiler support for
the ARMv8.2-A architecture extensions.
The value ‘armv8.1-a’ implies ‘armv8-a’ and enables compiler support for the
ARMv8.1-A architecture extension. In particular, it enables the ‘+crc’, ‘+lse’,
and ‘+rdma’ features.
The value ‘native’ is available on native AArch64 GNU/Linux and causes the
compiler to pick the architecture of the host system. This option has no effect
if the compiler is unable to recognize the architecture of the host system,
The permissible values for feature are listed in the sub-section on [‘-march’ and
‘-mcpu’ Feature Modifiers], page 250. Where conflicting feature modifiers are
specified, the right-most feature is used.
GCC uses name to determine what kind of instructions it can emit when generating assembly code. If ‘-march’ is specified without either of ‘-mtune’ or
‘-mcpu’ also being specified, the code is tuned to perform well across a range of
target processors implementing the target architecture.