### PR TITLE
Command line options for control over debug code generation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ Version 1.07.0
 - PRINT/LPRINT/WRITE will accept UDT as Z|WSTRING
 - '-earray' command line option to enable array bounds checking
 - '-enullptr' command line option to enable null pointer checking 
+- '-eassert' command line option to enable assert() and assertwarn() checking, plus __FB_DEBUG__, but not debug symbols
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,7 +26,9 @@ Version 1.07.0
 - PRINT/LPRINT/WRITE will accept UDT as Z|WSTRING
 - '-earray' command line option to enable array bounds checking
 - '-enullptr' command line option to enable null pointer checking 
-- '-eassert' command line option to enable assert() and assertwarn() checking, plus __FB_DEBUG__, but not debug symbols
+- '-eassert' command line option to enable assert() and assertwarn() checking
+- '-edebug' command line option to enable __FB_DEBUG__
+- '-edebuginfo' command line option to enable debug symbols
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,8 @@ Version 1.07.0
 - SWAP statement will accept UDT as Z|WSTRING
 - IIF function will accept UDT as Z|WSTRING
 - PRINT/LPRINT/WRITE will accept UDT as Z|WSTRING
+- '-earray' command line option to enable array bounds checking
+- '-enullptr' command line option to enable null pointer checking 
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 1.07.0
 
 [changed]
 - SADD/STRPTR(wstring) returns WSTRING PTR
+- '-v' be verbose command line option affects '-help' output
 
 [added]
 - CVA_LIST type, CVA_START(), CVA_COPY() CVA_END(), CVA_ARG() macros will map to gcc's __builtin_va_list and __builtin_va_* macros in gcc backend

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ Version 1.07.0
 - '-eassert' command line option to enable assert() and assertwarn() checking
 - '-edebug' command line option to enable __FB_DEBUG__
 - '-edebuginfo' command line option to enable debug symbols
+- '-elocation' command line option to enable reporting error location
 
 [fixed]
 - sf.net #881: C backend: support for varadic function parameters in gcc using __builtin_va_list type and related macros

--- a/doc/fbc.1
+++ b/doc/fbc.1
@@ -1,4 +1,4 @@
-.TH FBC 1 "2019-05-20" "FreeBASIC Compiler 1.07.0" "FreeBASIC Compiler"
+.TH FBC 1 "2019-07-23" "FreeBASIC Compiler 1.07.0" "FreeBASIC Compiler"
 .SH NAME
 fbc \- The FreeBASIC compiler
 .SH DESCRIPTION
@@ -45,6 +45,24 @@ Create a Win32 DLL or Linux/*BSD shared library
 \fB\-e\fR
 Enable runtime error checking
 .TP
+\fB\-earray\fR
+Enable array bounds checking
+.TP
+\fB\-eassert\fR
+Enable assert() and assertwarn() checking
+.TP
+\fB\-edebug\fR
+Enable __FB_DEBUG__
+.TP
+\fB\-edebuginfo\fR
+Add debug information
+.TP
+\fB\-elocation\fR
+Enable full error location reporting
+.TP
+\fB\-enullptr\fR
+Enable null-pointer checking
+.TP
 \fB\-ex\fR
 \fB-e\fR plus RESUME support
 .TP
@@ -64,7 +82,7 @@ Select floating-point math accuracy/speed
 Set target FPU
 .TP
 \fB\-g\fR
-Add debug info
+Add debug info, enable __FB_DEBUG__, and enable asserts
 .TP
 \fB\-gen\fR \fBgas\fR|\fBgcc\fR|\fBllvm\fR
 Select code generation backend

--- a/src/compiler/ast-helper.bas
+++ b/src/compiler/ast-helper.bas
@@ -440,7 +440,7 @@ function astBuildVtableLookup _
 
 		'' null pointer checking for ABSTRACTs
 		'' (in case it wasn't overridden)
-		if( env.clopt.extraerrchk ) then
+		if( env.clopt.nullptrchk ) then
 			if( symbIsAbstract( proc ) ) then
 				p = astBuildPTRCHK( p )
 			end if
@@ -793,7 +793,7 @@ function astBuildMultiDeref _
 			end select
 
 			'' null pointer checking
-			if( env.clopt.extraerrchk ) then
+			if( env.clopt.nullptrchk ) then
 				expr = astBuildPTRCHK( expr )
 			end if
 

--- a/src/compiler/ast-node-addr.bas
+++ b/src/compiler/ast-node-addr.bas
@@ -131,7 +131,7 @@ function astNewADDROF( byval l as ASTNODE ptr ) as ASTNODE ptr
 
 	select case( t->class )
 	case AST_NODECLASS_DEREF
-		if( env.clopt.extraerrchk ) then
+		if( env.clopt.nullptrchk ) then
 			hRemoveNullPtrCheck( t )
 		end if
 
@@ -152,7 +152,7 @@ function astNewADDROF( byval l as ASTNODE ptr ) as ASTNODE ptr
 	case AST_NODECLASS_FIELD
 		'' @0->field to const
 		if( t->l->class = AST_NODECLASS_DEREF ) then
-			if( env.clopt.extraerrchk ) then
+			if( env.clopt.nullptrchk ) then
 				hRemoveNullPtrCheck( t->l )
 			end if
 

--- a/src/compiler/ast-node-proc.bas
+++ b/src/compiler/ast-node-proc.bas
@@ -535,20 +535,18 @@ private function hCheckErrHnd _
 
 	'' error check? add to head (must be done only when closing the proc body
 	'' or constructor's field would be initialized and break ctor chaining)
-	if( env.clopt.extraerrchk ) then
+	if( env.clopt.errlocation ) then
 		head_node = astAddAfter( rtlErrorSetModName( sym, _
-										 			 astNewCONSTstr( @env.inf.name ) ), _
-							head_node )
+			astNewCONSTstr( @env.inf.name ) ), head_node )
 
 		head_node = astAddAfter( rtlErrorSetFuncName( sym, _
-												 	  astNewCONSTstr( symbGetName( sym ) ) ), _
-						    head_node )
+			astNewCONSTstr( symbGetName( sym ) ) ), head_node )
 	end if
 
 	with sym->proc.ext->err
 		if( .lastfun <> NULL ) then
 			astAdd( rtlErrorSetFuncName( NULL, astNewVAR( .lastfun ) ) )
-           	.lastfun = NULL
+			.lastfun = NULL
 		end if
 
 		if( .lastmod <> NULL ) then

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -459,6 +459,7 @@ sub fbGlobalInit()
 	env.clopt.lang          = FB_DEFAULT_LANG
 	env.clopt.forcelang     = FALSE
 
+	env.clopt.debug         = FALSE
 	env.clopt.debuginfo     = FALSE
 	env.clopt.assertions    = FALSE
 	env.clopt.errorcheck    = FALSE
@@ -531,6 +532,8 @@ sub fbSetOption( byval opt as integer, byval value as integer )
 	case FB_COMPOPT_FORCELANG
 		env.clopt.forcelang = value
 
+	case FB_COMPOPT_DEBUG
+		env.clopt.debug = value
 	case FB_COMPOPT_DEBUGINFO
 		env.clopt.debuginfo = value
 	case FB_COMPOPT_ASSERTIONS
@@ -614,6 +617,8 @@ function fbGetOption( byval opt as integer ) as integer
 	case FB_COMPOPT_FORCELANG
 		function = env.clopt.forcelang
 
+	case FB_COMPOPT_DEBUG
+		function = env.clopt.debug
 	case FB_COMPOPT_DEBUGINFO
 		function = env.clopt.debuginfo
 	case FB_COMPOPT_ASSERTIONS

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -464,6 +464,7 @@ sub fbGlobalInit()
 	env.clopt.assertions    = FALSE
 	env.clopt.errorcheck    = FALSE
 	env.clopt.extraerrchk   = FALSE
+	env.clopt.errlocation   = FALSE
 	env.clopt.arrayboundchk = FALSE
 	env.clopt.nullptrchk    = FALSE
 	env.clopt.resumeerr     = FALSE
@@ -544,6 +545,8 @@ sub fbSetOption( byval opt as integer, byval value as integer )
 		env.clopt.resumeerr = value
 	case FB_COMPOPT_EXTRAERRCHECK
 		env.clopt.extraerrchk = value
+	case FB_COMPOPT_ERRLOCATION
+		env.clopt.errlocation = value
 	case FB_COMPOPT_ARRAYBOUNDCHECK
 		env.clopt.arrayboundchk = value
 	case FB_COMPOPT_NULLPTRCHECK
@@ -629,6 +632,8 @@ function fbGetOption( byval opt as integer ) as integer
 		function = env.clopt.resumeerr
 	case FB_COMPOPT_EXTRAERRCHECK
 		function = env.clopt.extraerrchk
+	case FB_COMPOPT_ERRLOCATION
+		function = env.clopt.errlocation
 	case FB_COMPOPT_ARRAYBOUNDCHECK
 		function = env.clopt.arrayboundchk
 	case FB_COMPOPT_NULLPTRCHECK

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -463,6 +463,8 @@ sub fbGlobalInit()
 	env.clopt.assertions    = FALSE
 	env.clopt.errorcheck    = FALSE
 	env.clopt.extraerrchk   = FALSE
+	env.clopt.arrayboundchk = FALSE
+	env.clopt.nullptrchk    = FALSE
 	env.clopt.resumeerr     = FALSE
 	env.clopt.profile       = FALSE
 
@@ -539,6 +541,10 @@ sub fbSetOption( byval opt as integer, byval value as integer )
 		env.clopt.resumeerr = value
 	case FB_COMPOPT_EXTRAERRCHECK
 		env.clopt.extraerrchk = value
+	case FB_COMPOPT_ARRAYBOUNDCHECK
+		env.clopt.arrayboundchk = value
+	case FB_COMPOPT_NULLPTRCHECK
+		env.clopt.nullptrchk = value
 	case FB_COMPOPT_PROFILE
 		env.clopt.profile = value
 
@@ -618,6 +624,10 @@ function fbGetOption( byval opt as integer ) as integer
 		function = env.clopt.resumeerr
 	case FB_COMPOPT_EXTRAERRCHECK
 		function = env.clopt.extraerrchk
+	case FB_COMPOPT_ARRAYBOUNDCHECK
+		function = env.clopt.arrayboundchk
+	case FB_COMPOPT_NULLPTRCHECK
+		function = env.clopt.nullptrchk
 	case FB_COMPOPT_PROFILE
 		function = env.clopt.profile
 

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -75,6 +75,7 @@ enum FB_COMPOPT
 	FB_COMPOPT_ERRORCHECK           '' boolean: runtime error checks
 	FB_COMPOPT_RESUMEERROR          '' boolean: RESUME support
 	FB_COMPOPT_EXTRAERRCHECK        '' boolean: NULL pointer/array bounds checks
+	FB_COMPOPT_ERRLOCATION          '' boolean: enable reporting of error location
 	FB_COMPOPT_NULLPTRCHECK         '' boolean: NULL pointer
 	FB_COMPOPT_ARRAYBOUNDCHECK      '' boolean: array bounds checks
 	FB_COMPOPT_PROFILE              '' boolean: -profile
@@ -260,6 +261,7 @@ type FBCMMLINEOPT
 	errorcheck      as integer              '' enable runtime error checks?
 	resumeerr       as integer              '' enable RESUME support?
 	extraerrchk     as integer              '' enable NULL pointer/array bounds checks?
+	errlocation     as integer              '' enable reporting of error location (default = false)
 	arrayboundchk   as integer              '' enable array bounds checks?
 	nullptrchk      as integer              '' enable NULL pointer checks?
 	profile         as integer              '' build profiling code (default = false)

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -74,6 +74,8 @@ enum FB_COMPOPT
 	FB_COMPOPT_ERRORCHECK           '' boolean: runtime error checks
 	FB_COMPOPT_RESUMEERROR          '' boolean: RESUME support
 	FB_COMPOPT_EXTRAERRCHECK        '' boolean: NULL pointer/array bounds checks
+	FB_COMPOPT_NULLPTRCHECK         '' boolean: NULL pointer
+	FB_COMPOPT_ARRAYBOUNDCHECK      '' boolean: array bounds checks
 	FB_COMPOPT_PROFILE              '' boolean: -profile
 
 	'' error/warning reporting behaviour
@@ -256,6 +258,8 @@ type FBCMMLINEOPT
 	errorcheck      as integer              '' enable runtime error checks?
 	resumeerr       as integer              '' enable RESUME support?
 	extraerrchk     as integer              '' enable NULL pointer/array bounds checks?
+	arrayboundchk   as integer              '' enable array bounds checks?
+	nullptrchk      as integer              '' enable NULL pointer checks?
 	profile         as integer              '' build profiling code (default = false)
 
 	'' error/warning reporting behaviour

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -69,8 +69,9 @@ enum FB_COMPOPT
 	FB_COMPOPT_FORCELANG            '' boolean: TRUE if -forcelang was specified
 
 	'' debugging/error checking
-	FB_COMPOPT_DEBUGINFO            '' boolean: debugging info (affects code generation)
-	FB_COMPOPT_ASSERTIONS           '' boolean: enable assert() and __FB_DEBUG__
+	FB_COMPOPT_DEBUG                '' boolean: enable __FB_DEBUG__ (affects code generation)
+	FB_COMPOPT_DEBUGINFO            '' boolean: enable debugging info (affects code generation)
+	FB_COMPOPT_ASSERTIONS           '' boolean: enable assert()
 	FB_COMPOPT_ERRORCHECK           '' boolean: runtime error checks
 	FB_COMPOPT_RESUMEERROR          '' boolean: RESUME support
 	FB_COMPOPT_EXTRAERRCHECK        '' boolean: NULL pointer/array bounds checks
@@ -253,8 +254,9 @@ type FBCMMLINEOPT
 	forcelang       as integer              '' TRUE if -forcelang was specified
 
 	'' debugging/error checking
+	debug           as integer              '' true = enable __FB_DEBUG__ (default = false)
 	debuginfo       as integer              '' true = add debug info (default = false)
-	assertions      as integer              '' true = enable assert() and __FB_DEBUG__ (default = false)
+	assertions      as integer              '' true = enable assert() (default = false)
 	errorcheck      as integer              '' enable runtime error checks?
 	resumeerr       as integer              '' enable RESUME support?
 	extraerrchk     as integer              '' enable NULL pointer/array bounds checks?

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -3480,6 +3480,7 @@ private sub hPrintOptions( byval verbose as integer )
 	print "  -strip           Omit all symbol information from the output file"
 	print "  -t <value>       Set .exe stack size in kbytes, default: 1024 (win32/dos)"
 	if( verbose ) then
+	'' !!! TODO !!! provide more examples of available targets
 	print "  -target <name>   Set cross-compilation target"
 	else
 	print "  -target <name>   Set cross-compilation target"

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -3398,7 +3398,7 @@ private sub hAddDefaultLibs( )
 
 end sub
 
-private sub hPrintOptions( )
+private sub hPrintOptions( byval verbose as integer )
 	'' Note: must print each line separately to let the rtlib print the
 	'' proper line endings even if redirected to file/pipe, hard-coding \n
 	'' here isn't enough for DOS/Windows.
@@ -3420,12 +3420,16 @@ private sub hPrintOptions( )
 	print "  -dll             Same as -dylib"
 	print "  -dylib           Create a DLL (win32) or shared library (*nix/*BSD)"
 	print "  -e               Enable runtime error checking"
+
+	if( verbose ) then
 	print "  -earray          Enable array bounds checking"
 	print "  -eassert         Enable assert() and assertwarn() checking"
 	print "  -edebug          Enable __FB_DEBUG__"
 	print "  -edebuginfo      Add debug info"
 	print "  -elocation       Enable reporting error location"
 	print "  -enullptr        Enable null-pointer checking"
+	end if
+
 	print "  -ex              -e plus RESUME support"
 	print "  -exx             -ex plus array bounds/null-pointer checking"
 	print "  -export          Export symbols for dynamic linkage"
@@ -3433,12 +3437,20 @@ private sub hPrintOptions( )
 	print "  -fpmode fast|precise  Select floating-point math accuracy/speed"
 	print "  -fpu x87|sse     Set target FPU"
 	print "  -g               Add debug info, define __FB_DEBUG__, and enable assert()"
+
+	if( verbose ) then
+	print "  -gen gas         Select GNU gas assembler backend"
+	print "  -gen gcc         Select GNU gcc C backend"
+	print "  -gen llvm        Select LLVM backend"
+	else
 	print "  -gen gas|gcc|llvm  Select code generation backend"
+	end if
+
 	print "  [-]-help         Show this help output"
 	print "  -i <path>        Add an include file search path"
 	print "  -include <file>  Pre-#include a file for each input .bas"
 	print "  -l <name>        Link in a library"
-	print "  -lang <name>     Select FB dialect: deprecated, fblite, qb"
+	print "  -lang <name>     Select FB dialect: fb, deprecated, fblite, qb"
 	print "  -lib             Create a static library"
 	print "  -m <name>        Specify main module (default if not -c: first input .bas)"
 	print "  -map <file>      Save linking map to file"
@@ -3467,7 +3479,11 @@ private sub hPrintOptions( )
 	print "  -static          Prefer static libraries over dynamic ones when linking"
 	print "  -strip           Omit all symbol information from the output file"
 	print "  -t <value>       Set .exe stack size in kbytes, default: 1024 (win32/dos)"
+	if( verbose ) then
 	print "  -target <name>   Set cross-compilation target"
+	else
+	print "  -target <name>   Set cross-compilation target"
+	end if
 	print "  -title <name>    Set XBE display title (xbox)"
 	print "  -v               Be verbose"
 	print "  -vec <n>         Automatic vectorization level (default: 0)"
@@ -3477,7 +3493,12 @@ private sub hPrintOptions( )
 	print "  -Wc <a,b,c>      Pass options to 'gcc' (-gen gcc) or 'llc' (-gen llvm)"
 	print "  -Wl <a,b,c>      Pass options to 'ld'"
 	print "  -x <file>        Set output executable/library file name"
+
+	if( verbose ) then
 	print "  -z gosub-setjmp  Use setjmp/longjmp to implement GOSUB"
+	print "  -z valist-as-ptr Use pointer expressions to implement CVA_*() macros"
+	end if
+
 end sub
 
 private sub hAppendConfigInfo( byref config as string, byval info as zstring ptr )
@@ -3487,7 +3508,7 @@ private sub hAppendConfigInfo( byref config as string, byval info as zstring ptr
 	config += *info
 end sub
 
-private sub hPrintVersion( )
+private sub hPrintVersion( byval verbose as integer )
 	dim as string config
 
 	print "FreeBASIC Compiler - Version " + FB_VERSION + _
@@ -3510,24 +3531,24 @@ end sub
 	fbcInit( )
 
 	if( __FB_ARGC__ = 1 ) then
-		hPrintOptions( )
+		hPrintOptions( FALSE )
 		fbcEnd( 1 )
 	end if
 
 	hParseArgs( __FB_ARGC__, __FB_ARGV__ )
 
 	if( fbc.showversion ) then
-		hPrintVersion( )
+		hPrintVersion( fbc.verbose )
 		fbcEnd( 0 )
 	end if
 
 	if( fbc.verbose ) then
-		hPrintVersion( )
+		hPrintVersion( FALSE )
 	end if
 
 	'' Show help if --help was given
 	if( fbc.showhelp ) then
-		hPrintOptions( )
+		hPrintOptions( fbc.verbose )
 		fbcEnd( 1 )
 	end if
 
@@ -3574,7 +3595,7 @@ end sub
 
 	'' Show help if there are no input files
 	if( have_input_files = FALSE ) then
-		hPrintOptions( )
+		hPrintOptions( fbc.verbose )
 		fbcEnd( 1 )
 	end if
 

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -1405,6 +1405,7 @@ enum
 	OPT_EASSERT
 	OPT_EDEBUG
 	OPT_EDEBUGINFO
+	OPT_ELOCATION
 	OPT_ENULLPTR
 	OPT_EX
 	OPT_EXX
@@ -1475,6 +1476,7 @@ dim shared as integer option_takes_argument(0 to (OPT__COUNT - 1)) = _
 	FALSE, _ '' OPT_EASSERT
 	FALSE, _ '' OPT_EDEBUG
 	FALSE, _ '' OPT_EDEBUGINFO
+	FALSE, _ '' OPT_ELOCATION
 	FALSE, _ '' OPT_ENULLPTR
 	FALSE, _ '' OPT_EX
 	FALSE, _ '' OPT_EXX
@@ -1583,6 +1585,9 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 	case OPT_EDEBUGINFO
 		fbSetOption( FB_COMPOPT_DEBUGINFO, TRUE )
 
+	case OPT_ELOCATION
+		fbSetOption( FB_COMPOPT_ERRLOCATION, TRUE )
+
 	case OPT_ENULLPTR
 		fbSetOption( FB_COMPOPT_NULLPTRCHECK, TRUE )
 
@@ -1594,6 +1599,7 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 		fbSetOption( FB_COMPOPT_ERRORCHECK, TRUE )
 		fbSetOption( FB_COMPOPT_RESUMEERROR, TRUE )
 		fbSetOption( FB_COMPOPT_EXTRAERRCHECK, TRUE )
+		fbSetOption( FB_COMPOPT_ERRLOCATION, TRUE )
 		fbSetOption( FB_COMPOPT_ARRAYBOUNDCHECK, TRUE )
 		fbSetOption( FB_COMPOPT_NULLPTRCHECK, TRUE )
 
@@ -1976,6 +1982,7 @@ private function parseOption(byval opt as zstring ptr) as integer
 		CHECK("eassert", OPT_EASSERT)
 		CHECK("edebug", OPT_EDEBUG)
 		CHECK("edebuginfo", OPT_EDEBUGINFO)
+		CHECK("elocation", OPT_ELOCATION)
 		CHECK("enullptr", OPT_ENULLPTR)
 		CHECK("exx", OPT_EXX)
 		CHECK("export", OPT_EXPORT)
@@ -3417,6 +3424,7 @@ private sub hPrintOptions( )
 	print "  -eassert         Enable assert() and assertwarn() checking"
 	print "  -edebug          Enable __FB_DEBUG__"
 	print "  -edebuginfo      Add debug info"
+	print "  -elocation       Enable reporting error location"
 	print "  -enullptr        Enable null-pointer checking"
 	print "  -ex              -e plus RESUME support"
 	print "  -exx             -ex plus array bounds/null-pointer checking"

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -1403,6 +1403,8 @@ enum
 	OPT_E
 	OPT_EARRAY
 	OPT_EASSERT
+	OPT_EDEBUG
+	OPT_EDEBUGINFO
 	OPT_ENULLPTR
 	OPT_EX
 	OPT_EXX
@@ -1471,6 +1473,8 @@ dim shared as integer option_takes_argument(0 to (OPT__COUNT - 1)) = _
 	FALSE, _ '' OPT_E
 	FALSE, _ '' OPT_EARRAY
 	FALSE, _ '' OPT_EASSERT
+	FALSE, _ '' OPT_EDEBUG
+	FALSE, _ '' OPT_EDEBUGINFO
 	FALSE, _ '' OPT_ENULLPTR
 	FALSE, _ '' OPT_EX
 	FALSE, _ '' OPT_EXX
@@ -1573,6 +1577,12 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 	case OPT_EASSERT
 		fbSetOption( FB_COMPOPT_ASSERTIONS, TRUE )
 
+	case OPT_EDEBUG
+		fbSetOption( FB_COMPOPT_DEBUG, TRUE )
+
+	case OPT_EDEBUGINFO
+		fbSetOption( FB_COMPOPT_DEBUGINFO, TRUE )
+
 	case OPT_ENULLPTR
 		fbSetOption( FB_COMPOPT_NULLPTRCHECK, TRUE )
 
@@ -1629,6 +1639,7 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 		fbSetOption( FB_COMPOPT_FPUTYPE, value )
 
 	case OPT_G
+		fbSetOption( FB_COMPOPT_DEBUG, TRUE )
 		fbSetOption( FB_COMPOPT_DEBUGINFO, TRUE )
 		fbSetOption( FB_COMPOPT_ASSERTIONS, TRUE )
 
@@ -1963,6 +1974,8 @@ private function parseOption(byval opt as zstring ptr) as integer
 		CHECK("ex", OPT_EX)
 		CHECK("earray", OPT_EARRAY)
 		CHECK("eassert", OPT_EASSERT)
+		CHECK("edebug", OPT_EDEBUG)
+		CHECK("edebuginfo", OPT_EDEBUGINFO)
 		CHECK("enullptr", OPT_ENULLPTR)
 		CHECK("exx", OPT_EXX)
 		CHECK("export", OPT_EXPORT)
@@ -3402,6 +3415,8 @@ private sub hPrintOptions( )
 	print "  -e               Enable runtime error checking"
 	print "  -earray          Enable array bounds checking"
 	print "  -eassert         Enable assert() and assertwarn() checking"
+	print "  -edebug          Enable __FB_DEBUG__"
+	print "  -edebuginfo      Add debug info"
 	print "  -enullptr        Enable null-pointer checking"
 	print "  -ex              -e plus RESUME support"
 	print "  -exx             -ex plus array bounds/null-pointer checking"
@@ -3409,7 +3424,7 @@ private sub hPrintOptions( )
 	print "  -forcelang <name>  Override #lang statements in source code"
 	print "  -fpmode fast|precise  Select floating-point math accuracy/speed"
 	print "  -fpu x87|sse     Set target FPU"
-	print "  -g               Add debug info"
+	print "  -g               Add debug info, define __FB_DEBUG__, and enable assert()"
 	print "  -gen gas|gcc|llvm  Select code generation backend"
 	print "  [-]-help         Show this help output"
 	print "  -i <path>        Add an include file search path"

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -1402,6 +1402,7 @@ enum
 	OPT_DYLIB
 	OPT_E
 	OPT_EARRAY
+	OPT_EASSERT
 	OPT_ENULLPTR
 	OPT_EX
 	OPT_EXX
@@ -1469,6 +1470,7 @@ dim shared as integer option_takes_argument(0 to (OPT__COUNT - 1)) = _
 	FALSE, _ '' OPT_DYLIB
 	FALSE, _ '' OPT_E
 	FALSE, _ '' OPT_EARRAY
+	FALSE, _ '' OPT_EASSERT
 	FALSE, _ '' OPT_ENULLPTR
 	FALSE, _ '' OPT_EX
 	FALSE, _ '' OPT_EXX
@@ -1567,6 +1569,9 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 
 	case OPT_EARRAY
 		fbSetOption( FB_COMPOPT_ARRAYBOUNDCHECK, TRUE )
+
+	case OPT_EASSERT
+		fbSetOption( FB_COMPOPT_ASSERTIONS, TRUE )
 
 	case OPT_ENULLPTR
 		fbSetOption( FB_COMPOPT_NULLPTRCHECK, TRUE )
@@ -1957,6 +1962,7 @@ private function parseOption(byval opt as zstring ptr) as integer
 		ONECHAR(OPT_E)
 		CHECK("ex", OPT_EX)
 		CHECK("earray", OPT_EARRAY)
+		CHECK("eassert", OPT_EASSERT)
 		CHECK("enullptr", OPT_ENULLPTR)
 		CHECK("exx", OPT_EXX)
 		CHECK("export", OPT_EXPORT)
@@ -3395,6 +3401,7 @@ private sub hPrintOptions( )
 	print "  -dylib           Create a DLL (win32) or shared library (*nix/*BSD)"
 	print "  -e               Enable runtime error checking"
 	print "  -earray          Enable array bounds checking"
+	print "  -eassert         Enable assert() and assertwarn() checking"
 	print "  -enullptr        Enable null-pointer checking"
 	print "  -ex              -e plus RESUME support"
 	print "  -exx             -ex plus array bounds/null-pointer checking"

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -3426,7 +3426,7 @@ private sub hPrintOptions( byval verbose as integer )
 	print "  -eassert         Enable assert() and assertwarn() checking"
 	print "  -edebug          Enable __FB_DEBUG__"
 	print "  -edebuginfo      Add debug info"
-	print "  -elocation       Enable reporting error location"
+	print "  -elocation       Enable error location reporting"
 	print "  -enullptr        Enable null-pointer checking"
 	end if
 
@@ -3436,7 +3436,7 @@ private sub hPrintOptions( byval verbose as integer )
 	print "  -forcelang <name>  Override #lang statements in source code"
 	print "  -fpmode fast|precise  Select floating-point math accuracy/speed"
 	print "  -fpu x87|sse     Set target FPU"
-	print "  -g               Add debug info, define __FB_DEBUG__, and enable assert()"
+	print "  -g               Add debug info, enable __FB_DEBUG__, and enable assert()"
 
 	if( verbose ) then
 	print "  -gen gas         Select GNU gas assembler backend"

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -1401,6 +1401,8 @@ enum
 	OPT_DLL
 	OPT_DYLIB
 	OPT_E
+	OPT_EARRAY
+	OPT_ENULLPTR
 	OPT_EX
 	OPT_EXX
 	OPT_EXPORT
@@ -1466,6 +1468,8 @@ dim shared as integer option_takes_argument(0 to (OPT__COUNT - 1)) = _
 	FALSE, _ '' OPT_DLL
 	FALSE, _ '' OPT_DYLIB
 	FALSE, _ '' OPT_E
+	FALSE, _ '' OPT_EARRAY
+	FALSE, _ '' OPT_ENULLPTR
 	FALSE, _ '' OPT_EX
 	FALSE, _ '' OPT_EXX
 	FALSE, _ '' OPT_EXPORT
@@ -1561,6 +1565,12 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 	case OPT_E
 		fbSetOption( FB_COMPOPT_ERRORCHECK, TRUE )
 
+	case OPT_EARRAY
+		fbSetOption( FB_COMPOPT_ARRAYBOUNDCHECK, TRUE )
+
+	case OPT_ENULLPTR
+		fbSetOption( FB_COMPOPT_NULLPTRCHECK, TRUE )
+
 	case OPT_EX
 		fbSetOption( FB_COMPOPT_ERRORCHECK, TRUE )
 		fbSetOption( FB_COMPOPT_RESUMEERROR, TRUE )
@@ -1569,6 +1579,8 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 		fbSetOption( FB_COMPOPT_ERRORCHECK, TRUE )
 		fbSetOption( FB_COMPOPT_RESUMEERROR, TRUE )
 		fbSetOption( FB_COMPOPT_EXTRAERRCHECK, TRUE )
+		fbSetOption( FB_COMPOPT_ARRAYBOUNDCHECK, TRUE )
+		fbSetOption( FB_COMPOPT_NULLPTRCHECK, TRUE )
 
 	case OPT_EXPORT
 		fbSetOption( FB_COMPOPT_EXPORT, TRUE )
@@ -1944,6 +1956,8 @@ private function parseOption(byval opt as zstring ptr) as integer
 	case asc("e")
 		ONECHAR(OPT_E)
 		CHECK("ex", OPT_EX)
+		CHECK("earray", OPT_EARRAY)
+		CHECK("enullptr", OPT_ENULLPTR)
 		CHECK("exx", OPT_EXX)
 		CHECK("export", OPT_EXPORT)
 
@@ -3380,6 +3394,8 @@ private sub hPrintOptions( )
 	print "  -dll             Same as -dylib"
 	print "  -dylib           Create a DLL (win32) or shared library (*nix/*BSD)"
 	print "  -e               Enable runtime error checking"
+	print "  -earray          Enable array bounds checking"
+	print "  -enullptr        Enable null-pointer checking"
 	print "  -ex              -e plus RESUME support"
 	print "  -exx             -ex plus array bounds/null-pointer checking"
 	print "  -export          Export symbols for dynamic linkage"

--- a/src/compiler/parser-expr-variable.bas
+++ b/src/compiler/parser-expr-variable.bas
@@ -83,7 +83,7 @@ private function cFixedSizeArrayIndex( byval sym as FBSYMBOL ptr ) as ASTNODE pt
 		dimexpr = hCheckIntegerIndex( hIndexExpr( ) )
 
 		'' bounds checking
-		if( env.clopt.extraerrchk ) then
+		if( env.clopt.arrayboundchk ) then
 			dimexpr = astBuildBOUNDCHK( dimexpr, astNewCONSTi( lower ), astNewCONSTi( upper ) )
 			if( dimexpr = NULL ) then
 				errReport( FB_ERRMSG_ARRAYOUTOFBOUNDS )
@@ -457,7 +457,7 @@ private function hStrIndexing _
 	end if
 
 	'' null pointer checking
-	if( env.clopt.extraerrchk ) then
+	if( env.clopt.arrayboundchk ) then
 		varexpr = astBuildPTRCHK( varexpr )
 	end if
 
@@ -530,7 +530,7 @@ function cMemberDeref _
 					subtype = NULL
 				end select
 
-				if( env.clopt.extraerrchk ) then
+				if( env.clopt.nullptrchk ) then
 					varexpr = astBuildPTRCHK( varexpr )
 				end if
 
@@ -685,7 +685,7 @@ function cMemberDeref _
 				idxexpr = hCheckIntegerIndex( idxexpr )
 
 				'' null pointer checking
-				if( env.clopt.extraerrchk ) then
+				if( env.clopt.nullptrchk ) then
 					varexpr = astBuildPTRCHK( varexpr )
 				end if
 
@@ -770,7 +770,7 @@ function cFuncPtrOrMemberDeref _
 	end if
 
 	'' null pointer checking
-	if( env.clopt.extraerrchk ) then
+	if( env.clopt.nullptrchk ) then
 		expr = astBuildPTRCHK( expr )
 	end if
 
@@ -819,7 +819,7 @@ private function cDynamicArrayIndex _
 		dimexpr = hCheckIntegerIndex( hIndexExpr( ) )
 
 		'' bounds checking
-		if( env.clopt.extraerrchk ) then
+		if( env.clopt.arrayboundchk ) then
 			dimexpr = astBuildBOUNDCHK( dimexpr, _
 					astBuildDerefAddrOf( astCloneTree( descexpr ), dimoffset + symb.fbarraydim_lbound, FB_DATATYPE_INTEGER, NULL ), _
 					astBuildDerefAddrOf( astCloneTree( descexpr ), dimoffset + symb.fbarraydim_ubound, FB_DATATYPE_INTEGER, NULL ) )

--- a/src/compiler/rtl-macro.bas
+++ b/src/compiler/rtl-macro.bas
@@ -97,7 +97,7 @@ end type
 	 	), _
 		/' #define ASSERT(e) if (e) = FALSE then fb_Assert(__FILE__, __LINE__, __FUNCTION__, #e) '/ _
 		( _
-			@"ASSERT", FB_RTL_OPT_DBGONLY, _
+			@"ASSERT", FB_RTL_OPT_ASSERTONLY, _
 	 		1, _
 	 		{ _
 	 			@"E" _
@@ -113,7 +113,7 @@ end type
 	 	), _
 		/' #define ASSERTWARN(e) if (e) = FALSE then fb_AssertWarn(__FILE__, __LINE__, __FUNCTION__, #e) '/ _
 		( _
-			@"ASSERTWARN", FB_RTL_OPT_DBGONLY, _
+			@"ASSERTWARN", FB_RTL_OPT_ASSERTONLY, _
 	 		1, _
 	 		{ _
 	 			@"E" _
@@ -373,7 +373,7 @@ end type
 		), _
 		/' #define ASSERT(e) if (e) = FALSE then fb_Assert(__FILE__, __LINE__, __FUNCTION__, #e) '/ _
 		( _
-			@"__ASSERT", FB_RTL_OPT_DBGONLY, _
+			@"__ASSERT", FB_RTL_OPT_ASSERTONLY, _
 			1, _
 			{ _
 				@"E" _
@@ -389,7 +389,7 @@ end type
 		), _
 		/' #define ASSERTWARN(e) if (e) = FALSE then fb_AssertWarn(__FILE__, __LINE__, __FUNCTION__, #e) '/ _
 		( _
-			@"__ASSERTWARN", FB_RTL_OPT_DBGONLY, _
+			@"__ASSERTWARN", FB_RTL_OPT_ASSERTONLY, _
 			1, _
 			{ _
 				@"E" _
@@ -591,7 +591,7 @@ private sub hAddMacro( byval macdef as FB_RTL_MACRODEF ptr )
 	next
 
 	'' Only add the assert[warn]() macros in debug builds
-	if( (macdef->options and FB_RTL_OPT_DBGONLY) <> 0 ) then
+	if( (macdef->options and FB_RTL_OPT_ASSERTONLY) <> 0 ) then
 		if( env.clopt.assertions = FALSE ) then
 			addbody = FALSE
 		end if

--- a/src/compiler/rtl.bi
+++ b/src/compiler/rtl.bi
@@ -823,21 +823,21 @@ enum FB_RTL_IDX
 end enum
 
 enum FB_RTL_OPT
-	FB_RTL_OPT_NONE		  = &h00000000
-	FB_RTL_OPT_OVER		  = &h00000001					'' overloaded
-	FB_RTL_OPT_ERROR	  = &h00000002					'' returns an error
-	FB_RTL_OPT_MT		  = &h00000004					'' needs the multithreaded rtlib
+	FB_RTL_OPT_NONE           = &h00000000
+	FB_RTL_OPT_OVER           = &h00000001  '' overloaded
+	FB_RTL_OPT_ERROR          = &h00000002  '' returns an error
+	FB_RTL_OPT_MT             = &h00000004  '' needs the multithreaded rtlib
 
-	FB_RTL_OPT_DBGONLY	  = &h00000010                  '' Debug-build only (assertions/__FB_DEBUG__)
-				''= &h00000020
-	FB_RTL_OPT_STRSUFFIX  = &h00000040                  '' has a $ suffix (-lang qb only)
-	FB_RTL_OPT_NOQB		  = &h00000080                  '' anything but -lang qb
-	FB_RTL_OPT_QBONLY	  = &h00000100                  '' -lang qb only
-	FB_RTL_OPT_NOFB		  = &h00000200                  '' anything but -lang fb
-	FB_RTL_OPT_FBONLY	  = &h00000400                  ''
+	FB_RTL_OPT_ASSERTONLY     = &h00000010  '' only if asserts are enabled
+	''                        = &h00000020
+	FB_RTL_OPT_STRSUFFIX      = &h00000040  '' has a $ suffix (-lang qb only)
+	FB_RTL_OPT_NOQB           = &h00000080  '' anything but -lang qb
+	FB_RTL_OPT_QBONLY         = &h00000100  '' -lang qb only
+	FB_RTL_OPT_NOFB           = &h00000200  '' anything but -lang fb
+	FB_RTL_OPT_FBONLY         = &h00000400  ''
 	FB_RTL_OPT_CANBECLONED    = &h00000800  '' -> FB_PROCSTATS_CANBECLONED
-	                          ''&h00001000
-	FB_RTL_OPT_NOGCC	  = &h00002000                  '' anything but -gen gcc
+	''                        = &h00001000
+	FB_RTL_OPT_NOGCC          = &h00002000  '' anything but -gen gcc
 	FB_RTL_OPT_X86ONLY        = &h00004000  '' on x86 only
 	FB_RTL_OPT_32BIT          = &h00008000  '' 32bit only
 	FB_RTL_OPT_64BIT          = &h00010000  '' 64bit only

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -145,6 +145,10 @@ private function hDefErr_cb ( ) as string
 		res or= &h0080
 	end if
 
+	if( env.clopt.errlocation ) then
+		res or= &h0100
+	end if
+
 	function = str( res )
 end function
 

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -111,7 +111,7 @@ private function hDefDebug_cb ( ) as string
 end function
 
 private function hDefErr_cb ( ) as string
-    dim as integer res = &h0000
+	dim as integer res = &h0000
 
 	if( env.clopt.errorcheck ) then
 		res = &h0001
@@ -123,6 +123,14 @@ private function hDefErr_cb ( ) as string
 
 	if( env.clopt.extraerrchk ) then
 		res or= &h0004
+	end if
+
+	if( env.clopt.arrayboundchk ) then
+		res or= &h0008
+	end if
+
+	if( env.clopt.nullptrchk ) then
+		res or= &h0010
 	end if
 
 	function = str( res )

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -133,6 +133,10 @@ private function hDefErr_cb ( ) as string
 		res or= &h0010
 	end if
 
+	if( env.clopt.assertions ) then
+		res or= &h0020
+	end if
+
 	function = str( res )
 end function
 

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -107,7 +107,7 @@ private function hDefOutObj_cb ( ) as string
 end function
 
 private function hDefDebug_cb ( ) as string
-	function = str( env.clopt.assertions )
+	function = str( env.clopt.debug )
 end function
 
 private function hDefErr_cb ( ) as string
@@ -135,6 +135,14 @@ private function hDefErr_cb ( ) as string
 
 	if( env.clopt.assertions ) then
 		res or= &h0020
+	end if
+
+	if( env.clopt.debuginfo ) then
+		res or= &h0040
+	end if
+
+	if( env.clopt.debug ) then
+		res or= &h0080
 	end if
 
 	function = str( res )

--- a/todo.txt
+++ b/todo.txt
@@ -112,6 +112,11 @@ o ThreadCall
 o -exx should catch...
   - access to ERASEd or uninited (unREDIMed) dyn array
   - out-of-bounds dimension argument given to lbound()/ubound()
+  - add an -exx aka -eboolean check to detect illegal boolean values on read?
+  - expand on -elocation option to provide full location information or if not
+    given (or implied) optimize out calls to fb_ErrorSetFuncName() and 
+    fb_ErrorSetModName(), because we still get location from fb_ErrorThrowAt()
+	and fb_ErrorThrowEx().  Must test interaction with ON ERROR
 
 [ ] ctor/dtor
     - add 'function foo (...) as SomeObj = any', so #1682972 could be fixed AND when


### PR DESCRIPTION
This change adds a finer grain of control over debug code generation by adding several new command line options.  The existing meaning of `-e`, `-ex`, `-exx`, `-g` is not changed.

For reference, see discussion at [How to do -g but without assertions?](https://www.freebasic.net/forum/viewtopic.php?f=17&t=22958)

[changed]
- '-v' be verbose command line option affects '-help' output

[added]
- '-earray' command line option to enable array bounds checking
- '-enullptr' command line option to enable null pointer checking 
- '-eassert' command line option to enable assert() and assertwarn() checking
- '-edebug' command line option to enable `__FB_DEBUG__`
- '-edebuginfo' command line option to enable debug symbols
- '-elocation' command line option to enable reporting error location

Comparison to existing options:
- `-g` is same as before, implies `-edebug`, `-edebuginfo`, `-eassert`
- `-e` is same as before
- `-ex` is same as before, implies `-e`
- `-exx` is same as before, implies `-e`, `-ex`, `-earray`, `-enullptr`, `-elocation`

Unrelated to debug code generation, skeleton code is provided to help user determine how fbc is built and expected defaults:
- `-help -v` gives verbose help
- `-version -v` gives verbose version information
