### PR TITLE
Fix sf.net 893: wrong error message for invalid suffixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Version 1.07.0
 - sf.net #900: LTRIM( wstring, filter ) and TRIM( wstring, filter ) truncate result if filter is zero length string
 - github #116: Fix optimizations in [L/R]TrimAny rtlib functions (SkyFish)
 - github #145: WSTRING concat and assign buffer (&=) overrun
+- sf.net #893: 'Suffixes are only valid in -lang' error message showing incorrect -lang options allowed
 
 
 Version 1.06.0

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -388,7 +388,7 @@ private sub hReadIdentifier _
 
 	#macro hCheckIdentifierSuffix()
 		if( (fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE) and ((flags and LEXCHECK_ALLOWSUFFIX) = 0) ) then
-			errReportNotAllowed(FB_LANG_QB, FB_ERRMSG_SUFFIXONLYVALIDINLANG, "")
+			errReportNotAllowed( FB_LANG_OPT_SUFFIX, FB_ERRMSG_SUFFIXONLYVALIDINLANG )
 		end if
 	#endmacro
 


### PR DESCRIPTION
fbc: sf.net # 893 'Suffixes are only valid in -lang' error message showing incorrect -lang options allowed