### PR TITLE
user defined types can extend zstring or wstring

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Version 1.07.0
 - LSET/RSET statements will accept UDT as Z|WSTRING
 - MID statement will accept UDT as Z|WSTRING
 - ASC function will accept UDT as Z|WSTRING
+- STR/WSTR function will accept UDT as Z|WSTRING to return a Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Version 1.07.0
 - ASC function will accept UDT as Z|WSTRING
 - STR/WSTR function will accept UDT as Z|WSTRING to return a Z|WSTRING
 - SELECT statement will accept UDT as Z|WSTRING to return a Z|WSTRING
+- SWAP statement will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ Version 1.07.0
 - LTRIM/RTRIM/TRIM will accept UDT as Z|WSTRING
 - LCASE/UCASE will accept UDT as Z|WSTRING
 - Cxxx() conversion functions will accept UDT as Z|WSTRING
+- INSTR/INSTRREV will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 1.07.0
 
 [changed]
+- SADD/STRPTR(wstring) returns WSTRING PTR
 
 [added]
 - CVA_LIST type, CVA_START(), CVA_COPY() CVA_END(), CVA_ARG() macros will map to gcc's __builtin_va_list and __builtin_va_* macros in gcc backend
@@ -14,6 +15,7 @@ Version 1.07.0
 - Cxxx() conversion functions will accept UDT as Z|WSTRING
 - INSTR/INSTRREV will accept UDT as Z|WSTRING
 - MID function will accept UDT as Z|WSTRING
+- SADD/STRPTR will accept UDT as Z|WSTRING to return Z|WSTRING ptr
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Version 1.07.0
 - github #141: introduced '-strip'/'-nostrip' options to control symbol stripping of output files (William Breathitt Gray)
 - github #141: fbc will default to stripping symbols if '-d ENABLE_STRIPALL' is passed in FBCFLAGS (William Breathitt Gray)
 - github #141: makefile option 'ENABLE_STRIPALL=1' introduced to pass '-d ENABLE_STRIPALL' via FBCFLAGS by default for dos/win32 targets (William Breathitt Gray)
+- 'TYPE udt EXTENDS Z|WSTRING' allowed to specify that UDT is a kind of Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Version 1.07.0
 - SADD/STRPTR will accept UDT as Z|WSTRING to return Z|WSTRING ptr
 - LSET/RSET statements will accept UDT as Z|WSTRING
 - MID statement will accept UDT as Z|WSTRING
+- ASC function will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ Version 1.07.0
 - LCASE/UCASE will accept UDT as Z|WSTRING
 - Cxxx() conversion functions will accept UDT as Z|WSTRING
 - INSTR/INSTRREV will accept UDT as Z|WSTRING
+- MID function will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Version 1.07.0
 - MID function will accept UDT as Z|WSTRING
 - SADD/STRPTR will accept UDT as Z|WSTRING to return Z|WSTRING ptr
 - LSET/RSET statements will accept UDT as Z|WSTRING
+- MID statement will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ Version 1.07.0
 - github #141: makefile option 'ENABLE_STRIPALL=1' introduced to pass '-d ENABLE_STRIPALL' via FBCFLAGS by default for dos/win32 targets (William Breathitt Gray)
 - 'TYPE udt EXTENDS Z|WSTRING' allowed to specify that UDT is a kind of Z|WSTRING
 - LTRIM/RTRIM/TRIM will accept UDT as Z|WSTRING
+- LCASE/UCASE will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ Version 1.07.0
 - INSTR/INSTRREV will accept UDT as Z|WSTRING
 - MID function will accept UDT as Z|WSTRING
 - SADD/STRPTR will accept UDT as Z|WSTRING to return Z|WSTRING ptr
+- LSET/RSET statements will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Version 1.07.0
 - MID statement will accept UDT as Z|WSTRING
 - ASC function will accept UDT as Z|WSTRING
 - STR/WSTR function will accept UDT as Z|WSTRING to return a Z|WSTRING
+- SELECT statement will accept UDT as Z|WSTRING to return a Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Version 1.07.0
 - STR/WSTR function will accept UDT as Z|WSTRING to return a Z|WSTRING
 - SELECT statement will accept UDT as Z|WSTRING to return a Z|WSTRING
 - SWAP statement will accept UDT as Z|WSTRING
+- IIF function will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@ Version 1.07.0
 - github #141: fbc will default to stripping symbols if '-d ENABLE_STRIPALL' is passed in FBCFLAGS (William Breathitt Gray)
 - github #141: makefile option 'ENABLE_STRIPALL=1' introduced to pass '-d ENABLE_STRIPALL' via FBCFLAGS by default for dos/win32 targets (William Breathitt Gray)
 - 'TYPE udt EXTENDS Z|WSTRING' allowed to specify that UDT is a kind of Z|WSTRING
+- LTRIM/RTRIM/TRIM will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ Version 1.07.0
 - 'TYPE udt EXTENDS Z|WSTRING' allowed to specify that UDT is a kind of Z|WSTRING
 - LTRIM/RTRIM/TRIM will accept UDT as Z|WSTRING
 - LCASE/UCASE will accept UDT as Z|WSTRING
+- Cxxx() conversion functions will accept UDT as Z|WSTRING
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/src/compiler/ast-node-conv.bas
+++ b/src/compiler/ast-node-conv.bas
@@ -285,7 +285,7 @@ end function
 		proc = symbFindCastOvlProc( to_dtype, to_subtype, node, @err_num )
 		if( proc <> NULL ) then
 			'' build a proc call
-			return astBuildCall( proc, l )
+			return astBuildCall( proc, node )
 		else
 			if( err_num <> FB_ERRMSG_OK ) then
 				return NULL
@@ -295,7 +295,7 @@ end function
 #endmacro
 
 '':::::
-function astTryConvertUdtToWstring( byref expr as ASTNODE ptr ) as integer
+function astTryOvlStringCONV( byref expr as ASTNODE ptr ) as integer
 
 	dim as FBSYMBOL ptr proc = any, sym = any
 	dim as FB_ERRMSG err_num = any
@@ -318,8 +318,8 @@ function astTryConvertUdtToWstring( byref expr as ASTNODE ptr ) as integer
 			'' can cast to z|wstring?
 			proc = symbFindCastOvlProc( dtype, NULL, expr, @err_num )
 			if( proc ) then
-				'' full match?
-				if( symbGetFullType( proc ) = dtype ) then
+				'' same type?
+				if( symbGetType( proc ) = dtype ) then
 					expr = astBuildCall( proc, expr )
 					return TRUE
 				end if
@@ -383,6 +383,44 @@ function astNewCONV _
 			end if
 
 			return n
+		end if
+	end if
+
+	'' UDT? check if it is z|wstring? 
+	'' !!! TODO !!! make this block in to a function
+	''              re-use in astNewOvlCONV()
+	''              rewrite hDoGlobOpOverload() as astTry* function
+	if( typeGet( ldtype ) = FB_DATATYPE_STRUCT ) then
+		dim as FBSYMBOL ptr subtype = astGetSubtype( l )
+
+		if( symbGetUdtIsZstring( subtype ) or symbGetUdtIsWstring( subtype ) ) then
+			dim as FBSYMBOL ptr proc = NULL
+			dim as FB_ERRMSG err_num = any
+
+			'' check exact casts
+			proc = symbFindCastOvlProc( to_dtype, to_subtype, l, @err_num, TRUE )
+			if( proc <> NULL ) then
+				'' build a proc call
+				return astBuildCall( proc, l )
+			end if
+
+			'' check exact string pointer casts
+			if( symbGetUdtIsZstring( subtype ) ) then
+				proc = symbFindCastOvlProc( typeAddrof( FB_DATATYPE_CHAR ), NULL, l, @err_num, TRUE )
+			elseif( symbGetUdtIsWstring( subtype ) ) then
+				proc = symbFindCastOvlProc( typeAddrof( FB_DATATYPE_WCHAR ), NULL, l, @err_num, TRUE )
+			end if
+			if( proc <> NULL ) then
+				'' build a proc call
+				return astBuildCall( proc, l )
+			end if
+
+			'' strings? convert.
+			if( options and AST_CONVOPT_CHECKSTR ) then
+				if( astTryOvlStringCONV( l ) ) then
+					ldtype = astGetFullType( l )
+				end if
+			end if
 		end if
 	end if
 

--- a/src/compiler/ast-node-iif.bas
+++ b/src/compiler/ast-node-iif.bas
@@ -199,6 +199,35 @@ function astNewIIF _
 	dtype = FB_DATATYPE_INVALID
 	subtype = NULL
 
+	'' Maybe UDT extends Z|WSTRING? Check for string conversions...
+	if( truexpr->dtype <> falsexpr->dtype ) then
+		if( truexpr->dtype = FB_DATATYPE_STRUCT ) then
+			if( symbGetUdtIsZstring( truexpr->subtype ) ) then
+				if( falsexpr->dtype = FB_DATATYPE_CHAR ) then
+					astTryOvlStringCONV( truexpr )
+					truexpr->dtype = astGetDataType( truexpr )
+				end if
+			elseif( symbGetUdtIsWstring( truexpr->subtype ) ) then
+				if( falsexpr->dtype = FB_DATATYPE_WCHAR ) then
+					astTryOvlStringCONV( truexpr )
+					truexpr->dtype = astGetDataType( truexpr )
+				end if
+			end if
+		elseif( falsexpr->dtype = FB_DATATYPE_STRUCT ) then
+			if( symbGetUdtIsZstring( falsexpr->subtype ) ) then
+				if( truexpr->dtype = FB_DATATYPE_CHAR ) then
+					astTryOvlStringCONV( falsexpr )
+					falsexpr->dtype = astGetDataType( falsexpr )
+				end if
+			elseif( symbGetUdtIsWstring( falsexpr->subtype ) ) then
+				if( truexpr->dtype = FB_DATATYPE_WCHAR ) then
+					astTryOvlStringCONV( falsexpr )
+					falsexpr->dtype = astGetDataType( falsexpr )
+				end if
+			end if
+		end if
+	end if
+
 	'' check types & find the iif() result type
 	if( hCheckTypes( truexpr->dtype, truexpr->subtype, _
 	                 falsexpr->dtype, falsexpr->subtype, _

--- a/src/compiler/ast.bi
+++ b/src/compiler/ast.bi
@@ -536,7 +536,7 @@ enum AST_CONVOPT
 	AST_CONVOPT_DONTWARNFUNCPTR = &h20
 end enum
 
-declare function astTryConvertUdtToWstring( byref expr as ASTNODE ptr ) as integer
+declare function astTryOvlStringCONV( byref expr as ASTNODE ptr ) as integer
 
 declare function astNewCONV _
 	( _

--- a/src/compiler/ast.bi
+++ b/src/compiler/ast.bi
@@ -536,6 +536,8 @@ enum AST_CONVOPT
 	AST_CONVOPT_DONTWARNFUNCPTR = &h20
 end enum
 
+declare function astTryConvertUdtToWstring( byref expr as ASTNODE ptr ) as integer
+
 declare function astNewCONV _
 	( _
 		byval to_dtype as integer, _

--- a/src/compiler/parser-compound-select.bas
+++ b/src/compiler/parser-compound-select.bas
@@ -92,6 +92,8 @@ sub cSelectStmtBegin( )
 		expr = astNewCONSTi( 0 )
 	end if
 
+	astTryOvlStringCONV( expr )
+
 	'' can't be an UDT
 	if( astGetDataType( expr ) = FB_DATATYPE_STRUCT ) then
 		errReport( FB_ERRMSG_INVALIDDATATYPES )

--- a/src/compiler/parser-decl-struct.bas
+++ b/src/compiler/parser-decl-struct.bas
@@ -627,7 +627,8 @@ private function hTypeAdd _
 		byval isunion as integer, _
 		byval align as integer, _
 		byval baseDType as integer = 0, _
-		byval baseSubtype as FBSYMBOL ptr = NULL _
+		byval baseSubtype as FBSYMBOL ptr = NULL, _
+		byval baseStringType as integer = 0 _
 	) as FBSYMBOL ptr
 
 	dim as FBSYMBOL ptr s = any
@@ -639,12 +640,10 @@ private function hTypeAdd _
 		s = symbStructBegin( NULL, NULL, parent, symbUniqueLabel( ), NULL, isunion, align, (baseSubtype <> NULL), 0, 0 )
 	end if
 
-	select case baseDType
+	select case baseStringType
 	case FB_DATATYPE_CHAR
-		assert( baseSubtype = NULL )
 		symbSetUdtIsZstring( s )
 	case FB_DATATYPE_WCHAR
-		assert( baseSubtype = NULL )
 		symbSetUdtIsWstring( s )
 	end select
 
@@ -1009,6 +1008,7 @@ sub cTypeDecl( byval attrib as integer )
 	'' (EXTENDS SymbolType)?
 	dim as FBSYMBOL ptr baseSubtype = NULL
 	dim as integer baseDType = 0
+	dim as integer stringType = 0
 
 	if( lexGetToken( ) = FB_TK_EXTENDS ) then
 		lexSkipToken( )
@@ -1022,14 +1022,60 @@ sub cTypeDecl( byval attrib as integer )
 			'' allow extending WSTRING and ZSTRING, the UDT
 			'' will use different rules for conversions,
 			if (baseDType = FB_DATATYPE_WCHAR) or (baseDType = FB_DATATYPE_CHAR) then
+				stringType = baseDType
+				baseDType = 0
 				assert( baseSubtype = NULL )
-			
+
 			'' anything else? don't allow
 			else
 				errReport( FB_ERRMSG_EXPECTEDCLASSTYPE )
 				'' error recovery: skip
 				baseSubtype = NULL
 			end if
+		end if
+
+		'' got a string type?  check for another base type
+		if( stringType <> 0 ) then
+
+			'' ','?
+			if( lexGetToken( ) = CHAR_COMMA ) then
+				lexSkipToken( )
+
+				'' SymbolType
+				hSymbolType( baseDType, baseSubtype, 0, FALSE, TRUE )
+
+				'' is the base type a struct?
+				if( baseDType <> FB_DATATYPE_STRUCT ) then
+					errReport( FB_ERRMSG_EXPECTEDCLASSTYPE )
+					'' error recovery: skip
+					baseSubtype = NULL
+				end if
+			end if
+		end if
+
+		'' base type? check if z|wstring was already extended
+		if( baseSubType ) then
+			select case stringType
+			case FB_DATATYPE_CHAR
+				'' can't extend zstring if inheriting from wstring
+				if( symbGetUdtIsWstring( baseSubtype ) ) then
+					errReport( FB_ERRMSG_INVALIDDATATYPES )
+					stringType = FB_DATATYPE_WCHAR
+				end if
+			case FB_DATATYPE_WCHAR
+				'' can't extend wstring if inheriting from zstring
+				if( symbGetUdtIsZstring( baseSubtype ) ) then
+					errReport( FB_ERRMSG_INVALIDDATATYPES )
+					stringType = FB_DATATYPE_CHAR
+				end if
+			case else
+				'' inherit from base type
+				if( symbGetUdtIsZstring( baseSubtype ) ) then
+					stringType = FB_DATATYPE_CHAR
+				elseif( symbGetUdtIsWstring( baseSubtype ) ) then
+					stringType = FB_DATATYPE_WCHAR
+				end if
+			end select
 		end if
 	end if
 
@@ -1049,7 +1095,7 @@ sub cTypeDecl( byval attrib as integer )
 	dim as FBSYMBOL ptr currprocsym = parser.currproc, currblocksym = parser.currblock
 	dim as integer scope_depth = parser.scope
 
-	sym = hTypeAdd( NULL, id, palias, isunion, align, baseDType, baseSubtype )
+	sym = hTypeAdd( NULL, id, palias, isunion, align, baseDType, baseSubtype, stringType )
 
 	'' restore the context
 	ast.proc.curr = currproc

--- a/src/compiler/parser-decl-struct.bas
+++ b/src/compiler/parser-decl-struct.bas
@@ -626,6 +626,7 @@ private function hTypeAdd _
 		byval id_alias as zstring ptr, _
 		byval isunion as integer, _
 		byval align as integer, _
+		byval baseDType as integer = 0, _
 		byval baseSubtype as FBSYMBOL ptr = NULL _
 	) as FBSYMBOL ptr
 
@@ -637,6 +638,15 @@ private function hTypeAdd _
 		'' error recovery: create a fake symbol
 		s = symbStructBegin( NULL, NULL, parent, symbUniqueLabel( ), NULL, isunion, align, (baseSubtype <> NULL), 0, 0 )
 	end if
+
+	select case baseDType
+	case FB_DATATYPE_CHAR
+		assert( baseSubtype = NULL )
+		symbSetUdtIsZstring( s )
+	case FB_DATATYPE_WCHAR
+		assert( baseSubtype = NULL )
+		symbSetUdtIsWstring( s )
+	end select
 
 	if( baseSubtype ) then
 		symbStructAddBase( s, baseSubtype )
@@ -998,18 +1008,28 @@ sub cTypeDecl( byval attrib as integer )
 
 	'' (EXTENDS SymbolType)?
 	dim as FBSYMBOL ptr baseSubtype = NULL
+	dim as integer baseDType = 0
+
 	if( lexGetToken( ) = FB_TK_EXTENDS ) then
 		lexSkipToken( )
 
 		'' SymbolType
-		dim as integer baseDtype
-		hSymbolType( baseDtype, baseSubtype, 0 )
+		hSymbolType( baseDType, baseSubtype, 0, FALSE, TRUE )
 
 		'' is the base type a struct?
 		if( baseDType <> FB_DATATYPE_STRUCT ) then
-			errReport( FB_ERRMSG_EXPECTEDCLASSTYPE )
-			'' error recovery: skip
-			baseSubtype = NULL
+			
+			'' allow extending WSTRING and ZSTRING, the UDT
+			'' will use different rules for conversions,
+			if (baseDType = FB_DATATYPE_WCHAR) or (baseDType = FB_DATATYPE_CHAR) then
+				assert( baseSubtype = NULL )
+			
+			'' anything else? don't allow
+			else
+				errReport( FB_ERRMSG_EXPECTEDCLASSTYPE )
+				'' error recovery: skip
+				baseSubtype = NULL
+			end if
 		end if
 	end if
 
@@ -1029,7 +1049,7 @@ sub cTypeDecl( byval attrib as integer )
 	dim as FBSYMBOL ptr currprocsym = parser.currproc, currblocksym = parser.currblock
 	dim as integer scope_depth = parser.scope
 
-	sym = hTypeAdd( NULL, id, palias, isunion, align, baseSubtype )
+	sym = hTypeAdd( NULL, id, palias, isunion, align, baseDType, baseSubtype )
 
 	'' restore the context
 	ast.proc.curr = currproc

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -38,13 +38,17 @@ sub hSymbolType _
 		byref dtype as integer, _
 		byref subtype as FBSYMBOL ptr, _
 		byref lgt as longint, _
-		byval is_byref as integer _
+		byval is_byref as integer, _
+		byval is_extends as integer _
 	)
 
 	dim as integer options = FB_SYMBTYPEOPT_DEFAULT
 	if( is_byref ) then
 		options and= not FB_SYMBTYPEOPT_CHECKSTRPTR
 		options or= FB_SYMBTYPEOPT_ISBYREF
+	end if
+	if( is_extends ) then
+		options and= not FB_SYMBTYPEOPT_CHECKSTRPTR
 	end if
 
 	'' parse the symbol type (INTEGER, STRING, etc...)

--- a/src/compiler/parser-quirk-array.bas
+++ b/src/compiler/parser-quirk-array.bas
@@ -84,6 +84,37 @@ private function hScopedSwap( ) as integer
 	dim as integer ldtype = astGetDataType( l )
 	dim as integer rdtype = astGetDataType( r )
 
+	'' Maybe UDT extends Z|WSTRING? Check for string conversions...
+	if( ldtype <> rdtype ) then
+		if( ldtype = FB_DATATYPE_STRUCT ) then
+			var sym = astGetSubType( l )
+			if( symbGetUdtIsZstring( sym ) ) then
+				if( rdtype = FB_DATATYPE_CHAR ) then
+					astTryOvlStringCONV( l )
+					ldtype = astGetDataType( l )
+				end if
+			elseif( symbGetUdtIsWstring( sym ) ) then
+				if( rdtype = FB_DATATYPE_WCHAR ) then
+					astTryOvlStringCONV( l )
+					ldtype = astGetDataType( l )
+				end if
+			end if
+		elseif( rdtype = FB_DATATYPE_STRUCT ) then
+			var sym = astGetSubType( r )
+			if( symbGetUdtIsZstring( sym ) ) then
+				if( ldtype = FB_DATATYPE_CHAR ) then
+					astTryOvlStringCONV( r )
+					rdtype = astGetDataType( r )
+				end if
+			elseif( symbGetUdtIsWstring( sym ) ) then
+				if( ldtype = FB_DATATYPE_WCHAR ) then
+					astTryOvlStringCONV( r )
+					rdtype = astGetDataType( r )
+				end if
+			end if
+		end if
+	end if
+
 	select case( ldtype )
 	case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, FB_DATATYPE_CHAR
 		select case rdtype

--- a/src/compiler/parser-quirk-string.bas
+++ b/src/compiler/parser-quirk-string.bas
@@ -80,6 +80,8 @@ function cLRSetStmt(byval tk as FB_TOKEN) as integer
 		dstexpr = CREATEFAKEID( )
 	end if
 
+	astTryOvlStringCONV( dstexpr )
+
 	dtype1 = astGetDataType( dstexpr )
 	select case as const dtype1
 	case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, _
@@ -126,6 +128,8 @@ function cLRSetStmt(byval tk as FB_TOKEN) as integer
 	'' Expression
 	hMatchExpressionEx( srcexpr, dtype1 )
 
+	astTryOvlStringCONV( srcexpr )
+
 	dtype2 = astGetDataType( srcexpr )
 	select case as const dtype2
 	case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, _
@@ -163,6 +167,9 @@ function cLRSetStmt(byval tk as FB_TOKEN) as integer
 		function = rtlMemCopyClear( dstexpr, symbGetLen( dst->subtype ), _
 		                            srcexpr, symbGetLen( src->subtype ) )
 	else
+		'' !!! TODO !!! - if udt extends z|wstring, check if operator len()
+		'' was overloaded and pass the length parameters to a separate
+		'' rtlib function
 		function = rtlStrLRSet( dstexpr, srcexpr, is_rset )
 	end if
 

--- a/src/compiler/parser.bi
+++ b/src/compiler/parser.bi
@@ -873,7 +873,8 @@ declare sub hSymbolType _
 		byref dtype as integer, _
 		byref subtype as FBSYMBOL ptr, _
 		byref lgt as longint, _
-		byval is_byref as integer = FALSE _
+		byval is_byref as integer = FALSE, _
+		byval is_extends as integer = FALSE _
 	)
 
 declare function hCheckForDefiniteTypes _

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -2846,6 +2846,10 @@ function rtlToStr _
     	end if
     end if
 
+	astTryOvlStringCONV( expr )
+
+	dtype = astGetDataType( expr )
+
     ''
 	select case as const astGetDataClass( expr )
 	case FB_DATACLASS_INTEGER
@@ -2945,6 +2949,10 @@ function rtlToWstr _
 			end if
     	end if
     end if
+
+	astTryOvlStringCONV( expr )
+
+	dtype = astGetDataType( expr )
 
 	select case as const astGetDataClass( expr )
 	case FB_DATACLASS_INTEGER

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -3331,6 +3331,8 @@ function rtlStrAsc _
 
 	function = NULL
 
+	astTryOvlStringCONV( expr )
+
     ''
     if( astGetDataType( expr ) <> FB_DATATYPE_WCHAR ) then
     	proc = astNewCALL( PROCLOOKUP( STRASC ) )

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -3092,7 +3092,8 @@ function rtlStrMid _
 
     function = NULL
 
-	''
+	astTryOvlStringCONV( expr1 )
+
     if( astGetDataType( expr1 ) <> FB_DATATYPE_WCHAR ) then
     	proc = astNewCALL( PROCLOOKUP( STRMID ) )
     else

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -3526,9 +3526,9 @@ function rtlStrTrim _
 
     function = NULL
 
-	astTryConvertUdtToWstring( nd_text )
+	astTryOvlStringCONV( nd_text )
 	if( nd_pattern ) then
-		astTryConvertUdtToWstring( nd_pattern )
+		astTryOvlStringCONV( nd_pattern )
 	end if
 
 	dtype = astGetDataType( nd_text )
@@ -3584,9 +3584,9 @@ function rtlStrRTrim _
 
     function = NULL
 
-	astTryConvertUdtToWstring( nd_text )
+	astTryOvlStringCONV( nd_text )
 	if( nd_pattern ) then
-		astTryConvertUdtToWstring( nd_pattern )
+		astTryOvlStringCONV( nd_pattern )
 	end if
 
 	dtype = astGetDataType( nd_text )
@@ -3642,9 +3642,9 @@ function rtlStrLTrim _
 
     function = NULL
 
-	astTryConvertUdtToWstring( nd_text )
+	astTryOvlStringCONV( nd_text )
 	if( nd_pattern ) then
-		astTryConvertUdtToWstring( nd_pattern )
+		astTryOvlStringCONV( nd_pattern )
 	end if
 
 	dtype = astGetDataType( nd_text )
@@ -3791,7 +3791,7 @@ function rtlStrCase _
 		end if
 	end if
 
-	astTryConvertUdtToWstring( expr )
+	astTryOvlStringCONV( expr )
 
 	if( is_lcase ) then
 		if( astGetDataType( expr ) = FB_DATATYPE_WCHAR ) then

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -3526,6 +3526,11 @@ function rtlStrTrim _
 
     function = NULL
 
+	astTryConvertUdtToWstring( nd_text )
+	if( nd_pattern ) then
+		astTryConvertUdtToWstring( nd_pattern )
+	end if
+
 	dtype = astGetDataType( nd_text )
 
 	''
@@ -3579,6 +3584,11 @@ function rtlStrRTrim _
 
     function = NULL
 
+	astTryConvertUdtToWstring( nd_text )
+	if( nd_pattern ) then
+		astTryConvertUdtToWstring( nd_pattern )
+	end if
+
 	dtype = astGetDataType( nd_text )
 
 	''
@@ -3631,6 +3641,11 @@ function rtlStrLTrim _
     dim as integer dtype = any
 
     function = NULL
+
+	astTryConvertUdtToWstring( nd_text )
+	if( nd_pattern ) then
+		astTryConvertUdtToWstring( nd_pattern )
+	end if
 
 	dtype = astGetDataType( nd_text )
 

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -3131,6 +3131,8 @@ function rtlStrAssignMid _
 
     function = NULL
 
+	astTryOvlStringCONV( expr1 )
+
 	''
     if( astGetDataType( expr1 ) <> FB_DATATYPE_WCHAR ) then
     	proc = astNewCALL( PROCLOOKUP( STRASSIGNMID ) )

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -3791,6 +3791,8 @@ function rtlStrCase _
 		end if
 	end if
 
+	astTryConvertUdtToWstring( expr )
+
 	if( is_lcase ) then
 		if( astGetDataType( expr ) = FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( WSTRLCASE2 )

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -3425,6 +3425,11 @@ function rtlStrInstr _
 
     function = NULL
 
+	astTryOvlStringCONV( nd_text )
+	if( nd_pattern ) then
+		astTryOvlStringCONV( nd_pattern )
+	end if
+
 	dtype = astGetDataType( nd_text )
 
 	''
@@ -3475,6 +3480,11 @@ function rtlStrInstrRev _
 	dim as integer dtype = any
 
 	function = NULL
+
+	astTryOvlStringCONV( nd_text )
+	if( nd_pattern ) then
+		astTryOvlStringCONV( nd_pattern )
+	end if
 
 	dtype = astGetDataType( nd_text )
 

--- a/src/compiler/rtl.bas
+++ b/src/compiler/rtl.bas
@@ -387,6 +387,11 @@ end function
 '':::::
 '' note: this function must be called *before* astNewARG(e) because the
 ''		 expression 'e' can be changed inside the former (address-of string's etc)
+'' !!! TODO !!! - in places where rtlCalcStrLen() is called, if it is a UDT
+'' that overloads operator len(), then the value returned by operator len() should
+'' be prefered to calculating length in the run-time based on the null terminated
+'' length.  Many fb_Wstr* functions will need alternate versions that accept a length 
+'' parameter.
 function rtlCalcStrLen _
 	( _
 		byval expr as ASTNODE ptr, _

--- a/src/compiler/symb-proc.bas
+++ b/src/compiler/symb-proc.bas
@@ -2366,7 +2366,8 @@ private function hCheckCastOvl _
 	( _
 		byval proc as FBSYMBOL ptr, _
 		byval to_dtype as integer, _
-		byval to_subtype as FBSYMBOL ptr _
+		byval to_subtype as FBSYMBOL ptr, _
+		byval is_explicit as integer = FALSE _
 	) as FB_OVLPROC_MATCH_SCORE
 
 	dim as integer proc_dtype = any
@@ -2395,6 +2396,9 @@ private function hCheckCastOvl _
 	end if
 
 	'' different types..
+	if( is_explicit ) then
+		return FB_OVLPROC_NO_MATCH
+	end if
 
 	select case typeGet( proc_dtype )
 	'' UDT or enum? can't be different (this is the last resource,
@@ -2427,7 +2431,8 @@ function symbFindCastOvlProc _
 		byval to_dtype as integer, _
 		byval to_subtype as FBSYMBOL ptr, _
 		byval l as ASTNODE ptr, _
-		byval err_num as FB_ERRMSG ptr _
+		byval err_num as FB_ERRMSG ptr, _
+		byval is_explicit as integer = FALSE _
 	) as FBSYMBOL ptr
 
 	dim as FBSYMBOL ptr proc_head = any
@@ -2470,7 +2475,7 @@ function symbFindCastOvlProc _
 		proc = proc_head
 		do while( proc <> NULL )
 
-			matchscore = hCheckCastOvl( proc, to_dtype, to_subtype )
+			matchscore = hCheckCastOvl( proc, to_dtype, to_subtype, is_explicit )
 			if( matchscore > max_matchscore ) then
 		   		closest_proc = proc
 		   		max_matchscore = matchscore

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -432,7 +432,8 @@ enum FB_UDTOPT
 	FB_UDTOPT_HASBITFIELD           = &h8000
 	FB_UDTOPT_ISVALISTSTRUCT        = &h10000
 	FB_UDTOPT_ISVALISTSTRUCTARRAY   = &h20000
-
+	FB_UDTOPT_ISWSTRING             = &h40000
+	FB_UDTOPT_ISZSTRING             = &h80000
 end enum
 
 type FB_STRUCT_DBG
@@ -2250,6 +2251,12 @@ declare function symbCloneSimpleStruct( byval sym as FBSYMBOL ptr ) as FBSYMBOL 
 
 #define symbSetUdtIsValistStructArray( s )   (s)->udt.options or= FB_UDTOPT_ISVALISTSTRUCTARRAY
 #define symbGetUdtIsValistStructArray( s ) (((s)->udt.options and FB_UDTOPT_ISVALISTSTRUCTARRAY) <> 0)
+
+#define symbSetUdtIsZstring( s )   (s)->udt.options or= FB_UDTOPT_ISZSTRING
+#define symbGetUdtIsZstring( s ) (((s)->udt.options and FB_UDTOPT_ISZSTRING) <> 0 )
+
+#define symbSetUdtIsWstring( s )   (s)->udt.options or= FB_UDTOPT_ISWSTRING
+#define symbGetUdtIsWstring( s ) (((s)->udt.options and FB_UDTOPT_ISWSTRING) <> 0 )
 
 #define symbGetUDTIsUnionOrAnon(s) (((s)->udt.options and (FB_UDTOPT_ISUNION or FB_UDTOPT_ISANON)) <> 0)
 

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -978,7 +978,8 @@ declare function symbFindCastOvlProc _
 		byval to_dtype as integer, _
 		byval to_subtype as FBSYMBOL ptr, _
 		byval expr as ASTNODE ptr, _
-		byval err_num as FB_ERRMSG ptr _
+		byval err_num as FB_ERRMSG ptr, _
+		byval is_explicit as integer = FALSE _
 	) as FBSYMBOL ptr
 
 declare function symbFindCtorOvlProc _

--- a/tests/dirlist.mk
+++ b/tests/dirlist.mk
@@ -34,6 +34,8 @@ structs \
 swap \
 threads \
 typedef \
+udt-wstring \
+udt-zstring \
 virtual \
 visibility \
 wstring

--- a/tests/readme.txt
+++ b/tests/readme.txt
@@ -6,7 +6,10 @@ This is the directory for FreeBASIC compiler and runtime tests.
 Requirements - Windows / Linux / Dos
 ------------------------------------
    - FreeBASIC Compiler 1.06.0 or above
+   - a build environment with common *nix commands available
+     on the path
    - make, sh, find, xargs, grep, sed, cat, rm
+
 
 Summary
 -------
@@ -91,6 +94,7 @@ ENABLE_CONSOLE_OUTPUT=1
    Add '-d ENABLE_CONSOLE_OUTPUT' when compiling tests. This is used
    to turn on printing output to the console.
 
+
 How the tests are collected
 ---------------------------
 
@@ -98,7 +102,14 @@ All of the directories listed in 'dirlist.mk' in the makefile
 variable $(DIRLIST) are scanned for files with the extension
 '.bmk' or '.bas'.  When matching filenames are found, the contents
 of the file is then scanned to determine the method of testing
-needed for that specific file.
+needed for that specific file. For adding tests in new folders
+manually add the new folder names in dirlist.mk.
+
+This scan autogenerates "unit-tests.inc", which holds all files to be 
+included in unit-tests.
+
+For forcing a rescan you should run "make clean", which will remove all
+files resulting from previous runs and leave a cleaned tests environment.
 
 By default '-lang fb' tests are collected unless 'FB_LANG=?' option
 is given.
@@ -118,7 +129,7 @@ Sample FBCUNIT compatible test (using SUITE/TEST macros)
    #include "fbcunit.bi"
    SUITE( pretest )
       TEST( test_true )
-	      CU_ASSERT_TRUE( true ) 
+          CU_ASSERT_TRUE( true ) 
       END_TEST
    END_SUITE
    ' EOF
@@ -147,7 +158,7 @@ Sample FBCUNIT compatible test (using the 'old' way)
    ' EOF
 
 Consult the fbcunit documentation for a listing of available
-assertions and testing methods.
+assertions and testing methods (tests\fbcunit\inc\fbcunit.bi).
 
 
 non-unit compatible test (log-tests)

--- a/tests/udt-wstring/asc.bas
+++ b/tests/udt-wstring/asc.bas
@@ -1,0 +1,49 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.asc_ )
+
+	TEST( ascii )
+		dim s as wstring * 256
+		for i as uinteger = 1 to 255
+			s[i-1] = i
+		next
+		dim u as ustring = s
+
+		CU_ASSERT_EQUAL( asc( s ), asc( u ) )
+
+		for i as integer = -2 to 257
+			select case i
+			case 1 to 255
+				CU_ASSERT_EQUAL( i, asc( u, i ) )
+			case else
+				CU_ASSERT_EQUAL( 0, asc( u, i ) )
+			end select
+		next
+
+	END_TEST
+
+	TEST( ucs2 )
+		dim s as wstring * 256
+		for i as uinteger = 1 to 255
+			s[i-1] = i shl 8
+		next
+		dim u as ustring = s
+
+		CU_ASSERT_EQUAL( asc( s ), asc( u ) )
+
+		for i as integer = -2 to 257
+			select case i
+			case 1 to 255
+				CU_ASSERT_EQUAL( asc( s, i ), asc( u, i ) )
+			case else
+				CU_ASSERT_EQUAL( 0, asc( u, i ) )
+			end select
+		next
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/case.bas
+++ b/tests/udt-wstring/case.bas
@@ -1,0 +1,43 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.case_ )
+
+	'' U/LCASE( wstring )
+	#macro check_rtlfunc( rtlfunc, text )
+		scope
+			dim t as wstring * 50 = text
+			dim u as ustring = t
+
+			CU_ASSERT( t = text )
+			CU_ASSERT( u = t )
+
+			dim rt as wstring * 50 = rtlfunc( t )
+			dim ru as wstring * 50 = rtlfunc( u )
+			CU_ASSERT_WSTRING_EQUAL( rt, ru )
+
+		end scope
+	#endmacro
+
+	#macro check( text )
+		check_rtlfunc( ucase, text )
+		check_rtlfunc( lcase, text )
+	#endmacro
+
+	TEST( default )
+		check( "" )
+		check( " " )
+		check( "  " )
+		check( "abcde" )
+		check( "asdfghjkl" )
+		check( !"\u30a1\u30a3\u30a5\u30a7\u30a9" )       '' katakana
+		check( !"\u0444\u044b\u0432\u0430\u043f\u0440" ) '' russian
+		check( !"asd wstring fghjkl\u4644" )
+		check( "QWERTZUIOP" )
+		check( "1234567890" )
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/chk-wstring.bi
+++ b/tests/udt-wstring/chk-wstring.bi
@@ -1,0 +1,26 @@
+#pragma once
+
+#macro CU_ASSERT_WSTRING_EQUAL( u, w )
+
+	'' length check
+	CU_ASSERT( len(u) = len(w) )
+
+	'' comparison check
+	CU_ASSERT_EQUAL(u, w)
+
+	'' byte-by-byte check
+	scope
+		if(len(u) = len(w)) then
+			do
+				for i as integer = 0 to len(u) - 1
+					if(u[i] <> w[i]) then
+						CU_FAIL()
+						exit do
+					end if
+				next
+				CU_PASS()
+			loop until true
+		end if
+	end scope
+
+#endmacro

--- a/tests/udt-wstring/conversion.bas
+++ b/tests/udt-wstring/conversion.bas
@@ -1,0 +1,160 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.conversion )
+
+	#macro check( datatype, func, value )
+
+		scope
+			dim t as wstring * 50 = wstr( #value )
+			dim u as ustring = t
+
+			#if #datatype = "double"
+				CU_ASSERT_DOUBLE_EQUAL( func( t ), value, 0 )
+				CU_ASSERT_DOUBLE_EQUAL( func( u ), value, 0 )
+				CU_ASSERT_DOUBLE_EQUAL( func( t ), func( value ), 0 )
+				CU_ASSERT_DOUBLE_EQUAL( func( u ), func( value ), 0 )
+				CU_ASSERT_EQUAL( func( t ), func( u ) )
+			#elseif #datatype = "single"
+				CU_ASSERT_SINGLE_APPROX( func( t ), value, 0 )
+				CU_ASSERT_SINGLE_APPROX( func( u ), value, 0 )
+				CU_ASSERT_SINGLE_APPROX( func( t ), func( value ), 0 )
+				CU_ASSERT_SINGLE_APPROX( func( u ), func( value ), 0 )
+				CU_ASSERT_EQUAL( func( t ), func( u ) )
+			#else
+				CU_ASSERT_EQUAL( func( t ), value )
+				CU_ASSERT_EQUAL( func( u ), value )
+				CU_ASSERT_EQUAL( func( t ), func( value ) )
+				CU_ASSERT_EQUAL( func( u ), func( value ) )
+				CU_ASSERT_EQUAL( func( t ), func( u ) )
+			#endif
+			
+		end scope
+
+	#endmacro
+
+	TEST( cbool_ )
+		check( boolean, cbool, false )
+		check( boolean, cbool, true )
+	END_TEST
+
+	TEST( cbyte_ )
+		check( byte, cbyte, -128 )
+		check( byte, cbyte, -1 )
+		check( byte, cbyte, 0 )
+		check( byte, cbyte, 127 )
+	END_TEST
+
+	TEST( cubyte_ )
+		check( ubyte, cubyte, 0 )
+		check( ubyte, cubyte, 127 )
+		check( ubyte, cubyte, 128 )
+		check( ubyte, cubyte, 255 )
+	END_TEST
+
+	TEST( cshort_ )
+		check( short, cshort, -32768 )
+		check( short, cshort, -1 )
+		check( short, cshort, 0 )
+		check( short, cshort, 32767 )
+	END_TEST
+
+	TEST( cushort_ )
+		check( ushort, cushort, 0 )
+		check( ushort, cushort, 32767 )
+		check( ushort, cushort, 32768 )
+		check( ushort, cushort, 65535 )
+	END_TEST
+
+	TEST( clng_ )
+		check( long, clng, -2147483648 )
+		check( long, clng, -1 )
+		check( long, clng, 0 )
+		check( long, clng, 2147483647 )
+	END_TEST
+
+	TEST( culng_ )
+		check( ulong, culng, 0 )
+		check( ulong, culng, 2147483647 )
+		check( ulong, culng, 2147483648 )
+		check( ulong, culng, 4294967295 )
+	END_TEST
+
+
+#if sizeof(integer) = 4
+	TEST( cint_ )
+		check( integer, cint, -2147483648 )
+		check( integer, cint, -1 )
+		check( integer, cint, 0 )
+		check( integer, cint, 2147483647 )
+	END_TEST
+
+	TEST( cuint_ )
+		check( uinteger, cuint, 0 )
+		check( uinteger, cuint, 2147483647 )
+		check( uinteger, cuint, 2147483648 )
+		check( uinteger, cuint, 4294967295 )
+	END_TEST
+#else
+	TEST( cint_ )
+		check( integer, cint, -9223372036854775808ll )
+		check( integer, cint, -1 )
+		check( integer, cint, 0 )
+		check( integer, cint, 9223372036854775807ll )
+	END_TEST
+
+	TEST( cuint_ )
+		check( uinteger, cuint, 0 )
+		check( uinteger, cuint, 9223372036854775807 )
+		check( uinteger, cuint, 9223372036854775808 )
+		check( uinteger, cuint, 18446744073709551615 )
+	END_TEST
+#endif
+
+	TEST( clngint_ )
+		check( longint, clngint, -9223372036854775808 )
+		check( longint, clngint, -1 )
+		check( longint, clngint, 0 )
+		check( longint, clngint, 9223372036854775807 )
+	END_TEST
+
+	TEST( culngint_ )
+		check( ulongint, culngint, 0 )
+		check( ulongint, culngint, 9223372036854775807 )
+		check( ulongint, culngint, 9223372036854775808 )
+		check( ulongint, culngint, 18446744073709551615 )
+	END_TEST
+
+	TEST( csng_ )
+		check( single, csng, 1.1754943508e-38! )
+		check( single, csng, 3.4028234664e+38! )
+		check( single, csng, 0.9999999404! )
+		check( single, csng, 1.0000001192! )
+		check( single, csng, -1.5! )
+		check( single, csng, -1! )
+		check( single, csng, -0.5! )
+		check( single, csng, 0! )
+		check( single, csng, 0.5! )
+		check( single, csng, 1! )
+		check( single, csng, 1.5! )
+		check( single, csng, +1! )
+	END_TEST
+
+	TEST( cdbl_ )
+		check( double, cdbl, 2.2250738585072014d-308# )
+		check( double, cdbl, 1.7976931348623157d+308# )
+		check( double, cdbl, -1.5# )
+		check( double, cdbl, -1# )
+		check( double, cdbl, -0.5# )
+		check( double, cdbl, 0# )
+		check( double, cdbl, 0.5# )
+		check( double, cdbl, 1# )
+		check( double, cdbl, 1.5# )
+		check( double, cdbl, +1# )
+	END_TEST
+
+END_SUITE
+

--- a/tests/udt-wstring/iif.bas
+++ b/tests/udt-wstring/iif.bas
@@ -1,0 +1,215 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.iif_ )
+
+	#macro check_wstring( expr, true_expr, false_expr )
+		scope
+			dim t1 as wstring * 50 = true_expr
+			dim t2 as wstring * 50 = false_expr
+
+			dim u1 as ustring = true_expr
+			dim u2 as ustring = false_expr
+
+			'' WSTRING = iif( expr, LITERAL1, LITERAL2 )
+			scope
+				dim a as wstring * 50 = iif( expr, true_expr, false_expr )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' WSTRING = iif( expr, WSTRING1, LITERAL2 )
+			scope
+				dim a as wstring * 50 = iif( expr, t1, false_expr )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' WSTRING = iif( expr, LITERAL1, WSTRING2 )
+			scope
+				dim a as wstring * 50 = iif( expr, true_expr, t2 )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' WSTRING = iif( expr, WSTRING1, WSTRING2 )
+			scope
+				dim a as wstring * 50 = iif( expr, t1, t2 )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' WSTRING = iif( expr, USTRING1, LITERAL2 )
+			scope
+				dim a as wstring * 50 = iif( expr, u1, false_expr )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' WSTRING = iif( expr, LITERAL1, USTRING2 )
+			scope
+				dim a as wstring * 50 = iif( expr, true_expr, u2 )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' WSTRING = iif( expr, USTRING1, USTRING2 )
+			scope
+				dim a as wstring * 50 = iif( expr, u1, u2 )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+		end scope
+	#endmacro
+
+	#macro check_ustring( expr, true_expr, false_expr )
+		scope
+			dim t1 as wstring * 50 = true_expr
+			dim t2 as wstring * 50 = false_expr
+
+			dim u1 as ustring = true_expr
+			dim u2 as ustring = false_expr
+
+			'' USTRING = iif( expr, LITERAL1, LITERAL2 )
+			scope
+				dim a as ustring = iif( expr, true_expr, false_expr )
+				dim r as wstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, WSTRING1, LITERAL2 )
+			scope
+				dim a as ustring = iif( expr, t1, false_expr )
+				dim r as wstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, LITERAL1, WSTRING2 )
+			scope
+				dim a as ustring = iif( expr, true_expr, t2 )
+				dim r as wstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, WSTRING1, WSTRING2 )
+			scope
+				dim a as ustring = iif( expr, t1, t2 )
+				dim r as wstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, USTRING1, LITERAL2 )
+			scope
+				dim a as ustring = iif( expr, u1, false_expr )
+				dim r as wstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, LITERAL1, USTRING2 )
+			scope
+				dim a as ustring = iif( expr, true_expr, u2 )
+				dim r as wstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, USTRING1, USTRING2 )
+			scope
+				dim a as ustring = iif( expr, u1, u2 )
+				dim r as wstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+		end scope
+	#endmacro
+
+	TEST( wstring_iif )
+		
+		check_wstring(  0, "", "a" )
+		check_wstring( -1, "", "a" )
+
+		check_wstring(  0, "a", "xyz" )
+		check_wstring( -1, "a", "xyz" )
+
+		check_wstring(  0, !"\u3041\u3043\u3045", "a" )
+		check_wstring( -1, !"\u3041\u3043\u3045", "a" )
+
+		check_wstring(  0, "a", !"\u3041\u3043\u3045" )
+		check_wstring( -1, "a", !"\u3041\u3043\u3045" )
+
+		check_wstring(  0, !"\u3047", !"\u3041\u3043\u3045" )
+		check_wstring( -1, !"\u3047", !"\u3041\u3043\u3045" )
+
+	END_TEST
+
+	TEST( ustring_iif )
+		
+		check_ustring(  0, "", "a" )
+		check_ustring( -1, "", "a" )
+
+		check_ustring(  0, "a", "xyz" )
+		check_ustring( -1, "a", "xyz" )
+
+		check_ustring(  0, !"\u3041\u3043\u3045", "a" )
+		check_ustring( -1, !"\u3041\u3043\u3045", "a" )
+
+		check_ustring(  0, "a", !"\u3041\u3043\u3045" )
+		check_ustring( -1, "a", !"\u3041\u3043\u3045" )
+
+		check_ustring(  0, !"\u3047", !"\u3041\u3043\u3045" )
+		check_ustring( -1, !"\u3047", !"\u3041\u3043\u3045" )
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/instr.bas
+++ b/tests/udt-wstring/instr.bas
@@ -1,0 +1,201 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.instr_ )
+
+	'' INSTR( wstring, wstring )
+	#macro check_0( result, text, pattern )
+		scope
+			dim st as wstring * 50 = text
+			dim ut as ustring = st
+			dim sp as wstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instr( st, sp ) )
+			CU_ASSERT_EQUAL( result, instr( st, up ) )
+			CU_ASSERT_EQUAL( result, instr( ut, sp ) )
+			CU_ASSERT_EQUAL( result, instr( ut, up ) )
+		end scope
+	#endmacro
+
+		'' INSTR( index, wstring, wstring )
+	#macro check_x( result, index, text, pattern )
+		scope
+			dim st as wstring * 50 = text
+			dim ut as ustring = st
+			dim sp as wstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instr( index, st, sp ) )
+			CU_ASSERT_EQUAL( result, instr( index, st, up ) )
+			CU_ASSERT_EQUAL( result, instr( index, ut, sp ) )
+			CU_ASSERT_EQUAL( result, instr( index, ut, up ) )
+		end scope
+	#endmacro
+
+		'' INSTR( wstring, wstring )
+	#macro check_0_any( result, text, pattern )
+		scope
+			dim st as wstring * 50 = text
+			dim ut as ustring = st
+			dim sp as wstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instr( st, any sp ) )
+			CU_ASSERT_EQUAL( result, instr( st, any up ) )
+			CU_ASSERT_EQUAL( result, instr( ut, any sp ) )
+			CU_ASSERT_EQUAL( result, instr( ut, any up ) )
+		end scope
+	#endmacro
+
+		'' INSTR( index, wstring, wstring )
+	#macro check_x_any( result, index, text, pattern )
+		scope
+			dim st as wstring * 50 = text
+			dim ut as ustring = st
+			dim sp as wstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instr( index, st, any sp ) )
+			CU_ASSERT_EQUAL( result, instr( index, st, any up ) )
+			CU_ASSERT_EQUAL( result, instr( index, ut, any sp ) )
+			CU_ASSERT_EQUAL( result, instr( index, ut, any up ) )
+		end scope
+	#endmacro
+
+	TEST( instr_0 )
+		check_0( 0, !"", !"" )
+		check_0( 0, !"x", !"" )
+		check_0( 0, !"", !"x" )
+		check_0( 1, !"x", !"x" )
+		check_0( 2, !"yx", !"x" )
+
+		check_0( 1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_0( 2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_0( 3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_0( 4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+	END_TEST
+
+	TEST( instr_x )
+		check_x( 0, -1, !"", !"" )
+		check_x( 0,  0, !"", !"" )
+		check_x( 0,  1, !"", !"" )
+		check_x( 0,  2, !"", !"" )
+
+		check_x( 0, -1, !"x", !"" )
+		check_x( 0,  0, !"x", !"" )
+		check_x( 0,  1, !"x", !"" )
+		check_x( 0,  2, !"x", !"" )
+
+		check_x( 0, -1, !"", !"x" )
+		check_x( 0,  0, !"", !"x" )
+		check_x( 0,  1, !"", !"x" )
+		check_x( 0,  2, !"", !"x" )
+
+		check_x( 0, -1, !"x", !"x" )
+		check_x( 0,  0, !"x", !"x" )
+		check_x( 1,  1, !"x", !"x" )
+		check_x( 0,  2, !"x", !"x" )
+		check_x( 0,  3, !"x", !"x" )
+
+		check_x( 0, -1, !"xy", !"x" )
+		check_x( 0,  0, !"xy", !"x" )
+		check_x( 1,  1, !"xy", !"x" )
+		check_x( 0,  2, !"xy", !"x" )
+		check_x( 0,  3, !"xy", !"x" )
+
+		check_x( 0, -1, !"yx", !"x" )
+		check_x( 0,  0, !"yx", !"x" )
+		check_x( 2,  1, !"yx", !"x" )
+		check_x( 2,  2, !"yx", !"x" )
+		check_x( 0,  3, !"yx", !"x" )
+
+		check_x( 0,  0, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x( 1,  1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x( 0,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+
+		check_x( 2,  1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x( 2,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x( 0,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+
+		check_x( 3,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x( 3,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x( 0,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+
+		check_x( 4,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x( 4,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x( 0,  5, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+	END_TEST
+
+	TEST( instr_0_any )
+		check_0_any( 0, !"", !"" )
+		check_0_any( 0, !"x", !"" )
+		check_0_any( 0, !"", !"x" )
+		check_0_any( 1, !"x", !"x" )
+		check_0_any( 1, !"xy", !"x" )
+		check_0_any( 2, !"yx", !"x" )
+
+		check_0_any( 1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_0_any( 2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_0_any( 3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_0_any( 4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+	END_TEST
+
+	TEST( instr_x_any )
+		check_x_any( 0, -1, !"", !"" )
+		check_x_any( 0,  0, !"", !"" )
+		check_x_any( 0,  1, !"", !"" )
+		check_x_any( 0,  2, !"", !"" )
+
+		check_x_any( 0, -1, !"x", !"" )
+		check_x_any( 0,  0, !"x", !"" )
+		check_x_any( 0,  1, !"x", !"" )
+		check_x_any( 0,  2, !"x", !"" )
+
+		check_x_any( 0, -1, !"", !"x" )
+		check_x_any( 0,  0, !"", !"x" )
+		check_x_any( 0,  1, !"", !"x" )
+		check_x_any( 0,  2, !"", !"x" )
+
+		check_x_any( 0, -1, !"x", !"x" )
+		check_x_any( 0,  0, !"x", !"x" )
+		check_x_any( 1,  1, !"x", !"x" )
+		check_x_any( 0,  2, !"x", !"x" )
+
+		check_x_any( 0, -1, !"xy", !"x" )
+		check_x_any( 0,  0, !"xy", !"x" )
+		check_x_any( 1,  1, !"xy", !"x" )
+		check_x_any( 0,  2, !"xy", !"x" )
+		check_x_any( 0,  3, !"xy", !"x" )
+
+		check_x_any( 0, -1, !"yx", !"x" )
+		check_x_any( 0,  0, !"yx", !"x" )
+		check_x_any( 2,  1, !"yx", !"x" )
+		check_x_any( 2,  2, !"yx", !"x" )
+		check_x_any( 0,  3, !"yx", !"x" )
+
+		check_x_any( 0,  0, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x_any( 1,  1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x_any( 2,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x_any( 0,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+
+		check_x_any( 2,  1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x_any( 2,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x_any( 3,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x_any( 0,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+
+		check_x_any( 3,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x_any( 3,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x_any( 4,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x_any( 0,  5, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+
+		check_x_any( 4,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x_any( 4,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x_any( 5,  5, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x_any( 0,  6, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/instrrev.bas
+++ b/tests/udt-wstring/instrrev.bas
@@ -1,0 +1,223 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.instrrev_ )
+
+	'' INSTRREV( wstring, wstring )
+	#macro check_0( result, text, pattern )
+		scope
+			dim st as wstring * 50 = text
+			dim ut as ustring = st
+			dim sp as wstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instrrev( st, sp ) )
+			CU_ASSERT_EQUAL( result, instrrev( st, up ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, sp ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, up ) )
+		end scope
+	#endmacro
+
+		'' INSTRREV( index, wstring, wstring )
+	#macro check_x( result, index, text, pattern )
+		scope
+			dim st as wstring * 50 = text
+			dim ut as ustring = st
+			dim sp as wstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instrrev( st, sp, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( st, up, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, sp, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, up, index ) )
+		end scope
+	#endmacro
+
+		'' INSTRREV( wstring, wstring )
+	#macro check_0_any( result, text, pattern )
+		scope
+			dim st as wstring * 50 = text
+			dim ut as ustring = st
+			dim sp as wstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instrrev( st, any sp ) )
+			CU_ASSERT_EQUAL( result, instrrev( st, any up ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, any sp ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, any up ) )
+		end scope
+	#endmacro
+
+		'' INSTRREV( index, wstring, wstring )
+	#macro check_x_any( result, index, text, pattern )
+		scope
+			dim st as wstring * 50 = text
+			dim ut as ustring = st
+			dim sp as wstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instrrev( st, any sp, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( st, any up, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, any sp, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, any up, index ) )
+		end scope
+	#endmacro
+
+	TEST( instrrev_0 )
+		check_0( 0, !"", !"" )
+		check_0( 0, !"x", !"" )
+		check_0( 0, !"", !"x" )
+		check_0( 1, !"x", !"x" )
+		check_0( 2, !"yx", !"x" )
+
+		check_0( 1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_0( 2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_0( 3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_0( 4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+	END_TEST
+
+	TEST( instrrev_x )
+		check_x( 0, -2, !"", !"" )
+		check_x( 0, -1, !"", !"" )
+		check_x( 0,  0, !"", !"" )
+		check_x( 0,  1, !"", !"" )
+		check_x( 0,  2, !"", !"" )
+
+		check_x( 0, -2, !"x", !"" )
+		check_x( 0, -1, !"x", !"" )
+		check_x( 0,  0, !"x", !"" )
+		check_x( 0,  1, !"x", !"" )
+		check_x( 0,  2, !"x", !"" )
+
+		check_x( 0, -2, !"", !"x" )
+		check_x( 0, -1, !"", !"x" )
+		check_x( 0,  0, !"", !"x" )
+		check_x( 0,  1, !"", !"x" )
+		check_x( 0,  2, !"", !"x" )
+
+		check_x( 1, -2, !"x", !"x" )
+		check_x( 1, -1, !"x", !"x" )
+		check_x( 0,  0, !"x", !"x" )
+		check_x( 1,  1, !"x", !"x" )
+		check_x( 0,  2, !"x", !"x" )
+		check_x( 0,  3, !"x", !"x" )
+
+		check_x( 1, -2, !"xy", !"x" )
+		check_x( 1, -1, !"xy", !"x" )
+		check_x( 0,  0, !"xy", !"x" )
+		check_x( 1,  1, !"xy", !"x" )
+		check_x( 1,  2, !"xy", !"x" )
+		check_x( 0,  3, !"xy", !"x" )
+
+		check_x( 2, -2, !"yx", !"x" )
+		check_x( 2, -1, !"yx", !"x" )
+		check_x( 0,  0, !"yx", !"x" )
+		check_x( 0,  1, !"yx", !"x" )
+		check_x( 2,  2, !"yx", !"x" )
+		check_x( 0,  3, !"yx", !"x" )
+
+		check_x( 1, -1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x( 0,  0, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x( 1,  1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x( 1,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+
+		check_x( 0,  1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x( 2,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x( 2,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+
+		check_x( 0,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x( 3,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x( 3,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+
+		check_x( 0,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x( 4,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x( 4,  5, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x( 0,  6, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+	END_TEST
+
+	TEST( instrrev_0_any )
+		check_0_any( 0, !"", !"" )
+		check_0_any( 0, !"x", !"" )
+		check_0_any( 0, !"", !"x" )
+		check_0_any( 1, !"x", !"x" )
+		check_0_any( 1, !"xy", !"x" )
+		check_0_any( 2, !"yx", !"x" )
+
+		check_0_any( 2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_0_any( 3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_0_any( 4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_0_any( 5, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+
+		check_0_any( 2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3041" )
+		check_0_any( 3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3043" )
+		check_0_any( 4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3045" )
+		check_0_any( 5, !"\u3041\u3043\u3045\u3047\u3049", !"\u3049\u3047" )
+	END_TEST
+
+	TEST( instrrev_x_any )
+		check_x_any( 0, -2, !"", !"" )
+		check_x_any( 0, -1, !"", !"" )
+		check_x_any( 0,  0, !"", !"" )
+		check_x_any( 0,  1, !"", !"" )
+		check_x_any( 0,  2, !"", !"" )
+
+		check_x_any( 0, -2, !"x", !"" )
+		check_x_any( 0, -1, !"x", !"" )
+		check_x_any( 0,  0, !"x", !"" )
+		check_x_any( 0,  1, !"x", !"" )
+		check_x_any( 0,  2, !"x", !"" )
+
+		check_x_any( 0, -2, !"", !"x" )
+		check_x_any( 0, -1, !"", !"x" )
+		check_x_any( 0,  0, !"", !"x" )
+		check_x_any( 0,  1, !"", !"x" )
+		check_x_any( 0,  2, !"", !"x" )
+
+		check_x_any( 1, -2, !"x", !"x" )
+		check_x_any( 1, -1, !"x", !"x" )
+		check_x_any( 0,  0, !"x", !"x" )
+		check_x_any( 1,  1, !"x", !"x" )
+		check_x_any( 0,  2, !"x", !"x" )
+
+		check_x_any( 1, -2, !"xy", !"x" )
+		check_x_any( 1, -1, !"xy", !"x" )
+		check_x_any( 0,  0, !"xy", !"x" )
+		check_x_any( 1,  1, !"xy", !"x" )
+		check_x_any( 1,  2, !"xy", !"x" )
+		check_x_any( 0,  3, !"xy", !"x" )
+
+		check_x_any( 2, -2, !"yx", !"x" )
+		check_x_any( 2, -1, !"yx", !"x" )
+		check_x_any( 0,  0, !"yx", !"x" )
+		check_x_any( 0,  1, !"yx", !"x" )
+		check_x_any( 2,  2, !"yx", !"x" )
+		check_x_any( 0,  3, !"yx", !"x" )
+
+		check_x_any( 0,  0, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x_any( 1,  1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x_any( 2,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_x_any( 2,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+
+		check_x_any( 0,  0, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x_any( 0,  1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x_any( 2,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x_any( 3,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+		check_x_any( 3,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3045" )
+
+		check_x_any( 0,  1, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x_any( 0,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x_any( 3,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x_any( 4,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+		check_x_any( 4,  5, !"\u3041\u3043\u3045\u3047\u3049", !"\u3045\u3047" )
+
+		check_x_any( 0,  2, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x_any( 0,  3, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x_any( 4,  4, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x_any( 5,  5, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_x_any( 0,  6, !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/lrset.bas
+++ b/tests/udt-wstring/lrset.bas
@@ -1,0 +1,121 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED_MUTABLE
+
+SUITE( fbc_tests.udt_wstring_.lrset )
+
+	#macro check_lset( dst, src, length1, length2 )
+		scope
+			'' lset/rset
+			dim w1 as wstring * 50 = left( dst, (length1) )
+			dim w2 as wstring * 50 = left( src, (length2) )
+			dim e1 as wstring * 50
+
+			dim u1 as ustring = w1
+			dim u2 as ustring = w2
+
+			if( (length1) > (length2) ) then
+				e1 = (w2) & wspace( (length1) - (length2) )
+			else
+				e1 = left( w2, (length1) )
+			end if
+
+			CU_ASSERT( len(e1) = (length1) )
+
+			'' wstring are zero terminated and length
+			'' is determined from the string data
+			lset (w1) = (w2)
+			CU_ASSERT_WSTRING_EQUAL( w1, e1 )
+
+			lset (w1) = (u2)
+			CU_ASSERT_WSTRING_EQUAL( w1, e1 )
+
+			lset (u1) = (w2)
+			dim r1 as wstring * 50 = u1
+			CU_ASSERT_WSTRING_EQUAL( r1, e1 )
+
+			lset (u1) = (u2)
+			dim r2 as wstring * 50 = u1
+			CU_ASSERT_WSTRING_EQUAL( r2, e1 )
+		end scope
+	#endmacro
+
+	#macro check_rset( dst, src, length1, length2 )
+		scope
+			'' lset/rset
+			dim w1 as wstring * 50 = left( dst, (length1) )
+			dim w2 as wstring * 50 = left( src, (length2) )
+			dim e1 as wstring * 50
+
+			dim u1 as ustring = w1
+			dim u2 as ustring = w2
+
+			if( (length1) > (length2) ) then
+				e1 = wspace( (length1) - (length2) ) & (w2)
+			else
+				e1 = left( w2, (length1) )
+			end if
+
+			CU_ASSERT( len(e1) = (length1) )
+
+			'' wstring are zero terminated and length
+			'' is determined from the string data
+			rset (w1) = (w2)
+			CU_ASSERT_WSTRING_EQUAL( w1, e1 )
+
+			rset (w1) = (u2)
+			CU_ASSERT_WSTRING_EQUAL( w1, e1 )
+
+			rset (u1) = (w2)
+			dim r1 as wstring * 50 = u1
+			CU_ASSERT_WSTRING_EQUAL( r1, e1 )
+
+			rset (u1) = (u2)
+			dim r2 as wstring * 50 = u1
+			CU_ASSERT_WSTRING_EQUAL( r2, e1 )
+		end scope
+	#endmacro
+
+	TEST( ascii )
+
+		const MAX = 8
+		dim dst as wstring * (MAX+1)
+		dim src as wstring * (MAX+1)
+
+		dst = "12345678"
+		src = "ABCDEFGH"
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+
+				check_lset( dst, src, i1, i2 )
+				check_rset( dst, src, i1, i2 )
+
+			next i2
+		next i1
+
+	END_TEST
+
+	TEST( ucs2 )
+
+		const MAX = 5
+		dim dst as wstring * (MAX+1)
+		dim src as wstring * (MAX+1)
+
+		dst = !"\u3041\u3043\u3045\u3047\u3049"
+		src = !"\u3042\u3044\u3046\u3048\u3050"
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+
+				check_lset( dst, src, i1, i2 )
+				check_rset( dst, src, i1, i2 )
+
+			next i2
+		next i1
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/midfunc.bas
+++ b/tests/udt-wstring/midfunc.bas
@@ -1,0 +1,193 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.midfunc )
+
+	'' MID( wstring, start )
+	#macro check( text, start, expected )
+		scope
+			dim st as wstring * 50 = text
+			dim se as wstring * 50 = expected
+			dim ut as ustring = st
+
+			CU_ASSERT( st = text )
+			CU_ASSERT( ut = st )
+
+			dim rt as wstring * 50 = mid( st, start )
+			dim ru as wstring * 50 = mid( ut, start )
+			
+			CU_ASSERT_WSTRING_EQUAL( rt, ru )
+			CU_ASSERT_WSTRING_EQUAL( rt, se )
+			CU_ASSERT_WSTRING_EQUAL( ru, se )
+		end scope
+	#endmacro
+
+	'' MID( wstring, start, length )
+	#macro check_i_n( text, start, length, expected )
+		scope
+			dim st as wstring * 50 = text
+			dim se as wstring * 50 = expected
+			dim ut as ustring = st
+
+			CU_ASSERT( st = text )
+			CU_ASSERT( ut = st )
+
+			dim rt as wstring * 50 = mid( st, start, length )
+			dim ru as wstring * 50 = mid( ut, start, length )
+			
+			CU_ASSERT_WSTRING_EQUAL( rt, ru )
+			CU_ASSERT_WSTRING_EQUAL( rt, se )
+			CU_ASSERT_WSTRING_EQUAL( ru, se )
+		end scope
+	#endmacro
+
+	TEST( default )
+		check( ""       , -1, "" )
+		check( ""       ,  0, "" )
+		check( ""       ,  1, "" )
+
+		check( "a"      , -1, "" )
+		check( "a"      ,  0, "" )
+		check( "a"      ,  1, "a" )
+		check( "a"      ,  2, "" )
+
+		check( "ab"     , -1, "" )
+		check( "ab"     ,  0, "" )
+		check( "ab"     ,  1, "ab" )
+		check( "ab"     ,  2, "b" )
+		check( "ab"     ,  3, "" )
+
+		check( "abc"    , -1, "" )
+		check( "abc"    ,  0, "" )
+		check( "abc"    ,  1, "abc" )
+		check( "abc"    ,  2, "bc" )
+		check( "abc"    ,  3, "c" )
+		check( "abc"    ,  4, "" )
+
+		check( !"\u3041", -1, !"" )
+		check( !"\u3041",  0, !"" )
+		check( !"\u3041",  1, !"\u3041" )
+		check( !"\u3041",  2, !"" )
+
+		check( !"\u3041\u3043", -1, !"" )
+		check( !"\u3041\u3043",  0, !"" )
+		check( !"\u3041\u3043",  1, !"\u3041\u3043" )
+		check( !"\u3041\u3043",  2, !"\u3043" )
+		check( !"\u3041\u3043",  3, !"" )
+
+		check( !"\u3041\u3043\u3045", -1, !"" )
+		check( !"\u3041\u3043\u3045",  0, !"" )
+		check( !"\u3041\u3043\u3045",  1, !"\u3041\u3043\u3045" )
+		check( !"\u3041\u3043\u3045",  2, !"\u3043\u3045" )
+		check( !"\u3041\u3043\u3045",  3, !"\u3045" )
+		check( !"\u3041\u3043\u3045",  4, !"" )
+	END_TEST
+
+	TEST( length )
+		check_i_n( ""       , -1, -1, "" )
+		check_i_n( ""       , -1,  0, "" )
+		check_i_n( ""       , -1,  1, "" )
+
+		check_i_n( ""       ,  0, -1, "" )
+		check_i_n( ""       ,  0,  0, "" )
+		check_i_n( ""       ,  0,  1, "" )
+
+		check_i_n( ""       ,  1, -1, "" )
+		check_i_n( ""       ,  1,  0, "" )
+		check_i_n( ""       ,  1,  1, "" )
+
+		check_i_n( "a"      , -1, -1, "" )
+		check_i_n( "a"      , -1,  0, "" )
+		check_i_n( "a"      , -1,  1, "" )
+		check_i_n( "a"      , -1,  2, "" )
+
+		check_i_n( "a"      ,  0, -1, "" )
+		check_i_n( "a"      ,  0,  0, "" )
+		check_i_n( "a"      ,  0,  1, "" )
+		check_i_n( "a"      ,  0,  2, "" )
+
+		check_i_n( "a"      ,  1, -1, "a" )
+		check_i_n( "a"      ,  1,  0, "" )
+		check_i_n( "a"      ,  1,  1, "a" )
+		check_i_n( "a"      ,  1,  2, "a" )
+
+		check_i_n( "a"      ,  2, -1, "" )
+		check_i_n( "a"      ,  2,  0, "" )
+		check_i_n( "a"      ,  2,  1, "" )
+		check_i_n( "a"      ,  2,  2, "" )
+
+		check_i_n( "ab"     ,  1, -2, "ab" )
+		check_i_n( "ab"     ,  1, -1, "ab" )
+		check_i_n( "ab"     ,  1,  0, "" )
+		check_i_n( "ab"     ,  1,  1, "a" )
+		check_i_n( "ab"     ,  1,  2, "ab" )
+		check_i_n( "ab"     ,  1,  3, "ab" )
+
+		check_i_n( "ab"     ,  2, -2, "b" )
+		check_i_n( "ab"     ,  2, -1, "b" )
+		check_i_n( "ab"     ,  2,  0, "" )
+		check_i_n( "ab"     ,  2,  1, "b" )
+		check_i_n( "ab"     ,  2,  2, "b" )
+		check_i_n( "ab"     ,  2,  3, "b" )
+
+		check_i_n( "ab"     ,  3, -2, "" )
+		check_i_n( "ab"     ,  3, -1, "" )
+		check_i_n( "ab"     ,  3,  0, "" )
+		check_i_n( "ab"     ,  3,  1, "" )
+		check_i_n( "ab"     ,  3,  2, "" )
+		check_i_n( "ab"     ,  3,  3, "" )
+
+		check_i_n( !"\u3041\u3043\u3045", -1, -2, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1, -1, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  1, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  2, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  3, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  4, !"" )
+
+		check_i_n( !"\u3041\u3043\u3045",  0, -2, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0, -1, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  1, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  2, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  3, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  4, !"" )
+
+		check_i_n( !"\u3041\u3043\u3045",  1, -2, !"\u3041\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  1, -1, !"\u3041\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  1, !"\u3041" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  2, !"\u3041\u3043" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  3, !"\u3041\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  4, !"\u3041\u3043\u3045" )
+
+		check_i_n( !"\u3041\u3043\u3045",  2, -2, !"\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  2, -1, !"\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  1, !"\u3043" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  2, !"\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  3, !"\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  4, !"\u3043\u3045" )
+
+		check_i_n( !"\u3041\u3043\u3045",  3, -2, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3, -1, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  1, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  2, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  3, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  4, !"\u3045" )
+
+		check_i_n( !"\u3041\u3043\u3045",  4, -1, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  1, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  2, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  3, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  4, !"" )
+
+	END_TEST
+
+
+END_SUITE

--- a/tests/udt-wstring/midstmt.bas
+++ b/tests/udt-wstring/midstmt.bas
@@ -1,0 +1,115 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED_MUTABLE
+
+#define BUFFERSIZE 50
+
+'' fixed length strings are not cleared
+'' and the garbage in the buffer will affect the tests
+#macro INIT_FIXED_STRING( s, dtype, size, value )
+	dim s as dtype * size
+	clear @s, 0, sizeof(s)
+	s = value
+#endmacro
+
+SUITE( fbc_tests.udt_wstring_.midstmt )
+
+	'' we already test MID statment in ../wstring/midstmt.bas
+	'' just compare that we get same results
+
+	#macro check_mid_start( dst, start, src, length1, length2 )
+		scope
+			INIT_FIXED_STRING( w1, wstring, BUFFERSIZE, left( dst, (length1) ) )
+			INIT_FIXED_STRING( w2, wstring, BUFFERSIZE, left( src, (length2) ) )
+			mid( w1, start ) = w2
+
+			dim u1 as ustring = w1
+			mid( u1, start ) = w2
+
+			dim r1 as wstring * BUFFERSIZE = u1
+			CU_ASSERT_WSTRING_EQUAL( w1, r1 )
+		end scope
+	#endmacro
+
+	#macro check_mid_start_n( dst, start, length, src, length1, length2 )
+		scope
+			INIT_FIXED_STRING( w1, wstring, BUFFERSIZE, left( dst, (length1) ) )
+			INIT_FIXED_STRING( w2, wstring, BUFFERSIZE, left( src, (length2) ) )
+			mid( w1, start, length ) = w2
+
+			dim u1 as ustring = w1
+			dim u2 as ustring = w2
+			mid( u1, start, length ) = w2
+
+			dim r1 as wstring * BUFFERSIZE = u1
+			CU_ASSERT_WSTRING_EQUAL( w1, r1 )
+		end scope
+	#endmacro
+
+	TEST( ascii )
+		const MAX = 8
+
+		#define def_dst "12345678"
+		#define def_src "ABCDEFGH"
+
+		dim dst as wstring * (MAX*2+1)
+		dim src as wstring * (MAX*2+1)
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+				for istart as integer = -2 to MAX+2
+
+					dst = def_src
+					src = def_dst
+
+					check_mid_start( dst, istart, src, i1, i2 )
+
+					for length as integer = -2 to MAX+2
+
+						dst = def_src
+						src = def_dst
+
+						check_mid_start_n( dst, istart, length, src, i1, i2 )
+					next
+
+				next
+			next i2
+		next i1
+
+	END_TEST
+
+	TEST( ucs2 )
+		const MAX = 5
+
+		#define def_dst !"\u3041\u3043\u3045\u3047\u3049"
+		#define def_src !"\u3042\u3044\u3046\u3048\u3050"
+
+		dim dst as wstring * (MAX*2+1)
+		dim src as wstring * (MAX*2+1)
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+				for istart as integer = -1 to MAX+2
+
+					dst = def_src
+					src = def_dst
+
+					check_mid_start( dst, istart, src, i1, i2 )
+
+					for length as integer = -2 to MAX+2
+
+						dst = def_src
+						src = def_dst
+
+						check_mid_start_n( dst, istart, length, src, i1, i2 )
+					next
+
+				next
+			next i2
+		next i1
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/select.bas
+++ b/tests/udt-wstring/select.bas
@@ -1,28 +1,17 @@
 #include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
 
-SUITE( fbc_tests.wstring_.select_ )
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.select_ )
 
 	#macro check( expr, literal, is_match )
 		scope
 			dim w as wstring * 50 = expr
+			dim u as ustring = w
 			
-			select case w
-			case literal
-				if( is_match ) then
-					CU_PASS()
-				else
-					CU_FAIL()
-				end if
-			case else
-				if( is_match ) then
-					CU_FAIL()
-				else
-					CU_PASS()
-				end if
-			end select
-
-			dim pw as wstring ptr = strptr( w )
-			select case *pw
+			select case u
 			case literal
 				if( is_match ) then
 					CU_PASS()
@@ -42,24 +31,9 @@ SUITE( fbc_tests.wstring_.select_ )
 	#macro check_range( expr, literal1, literal2, is_match )
 		scope
 			dim w as wstring * 50 = expr
+			dim u as ustring = w
 			
-			select case w
-			case literal1 to literal2
-				if( is_match ) then
-					CU_PASS()
-				else
-					CU_FAIL()
-				end if
-			case else
-				if( is_match ) then
-					CU_FAIL()
-				else
-					CU_PASS()
-				end if
-			end select
-
-			dim pw as wstring ptr = strptr( w )
-			select case *pw
+			select case u
 			case literal1 to literal2
 				if( is_match ) then
 					CU_PASS()
@@ -132,25 +106,5 @@ SUITE( fbc_tests.wstring_.select_ )
 		check_range( "xyz", "b", "c", false )
 	END_TEST
 
-	TEST( default )
-
-		dim w as wstring * 10 => "abc"
-			
-		select case w
-		case "1" to "10"
-			CU_ASSERT( 0 )
-		
-		case "def"		
-			CU_ASSERT( 0 )
-		
-		case "abc"
-			CU_ASSERT( -1 )
-			
-		case else
-			CU_ASSERT( 0 )	
-		
-		end select
-
-	END_TEST
-
 END_SUITE
+ 

--- a/tests/udt-wstring/str.bas
+++ b/tests/udt-wstring/str.bas
@@ -1,0 +1,122 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.str_ )
+
+	#macro check( dtype, value )
+	
+		scope
+			dim t as dtype = value
+			dim w as wstring * 50 = str( t )
+			dim u as ustring = str( t )
+			dim r as wstring * 50 = u
+			CU_ASSERT_WSTRING_EQUAL( w, r )
+		end scope
+
+	#endmacro
+
+	TEST( numeric )
+
+		check( byte, -128 )
+		check( byte, -0 )
+		check( byte, 127 )
+
+		check( ubyte, 0 )
+		check( ubyte, 128 )
+		check( ubyte, 255 )
+
+		check( short, -32768 )
+		check( short, 0 )
+		check( short, 32767 )
+
+		check( ushort, 0 )
+		check( ushort, 32768 )
+		check( ushort, 65535 )
+
+		check( long, -2147483648ll )
+		check( long, 0 )
+		check( long, 2147483647ull )
+
+		check( ulong, 0 )
+		check( ulong, 2147483648ull )
+		check( ulong, 4294967295ull )
+
+		check( longint, (-9223372036854775807ll-1ll) )
+		check( longint, 0 )
+		check( longint, 9223372036854775807ull )
+
+		check( ulongint, 0 )
+		check( ulongint, 9223372036854775808ull )
+		check( ulongint, 18446744073709551615ull )
+
+		check( single, -1.5 )
+		check( single, -1.0 )
+		check( single, -1.0 )
+		check( single, -0.5 )
+		check( single,  0.0 )
+		check( single,  0.5 )
+		check( single,  1.0)
+		check( single,  1.5 )
+		check( single,  2.0 )
+		check( single,  2.5 )
+
+		check( double, -1.5 )
+		check( double, -1.0 )
+		check( double, -1.0 )
+		check( double, -0.5 )
+		check( double,  0.0 )
+		check( double,  0.5 )
+		check( double,  1.0)
+		check( double,  1.5 )
+		check( double,  2.0 )
+		check( double,  2.5 )
+
+	END_TEST
+
+	TEST( default )
+		
+		dim s1 as wstring * 10 = chr(65)
+		dim s2 as wstring * 10 = chr(65)
+		dim s3 as wstring * 10 = str( s1 )
+
+		dim u1 as ustring = chr(65)
+		dim u2 as ustring = chr(65)
+		dim u3 as ustring = str( s1 )
+		dim u4 as ustring = str( u1 )
+
+		dim s4 as wstring * 10 = str( u1 )
+
+		dim r1 as wstring * 10 = u1
+		dim r2 as wstring * 10 = u2
+		dim r3 as wstring * 10 = u3
+		dim r4 as wstring * 10 = u4
+
+		#macro check_group( g )
+
+			CU_ASSERT_WSTRING_EQUAL( g, s1 )
+			CU_ASSERT_WSTRING_EQUAL( g, s2 )
+			CU_ASSERT_WSTRING_EQUAL( g, s3 )
+			CU_ASSERT_WSTRING_EQUAL( g, s4 )
+
+			CU_ASSERT_WSTRING_EQUAL( g, r1 )
+			CU_ASSERT_WSTRING_EQUAL( g, r2 )
+			CU_ASSERT_WSTRING_EQUAL( g, r3 )
+			CU_ASSERT_WSTRING_EQUAL( g, r4 )
+
+		#endmacro
+
+		check_group( s1 )
+		check_group( s2 )
+		check_group( s3 )
+		check_group( s4 )
+		check_group( r1 )
+		check_group( r2 )
+		check_group( r3 )
+		check_group( r4 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/strptr.bas
+++ b/tests/udt-wstring/strptr.bas
@@ -1,0 +1,49 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.strptr_ )
+
+	TEST( deref )
+		dim s1 as wstring * 50 = "1234"
+		dim u1 as ustring = s1
+
+		dim as wstring ptr p1 = strptr( u1 )
+
+		CU_ASSERT_WSTRING_EQUAL( (*p1), s1 )
+	END_TEST
+
+	TEST( ptr_size )
+
+		dim s as wstring * 50 = "1234"
+		dim s1 as ustring = s
+
+		scope
+			dim as wstring ptr p1 = strptr(s1)
+			dim as wstring ptr p2 = (strptr(s1) + 1)
+			CU_ASSERT_EQUAL( cint(p2) - cint(p1), sizeof( wstring ) )
+		end scope
+
+		scope
+			dim as wstring ptr p1 = strptr(s1)
+			dim as wstring ptr p2 = @(strptr(s1)[1])
+			CU_ASSERT_EQUAL( cint(p2) - cint(p1), sizeof( wstring ) )
+		end scope
+
+		scope
+			dim as wstring ptr p1 = sadd(s1)
+			dim as wstring ptr p2 = (sadd(s1) + 1)
+			CU_ASSERT_EQUAL( cint(p2) - cint(p1), sizeof( wstring ) )
+		end scope
+
+		scope
+			dim as wstring ptr p1 = sadd(s1)
+			dim as wstring ptr p2 = @(sadd(s1)[1])
+			CU_ASSERT_EQUAL( cint(p2) - cint(p1), sizeof( wstring ) )
+		end scope
+
+	END_TEST
+		
+END_SUITE

--- a/tests/udt-wstring/swap.bas
+++ b/tests/udt-wstring/swap.bas
@@ -1,0 +1,121 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+type UWSTRING_HAS_ID extends UWSTRING_FIXED_MUTABLE
+	public:
+		id as integer
+		declare constructor()
+		declare constructor( byval rhs as const wstring const ptr )
+		declare constructor( byval rhs as const zstring const ptr )
+
+		declare operator cast() byref as wstring
+end type
+
+constructor UWSTRING_HAS_ID()
+end constructor
+
+constructor UWSTRING_HAS_ID( byval s as const wstring const ptr )
+	base( s )
+end constructor
+
+constructor UWSTRING_HAS_ID( byval s as const zstring const ptr )
+	base( s )
+end constructor
+
+operator UWSTRING_HAS_ID.Cast() byref as wstring
+	operator = *cast(wstring ptr, @_data)	
+end operator
+
+#define ustring UWSTRING_HAS_ID
+
+SUITE( fbc_tests.udt_wstring_.swap_ )
+
+	#macro check( literal1, literal2 )
+		scope
+			dim t1 as wstring * 50 = literal1
+			dim t2 as wstring * 50 = literal2
+
+			dim u1 as ustring = literal1
+			u1.id = 1
+			dim u2 as ustring = literal2
+			u2.id = 2
+
+			'' initial condition check
+			scope
+				dim r1 as wstring * 50 = u1
+				dim r2 as wstring * 50 = u2
+				CU_ASSERT( u1.id = 1 )
+				CU_ASSERT( u2.id = 2 )
+				CU_ASSERT_WSTRING_EQUAL( r1, t1 )
+				CU_ASSERT_WSTRING_EQUAL( r2, t2 )
+			end scope
+
+			'' swap string only
+			scope
+				swap wstr( u1 ), wstr( u2 )
+
+				dim r1 as wstring * 50 = u1
+				dim r2 as wstring * 50 = u2
+
+				CU_ASSERT( u1.id = 1 )
+				CU_ASSERT( u2.id = 2 )
+				CU_ASSERT_WSTRING_EQUAL( r1, t2 )
+				CU_ASSERT_WSTRING_EQUAL( r2, t1 )
+			end scope
+
+			'' swap string only
+			scope
+				swap wstr( u1 ), u2
+
+				dim r1 as wstring * 50 = u1
+				dim r2 as wstring * 50 = u2
+
+				CU_ASSERT( u1.id = 1 )
+				CU_ASSERT( u2.id = 2 )
+				CU_ASSERT_WSTRING_EQUAL( r1, t1 )
+				CU_ASSERT_WSTRING_EQUAL( r2, t2 )
+			end scope
+
+			'' swap string only
+			scope
+				swap u1, wstr( u2 )
+
+				dim r1 as wstring * 50 = u1
+				dim r2 as wstring * 50 = u2
+
+				CU_ASSERT( u1.id = 1 )
+				CU_ASSERT( u2.id = 2 )
+				CU_ASSERT_WSTRING_EQUAL( r1, t2 )
+				CU_ASSERT_WSTRING_EQUAL( r2, t1 )
+			end scope
+
+			'' swap complete UDT
+			scope
+				swap u1, u2
+
+				dim r1 as wstring * 50 = u1
+				dim r2 as wstring * 50 = u2
+
+				CU_ASSERT( u1.id = 2 )
+				CU_ASSERT( u2.id = 1 )
+				CU_ASSERT_WSTRING_EQUAL( r1, t1 )
+				CU_ASSERT_WSTRING_EQUAL( r2, t2 )
+			end scope
+		end scope
+	#endmacro
+
+	TEST( default )
+		check( "", "" )
+
+		check( "", "a" )
+		check( "a", "a" )
+		check( "a", "abcdefghi" )
+
+		check( "", !"\u3041\u3043\u3045\u3047\u3049" )
+		check( "abc", !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"\u3045", !"\u3041\u3043\u3047\u3049" )
+
+	END_TEST 
+
+END_SUITE

--- a/tests/udt-wstring/trim.bas
+++ b/tests/udt-wstring/trim.bas
@@ -1,0 +1,155 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.trim_ )
+
+	'' L/R/TRIM( wstring )
+	#macro check_rtlfunc( rtlfunc, text )
+		scope
+			dim t as wstring * 50 = text
+			dim u as ustring = t
+
+			CU_ASSERT( t = text )
+			CU_ASSERT( u = t )
+
+			dim rt as wstring * 50 = rtlfunc( t )
+			dim ru as wstring * 50 = rtlfunc( u )
+			CU_ASSERT_WSTRING_EQUAL( rt, ru )
+
+		end scope
+	#endmacro
+
+	'' L/R/TRIM( wstring, pattern )
+	#macro check_rtlfunc_filter( rtlfunc, text, pattern )
+		scope
+			dim t as wstring * 50 = text
+			dim u as ustring = t
+
+			CU_ASSERT( t = text )
+			CU_ASSERT( u = t )
+
+			dim tf as wstring * 50 = pattern
+			dim uf as ustring = tf
+
+			'' wstring, udt
+			scope
+				dim rt as wstring * 50 = rtlfunc( t, tf )
+				dim ru as wstring * 50 = rtlfunc( t, uf )
+				CU_ASSERT_WSTRING_EQUAL( rt, ru )
+			end scope
+
+			'' udt, wstring
+			scope
+				dim rt as wstring * 50 = rtlfunc( t, tf )
+				dim ru as wstring * 50 = rtlfunc( u, tf )
+				CU_ASSERT_WSTRING_EQUAL( rt, ru )
+			end scope
+
+			'' udt, udt
+			scope
+				dim rt as wstring * 50 = rtlfunc( t, tf )
+				dim ru as wstring * 50 = rtlfunc( u, uf )
+				CU_ASSERT_WSTRING_EQUAL( rt, ru )
+			end scope
+
+		end scope
+	#endmacro
+
+	'' L/R/TRIM( wstring, any pattern )
+	#macro check_rtlfunc_any( rtlfunc, text, pattern )
+		scope
+			dim t as wstring * 50 = text
+			dim u as ustring = t
+
+			CU_ASSERT( t = text )
+			CU_ASSERT( u = t )
+
+			dim tf as wstring * 50 = pattern
+			dim uf as ustring = tf
+
+			'' wstring, udt
+			scope
+				dim rt as wstring * 50 = rtlfunc( t, any tf )
+				dim ru as wstring * 50 = rtlfunc( t, any uf )
+				CU_ASSERT_WSTRING_EQUAL( rt, ru )
+			end scope
+
+			'' udt, wstring
+			scope
+				dim rt as wstring * 50 = rtlfunc( t, any tf )
+				dim ru as wstring * 50 = rtlfunc( u, any tf )
+				CU_ASSERT_WSTRING_EQUAL( rt, ru )
+			end scope
+
+			'' udt, udt
+			scope
+				dim rt as wstring * 50 = rtlfunc( t, any tf )
+				dim ru as wstring * 50 = rtlfunc( u, any uf )
+				CU_ASSERT_WSTRING_EQUAL( rt, ru )
+			end scope
+
+		end scope
+	#endmacro
+
+	#macro check( text )
+		check_rtlfunc( ltrim, text )
+		check_rtlfunc( rtrim, text )
+		check_rtlfunc( trim, text )
+	#endmacro
+
+	#macro check_filter( text, pattern )
+		check_rtlfunc_filter( ltrim, text, pattern )
+		check_rtlfunc_filter( rtrim, text, pattern )
+		check_rtlfunc_filter( trim, text, pattern )
+	#endmacro
+
+	#macro check_any( text, pattern )
+		check_rtlfunc_any( ltrim, text, pattern )
+		check_rtlfunc_any( rtrim, text, pattern )
+		check_rtlfunc_any( trim, text, pattern )
+	#endmacro
+
+
+	TEST( default )
+		check( "" )
+		check( " " )
+		check( "  " )
+		check( "abcde" )
+		check( "  abcde" )
+		check( "abcde  " )
+		check( "  abcde  " )
+		check( !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"  \u3041\u3043\u3045\u3047\u3049" )
+		check( !"\u3041\u3043\u3045\u3047\u3049  " )
+		check( !"  \u3041\u3043\u3045\u3047\u3049  " )
+
+		check_filter( "", "" )
+		check_filter( "", " " )
+		check_filter( " ", "" )
+		check_filter( " ", " " )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041" )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3041" )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049" )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049\u3047" )
+		check_filter( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3049" )
+
+		check_any( "", "" )
+		check_any( "", " " )
+		check_any( " ", "" )
+		check_any( " ", " " )
+		check_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041" )
+		check_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3043" )
+		check_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3043\u3041" )
+		check_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049" )
+		check_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3047\u3049" )
+		check_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3049\u3047" )
+		check_any( !"\u3041\u3043\u3045\u3047\u3049", !"\u3041\u3049" )
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/udt-wstring-fixed.bas
+++ b/tests/udt-wstring/udt-wstring-fixed.bas
@@ -1,0 +1,111 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+
+#define ustring uwstring_fixed
+
+'' test UWSTRING_FIXED, reference implementation
+
+SUITE( fbc_tests.udt_wstring_.udt_wstring_fixed )
+
+	TEST( initializer )
+
+		'' default initializer
+		scope
+			dim w as wstring * 50
+			dim u as ustring
+
+			CU_ASSERT( len(w) = 0 )
+			CU_ASSERT( len(u) = 0 )
+			CU_ASSERT( w = "" )
+			CU_ASSERT( u = "" )
+			CU_ASSERT( w = u )
+		end scope
+
+		'' null initializer
+		scope
+			dim w as wstring * 50 = ""
+			dim u as ustring = ""
+
+			CU_ASSERT( len(w) = 0 )
+			CU_ASSERT( len(u) = 0 )
+		end scope
+
+		'' initialize from STRING literal
+		scope
+			dim a as string = "abcdefghij"
+			dim w as wstring * 50 = "abcdefghij"
+			dim u as ustring = "abcdefghij"
+
+			CU_ASSERT( len("abcdefghij") = 10 )
+			CU_ASSERT( len(a) = 10 )
+			CU_ASSERT( len(w) = len(a) )
+			CU_ASSERT( len(u) = len(w) )
+			CU_ASSERT( u = w )
+			
+		end scope
+
+		'' initialize from WSTRING literal
+		scope
+			dim w as wstring * 50 = !"\u3041\u3043\u3045\u3047\u3049"
+			dim u as ustring = !"\u3041\u3043\u3045\u3047\u3049"
+
+			CU_ASSERT( len( !"\u3041\u3043\u3045\u3047\u3049" ) = 5)
+			CU_ASSERT( len(w) = 5)
+			CU_ASSERT( len(u) = len(w) )
+		end scope
+
+		'' initialize from STRING const
+		scope
+			const LIT_A = "abcdefghij"
+
+			dim a as string = LIT_A
+			dim w as wstring * 50 = LIT_A
+			dim u as ustring = LIT_A
+
+			CU_ASSERT( len(LIT_A) = 10 )
+			CU_ASSERT( len(a) = len(LIT_A) )
+			CU_ASSERT( len(w) = len(a) )
+			CU_ASSERT( len(u) = len(w) )
+			CU_ASSERT( u = w )
+		end scope
+
+		'' initialize from WSTRING const
+		scope
+			const LIT_W = !"\u3041\u3043\u3045\u3047\u3049"
+
+			dim w as wstring * 50 = LIT_W
+			dim u as ustring = LIT_W
+
+			CU_ASSERT( len(LIT_W) = 5 )
+			CU_ASSERT( len(w) = len(LIT_W) )
+			CU_ASSERT( len(u) = len(w) )
+			CU_ASSERT( u = w )
+		end scope
+
+		'' initialize from STRING variable
+		scope
+			dim a as string = "abcdefghij"
+			dim w as wstring * 50 = a
+			dim u as ustring = a
+
+			CU_ASSERT( len(a) = 10 )
+			CU_ASSERT( len(w) = len(a) )
+			CU_ASSERT( len(u) = len(w) )
+			CU_ASSERT( u = w )
+		end scope
+
+		'' initialize from WSTRING variable
+		scope
+			dim w0 as wstring * 20 = !"\u3041\u3043\u3045\u3047\u3049"
+			dim w as wstring * 50 = w0
+			dim u as ustring = w0
+
+			CU_ASSERT( len(w0) = 5 )
+			CU_ASSERT( len(w) = len(w0) )
+			CU_ASSERT( len(u) = len(w) )
+			CU_ASSERT( u = w )
+		end scope
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-wstring/uwstring-fixed.bas
+++ b/tests/udt-wstring/uwstring-fixed.bas
@@ -1,0 +1,33 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+
+'' reference implementation of fixed length UDT wstring
+
+''
+constructor UWSTRING_FIXED()
+	_data = ""
+end constructor
+
+''
+constructor UWSTRING_FIXED( byval s as const wstring const ptr )
+	_data = *s
+end constructor
+
+''
+constructor UWSTRING_FIXED( byval s as const zstring const ptr )
+	_data = wstr( *s )
+end constructor
+
+''
+operator UWSTRING_FIXED.Cast() byref as wstring
+	operator = *cast(wstring ptr, @_data)	
+end operator
+
+const function UWSTRING_FIXED.length() as integer
+	function = len( _data )
+end function
+
+''
+operator Len( byref s as const UWSTRING_FIXED ) as integer
+	return s.Length()
+end operator

--- a/tests/udt-wstring/uwstring-fixed.bas
+++ b/tests/udt-wstring/uwstring-fixed.bas
@@ -3,19 +3,51 @@
 
 '' reference implementation of fixed length UDT wstring
 
+'' -------------------
+'' UWSTRING_FIXED_BASE
+'' -------------------
+
 ''
-constructor UWSTRING_FIXED()
+constructor UWSTRING_FIXED_BASE()
 	_data = ""
 end constructor
 
 ''
-constructor UWSTRING_FIXED( byval s as const wstring const ptr )
+constructor UWSTRING_FIXED_BASE( byval s as const wstring const ptr )
 	_data = *s
 end constructor
 
 ''
-constructor UWSTRING_FIXED( byval s as const zstring const ptr )
+constructor UWSTRING_FIXED_BASE( byval s as const zstring const ptr )
 	_data = wstr( *s )
+end constructor
+
+const function UWSTRING_FIXED_BASE.length() as integer
+	function = len( _data )
+end function
+
+''
+operator Len( byref s as const UWSTRING_FIXED_BASE ) as integer
+	return s.Length()
+end operator
+
+
+'' --------------
+'' UWSTRING_FIXED
+'' --------------
+
+''
+constructor UWSTRING_FIXED()
+end constructor
+
+''
+constructor UWSTRING_FIXED( byval s as const wstring const ptr )
+	base( s )
+end constructor
+
+''
+constructor UWSTRING_FIXED( byval s as const zstring const ptr )
+	base( s )
 end constructor
 
 ''
@@ -23,11 +55,26 @@ operator UWSTRING_FIXED.Cast() byref as const wstring
 	operator = *cast(wstring ptr, @_data)	
 end operator
 
-const function UWSTRING_FIXED.length() as integer
-	function = len( _data )
-end function
+
+'' ----------------------
+'' UWSTRING_FIXED_MUTABLE
+'' ----------------------
 
 ''
-operator Len( byref s as const UWSTRING_FIXED ) as integer
-	return s.Length()
+constructor UWSTRING_FIXED_MUTABLE()
+end constructor
+
+''
+constructor UWSTRING_FIXED_MUTABLE( byval s as const wstring const ptr )
+	base( s )
+end constructor
+
+''
+constructor UWSTRING_FIXED_MUTABLE( byval s as const zstring const ptr )
+	base( s )
+end constructor
+
+''
+operator UWSTRING_FIXED_MUTABLE.Cast() byref as wstring
+	operator = *cast(wstring ptr, @_data)	
 end operator

--- a/tests/udt-wstring/uwstring-fixed.bas
+++ b/tests/udt-wstring/uwstring-fixed.bas
@@ -19,7 +19,7 @@ constructor UWSTRING_FIXED( byval s as const zstring const ptr )
 end constructor
 
 ''
-operator UWSTRING_FIXED.Cast() byref as wstring
+operator UWSTRING_FIXED.Cast() byref as const wstring
 	operator = *cast(wstring ptr, @_data)	
 end operator
 

--- a/tests/udt-wstring/uwstring-fixed.bi
+++ b/tests/udt-wstring/uwstring-fixed.bi
@@ -11,7 +11,7 @@ type UWSTRING_FIXED extends wstring
 		declare constructor()
 		declare constructor( byval rhs as const wstring const ptr )
 		declare constructor( byval rhs as const zstring const ptr )
-		declare operator cast() byref as wstring
+		declare operator cast() byref as const wstring
 		declare const function length() as integer
 
 end type

--- a/tests/udt-wstring/uwstring-fixed.bi
+++ b/tests/udt-wstring/uwstring-fixed.bi
@@ -2,18 +2,37 @@
 
 '' reference implementation of fixed length UDT wstring
 
-type UWSTRING_FIXED extends wstring
+type UWSTRING_FIXED_BASE extends wstring
 
-	private:
+	protected:
 		_data as wstring * 256
 
 	public:
 		declare constructor()
 		declare constructor( byval rhs as const wstring const ptr )
 		declare constructor( byval rhs as const zstring const ptr )
-		declare operator cast() byref as const wstring
 		declare const function length() as integer
 
 end type
 
-declare operator Len( byref s as const UWSTRING_FIXED ) as integer
+declare operator Len( byref s as const UWSTRING_FIXED_BASE ) as integer
+
+type UWSTRING_FIXED extends UWSTRING_FIXED_BASE
+
+	public:
+		declare constructor()
+		declare constructor( byval rhs as const wstring const ptr )
+		declare constructor( byval rhs as const zstring const ptr )
+
+		declare operator cast() byref as const wstring
+end type
+
+type UWSTRING_FIXED_MUTABLE extends UWSTRING_FIXED_BASE
+
+	public:
+		declare constructor()
+		declare constructor( byval rhs as const wstring const ptr )
+		declare constructor( byval rhs as const zstring const ptr )
+
+		declare operator cast() byref as wstring
+end type

--- a/tests/udt-wstring/uwstring-fixed.bi
+++ b/tests/udt-wstring/uwstring-fixed.bi
@@ -1,0 +1,19 @@
+#pragma once
+
+'' reference implementation of fixed length UDT wstring
+
+type UWSTRING_FIXED extends wstring
+
+	private:
+		_data as wstring * 256
+
+	public:
+		declare constructor()
+		declare constructor( byval rhs as const wstring const ptr )
+		declare constructor( byval rhs as const zstring const ptr )
+		declare operator cast() byref as wstring
+		declare const function length() as integer
+
+end type
+
+declare operator Len( byref s as const UWSTRING_FIXED ) as integer

--- a/tests/udt-wstring/wstr.bas
+++ b/tests/udt-wstring/wstr.bas
@@ -1,0 +1,122 @@
+#include "fbcunit.bi"
+#include once "uwstring-fixed.bi"
+#include once "chk-wstring.bi"
+
+#define ustring UWSTRING_FIXED
+
+SUITE( fbc_tests.udt_wstring_.wstr_ )
+
+	#macro check( dtype, value )
+	
+		scope
+			dim t as dtype = value
+			dim w as wstring * 50 = wstr( t )
+			dim u as ustring = wstr( t )
+			dim r as wstring * 50 = u
+			CU_ASSERT_WSTRING_EQUAL( w, r )
+		end scope
+
+	#endmacro
+
+	TEST( numeric )
+
+		check( byte, -128 )
+		check( byte, -0 )
+		check( byte, 127 )
+
+		check( ubyte, 0 )
+		check( ubyte, 128 )
+		check( ubyte, 255 )
+
+		check( short, -32768 )
+		check( short, 0 )
+		check( short, 32767 )
+
+		check( ushort, 0 )
+		check( ushort, 32768 )
+		check( ushort, 65535 )
+
+		check( long, -2147483648ll )
+		check( long, 0 )
+		check( long, 2147483647ull )
+
+		check( ulong, 0 )
+		check( ulong, 2147483648ull )
+		check( ulong, 4294967295ull )
+
+		check( longint, (-9223372036854775807ll-1ll) )
+		check( longint, 0 )
+		check( longint, 9223372036854775807ull )
+
+		check( ulongint, 0 )
+		check( ulongint, 9223372036854775808ull )
+		check( ulongint, 18446744073709551615ull )
+
+		check( single, -1.5 )
+		check( single, -1.0 )
+		check( single, -1.0 )
+		check( single, -0.5 )
+		check( single,  0.0 )
+		check( single,  0.5 )
+		check( single,  1.0)
+		check( single,  1.5 )
+		check( single,  2.0 )
+		check( single,  2.5 )
+
+		check( double, -1.5 )
+		check( double, -1.0 )
+		check( double, -1.0 )
+		check( double, -0.5 )
+		check( double,  0.0 )
+		check( double,  0.5 )
+		check( double,  1.0)
+		check( double,  1.5 )
+		check( double,  2.0 )
+		check( double,  2.5 )
+
+	END_TEST
+
+	TEST( default )
+		
+		dim s1 as wstring * 10 = wchr(1234)
+		dim s2 as wstring * 10 = wchr(1234)
+		dim s3 as wstring * 10 = wstr( s1 )
+
+		dim u1 as ustring = wchr(1234)
+		dim u2 as ustring = wchr(1234)
+		dim u3 as ustring = wstr( s1 )
+		dim u4 as ustring = wstr( u1 )
+
+		dim s4 as wstring * 10 = wstr( u1 )
+
+		dim r1 as wstring * 10 = u1
+		dim r2 as wstring * 10 = u2
+		dim r3 as wstring * 10 = u3
+		dim r4 as wstring * 10 = u4
+
+		#macro check_group( g )
+
+			CU_ASSERT_WSTRING_EQUAL( g, s1 )
+			CU_ASSERT_WSTRING_EQUAL( g, s2 )
+			CU_ASSERT_WSTRING_EQUAL( g, s3 )
+			CU_ASSERT_WSTRING_EQUAL( g, s4 )
+
+			CU_ASSERT_WSTRING_EQUAL( g, r1 )
+			CU_ASSERT_WSTRING_EQUAL( g, r2 )
+			CU_ASSERT_WSTRING_EQUAL( g, r3 )
+			CU_ASSERT_WSTRING_EQUAL( g, r4 )
+
+		#endmacro
+
+		check_group( s1 )
+		check_group( s2 )
+		check_group( s3 )
+		check_group( s4 )
+		check_group( r1 )
+		check_group( r2 )
+		check_group( r3 )
+		check_group( r4 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/asc.bas
+++ b/tests/udt-zstring/asc.bas
@@ -1,0 +1,49 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.asc_ )
+
+	TEST( ascii )
+		dim s as zstring * 256
+		for i as uinteger = 1 to 255
+			s[i-1] = i
+		next
+		dim u as ustring = s
+
+		CU_ASSERT_EQUAL( asc( s ), asc( u ) )
+
+		for i as integer = -2 to 257
+			select case i
+			case 1 to 255
+				CU_ASSERT_EQUAL( i, asc( u, i ) )
+			case else
+				CU_ASSERT_EQUAL( 0, asc( u, i ) )
+			end select
+		next
+
+	END_TEST
+
+	TEST( ucs2 )
+		dim s as zstring * 256
+		for i as uinteger = 1 to 255
+			s[i-1] = i shl 8
+		next
+		dim u as ustring = s
+
+		CU_ASSERT_EQUAL( asc( s ), asc( u ) )
+
+		for i as integer = -2 to 257
+			select case i
+			case 1 to 255
+				CU_ASSERT_EQUAL( asc( s, i ), asc( u, i ) )
+			case else
+				CU_ASSERT_EQUAL( 0, asc( u, i ) )
+			end select
+		next
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/case.bas
+++ b/tests/udt-zstring/case.bas
@@ -1,0 +1,39 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.case_ )
+
+	'' U/LCASE( zstring )
+	#macro check_rtlfunc( rtlfunc, text )
+		scope
+			dim t as zstring * 50 = text
+			dim u as ustring = t
+
+			CU_ASSERT( t = text )
+			CU_ASSERT( u = t )
+
+			dim rt as zstring * 50 = rtlfunc( t )
+			dim ru as zstring * 50 = rtlfunc( u )
+			CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+		end scope
+	#endmacro
+
+	#macro check( text )
+		check_rtlfunc( ucase, text )
+		check_rtlfunc( lcase, text )
+	#endmacro
+
+	TEST( default )
+		check( "" )
+		check( " " )
+		check( "  " )
+		check( "abcde" )
+		check( "asdfghjkl" )
+		check( "QWERTZUIOP" )
+		check( "1234567890" )
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/chk-zstring.bi
+++ b/tests/udt-zstring/chk-zstring.bi
@@ -1,0 +1,26 @@
+#pragma once
+
+#macro CU_ASSERT_ZSTRING_EQUAL( u, w )
+
+	'' length check
+	CU_ASSERT( len(u) = len(w) )
+
+	'' comparison check
+	CU_ASSERT_EQUAL(u, w)
+
+	'' byte-by-byte check
+	scope
+		if(len(u) = len(w)) then
+			do
+				for i as integer = 0 to len(u) - 1
+					if(u[i] <> w[i]) then
+						CU_FAIL()
+						exit do
+					end if
+				next
+				CU_PASS()
+			loop until true
+		end if
+	end scope
+
+#endmacro

--- a/tests/udt-zstring/conversion.bas
+++ b/tests/udt-zstring/conversion.bas
@@ -1,0 +1,159 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.conversion )
+
+	#macro check( datatype, func, value )
+
+		scope
+			dim t as zstring * 50 = str( #value )
+			dim u as ustring = t
+
+				CU_ASSERT_EQUAL( func( t ), func( u ) )
+
+			#if #datatype = "double"
+				CU_ASSERT_DOUBLE_EQUAL( func( t ), value, 0 )
+				CU_ASSERT_DOUBLE_EQUAL( func( u ), value, 0 )
+				CU_ASSERT_DOUBLE_EQUAL( func( t ), func( value ), 0 )
+				CU_ASSERT_DOUBLE_EQUAL( func( u ), func( value ), 0 )
+			#elseif #datatype = "single"
+				CU_ASSERT_SINGLE_APPROX( func( t ), value, 0 )
+				CU_ASSERT_SINGLE_APPROX( func( u ), value, 0 )
+				CU_ASSERT_SINGLE_APPROX( func( t ), func( value ), 0 )
+				CU_ASSERT_SINGLE_APPROX( func( u ), func( value ), 0 )
+			#else
+				CU_ASSERT_EQUAL( func( t ), value )
+				CU_ASSERT_EQUAL( func( u ), value )
+				CU_ASSERT_EQUAL( func( t ), func( value ) )
+				CU_ASSERT_EQUAL( func( u ), func( value ) )
+			#endif
+			
+		end scope
+
+	#endmacro
+
+	TEST( cbool_ )
+		check( boolean, cbool, false )
+		check( boolean, cbool, true )
+	END_TEST
+
+	TEST( cbyte_ )
+		check( byte, cbyte, -128 )
+		check( byte, cbyte, -1 )
+		check( byte, cbyte, 0 )
+		check( byte, cbyte, 127 )
+	END_TEST
+
+	TEST( cubyte_ )
+		check( ubyte, cubyte, 0 )
+		check( ubyte, cubyte, 127 )
+		check( ubyte, cubyte, 128 )
+		check( ubyte, cubyte, 255 )
+	END_TEST
+
+	TEST( cshort_ )
+		check( short, cshort, -32768 )
+		check( short, cshort, -1 )
+		check( short, cshort, 0 )
+		check( short, cshort, 32767 )
+	END_TEST
+
+	TEST( cushort_ )
+		check( ushort, cushort, 0 )
+		check( ushort, cushort, 32767 )
+		check( ushort, cushort, 32768 )
+		check( ushort, cushort, 65535 )
+	END_TEST
+
+	TEST( clng_ )
+		check( long, clng, -2147483648 )
+		check( long, clng, -1 )
+		check( long, clng, 0 )
+		check( long, clng, 2147483647 )
+	END_TEST
+
+	TEST( culng_ )
+		check( ulong, culng, 0 )
+		check( ulong, culng, 2147483647 )
+		check( ulong, culng, 2147483648 )
+		check( ulong, culng, 4294967295 )
+	END_TEST
+
+
+#if sizeof(integer) = 4
+	TEST( cint_ )
+		check( integer, cint, -2147483648 )
+		check( integer, cint, -1 )
+		check( integer, cint, 0 )
+		check( integer, cint, 2147483647 )
+	END_TEST
+
+	TEST( cuint_ )
+		check( uinteger, cuint, 0 )
+		check( uinteger, cuint, 2147483647 )
+		check( uinteger, cuint, 2147483648 )
+		check( uinteger, cuint, 4294967295 )
+	END_TEST
+#else
+	TEST( cint_ )
+		check( integer, cint, -9223372036854775808ll )
+		check( integer, cint, -1 )
+		check( integer, cint, 0 )
+		check( integer, cint, 9223372036854775807ll )
+	END_TEST
+
+	TEST( cuint_ )
+		check( uinteger, cuint, 0 )
+		check( uinteger, cuint, 9223372036854775807 )
+		check( uinteger, cuint, 9223372036854775808 )
+		check( uinteger, cuint, 18446744073709551615 )
+	END_TEST
+#endif
+
+	TEST( clngint_ )
+		check( longint, clngint, -9223372036854775808 )
+		check( longint, clngint, -1 )
+		check( longint, clngint, 0 )
+		check( longint, clngint, 9223372036854775807 )
+	END_TEST
+
+	TEST( culngint_ )
+		check( ulongint, culngint, 0 )
+		check( ulongint, culngint, 9223372036854775807 )
+		check( ulongint, culngint, 9223372036854775808 )
+		check( ulongint, culngint, 18446744073709551615 )
+	END_TEST
+
+	TEST( csng_ )
+		check( single, csng, 1.1754943508e-38! )
+		check( single, csng, 3.4028234664e+38! )
+		check( single, csng, 0.9999999404! )
+		check( single, csng, 1.0000001192! )
+		check( single, csng, -1.5! )
+		check( single, csng, -1! )
+		check( single, csng, -0.5! )
+		check( single, csng, 0! )
+		check( single, csng, 0.5! )
+		check( single, csng, 1! )
+		check( single, csng, 1.5! )
+		check( single, csng, +1! )
+	END_TEST
+
+	TEST( cdbl_ )
+		check( double, cdbl, 2.2250738585072014d-308# )
+		check( double, cdbl, 1.7976931348623157d+308# )
+		check( double, cdbl, -1.5# )
+		check( double, cdbl, -1# )
+		check( double, cdbl, -0.5# )
+		check( double, cdbl, 0# )
+		check( double, cdbl, 0.5# )
+		check( double, cdbl, 1# )
+		check( double, cdbl, 1.5# )
+		check( double, cdbl, +1# )
+	END_TEST
+
+END_SUITE
+

--- a/tests/udt-zstring/iif.bas
+++ b/tests/udt-zstring/iif.bas
@@ -1,0 +1,197 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.iif_ )
+
+	#macro check_zstring( expr, true_expr, false_expr )
+		scope
+			dim t1 as zstring * 50 = true_expr
+			dim t2 as zstring * 50 = false_expr
+
+			dim u1 as ustring = true_expr
+			dim u2 as ustring = false_expr
+
+			'' ZSTRING = iif( expr, LITERAL1, LITERAL2 )
+			scope
+				dim a as zstring * 50 = iif( expr, true_expr, false_expr )
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' ZSTRING = iif( expr, ZSTRING1, LITERAL2 )
+			scope
+				dim a as zstring * 50 = iif( expr, t1, false_expr )
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' ZSTRING = iif( expr, LITERAL1, ZSTRING2 )
+			scope
+				dim a as zstring * 50 = iif( expr, true_expr, t2 )
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' ZSTRING = iif( expr, ZSTRING1, ZSTRING2 )
+			scope
+				dim a as zstring * 50 = iif( expr, t1, t2 )
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' ZSTRING = iif( expr, USTRING1, LITERAL2 )
+			scope
+				dim a as zstring * 50 = iif( expr, u1, false_expr )
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' ZSTRING = iif( expr, LITERAL1, USTRING2 )
+			scope
+				dim a as zstring * 50 = iif( expr, true_expr, u2 )
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			'' ZSTRING = iif( expr, USTRING1, USTRING2 )
+			scope
+				dim a as zstring * 50 = iif( expr, u1, u2 )
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+		end scope
+	#endmacro
+
+	#macro check_ustring( expr, true_expr, false_expr )
+		scope
+			dim t1 as zstring * 50 = true_expr
+			dim t2 as zstring * 50 = false_expr
+
+			dim u1 as ustring = true_expr
+			dim u2 as ustring = false_expr
+
+			'' USTRING = iif( expr, LITERAL1, LITERAL2 )
+			scope
+				dim a as ustring = iif( expr, true_expr, false_expr )
+				dim r as zstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, ZSTRING1, LITERAL2 )
+			scope
+				dim a as ustring = iif( expr, t1, false_expr )
+				dim r as zstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, LITERAL1, ZSTRING2 )
+			scope
+				dim a as ustring = iif( expr, true_expr, t2 )
+				dim r as zstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, ZSTRING1, ZSTRING2 )
+			scope
+				dim a as ustring = iif( expr, t1, t2 )
+				dim r as zstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, USTRING1, LITERAL2 )
+			scope
+				dim a as ustring = iif( expr, u1, false_expr )
+				dim r as zstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, LITERAL1, USTRING2 )
+			scope
+				dim a as ustring = iif( expr, true_expr, u2 )
+				dim r as zstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+			'' USTRING = iif( expr, USTRING1, USTRING2 )
+			scope
+				dim a as ustring = iif( expr, u1, u2 )
+				dim r as zstring * 50 = a
+				if( expr ) then
+					CU_ASSERT_ZSTRING_EQUAL( r, t1 )
+				else
+					CU_ASSERT_ZSTRING_EQUAL( r, t2 )
+				endif
+			end scope
+
+		end scope
+	#endmacro
+
+	TEST( zstring_iif )
+		
+		check_zstring(  0, "", "a" )
+		check_zstring( -1, "", "a" )
+
+		check_zstring(  0, "a", "xyz" )
+		check_zstring( -1, "a", "xyz" )
+
+	END_TEST
+
+	TEST( ustring_iif )
+		
+		check_ustring(  0, "", "a" )
+		check_ustring( -1, "", "a" )
+
+		check_ustring(  0, "a", "xyz" )
+		check_ustring( -1, "a", "xyz" )
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/instr.bas
+++ b/tests/udt-zstring/instr.bas
@@ -1,0 +1,201 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.instr_ )
+
+	'' INSTR( zstring, zstring )
+	#macro check_0( result, text, pattern )
+		scope
+			dim st as zstring * 50 = text
+			dim ut as ustring = st
+			dim sp as zstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instr( st, sp ) )
+			CU_ASSERT_EQUAL( result, instr( st, up ) )
+			CU_ASSERT_EQUAL( result, instr( ut, sp ) )
+			CU_ASSERT_EQUAL( result, instr( ut, up ) )
+		end scope
+	#endmacro
+
+		'' INSTR( index, zstring, zstring )
+	#macro check_x( result, index, text, pattern )
+		scope
+			dim st as zstring * 50 = text
+			dim ut as ustring = st
+			dim sp as zstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instr( index, st, sp ) )
+			CU_ASSERT_EQUAL( result, instr( index, st, up ) )
+			CU_ASSERT_EQUAL( result, instr( index, ut, sp ) )
+			CU_ASSERT_EQUAL( result, instr( index, ut, up ) )
+		end scope
+	#endmacro
+
+		'' INSTR( zstring, zstring )
+	#macro check_0_any( result, text, pattern )
+		scope
+			dim st as zstring * 50 = text
+			dim ut as ustring = st
+			dim sp as zstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instr( st, any sp ) )
+			CU_ASSERT_EQUAL( result, instr( st, any up ) )
+			CU_ASSERT_EQUAL( result, instr( ut, any sp ) )
+			CU_ASSERT_EQUAL( result, instr( ut, any up ) )
+		end scope
+	#endmacro
+
+		'' INSTR( index, zstring, zstring )
+	#macro check_x_any( result, index, text, pattern )
+		scope
+			dim st as zstring * 50 = text
+			dim ut as ustring = st
+			dim sp as zstring * 50 = pattern
+			dim up as ustring = sp
+			
+			CU_ASSERT_EQUAL( result, instr( index, st, any sp ) )
+			CU_ASSERT_EQUAL( result, instr( index, st, any up ) )
+			CU_ASSERT_EQUAL( result, instr( index, ut, any sp ) )
+			CU_ASSERT_EQUAL( result, instr( index, ut, any up ) )
+		end scope
+	#endmacro
+
+	TEST( instr_0 )
+		check_0( 0, !"", !"" )
+		check_0( 0, !"x", !"" )
+		check_0( 0, !"", !"x" )
+		check_0( 1, !"x", !"x" )
+		check_0( 2, !"yx", !"x" )
+
+		check_0( 1, !"13579", !"13" )
+		check_0( 2, !"13579", !"35" )
+		check_0( 3, !"13579", !"57" )
+		check_0( 4, !"13579", !"79" )
+	END_TEST
+
+	TEST( instr_x )
+		check_x( 0, -1, !"", !"" )
+		check_x( 0,  0, !"", !"" )
+		check_x( 0,  1, !"", !"" )
+		check_x( 0,  2, !"", !"" )
+
+		check_x( 0, -1, !"x", !"" )
+		check_x( 0,  0, !"x", !"" )
+		check_x( 0,  1, !"x", !"" )
+		check_x( 0,  2, !"x", !"" )
+
+		check_x( 0, -1, !"", !"x" )
+		check_x( 0,  0, !"", !"x" )
+		check_x( 0,  1, !"", !"x" )
+		check_x( 0,  2, !"", !"x" )
+
+		check_x( 0, -1, !"x", !"x" )
+		check_x( 0,  0, !"x", !"x" )
+		check_x( 1,  1, !"x", !"x" )
+		check_x( 0,  2, !"x", !"x" )
+		check_x( 0,  3, !"x", !"x" )
+
+		check_x( 0, -1, !"xy", !"x" )
+		check_x( 0,  0, !"xy", !"x" )
+		check_x( 1,  1, !"xy", !"x" )
+		check_x( 0,  2, !"xy", !"x" )
+		check_x( 0,  3, !"xy", !"x" )
+
+		check_x( 0, -1, !"yx", !"x" )
+		check_x( 0,  0, !"yx", !"x" )
+		check_x( 2,  1, !"yx", !"x" )
+		check_x( 2,  2, !"yx", !"x" )
+		check_x( 0,  3, !"yx", !"x" )
+
+		check_x( 0,  0, !"13579", !"13" )
+		check_x( 1,  1, !"13579", !"13" )
+		check_x( 0,  2, !"13579", !"13" )
+
+		check_x( 2,  1, !"13579", !"35" )
+		check_x( 2,  2, !"13579", !"35" )
+		check_x( 0,  3, !"13579", !"35" )
+
+		check_x( 3,  2, !"13579", !"57" )
+		check_x( 3,  3, !"13579", !"57" )
+		check_x( 0,  4, !"13579", !"57" )
+
+		check_x( 4,  3, !"13579", !"79" )
+		check_x( 4,  4, !"13579", !"79" )
+		check_x( 0,  5, !"13579", !"79" )
+	END_TEST
+
+	TEST( instr_0_any )
+		check_0_any( 0, !"", !"" )
+		check_0_any( 0, !"x", !"" )
+		check_0_any( 0, !"", !"x" )
+		check_0_any( 1, !"x", !"x" )
+		check_0_any( 1, !"xy", !"x" )
+		check_0_any( 2, !"yx", !"x" )
+
+		check_0_any( 1, !"13579", !"13" )
+		check_0_any( 2, !"13579", !"35" )
+		check_0_any( 3, !"13579", !"57" )
+		check_0_any( 4, !"13579", !"79" )
+	END_TEST
+
+	TEST( instr_x_any )
+		check_x_any( 0, -1, !"", !"" )
+		check_x_any( 0,  0, !"", !"" )
+		check_x_any( 0,  1, !"", !"" )
+		check_x_any( 0,  2, !"", !"" )
+
+		check_x_any( 0, -1, !"x", !"" )
+		check_x_any( 0,  0, !"x", !"" )
+		check_x_any( 0,  1, !"x", !"" )
+		check_x_any( 0,  2, !"x", !"" )
+
+		check_x_any( 0, -1, !"", !"x" )
+		check_x_any( 0,  0, !"", !"x" )
+		check_x_any( 0,  1, !"", !"x" )
+		check_x_any( 0,  2, !"", !"x" )
+
+		check_x_any( 0, -1, !"x", !"x" )
+		check_x_any( 0,  0, !"x", !"x" )
+		check_x_any( 1,  1, !"x", !"x" )
+		check_x_any( 0,  2, !"x", !"x" )
+
+		check_x_any( 0, -1, !"xy", !"x" )
+		check_x_any( 0,  0, !"xy", !"x" )
+		check_x_any( 1,  1, !"xy", !"x" )
+		check_x_any( 0,  2, !"xy", !"x" )
+		check_x_any( 0,  3, !"xy", !"x" )
+
+		check_x_any( 0, -1, !"yx", !"x" )
+		check_x_any( 0,  0, !"yx", !"x" )
+		check_x_any( 2,  1, !"yx", !"x" )
+		check_x_any( 2,  2, !"yx", !"x" )
+		check_x_any( 0,  3, !"yx", !"x" )
+
+		check_x_any( 0,  0, !"13579", !"13" )
+		check_x_any( 1,  1, !"13579", !"13" )
+		check_x_any( 2,  2, !"13579", !"13" )
+		check_x_any( 0,  3, !"13579", !"13" )
+
+		check_x_any( 2,  1, !"13579", !"35" )
+		check_x_any( 2,  2, !"13579", !"35" )
+		check_x_any( 3,  3, !"13579", !"35" )
+		check_x_any( 0,  4, !"13579", !"35" )
+
+		check_x_any( 3,  2, !"13579", !"57" )
+		check_x_any( 3,  3, !"13579", !"57" )
+		check_x_any( 4,  4, !"13579", !"57" )
+		check_x_any( 0,  5, !"13579", !"57" )
+
+		check_x_any( 4,  3, !"13579", !"79" )
+		check_x_any( 4,  4, !"13579", !"79" )
+		check_x_any( 5,  5, !"13579", !"79" )
+		check_x_any( 0,  6, !"13579", !"79" )
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/instrrev.bas
+++ b/tests/udt-zstring/instrrev.bas
@@ -1,0 +1,231 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.instrrev_ )
+
+	'' INSTRREV( zstring, zstring )
+	#macro check_0( result, text, pattern )
+		scope
+			dim st as zstring * 50 = text
+			dim ut as ustring = st
+			dim sp as zstring * 50 = pattern
+			dim up as ustring = sp
+			
+			dim i as integer
+			
+			CU_ASSERT_EQUAL( result, instrrev( st, sp ) )
+			CU_ASSERT_EQUAL( result, instrrev( st, up ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, sp ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, up ) )
+		end scope
+	#endmacro
+
+		'' INSTRREV( index, zstring, zstring )
+	#macro check_x( result, index, text, pattern )
+		scope
+			dim st as zstring * 50 = text
+			dim ut as ustring = st
+			dim sp as zstring * 50 = pattern
+			dim up as ustring = sp
+			
+			dim i as integer
+			
+			CU_ASSERT_EQUAL( result, instrrev( st, sp, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( st, up, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, sp, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, up, index ) )
+		end scope
+	#endmacro
+
+		'' INSTRREV( zstring, zstring )
+	#macro check_0_any( result, text, pattern )
+		scope
+			dim st as zstring * 50 = text
+			dim ut as ustring = st
+			dim sp as zstring * 50 = pattern
+			dim up as ustring = sp
+			
+			dim i as integer
+			
+			CU_ASSERT_EQUAL( result, instrrev( st, any sp ) )
+			CU_ASSERT_EQUAL( result, instrrev( st, any up ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, any sp ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, any up ) )
+		end scope
+	#endmacro
+
+		'' INSTRREV( index, zstring, zstring )
+	#macro check_x_any( result, index, text, pattern )
+		scope
+			dim st as zstring * 50 = text
+			dim ut as ustring = st
+			dim sp as zstring * 50 = pattern
+			dim up as ustring = sp
+			
+			dim i as integer
+			
+			CU_ASSERT_EQUAL( result, instrrev( st, any sp, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( st, any up, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, any sp, index ) )
+			CU_ASSERT_EQUAL( result, instrrev( ut, any up, index ) )
+		end scope
+	#endmacro
+
+	TEST( instrrev_0 )
+		check_0( 0, !"", !"" )
+		check_0( 0, !"x", !"" )
+		check_0( 0, !"", !"x" )
+		check_0( 1, !"x", !"x" )
+		check_0( 2, !"yx", !"x" )
+
+		check_0( 1, !"13579", !"13" )
+		check_0( 2, !"13579", !"35" )
+		check_0( 3, !"13579", !"57" )
+		check_0( 4, !"13579", !"79" )
+	END_TEST
+
+	TEST( instrrev_x )
+		check_x( 0, -2, !"", !"" )
+		check_x( 0, -1, !"", !"" )
+		check_x( 0,  0, !"", !"" )
+		check_x( 0,  1, !"", !"" )
+		check_x( 0,  2, !"", !"" )
+
+		check_x( 0, -2, !"x", !"" )
+		check_x( 0, -1, !"x", !"" )
+		check_x( 0,  0, !"x", !"" )
+		check_x( 0,  1, !"x", !"" )
+		check_x( 0,  2, !"x", !"" )
+
+		check_x( 0, -2, !"", !"x" )
+		check_x( 0, -1, !"", !"x" )
+		check_x( 0,  0, !"", !"x" )
+		check_x( 0,  1, !"", !"x" )
+		check_x( 0,  2, !"", !"x" )
+
+		check_x( 1, -2, !"x", !"x" )
+		check_x( 1, -1, !"x", !"x" )
+		check_x( 0,  0, !"x", !"x" )
+		check_x( 1,  1, !"x", !"x" )
+		check_x( 0,  2, !"x", !"x" )
+		check_x( 0,  3, !"x", !"x" )
+
+		check_x( 1, -2, !"xy", !"x" )
+		check_x( 1, -1, !"xy", !"x" )
+		check_x( 0,  0, !"xy", !"x" )
+		check_x( 1,  1, !"xy", !"x" )
+		check_x( 1,  2, !"xy", !"x" )
+		check_x( 0,  3, !"xy", !"x" )
+
+		check_x( 2, -2, !"yx", !"x" )
+		check_x( 2, -1, !"yx", !"x" )
+		check_x( 0,  0, !"yx", !"x" )
+		check_x( 0,  1, !"yx", !"x" )
+		check_x( 2,  2, !"yx", !"x" )
+		check_x( 0,  3, !"yx", !"x" )
+
+		check_x( 1, -1, !"13579", !"13" )
+		check_x( 0,  0, !"13579", !"13" )
+		check_x( 1,  1, !"13579", !"13" )
+		check_x( 1,  2, !"13579", !"13" )
+
+		check_x( 0,  1, !"13579", !"35" )
+		check_x( 2,  2, !"13579", !"35" )
+		check_x( 2,  3, !"13579", !"35" )
+
+		check_x( 0,  2, !"13579", !"57" )
+		check_x( 3,  3, !"13579", !"57" )
+		check_x( 3,  4, !"13579", !"57" )
+
+		check_x( 0,  3, !"13579", !"79" )
+		check_x( 4,  4, !"13579", !"79" )
+		check_x( 4,  5, !"13579", !"79" )
+		check_x( 0,  6, !"13579", !"79" )
+	END_TEST
+
+	TEST( instrrev_0_any )
+		check_0_any( 0, !"", !"" )
+		check_0_any( 0, !"x", !"" )
+		check_0_any( 0, !"", !"x" )
+		check_0_any( 1, !"x", !"x" )
+		check_0_any( 1, !"xy", !"x" )
+		check_0_any( 2, !"yx", !"x" )
+
+		check_0_any( 2, !"13579", !"13" )
+		check_0_any( 3, !"13579", !"35" )
+		check_0_any( 4, !"13579", !"57" )
+		check_0_any( 5, !"13579", !"79" )
+
+		check_0_any( 2, !"13579", !"31" )
+		check_0_any( 3, !"13579", !"53" )
+		check_0_any( 4, !"13579", !"75" )
+		check_0_any( 5, !"13579", !"97" )
+	END_TEST
+
+	TEST( instrrev_x_any )
+		check_x_any( 0, -2, !"", !"" )
+		check_x_any( 0, -1, !"", !"" )
+		check_x_any( 0,  0, !"", !"" )
+		check_x_any( 0,  1, !"", !"" )
+		check_x_any( 0,  2, !"", !"" )
+
+		check_x_any( 0, -2, !"x", !"" )
+		check_x_any( 0, -1, !"x", !"" )
+		check_x_any( 0,  0, !"x", !"" )
+		check_x_any( 0,  1, !"x", !"" )
+		check_x_any( 0,  2, !"x", !"" )
+
+		check_x_any( 0, -2, !"", !"x" )
+		check_x_any( 0, -1, !"", !"x" )
+		check_x_any( 0,  0, !"", !"x" )
+		check_x_any( 0,  1, !"", !"x" )
+		check_x_any( 0,  2, !"", !"x" )
+
+		check_x_any( 1, -2, !"x", !"x" )
+		check_x_any( 1, -1, !"x", !"x" )
+		check_x_any( 0,  0, !"x", !"x" )
+		check_x_any( 1,  1, !"x", !"x" )
+		check_x_any( 0,  2, !"x", !"x" )
+
+		check_x_any( 1, -2, !"xy", !"x" )
+		check_x_any( 1, -1, !"xy", !"x" )
+		check_x_any( 0,  0, !"xy", !"x" )
+		check_x_any( 1,  1, !"xy", !"x" )
+		check_x_any( 1,  2, !"xy", !"x" )
+		check_x_any( 0,  3, !"xy", !"x" )
+
+		check_x_any( 2, -2, !"yx", !"x" )
+		check_x_any( 2, -1, !"yx", !"x" )
+		check_x_any( 0,  0, !"yx", !"x" )
+		check_x_any( 0,  1, !"yx", !"x" )
+		check_x_any( 2,  2, !"yx", !"x" )
+		check_x_any( 0,  3, !"yx", !"x" )
+
+		check_x_any( 0,  0, !"13579", !"13" )
+		check_x_any( 1,  1, !"13579", !"13" )
+		check_x_any( 2,  2, !"13579", !"13" )
+		check_x_any( 2,  3, !"13579", !"13" )
+
+		check_x_any( 0,  0, !"13579", !"35" )
+		check_x_any( 0,  1, !"13579", !"35" )
+		check_x_any( 2,  2, !"13579", !"35" )
+		check_x_any( 3,  3, !"13579", !"35" )
+		check_x_any( 3,  4, !"13579", !"35" )
+
+		check_x_any( 0,  1, !"13579", !"57" )
+		check_x_any( 0,  2, !"13579", !"57" )
+		check_x_any( 3,  3, !"13579", !"57" )
+		check_x_any( 4,  4, !"13579", !"57" )
+		check_x_any( 4,  5, !"13579", !"57" )
+
+		check_x_any( 0,  2, !"13579", !"79" )
+		check_x_any( 0,  3, !"13579", !"79" )
+		check_x_any( 4,  4, !"13579", !"79" )
+		check_x_any( 5,  5, !"13579", !"79" )
+		check_x_any( 0,  6, !"13579", !"79" )
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/lrset.bas
+++ b/tests/udt-zstring/lrset.bas
@@ -1,0 +1,101 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED_MUTABLE
+
+SUITE( fbc_tests.udt_zstring_.lrset )
+
+	#macro check_lset( dst, src, length1, length2 )
+		scope
+			'' lset/rset
+			dim z1 as zstring * 50 = left( dst, (length1) )
+			dim z2 as zstring * 50 = left( src, (length2) )
+			dim e1 as zstring * 50
+
+			dim u1 as ustring = z1
+			dim u2 as ustring = z2
+
+			if( (length1) > (length2) ) then
+				e1 = (z2) & space( (length1) - (length2) )
+			else
+				e1 = left( z2, (length1) )
+			end if
+
+			CU_ASSERT( len(e1) = (length1) )
+
+			'' zstring are zero terminated and length
+			'' is determined from the string data
+			lset (z1) = (z2)
+			CU_ASSERT_ZSTRING_EQUAL( z1, e1 )
+
+			lset (z1) = (u2)
+			CU_ASSERT_ZSTRING_EQUAL( z1, e1 )
+
+			lset (u1) = (z2)
+			dim r1 as zstring * 50 = u1
+			CU_ASSERT_ZSTRING_EQUAL( r1, e1 )
+
+			lset (u1) = (u2)
+			dim r2 as zstring * 50 = u1
+			CU_ASSERT_ZSTRING_EQUAL( r2, e1 )
+		end scope
+	#endmacro
+
+	#macro check_rset( dst, src, length1, length2 )
+		scope
+			'' lset/rset
+			dim z1 as zstring * 50 = left( dst, (length1) )
+			dim z2 as zstring * 50 = left( src, (length2) )
+			dim e1 as zstring * 50
+
+			dim u1 as ustring = z1
+			dim u2 as ustring = z2
+
+			if( (length1) > (length2) ) then
+				e1 = wspace( (length1) - (length2) ) & (z2)
+			else
+				e1 = left( z2, (length1) )
+			end if
+
+			CU_ASSERT( len(e1) = (length1) )
+
+			'' zstring are zero terminated and length
+			'' is determined from the string data
+			rset (z1) = (z2)
+			CU_ASSERT_ZSTRING_EQUAL( z1, e1 )
+
+			rset (z1) = (u2)
+			CU_ASSERT_ZSTRING_EQUAL( z1, e1 )
+
+			rset (u1) = (z2)
+			dim r1 as zstring * 50 = u1
+			CU_ASSERT_ZSTRING_EQUAL( r1, e1 )
+
+			rset (u1) = (u2)
+			dim r2 as zstring * 50 = u1
+			CU_ASSERT_ZSTRING_EQUAL( r2, e1 )
+		end scope
+	#endmacro
+
+	TEST( ascii )
+
+		const MAX = 8
+		dim dst as zstring * (MAX+1)
+		dim src as zstring * (MAX+1)
+
+		dst = "12345678"
+		src = "ABCDEFGH"
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+
+				check_lset( dst, src, i1, i2 )
+				check_rset( dst, src, i1, i2 )
+
+			next i2
+		next i1
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/midfunc.bas
+++ b/tests/udt-zstring/midfunc.bas
@@ -1,0 +1,129 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.midfunc )
+
+	'' MID( wstring, start )
+	#macro check( text, start, expected )
+		scope
+			dim st as zstring * 50 = text
+			dim se as zstring * 50 = expected
+			dim ut as ustring = st
+
+			CU_ASSERT( st = text )
+			CU_ASSERT( ut = st )
+
+			dim rt as zstring * 50 = mid( st, start )
+			dim ru as wstring * 50 = mid( ut, start )
+			
+			CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+			CU_ASSERT_ZSTRING_EQUAL( rt, se )
+			CU_ASSERT_ZSTRING_EQUAL( ru, se )
+		end scope
+	#endmacro
+
+	'' MID( wstring, start, length )
+	#macro check_i_n( text, start, length, expected )
+		scope
+			dim st as zstring * 50 = text
+			dim se as zstring * 50 = expected
+			dim ut as ustring = st
+
+			CU_ASSERT( st = text )
+			CU_ASSERT( ut = st )
+
+			dim rt as zstring * 50 = mid( st, start, length )
+			dim ru as wstring * 50 = mid( ut, start, length )
+			
+			CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+			CU_ASSERT_ZSTRING_EQUAL( rt, se )
+			CU_ASSERT_ZSTRING_EQUAL( ru, se )
+		end scope
+	#endmacro
+
+	TEST( default )
+		check( ""       , -1, "" )
+		check( ""       ,  0, "" )
+		check( ""       ,  1, "" )
+
+		check( "a"      , -1, "" )
+		check( "a"      ,  0, "" )
+		check( "a"      ,  1, "a" )
+		check( "a"      ,  2, "" )
+
+		check( "ab"     , -1, "" )
+		check( "ab"     ,  0, "" )
+		check( "ab"     ,  1, "ab" )
+		check( "ab"     ,  2, "b" )
+		check( "ab"     ,  3, "" )
+
+		check( "abc"    , -1, "" )
+		check( "abc"    ,  0, "" )
+		check( "abc"    ,  1, "abc" )
+		check( "abc"    ,  2, "bc" )
+		check( "abc"    ,  3, "c" )
+		check( "abc"    ,  4, "" )
+
+	END_TEST
+
+	TEST( length )
+		check_i_n( ""       , -1, -1, "" )
+		check_i_n( ""       , -1,  0, "" )
+		check_i_n( ""       , -1,  1, "" )
+
+		check_i_n( ""       ,  0, -1, "" )
+		check_i_n( ""       ,  0,  0, "" )
+		check_i_n( ""       ,  0,  1, "" )
+
+		check_i_n( ""       ,  1, -1, "" )
+		check_i_n( ""       ,  1,  0, "" )
+		check_i_n( ""       ,  1,  1, "" )
+
+		check_i_n( "a"      , -1, -1, "" )
+		check_i_n( "a"      , -1,  0, "" )
+		check_i_n( "a"      , -1,  1, "" )
+		check_i_n( "a"      , -1,  2, "" )
+
+		check_i_n( "a"      ,  0, -1, "" )
+		check_i_n( "a"      ,  0,  0, "" )
+		check_i_n( "a"      ,  0,  1, "" )
+		check_i_n( "a"      ,  0,  2, "" )
+
+		check_i_n( "a"      ,  1, -1, "a" )
+		check_i_n( "a"      ,  1,  0, "" )
+		check_i_n( "a"      ,  1,  1, "a" )
+		check_i_n( "a"      ,  1,  2, "a" )
+
+		check_i_n( "a"      ,  2, -1, "" )
+		check_i_n( "a"      ,  2,  0, "" )
+		check_i_n( "a"      ,  2,  1, "" )
+		check_i_n( "a"      ,  2,  2, "" )
+
+		check_i_n( "ab"     ,  1, -2, "ab" )
+		check_i_n( "ab"     ,  1, -1, "ab" )
+		check_i_n( "ab"     ,  1,  0, "" )
+		check_i_n( "ab"     ,  1,  1, "a" )
+		check_i_n( "ab"     ,  1,  2, "ab" )
+		check_i_n( "ab"     ,  1,  3, "ab" )
+
+		check_i_n( "ab"     ,  2, -2, "b" )
+		check_i_n( "ab"     ,  2, -1, "b" )
+		check_i_n( "ab"     ,  2,  0, "" )
+		check_i_n( "ab"     ,  2,  1, "b" )
+		check_i_n( "ab"     ,  2,  2, "b" )
+		check_i_n( "ab"     ,  2,  3, "b" )
+
+		check_i_n( "ab"     ,  3, -2, "" )
+		check_i_n( "ab"     ,  3, -1, "" )
+		check_i_n( "ab"     ,  3,  0, "" )
+		check_i_n( "ab"     ,  3,  1, "" )
+		check_i_n( "ab"     ,  3,  2, "" )
+		check_i_n( "ab"     ,  3,  3, "" )
+
+	END_TEST
+
+
+END_SUITE

--- a/tests/udt-zstring/midstmt.bas
+++ b/tests/udt-zstring/midstmt.bas
@@ -1,0 +1,112 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED_MUTABLE
+
+#define BUFFERSIZE 50
+
+'' fixed length strings are not cleared
+'' and the garbage in the buffer will affect the tests
+#macro INIT_FIXED_STRING( s, dtype, size, value )
+	dim s as dtype * size
+	clear @s, 0, sizeof(s)
+	s = value
+#endmacro
+
+SUITE( fbc_tests.udt_zstring_.midstmt )
+
+	#macro check_mid_start( dst, start, src, length1, length2 )
+		scope
+			INIT_FIXED_STRING( w1, zstring, BUFFERSIZE, left( dst, (length1) ) )
+			INIT_FIXED_STRING( w2, zstring, BUFFERSIZE, left( src, (length2) ) )
+			mid( w1, start ) = w2
+
+			dim u1 as ustring = w1
+			mid( u1, start ) = w2
+
+			dim r1 as zstring * BUFFERSIZE = u1
+			CU_ASSERT_ZSTRING_EQUAL( w1, r1 )
+		end scope
+	#endmacro
+
+	#macro check_mid_start_n( dst, start, length, src, length1, length2 )
+		scope
+			INIT_FIXED_STRING( w1, zstring, BUFFERSIZE, left( dst, (length1) ) )
+			INIT_FIXED_STRING( w2, zstring, BUFFERSIZE, left( src, (length2) ) )
+			mid( w1, start, length ) = w2
+
+			dim u1 as ustring = w1
+			dim u2 as ustring = w2
+			mid( u1, start, length ) = w2
+
+			dim r1 as zstring * BUFFERSIZE = u1
+			CU_ASSERT_ZSTRING_EQUAL( w1, r1 )
+		end scope
+	#endmacro
+
+	TEST( ascii )
+		const MAX = 8
+
+		#define def_dst "12345678"
+		#define def_src "ABCDEFGH"
+
+		dim dst as zstring * (MAX*2+1)
+		dim src as zstring * (MAX*2+1)
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+				for istart as integer = -2 to MAX+2
+
+					dst = def_src
+					src = def_dst
+
+					check_mid_start( dst, istart, src, i1, i2 )
+
+					for length as integer = -2 to MAX+2
+
+						dst = def_src
+						src = def_dst
+
+						check_mid_start_n( dst, istart, length, src, i1, i2 )
+					next
+
+				next
+			next i2
+		next i1
+
+	END_TEST
+
+	TEST( ucs2 )
+		const MAX = 5
+
+		#define def_dst !"\u3041\u3043\u3045\u3047\u3049"
+		#define def_src !"\u3042\u3044\u3046\u3048\u3050"
+
+		dim dst as zstring * (MAX*2+1)
+		dim src as zstring * (MAX*2+1)
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+				for istart as integer = -1 to MAX+2
+
+					dst = def_src
+					src = def_dst
+
+					check_mid_start( dst, istart, src, i1, i2 )
+
+					for length as integer = -2 to MAX+2
+
+						dst = def_src
+						src = def_dst
+
+						check_mid_start_n( dst, istart, length, src, i1, i2 )
+					next
+
+				next
+			next i2
+		next i1
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/select.bas
+++ b/tests/udt-zstring/select.bas
@@ -1,0 +1,80 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.select_ )
+
+	#macro check( expr, literal, is_match )
+		scope
+			dim w as zstring * 50 = expr
+			dim u as ustring = w
+			
+			select case u
+			case literal
+				if( is_match ) then
+					CU_PASS()
+				else
+					CU_FAIL()
+				end if
+			case else
+				if( is_match ) then
+					CU_FAIL()
+				else
+					CU_PASS()
+				end if
+			end select
+		end scope
+	#endmacro
+
+	#macro check_range( expr, literal1, literal2, is_match )
+		scope
+			dim w as zstring * 50 = expr
+			dim u as ustring = w
+			
+			select case u
+			case literal1 to literal2
+				if( is_match ) then
+					CU_PASS()
+				else
+					CU_FAIL()
+				end if
+			case else
+				if( is_match ) then
+					CU_FAIL()
+				else
+					CU_PASS()
+				end if
+			end select
+		end scope
+	#endmacro
+
+	TEST( ascii )
+		check( "0123456789", "0123456789", true )
+		check( "0123456789", "012345678", false )
+		check( "abc", "abc", true )
+		check( "abc", "ABC", false )
+
+		dim arg as zstring * 50 = "abcdefghij"
+		check( left( arg, 0 ), "", true )
+		check( left( arg, 1 ), "a", true )
+		check( left( arg, 2 ), "ab", true )
+		check( left( arg, 3 ), "abc", true )
+
+		check( right( arg, 0 ), "", true )
+		check( right( arg, 1 ), "j", true )
+		check( right( arg, 2 ), "ij", true )
+		check( right( arg, 3 ), "hij", true )
+
+		check( mid( arg, 2 ), "bcdefghij", true )
+		check( mid( arg, 3 ), "cdefghij", true )
+		check( mid( arg, 4 ), "defghij", true )
+		check( mid( arg, 5 ), "efghij", true )
+
+		check_range( "bcd", "b", "c", true )
+		check_range( "xyz", "b", "c", false )
+	END_TEST
+
+END_SUITE
+ 

--- a/tests/udt-zstring/str.bas
+++ b/tests/udt-zstring/str.bas
@@ -1,0 +1,122 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.str_ )
+
+	#macro check( dtype, value )
+	
+		scope
+			dim t as dtype = value
+			dim w as zstring * 50 = str( t )
+			dim u as ustring = str( t )
+			dim r as zstring * 50 = u
+			CU_ASSERT_ZSTRING_EQUAL( w, r )
+		end scope
+
+	#endmacro
+
+	TEST( numeric )
+
+		check( byte, -128 )
+		check( byte, -0 )
+		check( byte, 127 )
+
+		check( ubyte, 0 )
+		check( ubyte, 128 )
+		check( ubyte, 255 )
+
+		check( short, -32768 )
+		check( short, 0 )
+		check( short, 32767 )
+
+		check( ushort, 0 )
+		check( ushort, 32768 )
+		check( ushort, 65535 )
+
+		check( long, -2147483648ll )
+		check( long, 0 )
+		check( long, 2147483647ull )
+
+		check( ulong, 0 )
+		check( ulong, 2147483648ull )
+		check( ulong, 4294967295ull )
+
+		check( longint, (-9223372036854775807ll-1ll) )
+		check( longint, 0 )
+		check( longint, 9223372036854775807ull )
+
+		check( ulongint, 0 )
+		check( ulongint, 9223372036854775808ull )
+		check( ulongint, 18446744073709551615ull )
+
+		check( single, -1.5 )
+		check( single, -1.0 )
+		check( single, -1.0 )
+		check( single, -0.5 )
+		check( single,  0.0 )
+		check( single,  0.5 )
+		check( single,  1.0)
+		check( single,  1.5 )
+		check( single,  2.0 )
+		check( single,  2.5 )
+
+		check( double, -1.5 )
+		check( double, -1.0 )
+		check( double, -1.0 )
+		check( double, -0.5 )
+		check( double,  0.0 )
+		check( double,  0.5 )
+		check( double,  1.0)
+		check( double,  1.5 )
+		check( double,  2.0 )
+		check( double,  2.5 )
+
+	END_TEST
+
+	TEST( default )
+		
+		dim s1 as zstring * 10 = chr(1234)
+		dim s2 as zstring * 10 = chr(1234)
+		dim s3 as zstring * 10 = str( s1 )
+
+		dim u1 as ustring = chr(1234)
+		dim u2 as ustring = chr(1234)
+		dim u3 as ustring = str( s1 )
+		dim u4 as ustring = wstr( u1 )
+
+		dim s4 as zstring * 10 = str( u1 )
+
+		dim r1 as zstring * 10 = u1
+		dim r2 as zstring * 10 = u2
+		dim r3 as zstring * 10 = u3
+		dim r4 as zstring * 10 = u4
+
+		#macro check_group( g )
+
+			CU_ASSERT_ZSTRING_EQUAL( g, s1 )
+			CU_ASSERT_ZSTRING_EQUAL( g, s2 )
+			CU_ASSERT_ZSTRING_EQUAL( g, s3 )
+			CU_ASSERT_ZSTRING_EQUAL( g, s4 )
+
+			CU_ASSERT_ZSTRING_EQUAL( g, r1 )
+			CU_ASSERT_ZSTRING_EQUAL( g, r2 )
+			CU_ASSERT_ZSTRING_EQUAL( g, r3 )
+			CU_ASSERT_ZSTRING_EQUAL( g, r4 )
+
+		#endmacro
+
+		check_group( s1 )
+		check_group( s2 )
+		check_group( s3 )
+		check_group( s4 )
+		check_group( r1 )
+		check_group( r2 )
+		check_group( r3 )
+		check_group( r4 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/strptr.bas
+++ b/tests/udt-zstring/strptr.bas
@@ -1,21 +1,24 @@
 #include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
 
-SUITE( fbc_tests.string_.strptr_ )
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.strptr_ )
 
 	TEST( deref )
-		dim as string ptr foo
-		dim as string bar = "1234"
-		dim as zstring ptr p
+		dim s1 as zstring * 50 = "1234"
+		dim u1 as ustring = s1
 
-		foo = @bar
-		p = strptr( *foo )
-		CU_ASSERT_EQUAL( *p, "1234" )
+		dim as zstring ptr p1 = strptr( u1 )
+
+		CU_ASSERT_zstring_EQUAL( (*p1), s1 )
 	END_TEST
 
 	TEST( ptr_size )
 
-		dim s1 as zstring * 50 = "1234"
-		dim as zstring ptr p0 = @s1
+		dim s as zstring * 50 = "1234"
+		dim s1 as ustring = s
 
 		scope
 			dim as zstring ptr p1 = strptr(s1)
@@ -42,5 +45,5 @@ SUITE( fbc_tests.string_.strptr_ )
 		end scope
 
 	END_TEST
-
+		
 END_SUITE

--- a/tests/udt-zstring/swap.bas
+++ b/tests/udt-zstring/swap.bas
@@ -1,0 +1,121 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+type UZSTRING_HAS_ID extends UZSTRING_FIXED_MUTABLE
+	public:
+		id as integer
+		declare constructor()
+		declare constructor( byval rhs as const wstring const ptr )
+		declare constructor( byval rhs as const zstring const ptr )
+
+		declare operator cast() byref as zstring
+end type
+
+constructor UZSTRING_HAS_ID()
+end constructor
+
+constructor UZSTRING_HAS_ID( byval s as const wstring const ptr )
+	base( s )
+end constructor
+
+constructor UZSTRING_HAS_ID( byval s as const zstring const ptr )
+	base( s )
+end constructor
+
+operator UZSTRING_HAS_ID.Cast() byref as zstring
+	operator = *cast(zstring ptr, @_data)	
+end operator
+
+#define ustring UZSTRING_HAS_ID
+
+SUITE( fbc_tests.udt_zstring_.swap_ )
+
+	#macro check( literal1, literal2 )
+		scope
+			dim t1 as zstring * 50 = literal1
+			dim t2 as zstring * 50 = literal2
+
+			dim u1 as ustring = literal1
+			u1.id = 1
+			dim u2 as ustring = literal2
+			u2.id = 2
+
+			'' initial condition check
+			scope
+				dim r1 as zstring * 50 = u1
+				dim r2 as zstring * 50 = u2
+				CU_ASSERT( u1.id = 1 )
+				CU_ASSERT( u2.id = 2 )
+				CU_ASSERT_ZSTRING_EQUAL( r1, t1 )
+				CU_ASSERT_ZSTRING_EQUAL( r2, t2 )
+			end scope
+
+			'' swap string only
+			scope
+				swap str( u1 ), str( u2 )
+
+				dim r1 as zstring * 50 = u1
+				dim r2 as zstring * 50 = u2
+
+				CU_ASSERT( u1.id = 1 )
+				CU_ASSERT( u2.id = 2 )
+				CU_ASSERT_ZSTRING_EQUAL( r1, t2 )
+				CU_ASSERT_ZSTRING_EQUAL( r2, t1 )
+			end scope
+
+			'' swap string only
+			scope
+				swap str( u1 ), u2
+
+				dim r1 as zstring * 50 = u1
+				dim r2 as zstring * 50 = u2
+
+				CU_ASSERT( u1.id = 1 )
+				CU_ASSERT( u2.id = 2 )
+				CU_ASSERT_ZSTRING_EQUAL( r1, t1 )
+				CU_ASSERT_ZSTRING_EQUAL( r2, t2 )
+			end scope
+
+			'' swap string only
+			scope
+				swap u1, str( u2 )
+
+				dim r1 as zstring * 50 = u1
+				dim r2 as zstring * 50 = u2
+
+				CU_ASSERT( u1.id = 1 )
+				CU_ASSERT( u2.id = 2 )
+				CU_ASSERT_ZSTRING_EQUAL( r1, t2 )
+				CU_ASSERT_ZSTRING_EQUAL( r2, t1 )
+			end scope
+
+			'' swap complete UDT
+			scope
+				swap u1, u2
+
+				dim r1 as zstring * 50 = u1
+				dim r2 as zstring * 50 = u2
+
+				CU_ASSERT( u1.id = 2 )
+				CU_ASSERT( u2.id = 1 )
+				CU_ASSERT_ZSTRING_EQUAL( r1, t1 )
+				CU_ASSERT_ZSTRING_EQUAL( r2, t2 )
+			end scope
+		end scope
+	#endmacro
+
+	TEST( default )
+		check( "", "" )
+
+		check( "", "a" )
+		check( "a", "a" )
+		check( "a", "abcdefghi" )
+
+		check( "", !"\u3041\u3043\u3045\u3047\u3049" )
+		check( "abc", !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"\u3045", !"\u3041\u3043\u3047\u3049" )
+
+	END_TEST 
+
+END_SUITE

--- a/tests/udt-zstring/trim.bas
+++ b/tests/udt-zstring/trim.bas
@@ -1,0 +1,151 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.trim_ )
+
+	'' L/R/TRIM( zstring )
+	#macro check_rtlfunc( rtlfunc, text )
+		scope
+			dim t as zstring * 50 = text
+			dim u as ustring = t
+
+			CU_ASSERT( t = text )
+			CU_ASSERT( u = t )
+
+			dim rt as zstring * 50 = rtlfunc( t )
+			dim ru as zstring * 50 = rtlfunc( u )
+			CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+
+		end scope
+	#endmacro
+
+	'' L/R/TRIM( zstring, pattern )
+	#macro check_rtlfunc_filter( rtlfunc, text, pattern )
+		scope
+			dim t as zstring * 50 = text
+			dim u as ustring = t
+
+			CU_ASSERT( t = text )
+			CU_ASSERT( u = t )
+
+			dim tf as zstring * 50 = pattern
+			dim uf as ustring = tf
+
+			'' zstring, udt
+			scope
+				dim rt as zstring * 50 = rtlfunc( t, tf )
+				dim ru as zstring * 50 = rtlfunc( t, uf )
+				CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+			end scope
+
+			'' udt, zstring
+			scope
+				dim rt as zstring * 50 = rtlfunc( t, tf )
+				dim ru as zstring * 50 = rtlfunc( u, tf )
+				CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+			end scope
+
+			'' udt, udt
+			scope
+				dim rt as zstring * 50 = rtlfunc( t, tf )
+				dim ru as zstring * 50 = rtlfunc( u, uf )
+				CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+			end scope
+
+		end scope
+	#endmacro
+
+	'' L/R/TRIM( zstring, any pattern )
+	#macro check_rtlfunc_any( rtlfunc, text, pattern )
+		scope
+			dim t as zstring * 50 = text
+			dim u as ustring = t
+
+			CU_ASSERT( t = text )
+			CU_ASSERT( u = t )
+
+			dim tf as zstring * 50 = pattern
+			dim uf as ustring = tf
+
+			'' zstring, udt
+			scope
+				dim rt as zstring * 50 = rtlfunc( t, any tf )
+				dim ru as zstring * 50 = rtlfunc( t, any uf )
+				CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+			end scope
+
+			'' udt, zstring
+			scope
+				dim rt as zstring * 50 = rtlfunc( t, any tf )
+				dim ru as zstring * 50 = rtlfunc( u, any tf )
+				CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+			end scope
+
+			'' udt, udt
+			scope
+				dim rt as zstring * 50 = rtlfunc( t, any tf )
+				dim ru as zstring * 50 = rtlfunc( u, any uf )
+				CU_ASSERT_ZSTRING_EQUAL( rt, ru )
+			end scope
+
+		end scope
+	#endmacro
+
+	#macro check( s )
+		check_rtlfunc( ltrim, s )
+		check_rtlfunc( rtrim, s )
+		check_rtlfunc( trim, s )
+	#endmacro
+
+	#macro check_filter( s, f )
+		check_rtlfunc_filter( ltrim, s, f )
+		check_rtlfunc_filter( rtrim, s, f )
+		check_rtlfunc_filter( trim, s, f )
+	#endmacro
+
+	#macro check_any( s, f )
+		check_rtlfunc_any( ltrim, s, f )
+		check_rtlfunc_any( rtrim, s, f )
+		check_rtlfunc_any( trim, s, f )
+	#endmacro
+
+	TEST( default )
+		check( "" )
+		check( " " )
+		check( "  " )
+		check( "abcde" )
+		check( "  abcde" )
+		check( "abcde  " )
+		check( "  abcde  " )
+
+		check_filter( "", "" )
+		check_filter( "", " " )
+		check_filter( " ", "" )
+		check_filter( " ", " " )
+		check_filter( "abcde", "a" )
+		check_filter( "abcde", "ab" )
+		check_filter( "abcde", "ba" )
+		check_filter( "abcde", "e" )
+		check_filter( "abcde", "de" )
+		check_filter( "abcde", "ed" )
+		check_filter( "abcde", "ae" )
+
+
+		check_any( "", "" )
+		check_any( "", " " )
+		check_any( " ", "" )
+		check_any( " ", " " )
+		check_any( "abcde", "a" )
+		check_any( "abcde", "ab" )
+		check_any( "abcde", "ba" )
+		check_any( "abcde", "e" )
+		check_any( "abcde", "de" )
+		check_any( "abcde", "ed" )
+		check_any( "abcde", "ae" )
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/udt-zstring-fixed.bas
+++ b/tests/udt-zstring/udt-zstring-fixed.bas
@@ -1,0 +1,110 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+
+#define ustring uzstring_fixed
+
+'' test UZSTRING_FIXED, reference implementation
+
+SUITE( fbc_tests.udt_zstring_.udt_zstring_fixed )
+
+	TEST( initializer )
+
+		'' default initializer
+		scope
+			dim z as zstring * 50
+			dim u as ustring
+
+			CU_ASSERT( len(z) = 0 )
+			CU_ASSERT( len(u) = 0 )
+			CU_ASSERT( z = "" )
+			CU_ASSERT( u = "" )
+			CU_ASSERT( z = u )
+		end scope
+
+		'' null initializer
+		scope
+			dim z as zstring * 50 = ""
+			dim u as ustring = ""
+
+			CU_ASSERT( len(z) = 0 )
+			CU_ASSERT( len(u) = 0 )
+		end scope
+
+		'' initialize from STRING literal
+		scope
+			dim a as string = "abcdefghij"
+			dim z as zstring * 50 = "abcdefghij"
+			dim u as ustring = "abcdefghij"
+
+			CU_ASSERT( len("abcdefghij") = 10 )
+			CU_ASSERT( len(a) = 10 )
+			CU_ASSERT( len(z) = len(a) )
+			CU_ASSERT( len(u) = len(z) )
+			CU_ASSERT( u = z )
+			
+		end scope
+
+		'' initialize from WSTRING literal
+		scope
+			dim z as zstring * 50 = !"\u0061\u0062\u0063\u0064\u0065"
+			dim u as ustring = !"\u0061\u0062\u0063\u0064\u0065"
+
+			CU_ASSERT( len( !"\u0061\u0062\u0063\u0064\u0065" ) = 5)
+			CU_ASSERT( len(z) = 5)
+			CU_ASSERT( len(u) = len(z) )
+		end scope
+
+		'' initialize from STRING const
+		scope
+			const LIT_A = "abcdefghij"
+
+			dim a as string = LIT_A
+			dim z as zstring * 50 = LIT_A
+			dim u as ustring = LIT_A
+
+			CU_ASSERT( len(LIT_A) = 10 )
+			CU_ASSERT( len(a) = len(LIT_A) )
+			CU_ASSERT( len(z) = len(a) )
+			CU_ASSERT( len(u) = len(z) )
+			CU_ASSERT( u = z )
+		end scope
+
+		'' initialize from WSTRING const
+		scope
+			const LIT_W = !"\u0061\u0062\u0063\u0064\u0065"
+
+			dim z as zstring * 50 = LIT_W
+			dim u as ustring = LIT_W
+
+			CU_ASSERT( len(LIT_W) = 5 )
+			CU_ASSERT( len(z) = len(LIT_W) )
+			CU_ASSERT( len(u) = len(z) )
+			CU_ASSERT( u = z )
+		end scope
+
+		'' initialize from STRING variable
+		scope
+			dim a as string = "abcdefghij"
+			dim z as zstring * 50 = a
+			dim u as ustring = a
+
+			CU_ASSERT( len(a) = 10 )
+			CU_ASSERT( len(z) = len(a) )
+			CU_ASSERT( len(u) = len(z) )
+			CU_ASSERT( u = z )
+		end scope
+
+		'' initialize from WSTRING variable
+		scope
+			dim w as wstring * 20 = !"\u0061\u0062\u0063\u0064\u0065"
+			dim z as zstring * 50 = w
+			dim u as ustring = w
+
+			CU_ASSERT( len(z) = 5 )
+			CU_ASSERT( len(u) = len(z) )
+			CU_ASSERT( u = z )
+		end scope
+
+	END_TEST
+
+END_SUITE

--- a/tests/udt-zstring/uzstring-fixed.bas
+++ b/tests/udt-zstring/uzstring-fixed.bas
@@ -1,21 +1,53 @@
 #include "fbcunit.bi"
 #include once "uzstring-fixed.bi"
 
-'' reference implementation of fixed length UDT wstring
+'' reference implementation of fixed length UDT zstring
+
+'' -------------------
+'' UZSTRING_FIXED_BASE
+'' -------------------
 
 ''
-constructor UZSTRING_FIXED()
+constructor UZSTRING_FIXED_BASE()
 	_data = ""
 end constructor
 
 ''
-constructor UZSTRING_FIXED( byval s as const zstring const ptr )
+constructor UZSTRING_FIXED_BASE( byval s as const zstring const ptr )
 	_data = *s
 end constructor
 
 ''
-constructor UZSTRING_FIXED( byval s as const wstring const ptr )
+constructor UZSTRING_FIXED_BASE( byval s as const wstring const ptr )
 	_data = str( *s )
+end constructor
+
+''
+const function UZSTRING_FIXED_BASE.length() as integer
+	function = len( _data )
+end function
+
+''
+operator Len( byref s as const UZSTRING_FIXED_BASE ) as integer
+	return s.Length()
+end operator
+
+'' --------------
+'' UZSTRING_FIXED
+'' --------------
+
+''
+constructor UZSTRING_FIXED()
+end constructor
+
+''
+constructor UZSTRING_FIXED( byval s as const wstring const ptr )
+	base( s )
+end constructor
+
+''
+constructor UZSTRING_FIXED( byval s as const zstring const ptr )
+	base( s )
 end constructor
 
 ''
@@ -23,11 +55,26 @@ operator UZSTRING_FIXED.Cast() byref as const zstring
 	operator = *cast(zstring ptr, @_data)
 end operator
 
-const function UZSTRING_FIXED.length() as integer
-	function = len( _data )
-end function
+
+'' ----------------------
+'' UZSTRING_FIXED_MUTABLE
+'' ----------------------
 
 ''
-operator Len( byref s as const UZSTRING_FIXED ) as integer
-	return s.Length()
+constructor UZSTRING_FIXED_MUTABLE()
+end constructor
+
+''
+constructor UZSTRING_FIXED_MUTABLE( byval s as const wstring const ptr )
+	base( s )
+end constructor
+
+''
+constructor UZSTRING_FIXED_MUTABLE( byval s as const zstring const ptr )
+	base( s )
+end constructor
+
+''
+operator UZSTRING_FIXED_MUTABLE.Cast() byref as zstring
+	operator = *cast(zstring ptr, @_data)
 end operator

--- a/tests/udt-zstring/uzstring-fixed.bas
+++ b/tests/udt-zstring/uzstring-fixed.bas
@@ -1,0 +1,33 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+
+'' reference implementation of fixed length UDT wstring
+
+''
+constructor UZSTRING_FIXED()
+	_data = ""
+end constructor
+
+''
+constructor UZSTRING_FIXED( byval s as const zstring const ptr )
+	_data = *s
+end constructor
+
+''
+constructor UZSTRING_FIXED( byval s as const wstring const ptr )
+	_data = str( *s )
+end constructor
+
+''
+operator UZSTRING_FIXED.Cast() byref as const zstring
+	operator = *cast(zstring ptr, @_data)
+end operator
+
+const function UZSTRING_FIXED.length() as integer
+	function = len( _data )
+end function
+
+''
+operator Len( byref s as const UZSTRING_FIXED ) as integer
+	return s.Length()
+end operator

--- a/tests/udt-zstring/uzstring-fixed.bi
+++ b/tests/udt-zstring/uzstring-fixed.bi
@@ -1,0 +1,19 @@
+#pragma once
+
+'' reference implementation of fixed length UDT wstring
+
+type UZSTRING_FIXED extends zstring
+
+	private:
+		_data as zstring * 256
+
+	public:
+		declare constructor()
+		declare constructor( byval rhs as const zstring const ptr )
+		declare constructor( byval rhs as const wstring const ptr )
+		declare operator cast() byref as const zstring
+		declare const function length() as integer
+
+end type
+
+declare operator Len( byref s as const UZSTRING_FIXED ) as integer

--- a/tests/udt-zstring/uzstring-fixed.bi
+++ b/tests/udt-zstring/uzstring-fixed.bi
@@ -1,19 +1,38 @@
 #pragma once
 
-'' reference implementation of fixed length UDT wstring
+'' reference implementation of fixed length UDT zstring
 
-type UZSTRING_FIXED extends zstring
+type UZSTRING_FIXED_BASE extends zstring
 
-	private:
+	protected:
 		_data as zstring * 256
 
 	public:
 		declare constructor()
 		declare constructor( byval rhs as const zstring const ptr )
 		declare constructor( byval rhs as const wstring const ptr )
-		declare operator cast() byref as const zstring
 		declare const function length() as integer
 
 end type
 
-declare operator Len( byref s as const UZSTRING_FIXED ) as integer
+declare operator Len( byref s as const UZSTRING_FIXED_BASE ) as integer
+
+type UZSTRING_FIXED extends UZSTRING_FIXED_BASE
+
+	public:
+		declare constructor()
+		declare constructor( byval rhs as const wstring const ptr )
+		declare constructor( byval rhs as const zstring const ptr )
+
+		declare operator cast() byref as const zstring
+end type
+
+type UZSTRING_FIXED_MUTABLE extends UZSTRING_FIXED_BASE
+
+	public:
+		declare constructor()
+		declare constructor( byval rhs as const wstring const ptr )
+		declare constructor( byval rhs as const zstring const ptr )
+
+		declare operator cast() byref as zstring
+end type

--- a/tests/udt-zstring/wstr.bas
+++ b/tests/udt-zstring/wstr.bas
@@ -1,0 +1,122 @@
+#include "fbcunit.bi"
+#include once "uzstring-fixed.bi"
+#include once "chk-zstring.bi"
+
+#define ustring UZSTRING_FIXED
+
+SUITE( fbc_tests.udt_zstring_.wstr_ )
+
+	#macro check( dtype, value )
+	
+		scope
+			dim t as dtype = value
+			dim w as zstring * 50 = wstr( t )
+			dim u as ustring = wstr( t )
+			dim r as zstring * 50 = u
+			CU_ASSERT_ZSTRING_EQUAL( w, r )
+		end scope
+
+	#endmacro
+
+	TEST( numeric )
+
+		check( byte, -128 )
+		check( byte, -0 )
+		check( byte, 127 )
+
+		check( ubyte, 0 )
+		check( ubyte, 128 )
+		check( ubyte, 255 )
+
+		check( short, -32768 )
+		check( short, 0 )
+		check( short, 32767 )
+
+		check( ushort, 0 )
+		check( ushort, 32768 )
+		check( ushort, 65535 )
+
+		check( long, -2147483648ll )
+		check( long, 0 )
+		check( long, 2147483647ull )
+
+		check( ulong, 0 )
+		check( ulong, 2147483648ull )
+		check( ulong, 4294967295ull )
+
+		check( longint, (-9223372036854775807ll-1ll) )
+		check( longint, 0 )
+		check( longint, 9223372036854775807ull )
+
+		check( ulongint, 0 )
+		check( ulongint, 9223372036854775808ull )
+		check( ulongint, 18446744073709551615ull )
+
+		check( single, -1.5 )
+		check( single, -1.0 )
+		check( single, -1.0 )
+		check( single, -0.5 )
+		check( single,  0.0 )
+		check( single,  0.5 )
+		check( single,  1.0)
+		check( single,  1.5 )
+		check( single,  2.0 )
+		check( single,  2.5 )
+
+		check( double, -1.5 )
+		check( double, -1.0 )
+		check( double, -1.0 )
+		check( double, -0.5 )
+		check( double,  0.0 )
+		check( double,  0.5 )
+		check( double,  1.0)
+		check( double,  1.5 )
+		check( double,  2.0 )
+		check( double,  2.5 )
+
+	END_TEST
+
+	TEST( default )
+		
+		dim s1 as zstring * 10 = wchr(65)
+		dim s2 as zstring * 10 = wchr(65)
+		dim s3 as zstring * 10 = wstr( s1 )
+
+		dim u1 as ustring = wchr(65)
+		dim u2 as ustring = wchr(65)
+		dim u3 as ustring = wstr( s1 )
+		dim u4 as ustring = wstr( u1 )
+
+		dim s4 as zstring * 10 = str( u1 )
+
+		dim r1 as zstring * 10 = u1
+		dim r2 as zstring * 10 = u2
+		dim r3 as zstring * 10 = u3
+		dim r4 as zstring * 10 = u4
+
+		#macro check_group( g )
+
+			CU_ASSERT_ZSTRING_EQUAL( g, s1 )
+			CU_ASSERT_ZSTRING_EQUAL( g, s2 )
+			CU_ASSERT_ZSTRING_EQUAL( g, s3 )
+			CU_ASSERT_ZSTRING_EQUAL( g, s4 )
+
+			CU_ASSERT_ZSTRING_EQUAL( g, r1 )
+			CU_ASSERT_ZSTRING_EQUAL( g, r2 )
+			CU_ASSERT_ZSTRING_EQUAL( g, r3 )
+			CU_ASSERT_ZSTRING_EQUAL( g, r4 )
+
+		#endmacro
+
+		check_group( s1 )
+		check_group( s2 )
+		check_group( s3 )
+		check_group( s4 )
+		check_group( r1 )
+		check_group( r2 )
+		check_group( r3 )
+		check_group( r4 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/wstring/asc.bas
+++ b/tests/wstring/asc.bas
@@ -19,4 +19,40 @@ SUITE( fbc_tests.wstring_.asc_ )
 		
 	END_TEST
 
+	TEST( ascii )
+		dim w as wstring * 256
+		for i as integer = 1 to 255
+			w[i-1] = i
+		next
+		
+		CU_ASSERT_EQUAL( 1, asc( w ) )
+
+		for i as integer = -2 to 257
+			select case i
+			case 1 to 255
+				CU_ASSERT_EQUAL( i, asc( w, i ) )
+			case else
+				CU_ASSERT_EQUAL( 0, asc( w, i ) )
+			end select
+		next
+	END_TEST
+
+	TEST( ucs2 )
+		dim w as wstring * 256
+		for i as integer = 1 to 255
+			w[i-1] = i shl 8
+		next
+
+		CU_ASSERT_EQUAL( 256, asc( w ) )
+
+		for i as integer = -2 to 257
+			select case i
+			case 1 to 255
+				CU_ASSERT_EQUAL( w[i-1], asc( w, i ) )
+			case else
+				CU_ASSERT_EQUAL( 0, asc( w, i ) )
+			end select
+		next
+	END_TEST
+
 END_SUITE

--- a/tests/wstring/iif.bas
+++ b/tests/wstring/iif.bas
@@ -1,0 +1,69 @@
+#include "fbcunit.bi"
+#include once "chk-wstring.bi"
+
+SUITE( fbc_tests.wstring_.iif_ )
+
+	#macro check( expr, true_expr, false_expr )
+		scope
+			dim t1 as wstring * 50 = true_expr
+			dim t2 as wstring * 50 = false_expr
+
+			scope
+				dim a as wstring * 50 = iif( expr, true_expr, false_expr )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			scope
+				dim a as wstring * 50 = iif( expr, t1, false_expr )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			scope
+				dim a as wstring * 50 = iif( expr, true_expr, t2 )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+			scope
+				dim a as wstring * 50 = iif( expr, t1, t2 )
+				if( expr ) then
+					CU_ASSERT_WSTRING_EQUAL( a, t1 )
+				else
+					CU_ASSERT_WSTRING_EQUAL( a, t2 )
+				endif
+			end scope
+
+		end scope
+	#endmacro
+
+	TEST( default )
+		
+		check(  0, "", "a" )
+		check( -1, "", "a" )
+
+		check(  0, "a", "xyz" )
+		check( -1, "a", "xyz" )
+
+		check(  0, !"\u3041\u3043\u3045", "a" )
+		check( -1, !"\u3041\u3043\u3045", "a" )
+
+		check(  0, "a", !"\u3041\u3043\u3045" )
+		check( -1, "a", !"\u3041\u3043\u3045" )
+
+		check(  0, !"\u3047", !"\u3041\u3043\u3045" )
+		check( -1, !"\u3047", !"\u3041\u3043\u3045" )
+
+	END_TEST
+
+END_SUITE

--- a/tests/wstring/lrset.bas
+++ b/tests/wstring/lrset.bas
@@ -1,0 +1,90 @@
+#include "fbcunit.bi"
+#include once "chk-wstring.bi"
+
+SUITE( fbc_tests.wstring_.lrset )
+
+	#macro check_lset( dst, src, length1, length2 )
+		scope
+			'' lset/rset
+			dim w1 as wstring * 50 = left( dst, (length1) )
+			dim w2 as wstring * 50 = left( src, (length2) )
+			dim e1 as wstring * 50
+
+			if( (length1) > (length2) ) then
+				e1 = (w2) & wspace( (length1) - (length2) )
+			else
+				e1 = left( w2, (length1) )
+			end if
+
+			CU_ASSERT( len(e1) = (length1) )
+
+			'' wstring are zero terminated and length
+			'' is determined from the string data
+			lset (w1) = (w2)
+			CU_ASSERT_WSTRING_EQUAL( w1, e1 )
+		end scope
+	#endmacro
+
+	#macro check_rset( dst, src, length1, length2 )
+		scope
+			'' lset/rset
+			dim w1 as wstring * 50 = left( dst, (length1) )
+			dim w2 as wstring * 50 = left( src, (length2) )
+			dim e1 as wstring * 50
+
+			if( (length1) > (length2) ) then
+				e1 = wspace( (length1) - (length2) ) & (w2)
+			else
+				e1 = left( w2, (length1) )
+			end if
+
+			CU_ASSERT( len(e1) = (length1) )
+
+			'' wstring are zero terminated and length
+			'' is determined from the string data
+			rset (w1) = (w2)
+			CU_ASSERT_WSTRING_EQUAL( w1, e1 )
+		end scope
+	#endmacro
+
+	TEST( ascii )
+
+		const MAX = 8
+		dim dst as wstring * (MAX+1)
+		dim src as wstring * (MAX+1)
+
+		dst = "12345678"
+		src = "ABCDEFGH"
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+
+				check_lset( dst, src, i1, i2 )
+				check_rset( dst, src, i1, i2 )
+
+			next i2
+		next i1
+
+	END_TEST
+
+	TEST( ucs2 )
+
+		const MAX = 5
+		dim dst as wstring * (MAX+1)
+		dim src as wstring * (MAX+1)
+
+		dst = !"\u3041\u3043\u3045\u3047\u3049"
+		src = !"\u3042\u3044\u3046\u3048\u3050"
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+
+				check_lset( dst, src, i1, i2 )
+				check_rset( dst, src, i1, i2 )
+
+			next i2
+		next i1
+
+	END_TEST
+
+END_SUITE

--- a/tests/wstring/ltrim.bas
+++ b/tests/wstring/ltrim.bas
@@ -3,9 +3,9 @@
 
 SUITE( fbc_tests.wstring_.ltrim_ )
 
-	#macro check( a, length, expected )
+	#macro check( text, length, expected )
 		scope
-			dim wr as wstring * 50 = ltrim( wstr(a) )
+			dim wr as wstring * 50 = ltrim( wstr(text) )
 			dim we as wstring * 50 = wstr( expected )
 
 			CU_ASSERT( len(wr) = length )
@@ -13,38 +13,18 @@ SUITE( fbc_tests.wstring_.ltrim_ )
 		end scope
 
 		scope
-			dim wa as wstring * 50 = wstr(a)
+			dim wt as wstring * 50 = wstr( text )
 			dim we as wstring * 50 = wstr( expected )
-			dim wr as wstring * 50 = ltrim( wa )
-
-			CU_ASSERT( len(wr) = length )
-			CU_ASSERT_WSTRING_EQUAL( wr, we )
-		end scope
-	#endmacro
-
-	#macro check_filter( a, filter, length, expected )
-		scope
-			dim wr as wstring * 50 = ltrim( wstr(a), wstr(filter) )
-			dim we as wstring * 50 = wstr( expected )
-
-			CU_ASSERT( len(wr) = length )
-			CU_ASSERT_WSTRING_EQUAL( wr, we )
-		end scope
-
-		scope
-			dim wa as wstring * 50 = wstr(a)
-			dim wf as wstring * 50 = wstr(filter)
-			dim wr as wstring * 50 = ltrim( wa, wf )
-			dim we as wstring * 50 = wstr( expected )
+			dim wr as wstring * 50 = ltrim( wt )
 
 			CU_ASSERT( len(wr) = length )
 			CU_ASSERT_WSTRING_EQUAL( wr, we )
 		end scope
 	#endmacro
 
-	#macro check_filter_any( a, filter, length, expected )
+	#macro check_filter( text, pattern, length, expected )
 		scope
-			dim wr as wstring * 50 = ltrim( wstr(a), any wstr(filter) )
+			dim wr as wstring * 50 = ltrim( wstr(text), wstr(pattern) )
 			dim we as wstring * 50 = wstr( expected )
 
 			CU_ASSERT( len(wr) = length )
@@ -52,9 +32,29 @@ SUITE( fbc_tests.wstring_.ltrim_ )
 		end scope
 
 		scope
-			dim wa as wstring * 50 = wstr(a)
-			dim wf as wstring * 50 = wstr(filter)
-			dim wr as wstring * 50 = ltrim( wa, any wf )
+			dim wt as wstring * 50 = wstr( text )
+			dim wf as wstring * 50 = wstr( pattern )
+			dim wr as wstring * 50 = ltrim( wt, wf )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
+
+	#macro check_filter_any( text, pattern, length, expected )
+		scope
+			dim wr as wstring * 50 = ltrim( wstr(text), any wstr(pattern) )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+
+		scope
+			dim wt as wstring * 50 = wstr( text )
+			dim wf as wstring * 50 = wstr( pattern )
+			dim wr as wstring * 50 = ltrim( wt, any wf )
 			dim we as wstring * 50 = wstr( expected )
 
 			CU_ASSERT( len(wr) = length )

--- a/tests/wstring/midfunc.bas
+++ b/tests/wstring/midfunc.bas
@@ -1,0 +1,182 @@
+#include "fbcunit.bi"
+#include once "chk-wstring.bi"
+
+SUITE( fbc_tests.wstring_.midfunc )
+
+	#macro check( text, start, expected )
+		scope
+			dim wr as wstring * 50 = mid( wstr(text), start )
+			dim we as wstring * 50 = wstr( expected )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+
+		scope
+			dim wt as wstring * 50 = wstr( text )
+			dim we as wstring * 50 = wstr( expected )
+			dim wr as wstring * 50 = mid( wt, start )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
+
+	#macro check_i_n( text, start, length, expected )
+		scope
+			dim wr as wstring * 50 = mid( wstr(text), start, length )
+			dim we as wstring * 50 = wstr( expected )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+
+		scope
+			dim wt as wstring * 50 = wstr( text )
+			dim we as wstring * 50 = wstr( expected )
+			dim wr as wstring * 50 = mid( wt, start, length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
+
+	TEST( default )
+		check( ""       , -1, "" )
+		check( ""       ,  0, "" )
+		check( ""       ,  1, "" )
+
+		check( "a"      , -1, "" )
+		check( "a"      ,  0, "" )
+		check( "a"      ,  1, "a" )
+		check( "a"      ,  2, "" )
+
+		check( "ab"     , -1, "" )
+		check( "ab"     ,  0, "" )
+		check( "ab"     ,  1, "ab" )
+		check( "ab"     ,  2, "b" )
+		check( "ab"     ,  3, "" )
+
+		check( "abc"    , -1, "" )
+		check( "abc"    ,  0, "" )
+		check( "abc"    ,  1, "abc" )
+		check( "abc"    ,  2, "bc" )
+		check( "abc"    ,  3, "c" )
+		check( "abc"    ,  4, "" )
+
+		check( !"\u3041", -1, !"" )
+		check( !"\u3041",  0, !"" )
+		check( !"\u3041",  1, !"\u3041" )
+		check( !"\u3041",  2, !"" )
+
+		check( !"\u3041\u3043", -1, !"" )
+		check( !"\u3041\u3043",  0, !"" )
+		check( !"\u3041\u3043",  1, !"\u3041\u3043" )
+		check( !"\u3041\u3043",  2, !"\u3043" )
+		check( !"\u3041\u3043",  3, !"" )
+
+		check( !"\u3041\u3043\u3045", -1, !"" )
+		check( !"\u3041\u3043\u3045",  0, !"" )
+		check( !"\u3041\u3043\u3045",  1, !"\u3041\u3043\u3045" )
+		check( !"\u3041\u3043\u3045",  2, !"\u3043\u3045" )
+		check( !"\u3041\u3043\u3045",  3, !"\u3045" )
+		check( !"\u3041\u3043\u3045",  4, !"" )
+	END_TEST
+
+	TEST( length )
+		check_i_n( ""       , -1, -1, "" )
+		check_i_n( ""       , -1,  0, "" )
+		check_i_n( ""       , -1,  1, "" )
+
+		check_i_n( ""       ,  0, -1, "" )
+		check_i_n( ""       ,  0,  0, "" )
+		check_i_n( ""       ,  0,  1, "" )
+
+		check_i_n( ""       ,  1, -1, "" )
+		check_i_n( ""       ,  1,  0, "" )
+		check_i_n( ""       ,  1,  1, "" )
+
+		check_i_n( "a"      , -1, -1, "" )
+		check_i_n( "a"      , -1,  0, "" )
+		check_i_n( "a"      , -1,  1, "" )
+		check_i_n( "a"      , -1,  2, "" )
+
+		check_i_n( "a"      ,  0, -1, "" )
+		check_i_n( "a"      ,  0,  0, "" )
+		check_i_n( "a"      ,  0,  1, "" )
+		check_i_n( "a"      ,  0,  2, "" )
+
+		check_i_n( "a"      ,  1, -1, "a" )
+		check_i_n( "a"      ,  1,  0, "" )
+		check_i_n( "a"      ,  1,  1, "a" )
+		check_i_n( "a"      ,  1,  2, "a" )
+
+		check_i_n( "a"      ,  2, -1, "" )
+		check_i_n( "a"      ,  2,  0, "" )
+		check_i_n( "a"      ,  2,  1, "" )
+		check_i_n( "a"      ,  2,  2, "" )
+
+		check_i_n( "ab"     ,  1, -2, "ab" )
+		check_i_n( "ab"     ,  1, -1, "ab" )
+		check_i_n( "ab"     ,  1,  0, "" )
+		check_i_n( "ab"     ,  1,  1, "a" )
+		check_i_n( "ab"     ,  1,  2, "ab" )
+		check_i_n( "ab"     ,  1,  3, "ab" )
+
+		check_i_n( "ab"     ,  2, -2, "b" )
+		check_i_n( "ab"     ,  2, -1, "b" )
+		check_i_n( "ab"     ,  2,  0, "" )
+		check_i_n( "ab"     ,  2,  1, "b" )
+		check_i_n( "ab"     ,  2,  2, "b" )
+		check_i_n( "ab"     ,  2,  3, "b" )
+
+		check_i_n( "ab"     ,  3, -2, "" )
+		check_i_n( "ab"     ,  3, -1, "" )
+		check_i_n( "ab"     ,  3,  0, "" )
+		check_i_n( "ab"     ,  3,  1, "" )
+		check_i_n( "ab"     ,  3,  2, "" )
+		check_i_n( "ab"     ,  3,  3, "" )
+
+		check_i_n( !"\u3041\u3043\u3045", -1, -2, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1, -1, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  1, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  2, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  3, !"" )
+		check_i_n( !"\u3041\u3043\u3045", -1,  4, !"" )
+
+		check_i_n( !"\u3041\u3043\u3045",  0, -2, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0, -1, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  1, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  2, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  3, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  0,  4, !"" )
+
+		check_i_n( !"\u3041\u3043\u3045",  1, -2, !"\u3041\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  1, -1, !"\u3041\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  1, !"\u3041" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  2, !"\u3041\u3043" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  3, !"\u3041\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  1,  4, !"\u3041\u3043\u3045" )
+
+		check_i_n( !"\u3041\u3043\u3045",  2, -2, !"\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  2, -1, !"\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  1, !"\u3043" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  2, !"\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  3, !"\u3043\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  2,  4, !"\u3043\u3045" )
+
+		check_i_n( !"\u3041\u3043\u3045",  3, -2, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3, -1, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  1, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  2, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  3, !"\u3045" )
+		check_i_n( !"\u3041\u3043\u3045",  3,  4, !"\u3045" )
+
+		check_i_n( !"\u3041\u3043\u3045",  4, -1, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  0, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  1, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  2, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  3, !"" )
+		check_i_n( !"\u3041\u3043\u3045",  4,  4, !"" )
+
+	END_TEST
+
+
+END_SUITE

--- a/tests/wstring/midstmt.bas
+++ b/tests/wstring/midstmt.bas
@@ -1,0 +1,134 @@
+#include "fbcunit.bi"
+#include once "chk-wstring.bi"
+
+#define BUFFERSIZE 50
+
+'' fixed length strings are not cleared
+'' and the garbage in the buffer will affect the tests
+#macro INIT_FIXED_STRING( s, dtype, size, value )
+	dim s as dtype * size
+	clear @s, 0, sizeof(s)
+	s = value
+#endmacro
+
+SUITE( fbc_tests.wstring_.midstmt )
+
+	#macro check_mid_start( dst, start, src, length1, length2 )
+		scope
+			INIT_FIXED_STRING( w1, wstring, BUFFERSIZE, left( dst, (length1) ) )
+			INIT_FIXED_STRING( w2, wstring, BUFFERSIZE, left( src, (length2) ) )
+			INIT_FIXED_STRING( e1, wstring, BUFFERSIZE, w1 )
+			dim n1 as integer = 50 '' len(w1)
+			dim n2 as integer = len(w2)
+			dim idx1 as integer = start
+			dim idx2 as integer = 1
+
+			'' compute the expected string
+			if( (n1 > 0) and (start >= 1) and (start <= n1) ) then
+				while( idx1 >= 1 and idx1 <= n1 and idx2 >= 1 and idx2 <= n2 )
+					e1[idx1-1] = w2[idx2-1]
+					idx1 += 1
+					idx2 += 1
+				wend
+				e1[n1] = 0
+			end if
+
+			mid( w1, start ) = w2
+
+			CU_ASSERT_WSTRING_EQUAL( w1, e1 )
+		end scope
+	#endmacro
+
+	#macro check_mid_start_n( dst, start, length, src, length1, length2 )
+		scope
+			INIT_FIXED_STRING( w1, wstring, BUFFERSIZE, left( dst, (length1) ) )
+			INIT_FIXED_STRING( w2, wstring, BUFFERSIZE, left( src, (length2) ) )
+			INIT_FIXED_STRING( e1, wstring, BUFFERSIZE, w1 )
+			dim n1 as integer = BUFFERSIZE '' len(w1)
+			dim n2 as integer = len(w2)
+			dim idx1 as integer = start
+			dim idx2 as integer = 1
+			dim n as integer = 0
+
+			'' compute the expected string
+			if( (n1 > 0) and (start >= 1) and (start <= n1) ) then
+				while( idx1 >= 1 and idx1 <= n1 and idx2 >= 1 and idx2 <= n2 and (n < length or length < 1) )
+					e1[idx1-1] = w2[idx2-1]
+					idx1 += 1
+					idx2 += 1
+					n += 1
+				wend
+				e1[n1] = 0
+			end if
+
+			mid( w1, start, length ) = w2
+
+			CU_ASSERT_WSTRING_EQUAL( w1, e1 )
+		end scope
+	#endmacro
+
+	TEST( ascii )
+		const MAX = 8
+
+		#define def_dst "12345678"
+		#define def_src "ABCDEFGH"
+
+		dim dst as wstring * (MAX*2+1)
+		dim src as wstring * (MAX*2+1)
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+				for istart as integer = -2 to MAX+2
+
+					dst = def_src
+					src = def_dst
+
+					check_mid_start( dst, istart, src, i1, i2 )
+
+					for length as integer = -2 to MAX+2
+
+						dst = def_src
+						src = def_dst
+
+						check_mid_start_n( dst, istart, length, src, i1, i2 )
+					next
+
+				next
+			next i2
+		next i1
+
+	END_TEST
+
+	TEST( ucs2 )
+		const MAX = 5
+
+		#define def_dst !"\u3041\u3043\u3045\u3047\u3049"
+		#define def_src !"\u3042\u3044\u3046\u3048\u3050"
+
+		dim dst as wstring * (MAX*2+1)
+		dim src as wstring * (MAX*2+1)
+
+		for i1 as integer = 0 to MAX
+			for i2 as integer = 0 to MAX
+				for istart as integer = -1 to MAX+2
+
+					dst = def_src
+					src = def_dst
+
+					check_mid_start( dst, istart, src, i1, i2 )
+
+					for length as integer = -2 to MAX+2
+
+						dst = def_src
+						src = def_dst
+
+						check_mid_start_n( dst, istart, length, src, i1, i2 )
+					next
+
+				next
+			next i2
+		next i1
+
+	END_TEST
+
+END_SUITE

--- a/tests/wstring/strptr.bas
+++ b/tests/wstring/strptr.bas
@@ -1,0 +1,48 @@
+#include "fbcunit.bi"
+#include once "chk-wstring.bi"
+
+SUITE( fbc_tests.wstring_.strptr_ )
+
+	TEST( deref )
+		dim s1 as wstring * 50 = "1234"
+		dim s2 as wstring * 50 = s1
+
+		dim as wstring ptr p1 = @s1
+		CU_ASSERT( p1 <> strptr( s2 ) )
+
+		CU_ASSERT_WSTRING_EQUAL( s1, s2 )
+		CU_ASSERT_WSTRING_EQUAL( (*p1), s2 )
+
+	END_TEST
+
+	TEST( ptr_size )
+
+		dim s1 as wstring * 50 = "1234"
+
+		scope
+			dim as wstring ptr p1 = strptr(s1)
+			dim as wstring ptr p2 = (strptr(s1) + 1)
+			CU_ASSERT_EQUAL( cint(p2) - cint(p1), sizeof( wstring ) )
+		end scope
+
+		scope
+			dim as wstring ptr p1 = strptr(s1)
+			dim as wstring ptr p2 = @(strptr(s1)[1])
+			CU_ASSERT_EQUAL( cint(p2) - cint(p1), sizeof( wstring ) )
+		end scope
+
+		scope
+			dim as wstring ptr p1 = sadd(s1)
+			dim as wstring ptr p2 = (sadd(s1) + 1)
+			CU_ASSERT_EQUAL( cint(p2) - cint(p1), sizeof( wstring ) )
+		end scope
+
+		scope
+			dim as wstring ptr p1 = sadd(s1)
+			dim as wstring ptr p2 = @(sadd(s1)[1])
+			CU_ASSERT_EQUAL( cint(p2) - cint(p1), sizeof( wstring ) )
+		end scope
+
+	END_TEST
+		
+END_SUITE

--- a/tests/wstring/swap.bas
+++ b/tests/wstring/swap.bas
@@ -1,0 +1,42 @@
+#include "fbcunit.bi"
+#include once "chk-wstring.bi"
+
+SUITE( fbc_tests.wstring_.swap_ )
+
+	#macro check( literal1, literal2 )
+		scope
+			dim w1 as wstring * 50 = literal1
+			dim w2 as wstring * 50 = literal2
+
+			dim t1 as wstring * 50 = literal1
+			dim t2 as wstring * 50 = literal2
+
+			CU_ASSERT_WSTRING_EQUAL( w1, t1 )
+			CU_ASSERT_WSTRING_EQUAL( w2, t2 )
+
+			swap w1, w2
+
+			CU_ASSERT_WSTRING_EQUAL( w1, t2 )
+			CU_ASSERT_WSTRING_EQUAL( w2, t1 )
+
+			swap w2, w1
+
+			CU_ASSERT_WSTRING_EQUAL( w1, t1 )
+			CU_ASSERT_WSTRING_EQUAL( w2, t2 )
+		end scope
+	#endmacro
+
+	TEST( default )
+		check( "", "" )
+
+		check( "", "a" )
+		check( "a", "a" )
+		check( "a", "abcdefghi" )
+
+		check( "", !"\u3041\u3043\u3045\u3047\u3049" )
+		check( "abc", !"\u3041\u3043\u3045\u3047\u3049" )
+		check( !"\u3045", !"\u3041\u3043\u3047\u3049" )
+
+	END_TEST
+
+END_SUITE

--- a/tests/wstring/trim.bas
+++ b/tests/wstring/trim.bas
@@ -3,9 +3,9 @@
 
 SUITE( fbc_tests.wstring_.trim_ )
 
-	#macro check( a, length, expected )
+	#macro check( text, length, expected )
 		scope
-			dim wr as wstring * 50 = trim( wstr(a) )
+			dim wr as wstring * 50 = trim( wstr(text) )
 			dim we as wstring * 50 = wstr( expected )
 
 			CU_ASSERT( len(wr) = length )
@@ -13,38 +13,18 @@ SUITE( fbc_tests.wstring_.trim_ )
 		end scope
 
 		scope
-			dim wa as wstring * 50 = wstr(a)
+			dim wt as wstring * 50 = wstr( text )
 			dim we as wstring * 50 = wstr( expected )
-			dim wr as wstring * 50 = trim( wa )
-
-			CU_ASSERT( len(wr) = length )
-			CU_ASSERT_WSTRING_EQUAL( wr, we )
-		end scope
-	#endmacro
-
-	#macro check_filter( a, filter, length, expected )
-		scope
-			dim wr as wstring * 50 = trim( wstr(a), wstr(filter) )
-			dim we as wstring * 50 = wstr( expected )
-
-			CU_ASSERT( len(wr) = length )
-			CU_ASSERT_WSTRING_EQUAL( wr, we )
-		end scope
-
-		scope
-			dim wa as wstring * 50 = wstr(a)
-			dim wf as wstring * 50 = wstr(filter)
-			dim wr as wstring * 50 = trim( wa, wf )
-			dim we as wstring * 50 = wstr( expected )
+			dim wr as wstring * 50 = trim( wt )
 
 			CU_ASSERT( len(wr) = length )
 			CU_ASSERT_WSTRING_EQUAL( wr, we )
 		end scope
 	#endmacro
 
-	#macro check_filter_any( a, filter, length, expected )
+	#macro check_filter( text, pattern, length, expected )
 		scope
-			dim wr as wstring * 50 = trim( wstr(a), any wstr(filter) )
+			dim wr as wstring * 50 = trim( wstr(text), wstr(pattern) )
 			dim we as wstring * 50 = wstr( expected )
 
 			CU_ASSERT( len(wr) = length )
@@ -52,9 +32,29 @@ SUITE( fbc_tests.wstring_.trim_ )
 		end scope
 
 		scope
-			dim wa as wstring * 50 = wstr(a)
-			dim wf as wstring * 50 = wstr(filter)
-			dim wr as wstring * 50 = trim( wa, any wf )
+			dim wt as wstring * 50 = wstr( text )
+			dim wf as wstring * 50 = wstr( pattern )
+			dim wr as wstring * 50 = trim( wt, wf )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+	#endmacro
+
+	#macro check_filter_any( text, pattern, length, expected )
+		scope
+			dim wr as wstring * 50 = trim( wstr(text), any wstr(pattern) )
+			dim we as wstring * 50 = wstr( expected )
+
+			CU_ASSERT( len(wr) = length )
+			CU_ASSERT_WSTRING_EQUAL( wr, we )
+		end scope
+
+		scope
+			dim wt as wstring * 50 = wstr( text )
+			dim wf as wstring * 50 = wstr( pattern )
+			dim wr as wstring * 50 = trim( wt, any wf )
 			dim we as wstring * 50 = wstr( expected )
 
 			CU_ASSERT( len(wr) = length )


### PR DESCRIPTION
Allow a user defined type (UDT) to inherit properties and behaviours of a zstring or wstring by extending existing syntax.  Purpose is to allow users to create custom string types (i.e. dynamic memory management) that can integrate well in to existing fbc compiler built ins. 

New Syntax:
```
type UDT extends zstring|wstring [, base-type]
end type
```

In places where fbc compiler would have normally rejected a UDT, this declaration of a UDT will instruct compiler to convert the UDT to a `z|wstring` through a suitable `CAST` operator.

`zstring|wstring` behaviour can be inherited directly from `zstring|wstring`, or indirectly and singly from the base type:
```
type B extends wstring
	'' member data
	'' inherits from wstring
end type

type D extends B
	'' D inherits from B and wstring
end type
```
Or `zstring|wstring` behaviours can also be inherited in a UDT with a kind of pseudo multiple-inheritance:
```
type B
	'' member data
end type

type D extends wstring, B
	'' D inherits from B and wstring
end type
```

Changed:
- SADD/STRPTR(wstring) returns WSTRING PTR

Added:
- 'TYPE udt EXTENDS Z|WSTRING' allowed to specify that UDT is a kind of Z|WSTRING
- LTRIM/RTRIM/TRIM will accept UDT as Z|WSTRING
- LCASE/UCASE will accept UDT as Z|WSTRING
- Cxxx() conversion functions will accept UDT as Z|WSTRING
- INSTR/INSTRREV will accept UDT as Z|WSTRING
- MID function will accept UDT as Z|WSTRING
- SADD/STRPTR will accept UDT as Z|WSTRING to return Z|WSTRING ptr
- LSET/RSET statements will accept UDT as Z|WSTRING
- MID statement will accept UDT as Z|WSTRING
- ASC function will accept UDT as Z|WSTRING
- STR/WSTR function will accept UDT as Z|WSTRING to return a Z|WSTRING

The only change to existing behaviour is `SADD/STRPTR(wstring)` now returns `WSTRING PTR`.  This will break any user code where `STRPTR(wstring)` is expected to return a `ZSTRING PTR`

New implicit conversions and behaviours are activated only if a UDT extends `zstring` or `wstring`.

In future expect separate pull requests for:
- `LEFT`, `RIGHT` to accept UDT extends `z|wstring` without having to explicitly overload `LEFT`, `RIGHT`.  This involves fixing, in my opinion multiple string related bugs on sf.net
- `IIF` to allow handling UDT's that inherit `zstring|wstring`
- `SELECT CASE` to allow handling UDT's that inherit `zstring|wstring`
- `SWAP` which maybe would be handled best with an overloaded member function rather than implicit conversion to `zstring|wstring`

This pull request introduces the initial feature and handles nearly all the quirk keywords.  I'd like to merge this change in before working on the remaining features in separate pull requests.

Forum discussion at [Extending Wstring and Zstring with UDTs](https://www.freebasic.net/forum/viewtopic.php?f=17&t=27569)