### PR TITLE
fix passed z/wstring array bug

### DIFF
--- a/src/compiler/ast-misc.bas
+++ b/src/compiler/ast-misc.bas
@@ -47,14 +47,14 @@ function astIsTreeEqual _
 		byval r as ASTNODE ptr _
 	) as integer
 
-    function = FALSE
+	function = FALSE
 
-    if( (l = NULL) or (r = NULL) ) then
-    	if( l = r ) then
-    		function = TRUE
-    	end if
-    	exit function
-    end if
+	if( (l = NULL) or (r = NULL) ) then
+		if( l = r ) then
+			function = TRUE
+		end if
+		exit function
+	end if
 
 	if( l->class <> r->class ) then
 		exit function
@@ -162,7 +162,7 @@ function astIsTreeEqual _
 
 	end select
 
-    '' check childs
+	'' check childs
 	if( astIsTreeEqual( l->l, r->l ) = FALSE ) then
 		exit function
 	end if
@@ -171,7 +171,7 @@ function astIsTreeEqual _
 		exit function
 	end if
 
-    ''
+	''
 	function = TRUE
 
 end function
@@ -516,7 +516,7 @@ function astGetStrLitSymbol _
 
 	dim as FBSYMBOL ptr s = any
 
-    function = NULL
+	function = NULL
 
    	if( astIsVAR( n ) ) then
 		s = astGetSymbol( n )
@@ -746,16 +746,16 @@ function astBuildBranch _
 		return NULL
 	end if
 
-    '' CHAR and WCHAR literals are also from the INTEGER class
-    select case as const dtype
-    case FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
+	'' CHAR and WCHAR literals are also from the INTEGER class
+	select case as const dtype
+	case FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
 		'' don't allow, unless it's a deref pointer
 		if( astIsDEREF( expr ) = FALSE ) then
 			return NULL
 		end if
 
 	'' UDT or CLASS?
-	case FB_DATATYPE_STRUCT ', FB_DATATYPE_CLASS
+	case FB_DATATYPE_STRUCT '', FB_DATATYPE_CLASS
 		dim as FB_ERRMSG err_num = any
 		dim as FBSYMBOL ptr ovlProc = any
 
@@ -1061,7 +1061,7 @@ sub astDtorListRemoveRef( byval sym as FBSYMBOL ptr )
 end sub
 
 function astDtorListFlush( byval cookie as integer ) as ASTNODE ptr
-    dim as AST_DTORLIST_ITEM ptr n = any, p = any
+	dim as AST_DTORLIST_ITEM ptr n = any, p = any
 	dim as ASTNODE ptr t = any
 
 	'' call the dtors in the reverse order
@@ -1183,8 +1183,8 @@ sub astSetType _
 	end if
 #endif
 
-    astGetFullType( n ) = dtype
-    n->subtype = subtype
+	astGetFullType( n ) = dtype
+	n->subtype = subtype
 
 	select case n->class
 	case AST_NODECLASS_LINK

--- a/src/compiler/parser-decl-proc-params.bas
+++ b/src/compiler/parser-decl-proc-params.bas
@@ -7,7 +7,7 @@
 #include once "parser.bi"
 #include once "ast.bi"
 
-declare function hParamDecl	_
+declare function hParamDecl    _
 	( _
 		byval proc as FBSYMBOL ptr, _
 		byval procmode as integer, _
@@ -69,9 +69,9 @@ sub cParameters _
 		end if
 
 		'' ','
-	   	if( lexGetToken( ) <> CHAR_COMMA ) then
-	   		exit do
-	   	end if
+		   if( lexGetToken( ) <> CHAR_COMMA ) then
+			   exit do
+		   end if
 
 		lexSkipToken( )
 	loop
@@ -129,10 +129,10 @@ private function hOptionalExpr _
 		byval param as FBSYMBOL ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr expr = any
+	dim as ASTNODE ptr expr = any
 	dim as integer inioptions = any
 
-    function = NULL
+	function = NULL
 
 	'' Must be BYVAL/BYREF in order to allow an optional expression
 	'' (not BYDESC nor VARARG)
@@ -218,13 +218,13 @@ private function hParamDecl _
 
 	function = NULL
 
-    attrib = 0
+	attrib = 0
 
 	'' '...'?
 	if( lexGetToken( ) = CHAR_DOT ) then
 		if( lexGetLookAhead( 1 ) = CHAR_DOT ) then
-		    lexSkipToken( )
-		    lexSkipToken( )
+			lexSkipToken( )
+			lexSkipToken( )
 
 			if( lexGetToken( ) <> CHAR_DOT ) then
 				hParamError( proc, "..." )
@@ -248,7 +248,7 @@ private function hParamDecl _
 			end if
 
 			return symbAddProcParam( proc, NULL, FB_DATATYPE_INVALID, NULL, _
-			                         0, FB_PARAMMODE_VARARG, 0 )
+									 0, FB_PARAMMODE_VARARG, 0 )
 
 		'' syntax error..
 		else
@@ -369,9 +369,9 @@ private function hParamDecl _
 	if( mode = INVALID ) then
 		mode = env.opt.parammode
 		use_default = TRUE
-    	if( fbPdCheckIsSet( FB_PDCHECK_PARAMMODE ) ) then
-    		hParamWarning( proc, id, FB_WARNINGMSG_NOEXPLICITPARAMMODE )
-    	end if
+		if( fbPdCheckIsSet( FB_PDCHECK_PARAMMODE ) ) then
+			hParamWarning( proc, id, FB_WARNINGMSG_NOEXPLICITPARAMMODE )
+		end if
 	end if
 
 	'' (AS SymbolType)?
@@ -396,7 +396,8 @@ private function hParamDecl _
 			options or= FB_SYMBTYPEOPT_ISBYREF
 		end if
 
-		if( cSymbolType( dtype, subtype, , , options ) = FALSE ) then
+		'' pass mode for allowing z/wstring arrays to be passed without "*...", which is pointless anyway
+		if( cSymbolType( dtype, subtype, , , options, mode ) = FALSE ) then 
 			hParamError( proc, id )
 			'' error recovery: fake type
 			dtype = FB_DATATYPE_INTEGER
@@ -434,18 +435,18 @@ private function hParamDecl _
 		end if
 	end if
 
-    '' QB def-by-letter hax
-    if( dtype = FB_DATATYPE_INVALID ) then
-        dtype = symbGetDefType( id )
-    end if
+	'' QB def-by-letter hax
+	if( dtype = FB_DATATYPE_INVALID ) then
+		dtype = symbGetDefType( id )
+	end if
 
 	if( doskip ) then
 		hSkipUntil( CHAR_COMMA )
 	end if
 
-    '' check for invalid args
-    select case as const typeGet( dtype )
-    '' can't be a fixed-len string
+	'' check for invalid args
+	select case as const typeGet( dtype )
+	'' can't be a fixed-len string
 	case FB_DATATYPE_FIXSTR, FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
 		if( mode = FB_PARAMMODE_BYVAL or typeGet( dtype ) = FB_DATATYPE_FIXSTR ) then
 			hParamError( proc, id )
@@ -454,32 +455,32 @@ private function hParamDecl _
 		end if
 
 	'' can't be as ANY on non-prototypes
-    case FB_DATATYPE_VOID
-    	if( isproto = FALSE ) then
+	case FB_DATATYPE_VOID
+		if( isproto = FALSE ) then
 			hParamError( proc, id )
 			'' error recovery: fake correct type
 			dtype = typeAddrOf( dtype )
-    	else
-    		if( mode = FB_PARAMMODE_BYVAL ) then
+		else
+			if( mode = FB_PARAMMODE_BYVAL ) then
 				hParamError( proc, id )
 				'' error recovery: fake correct param
 				dtype = typeAddrOf( dtype )
-    		end if
-    	end if
+			end if
+		end if
 
-    case FB_DATATYPE_STRUCT
-    	if( isproto = FALSE ) then
-    		'' contains a period?
-    		if( dotpos > 0 ) then
+	case FB_DATATYPE_STRUCT
+		if( isproto = FALSE ) then
+			'' contains a period?
+			if( dotpos > 0 ) then
 				hParamError( proc, id )
-    		end if
-    	end if
+			end if
+		end if
 
-    end select
+	end select
 
 	'' Add new param
 	param = symbAddProcParam( proc, iif( isproto, cptr( zstring ptr, NULL ), id ), _
-	                          dtype, subtype, dimensions, mode, attrib )
+							  dtype, subtype, dimensions, mode, attrib )
 	if( param = NULL ) then
 		exit function
 	end if

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -141,8 +141,6 @@ private function cSymbolTypeFuncPtr( byval is_func as integer ) as FBSYMBOL ptr
 	attrib = 0
 	subtype = NULL
 
-	' no need for naked check here, naked only effects the way a function
-	' is emitted, not the way it's called
 
 	'' mode
 	mode = cProcCallingConv( )
@@ -231,8 +229,8 @@ sub AmbigiousSizeofInfo.maybeWarn( byval tk as integer, byval refers_to_type as 
 	'' Don't warn if it's a type and a var of that type, because then the
 	'' len() or sizeof() would return the same value in either case.
 	if( symbIsVar( nontype ) and _
-	    (symbGetType( nontype ) = FB_DATATYPE_STRUCT) and _
-	    (nontype->subtype = typ) ) then
+		(symbGetType( nontype ) = FB_DATATYPE_STRUCT) and _
+		(nontype->subtype = typ) ) then
 		exit sub
 	end if
 
@@ -290,8 +288,8 @@ function cTypeOrExpression _
 
 	'' Token followed by an operator except '*' / '<'?
 	if( (lexGetLookAheadClass( 1 ) = FB_TKCLASS_OPERATOR) andalso _
-	    (lexGetLookAhead( 1 ) <> CHAR_TIMES) andalso _
-	    (lexGetLookAhead( 1 ) <> FB_TK_LT) ) then
+		(lexGetLookAhead( 1 ) <> CHAR_TIMES) andalso _
+		(lexGetLookAhead( 1 ) <> FB_TK_LT) ) then
 		maybe_type = FALSE
 	else
 		'' Check for some non-operator tokens
@@ -439,14 +437,14 @@ private function cMangleModifier _
 						dtype = typeSetMangleDt( dtype, FB_DATATYPE_UINT )
 						function = TRUE
 					case else
-						errReport( FB_ERRMSG_SYNTAXERROR )	
+						errReport( FB_ERRMSG_SYNTAXERROR )    
 					end select
 				else
 					select case dtype
 					case FB_DATATYPE_LONG
 					case FB_DATATYPE_ULONG
 					case else
-						errReport( FB_ERRMSG_SYNTAXERROR )	
+						errReport( FB_ERRMSG_SYNTAXERROR )    
 					end select
 				end if
 				
@@ -455,7 +453,7 @@ private function cMangleModifier _
 				case FB_DATATYPE_VOID
 					dtype = typeSetMangleDt( dtype, FB_DATATYPE_CHAR )
 				case else
-					errReport( FB_ERRMSG_SYNTAXERROR )	
+					errReport( FB_ERRMSG_SYNTAXERROR )    
 				end select
 
 			case "__builtin_va_list"
@@ -472,7 +470,7 @@ private function cMangleModifier _
 					'' subtype = symbCloneSymbol( subtype )
 					symbSetUdtIsValistStruct( subtype )
 				case else
-					errReport( FB_ERRMSG_SYNTAXERROR )	
+					errReport( FB_ERRMSG_SYNTAXERROR )    
 				end select
 
 			case "__builtin_va_list[]"
@@ -484,14 +482,14 @@ private function cMangleModifier _
 					symbSetUdtIsValistStruct( subtype )
 					symbSetUdtIsValistStructArray( subtype )
 				case else
-					errReport( FB_ERRMSG_SYNTAXERROR )	
+					errReport( FB_ERRMSG_SYNTAXERROR )    
 				end select
 
 			case ""
 				errReport( FB_ERRMSG_EMPTYALIASSTRING )
 
 			case else
-				errReport( FB_ERRMSG_SYNTAXERROR )	
+				errReport( FB_ERRMSG_SYNTAXERROR )    
 			end select
 
 			lexSkipToken( )
@@ -505,17 +503,17 @@ end function
 
 '':::::
 ''SymbolType      =   CONST? UNSIGNED? (
-''				      ANY
-''				  |   BOOLEAN (BYTE|INTEGER)?
-''				  |   CHAR|BYTE
-''				  |	  SHORT|WORD
-''				  |	  INTEGER|LONG|DWORD
-''				  |   SINGLE
-''				  |   DOUBLE
+''                      ANY
+''                  |   BOOLEAN (BYTE|INTEGER)?
+''                  |   CHAR|BYTE
+''                  |      SHORT|WORD
+''                  |      INTEGER|LONG|DWORD
+''                  |   SINGLE
+''                  |   DOUBLE
 ''                |   STRING ('*' NUM_LIT)?
 ''                |   USERDEFTYPE
-''				  |   (FUNCTION|SUB) ('(' args ')') (AS SymbolType)?
-''				      (CONST? (PTR|POINTER))* .
+''                  |   (FUNCTION|SUB) ('(' args ')') (AS SymbolType)?
+''                      (CONST? (PTR|POINTER))* .
 ''
 function cSymbolType _
 	( _
@@ -523,7 +521,8 @@ function cSymbolType _
 		byref subtype as FBSYMBOL ptr, _
 		byref lgt as longint, _
 		byref is_fixlenstr as integer, _
-		byval options as FB_SYMBTYPEOPT _
+		byval options as FB_SYMBTYPEOPT, _
+		byval mode as INTEGER _
 	) as integer
 
 	dim as integer isunsigned = any, isfunction = any
@@ -829,9 +828,9 @@ function cSymbolType _
 			end if
 
 			'' note: len of "wstring * expr" symbols will be actually
-			''		 the number of chars times sizeof(wstring), so
-			''		 always use symbGetWstrLen( ) to retrieve the
-			''		 len in characters, not the bytes
+			''         the number of chars times sizeof(wstring), so
+			''         always use symbGetWstrLen( ) to retrieve the
+			''         len in characters, not the bytes
 			if( typeGet( dtype ) = FB_DATATYPE_WCHAR ) then
 				lgt *= typeGetSize( FB_DATATYPE_WCHAR )
 			end if
@@ -909,6 +908,9 @@ function cSymbolType _
 				dtype = typeAddrOf( FB_DATATYPE_VOID )
 				subtype = NULL
 			end if
+
+		'' prevent error for z/wstring arrays without lgt
+		elseif (mode = FB_PARAMMODE_BYDESC) then    
 
 		elseif( lgt <= 0 ) then
 			select case( typeGetDtAndPtrOnly( dtype ) )

--- a/src/compiler/parser-expr-variable.bas
+++ b/src/compiler/parser-expr-variable.bas
@@ -1,7 +1,7 @@
 '' variable parsing (scalars, arrays, fields and anything between)
 ''
 '' chng: sep/2004 written [v1ctor]
-''		 oct/2004 arrays on fields [v1c]
+''         oct/2004 arrays on fields [v1c]
 
 
 #include once "fb.bi"
@@ -60,7 +60,7 @@ end function
 '' descriptor.
 ''
 private function cFixedSizeArrayIndex( byval sym as FBSYMBOL ptr ) as ASTNODE ptr
-    dim as ASTNODE ptr expr = any, dimexpr = any
+	dim as ASTNODE ptr expr = any, dimexpr = any
 	dim as integer dimension = any
 	dim as longint lower = any, upper = any
 
@@ -253,16 +253,16 @@ private function hMemberId( byval parent as FBSYMBOL ptr ) as FBSYMBOL ptr
 		return res
 	end if
 
-    dim as FBSYMCHAIN ptr chain_ = symbLookupCompField( parent, lexGetText( ) )
-    if( chain_ = NULL ) then
+	dim as FBSYMCHAIN ptr chain_ = symbLookupCompField( parent, lexGetText( ) )
+	if( chain_ = NULL ) then
 		errReportUndef( FB_ERRMSG_ELEMENTNOTDEFINED, lexGetText( ) )
 		'' no error recovery: caller will take care
 		lexSkipToken( )
 		return NULL
-    end if
+	end if
 
-    '' since methods don't start a new hash, params and local
-    '' symbol dups will also be found
+	'' since methods don't start a new hash, params and local
+	'' symbol dups will also be found
 	do
 		dim as FBSYMBOL ptr sym = chain_->sym
 		do
@@ -270,7 +270,7 @@ private function hMemberId( byval parent as FBSYMBOL ptr ) as FBSYMBOL ptr
 				select case as const symbGetClass( sym )
 				'' field or static members?
 				case FB_SYMBCLASS_FIELD, FB_SYMBCLASS_VAR, _
-				     FB_SYMBCLASS_CONST, FB_SYMBCLASS_ENUM
+					 FB_SYMBCLASS_CONST, FB_SYMBCLASS_ENUM
 					'' check visibility
 					if( symbCheckAccess( sym ) = FALSE ) then
 						errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
@@ -291,14 +291,14 @@ private function hMemberId( byval parent as FBSYMBOL ptr ) as FBSYMBOL ptr
 		loop while( sym <> NULL )
 
 		chain_ = chain_->next
-    loop while( chain_ <> NULL )
+	loop while( chain_ <> NULL )
 
-    '' nothing found..
-    errReportUndef( FB_ERRMSG_ELEMENTNOTDEFINED, lexGetText( ) )
-    '' no error recovery: caller will take care
-    lexSkipToken( )
+	'' nothing found..
+	errReportUndef( FB_ERRMSG_ELEMENTNOTDEFINED, lexGetText( ) )
+	'' no error recovery: caller will take care
+	lexSkipToken( )
 
-    function = NULL
+	function = NULL
 
 end function
 
@@ -318,24 +318,24 @@ function cUdtMember _
 	dim as integer is_ptr = TRUE, mask = typeGetConstMask( dtype )
 
 	do
-		dim	as FBSYMBOL	ptr	fld	= hMemberId( subtype )
-		if(	fld	= NULL ) then
+		dim    as FBSYMBOL    ptr    fld    = hMemberId( subtype )
+		if(    fld    = NULL ) then
 			return NULL
-		end	if
+		end    if
 
-		select case	as const symbGetClass( fld )
+		select case    as const symbGetClass( fld )
 		'' const? (enum elmts too), exit
 		case FB_SYMBCLASS_CONST
 			lexSkipToken( )
 
-			astDeltree(	varexpr	)
+			astDeltree(    varexpr    )
 			return astBuildConst( fld )
 
 		'' enum?
 		case FB_SYMBCLASS_ENUM
 			lexSkipToken( )
 
-			astDeltree(	varexpr	)
+			astDeltree(    varexpr    )
 			varexpr = NULL
 
 			'' '.'?
@@ -348,8 +348,8 @@ function cUdtMember _
 			lexSkipToken( )
 
 			'' make sure the field inherits the parent's constant mask
-			dtype =	symbGetFullType( fld ) or mask
-			subtype	= symbGetSubType( fld )
+			dtype =    symbGetFullType( fld ) or mask
+			subtype    = symbGetSubType( fld )
 
 			if( is_ptr = FALSE ) then
 				varexpr = astNewADDROF( varexpr )
@@ -359,8 +359,8 @@ function cUdtMember _
 
 			'' Only continue if the field was an UDT and there's a '.' following
 			if( (typeGetDtAndPtrOnly( dtype ) <> FB_DATATYPE_STRUCT) or _
-			    (lexGetToken( ) <> CHAR_DOT) or _
-			    astIsNIDXARRAY( varexpr ) ) then
+				(lexGetToken( ) <> CHAR_DOT) or _
+				astIsNIDXARRAY( varexpr ) ) then
 				return varexpr
 			end if
 
@@ -372,25 +372,25 @@ function cUdtMember _
 			varexpr = cVariableEx( fld, check_array )
 
 			'' make sure the field inherits the parent's constant mask
-			dtype =	symbGetFullType( fld ) or mask
-			subtype	= symbGetSubType( fld )
+			dtype =    symbGetFullType( fld ) or mask
+			subtype    = symbGetSubType( fld )
 
-			select case	typeGet( dtype )
-			case FB_DATATYPE_STRUCT	', FB_DATATYPE_CLASS
-				if(	lexGetToken( ) <> CHAR_DOT ) then
+			select case    typeGet( dtype )
+			case FB_DATATYPE_STRUCT    '', FB_DATATYPE_CLASS
+				if(    lexGetToken( ) <> CHAR_DOT ) then
 					return varexpr
-				end	if
+				end    if
 
 			case else
 				return varexpr
-			end	select
+			end    select
 
 			is_ptr = FALSE
 
 		'' method?
 		case FB_SYMBCLASS_PROC
 			if( is_ptr ) then
-				varexpr	= astNewDEREF( varexpr,	dtype, subtype )
+				varexpr    = astNewDEREF( varexpr,    dtype, subtype )
 			end if
 
 			return cMethodCall( fld, varexpr, options )
@@ -398,9 +398,9 @@ function cUdtMember _
 		case else
 			errReportEx( FB_ERRMSG_INTERNAL, __FUNCTION__ )
 			return NULL
-		end	select
+		end    select
 
-		lexSkipToken( LEXCHECK_NOPERIOD	)
+		lexSkipToken( LEXCHECK_NOPERIOD    )
 	loop
 
 	function = varexpr
@@ -419,7 +419,7 @@ function cMemberAccess _
 		expr = astBuildCallResultUdt( expr )
 	end if
 
- 	'' build: cast( udt ptr, (cast( byte ptr, @udt) + fldexpr))->field
+	 '' build: cast( udt ptr, (cast( byte ptr, @udt) + fldexpr))->field
 	function = cUdtMember( dtype, subtype, astNewADDROF( expr ), TRUE )
 
 end function
@@ -486,7 +486,7 @@ private function hMultiDeref( ) as integer
 end function
 
 '':::::
-''MemberDeref	=   (('->' DREF* | '[' Expression ']' '.'?) UdtMember)* .
+''MemberDeref    =   (('->' DREF* | '[' Expression ']' '.'?) UdtMember)* .
 ''
 function cMemberDeref _
 	( _
@@ -522,7 +522,7 @@ function cMemberDeref _
 					dtype = FB_DATATYPE_INTEGER
 					subtype = NULL
 
-				case FB_DATATYPE_STRUCT ', FB_DATATYPE_CLASS
+				case FB_DATATYPE_STRUCT '', FB_DATATYPE_CLASS
 
 				case else
 					errReport( FB_ERRMSG_INVALIDDATATYPES, TRUE )
@@ -731,8 +731,8 @@ function cMemberDeref _
 end function
 
 '':::::
-''FuncPtrOrDeref	=   FuncPtr '(' Args? ')'
-''					|   MemberDeref .
+''FuncPtrOrDeref    =   FuncPtr '(' Args? ')'
+''                    |   MemberDeref .
 ''
 function cFuncPtrOrMemberDeref _
 	( _
@@ -748,7 +748,7 @@ function cFuncPtrOrMemberDeref _
 	''
 	if( isfuncptr = FALSE ) then
 		'' MemberDeref?
-		expr = 	cMemberDeref( dtype, subtype, expr, checkarray )
+		expr =     cMemberDeref( dtype, subtype, expr, checkarray )
 		if( expr = NULL ) then
 			exit function
 		end if
@@ -756,12 +756,12 @@ function cFuncPtrOrMemberDeref _
 		dtype = astGetDataType( expr )
 		subtype = astGetSubType( expr )
 
-   		'' check for functions called through pointers
-   		if( lexGetToken( ) = CHAR_LPRNT ) then
-   			if( dtype = typeAddrOf( FB_DATATYPE_FUNCTION ) ) then
+		   '' check for functions called through pointers
+		   if( lexGetToken( ) = CHAR_LPRNT ) then
+			   if( dtype = typeAddrOf( FB_DATATYPE_FUNCTION ) ) then
 				isfuncptr = TRUE
-   			end if
-   		end if
+			   end if
+		   end if
 	end if
 
 	'' function pointer dref? call it
@@ -838,7 +838,9 @@ private function cDynamicArrayIndex _
 	loop while( hMatch( CHAR_COMMA ) )
 
 	'' times length
-	expr = astNewBOP( AST_OP_MUL, expr, astNewCONSTi( symbGetLen( sym ) ) )
+	'' symbGetLen( sym )  ->  sym may have wrong lgt for z/wstring if passed as parameter
+	'' must take element_len, because this is always correct 
+	expr = astNewBOP( AST_OP_MUL, expr, astBuildDerefAddrOf( astCloneTree( descexpr ), symb.fbarray_dimtb - symb.fbarray_size, FB_DATATYPE_INTEGER, NULL ))
 
 	'' No longer needed, all places using it should have cloned
 	astDelTree( descexpr )
@@ -897,7 +899,7 @@ private function hVarAddUndecl _
 	if( fbLangOptIsSet( FB_LANG_OPT_SCOPE ) ) then
 		'' deprecated quirk: not inside an explicit SCOPE .. END SCOPE block?
 		if( fbGetIsScope( ) = FALSE ) then
- 			options or= FB_SYMBOPT_UNSCOPE
+			 options or= FB_SYMBOPT_UNSCOPE
 		end if
 
 	'' no scopes..
@@ -940,7 +942,7 @@ private function hMakeArrayIdx( byval sym as FBSYMBOL ptr ) as ASTNODE ptr
 				symb.fbarray_data, FB_DATATYPE_INTEGER )
 	end if
 
-    '' static array, return lbound( array )
+	'' static array, return lbound( array )
 	assert( symbGetArrayDimensions( sym ) > 0 )
 	function = astNewCONSTi( symbArrayLbound( sym, 0 ) )
 end function
@@ -973,8 +975,8 @@ function cVariableEx overload _
 	is_array = symbIsArray( sym )
 	is_funcptr = FALSE
 
-    varexpr = NULL
-    idxexpr = NULL
+	varexpr = NULL
+	idxexpr = NULL
 
 	dim as integer check_fields = TRUE, is_nidxarray = FALSE
 
@@ -1016,7 +1018,7 @@ function cVariableEx overload _
 					hSkipUntil( CHAR_RPRNT, TRUE )
 				end if
 			else
-   				'' check if calling functions through pointers
+				   '' check if calling functions through pointers
 				is_funcptr = (symbGetType( sym ) = typeAddrOf( FB_DATATYPE_FUNCTION ))
 
 				'' using (...) with scalars?
@@ -1070,10 +1072,10 @@ function cVariableEx overload _
 	assert( varexpr->dtype = sym->typ )
 	assert( varexpr->subtype = sym->subtype )
 
-   	if( is_funcptr = FALSE ) then
-   		if( check_fields ) then
-   			'' ('.' UdtMember)?
-   			if( lexGetToken( ) = CHAR_DOT ) then
+	   if( is_funcptr = FALSE ) then
+		   if( check_fields ) then
+			   '' ('.' UdtMember)?
+			   if( lexGetToken( ) = CHAR_DOT ) then
 
 				if( astGetDataType( varexpr ) <> FB_DATATYPE_STRUCT ) then
 					errReport( FB_ERRMSG_EXPECTEDUDT, TRUE )
@@ -1081,29 +1083,29 @@ function cVariableEx overload _
 					return varexpr
 				end if
 
-   				lexSkipToken( LEXCHECK_NOPERIOD )
+				   lexSkipToken( LEXCHECK_NOPERIOD )
 
 				varexpr = cUdtMember( varexpr->dtype, varexpr->subtype, astNewADDROF( varexpr ), check_array )
-   				if( varexpr = NULL ) then
-   					exit function
-   				end if
+				   if( varexpr = NULL ) then
+					   exit function
+				   end if
 
-   				'' non-indexed array?
+				   '' non-indexed array?
 				if( astIsNIDXARRAY( varexpr ) ) then
 					return varexpr
 				end if
 
-				'' check if	calling	functions through pointers
-				if(	lexGetToken( ) = CHAR_LPRNT	) then
+				'' check if    calling    functions through pointers
+				if(    lexGetToken( ) = CHAR_LPRNT    ) then
 					is_funcptr = (astGetDataType( varexpr ) = typeAddrOf( FB_DATATYPE_FUNCTION ))
-				end	if
+				end    if
 
 			end if
-   		end if
-   	end if
+		   end if
+	   end if
 
-    if( check_fields ) then
-    	'' FuncPtrOrMemberDeref?
+	if( check_fields ) then
+		'' FuncPtrOrMemberDeref?
 		varexpr = cFuncPtrOrMemberDeref( varexpr->dtype, varexpr->subtype, varexpr, is_funcptr, check_array )
 	else
 		if( is_nidxarray ) then
@@ -1141,13 +1143,13 @@ function cVariableEx _
 	end if
 
 	if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then
-    	'' no suffix? lookup the default type (last DEF###) in the
-    	'' case symbol could not be found..
-    	if( suffix = FB_DATATYPE_INVALID ) then
-    		sym = symbFindVarByDefType( chain_, symbGetDefType( id ) )
-    	else
-    		sym = symbFindVarBySuffix( chain_, suffix )
-    	end if
+		'' no suffix? lookup the default type (last DEF###) in the
+		'' case symbol could not be found..
+		if( suffix = FB_DATATYPE_INVALID ) then
+			sym = symbFindVarByDefType( chain_, symbGetDefType( id ) )
+		else
+			sym = symbFindVarBySuffix( chain_, suffix )
+		end if
 
 	else
 		if( suffix <> FB_DATATYPE_INVALID ) then
@@ -1166,18 +1168,18 @@ function cVariableEx _
 		end if
 
 		'' don't allow explicit namespaces
-    	if( chain_ <> NULL ) then
-    		if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then
-    			'' variable?
-    			sym = symbFindByClass( chain_, FB_SYMBCLASS_VAR )
-    			if( sym <> NULL ) then
-    				'' from a different namespace?
-    				if( symbGetNamespace( sym ) <> symbGetCurrentNamespc( ) ) then
+		if( chain_ <> NULL ) then
+			if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then
+				'' variable?
+				sym = symbFindByClass( chain_, FB_SYMBCLASS_VAR )
+				if( sym <> NULL ) then
+					'' from a different namespace?
+					if( symbGetNamespace( sym ) <> symbGetCurrentNamespc( ) ) then
 						errReport( FB_ERRMSG_DECLOUTSIDENAMESPC )
-    				end if
-    			end if
-    		end if
-    	end if
+					end if
+				end if
+			end if
+		end if
 
 		'' add undeclared variable
 		sym = hVarAddUndecl( id, suffix )
@@ -1220,30 +1222,30 @@ private function hImpField _
 
 	varexpr = cUdtMember( dtype, subtype, varexpr, check_array, options )
 
-   	if( varexpr = NULL ) then
-   		return NULL
-   	end if
+	   if( varexpr = NULL ) then
+		   return NULL
+	   end if
 
-   	'' non-indexed array?
-   	if( astIsNIDXARRAY( varexpr ) ) then
-   		return varexpr
-   	end if
+	   '' non-indexed array?
+	   if( astIsNIDXARRAY( varexpr ) ) then
+		   return varexpr
+	   end if
 
-	dtype =	astGetFullType( varexpr )
-	subtype	= astGetSubType( varexpr )
+	dtype =    astGetFullType( varexpr )
+	subtype    = astGetSubType( varexpr )
 
-	'' check if	calling	functions through pointers
+	'' check if    calling    functions through pointers
 	dim as integer is_funcptr = FALSE
-	if(	lexGetToken( ) = CHAR_LPRNT	) then
+	if(    lexGetToken( ) = CHAR_LPRNT    ) then
 		is_funcptr = (typeGetDtAndPtrOnly( dtype ) = typeAddrOf( FB_DATATYPE_FUNCTION ))
-	end	if
+	end    if
 
-    '' FuncPtrOrMemberDeref?
+	'' FuncPtrOrMemberDeref?
 	function = cFuncPtrOrMemberDeref( dtype, _
-								 	  subtype, _
-								 	  varexpr, _
-								 	  is_funcptr, _
-								 	  check_array )
+									   subtype, _
+									   varexpr, _
+									   is_funcptr, _
+									   check_array )
 end function
 
 ''  WithVariable  = '.' UdtMember FuncPtrOrMemberDeref? .
@@ -1274,9 +1276,9 @@ function cVariable _
 	) as ASTNODE ptr
 
 	'' ID
-    select case lexGetClass( )
-    case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_QUIRKWD
-	    return cVariableEx( chain_, check_array )
+	select case lexGetClass( )
+	case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_QUIRKWD
+		return cVariableEx( chain_, check_array )
 
 	case else
 		if( parser.stmt.with = NULL ) then
@@ -1361,7 +1363,7 @@ function cVarOrDeref _
 
 		select case as const astGetClass( t )
 		case AST_NODECLASS_VAR, AST_NODECLASS_IDX, _
-		     AST_NODECLASS_FIELD, AST_NODECLASS_DEREF
+			 AST_NODECLASS_FIELD, AST_NODECLASS_DEREF
 			complain = FALSE
 
 		case AST_NODECLASS_CALL, AST_NODECLASS_NIDXARRAY

--- a/src/compiler/parser-quirk-math.bas
+++ b/src/compiler/parser-quirk-math.bas
@@ -110,8 +110,7 @@ private function hLenSizeof( byval tk as integer, byval isasm as integer ) as AS
 	dim as integer dtype = any
 	dim as longint lgt = any
 	dim as FBSYMBOL ptr subtype = any
-	dim descexpr as astnode ptr                       
-	dim sizeexpr as astnode ptr
+	dim sizeexpr as ASTNODE ptr
 
 	'' LEN | SIZEOF
 	lexSkipToken( )
@@ -152,32 +151,15 @@ private function hLenSizeof( byval tk as integer, byval isasm as integer ) as AS
 				expr = astNewCONSTi( lgt )
 			end if
 		else
-			'' sizeof() - special handling for passed z/wstring arrays
-			select case( typeGetDtAndPtrOnly( expr->dtype ) )             
-			case FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR, FB_DATATYPE_FIXSTR
-				if( expr->sym ) then
-					if symbIsParamBydesc(expr->sym) then
-						'' Build a VAR access with the BYDESC param's real dtype
-						descexpr = astNewVAR( expr->sym )
-						assert( symbIsStruct( expr->sym->var_.array.desctype ) and symbIsDescriptor( expr->sym->var_.array.desctype ) )
-						astSetType( descexpr, typeAddrOf( FB_DATATYPE_STRUCT ), expr->sym->var_.array.desctype )
+			'' sizeof()
+			sizeexpr = bydescStringSize(expr)         
+			if sizeexpr <> null then
+				astDelTree( expr )
+				function = sizeexpr
+				exit function
+			end if
 
-						'' And DEREF to get to the descriptor
-						descexpr = astNewDEREF( descexpr )
-						sizeexpr = astBuildDerefAddrOf( astCloneTree( descexpr ), symb.fbarray_dimtb - symb.fbarray_size, FB_DATATYPE_INTEGER, NULL )
-
-						if sizeexpr <> null then
-							astDelTree( expr )
-							astDelTree( descexpr )
-							function = sizeexpr
-							exit function
-						end if
-					end if
-				end if
-			end select
-
-			'' sizeof() - regular processing
-			lgt = astSizeOf( expr )
+			lgt = astSizeOf( expr )                   
 			astDelTree( expr )
 			expr = astNewCONSTi( lgt )
 		end if

--- a/src/compiler/parser.bi
+++ b/src/compiler/parser.bi
@@ -7,92 +7,92 @@
 
 '' compound statements permissions
 enum FB_CMPSTMT_MASK
-	FB_CMPSTMT_MASK_NOTHING		= &h00000000
-	FB_CMPSTMT_MASK_CODE		= &h00000001
-	FB_CMPSTMT_MASK_PROC		= &h00000002
-	FB_CMPSTMT_MASK_NAMESPC		= &h00000004
-	FB_CMPSTMT_MASK_DECL		= &h00000008
-	FB_CMPSTMT_MASK_EXTERN		= &h00000010
-	FB_CMPSTMT_MASK_DATA		= &h00000020
-	FB_CMPSTMT_MASK_ALL 		= &hFFFFFFFF
-	FB_CMPSTMT_MASK_DEFAULT		= FB_CMPSTMT_MASK_CODE
+	FB_CMPSTMT_MASK_NOTHING        = &h00000000
+	FB_CMPSTMT_MASK_CODE        = &h00000001
+	FB_CMPSTMT_MASK_PROC        = &h00000002
+	FB_CMPSTMT_MASK_NAMESPC        = &h00000004
+	FB_CMPSTMT_MASK_DECL        = &h00000008
+	FB_CMPSTMT_MASK_EXTERN        = &h00000010
+	FB_CMPSTMT_MASK_DATA        = &h00000020
+	FB_CMPSTMT_MASK_ALL         = &hFFFFFFFF
+	FB_CMPSTMT_MASK_DEFAULT        = FB_CMPSTMT_MASK_CODE
 end enum
 
 '' compound statements stats
 type FB_CMPSTMTSTK_ as FB_CMPSTMTSTK
 
 type FB_CMPSTMT_DO
-	attop			as integer
-	inilabel		as FBSYMBOL ptr
-	cmplabel		as FBSYMBOL ptr
-	endlabel		as FBSYMBOL ptr
-	last			as FB_CMPSTMTSTK_ ptr
+	attop            as integer
+	inilabel        as FBSYMBOL ptr
+	cmplabel        as FBSYMBOL ptr
+	endlabel        as FBSYMBOL ptr
+	last            as FB_CMPSTMTSTK_ ptr
 end type
 
 type FB_CMPSTMT_WHILE
-	cmplabel		as FBSYMBOL ptr
-	endlabel		as FBSYMBOL ptr
-	last			as FB_CMPSTMTSTK_ ptr
+	cmplabel        as FBSYMBOL ptr
+	endlabel        as FBSYMBOL ptr
+	last            as FB_CMPSTMTSTK_ ptr
 end type
 
 type FB_CMPSTMT_FORELM
-	sym				as FBSYMBOL ptr				'' if sym = null, value will be used
-	value			as FBVALUE
-	dtype			as integer
+	sym                as FBSYMBOL ptr                '' if sym = null, value will be used
+	value            as FBVALUE
+	dtype            as integer
 end type
 
 type FB_CMPSTMT_FOR
-	outerscopenode	as ASTNODE ptr
-	cnt				as FB_CMPSTMT_FORELM
-	end            	as FB_CMPSTMT_FORELM
-	stp				as FB_CMPSTMT_FORELM
-	ispos			as FB_CMPSTMT_FORELM
-	testlabel		as FBSYMBOL ptr
-	inilabel		as FBSYMBOL ptr
-	cmplabel		as FBSYMBOL ptr
-	endlabel		as FBSYMBOL ptr
-	last			as FB_CMPSTMTSTK_ ptr
+	outerscopenode    as ASTNODE ptr
+	cnt                as FB_CMPSTMT_FORELM
+	end                as FB_CMPSTMT_FORELM
+	stp                as FB_CMPSTMT_FORELM
+	ispos            as FB_CMPSTMT_FORELM
+	testlabel        as FBSYMBOL ptr
+	inilabel        as FBSYMBOL ptr
+	cmplabel        as FBSYMBOL ptr
+	endlabel        as FBSYMBOL ptr
+	last            as FB_CMPSTMTSTK_ ptr
 	explicit_step   as integer
 end type
 
 type FB_CMPSTMT_IF
-	issingle		as integer
-	nxtlabel		as FBSYMBOL ptr
-	endlabel		as FBSYMBOL ptr
-	elsecnt			as integer
+	issingle        as integer
+	nxtlabel        as FBSYMBOL ptr
+	endlabel        as FBSYMBOL ptr
+	elsecnt            as integer
 end type
 
 type FB_CMPSTMT_PROC
-	tkn				as FB_TOKEN
-	is_nested		as integer
-	endlabel		as FBSYMBOL ptr
-	last			as FB_CMPSTMTSTK_ ptr
+	tkn                as FB_TOKEN
+	is_nested        as integer
+	endlabel        as FBSYMBOL ptr
+	last            as FB_CMPSTMTSTK_ ptr
 end type
 
 type FB_CMPSTMT_SELCONST
-	base			as integer
-	deflabel 		as FBSYMBOL ptr
-	dtype			as integer  '' original data type SELECT CASE AS CONST converts sym to u(long)int
-	bias			as ulongint '' bias (distance to zero)
+	base            as integer
+	deflabel         as FBSYMBOL ptr
+	dtype            as integer  '' original data type SELECT CASE AS CONST converts sym to u(long)int
+	bias            as ulongint '' bias (distance to zero)
 end type
 
 type FB_CMPSTMT_SELECT
-	isconst			as integer
-	sym				as FBSYMBOL ptr
-	casecnt			as integer
-	const_			as FB_CMPSTMT_SELCONST
-	cmplabel		as FBSYMBOL ptr
-	endlabel		as FBSYMBOL ptr
-	last			as FB_CMPSTMTSTK_ ptr
-	outerscopenode		as ASTNODE ptr '' Big scope around the whole SELECT compound (to destroy its temp var)
+	isconst            as integer
+	sym                as FBSYMBOL ptr
+	casecnt            as integer
+	const_            as FB_CMPSTMT_SELCONST
+	cmplabel        as FBSYMBOL ptr
+	endlabel        as FBSYMBOL ptr
+	last            as FB_CMPSTMTSTK_ ptr
+	outerscopenode        as ASTNODE ptr '' Big scope around the whole SELECT compound (to destroy its temp var)
 end type
 
 type FB_CMPSTMT_WITH
 	'' The WITH temp var (if it needed to use a pointer), or the variable
 	'' (if a simple VAR access was given to the WITH)
-	sym		as FBSYMBOL ptr
-	is_ptr		as integer
-	last		as FB_CMPSTMTSTK_ ptr  '' Previous WITH node on the stack; so parser.stmt.with can be restored in cCompStmtPop()
+	sym        as FBSYMBOL ptr
+	is_ptr        as integer
+	last        as FB_CMPSTMTSTK_ ptr  '' Previous WITH node on the stack; so parser.stmt.with can be restored in cCompStmtPop()
 end type
 
 type FB_CMPSTMT_NAMESPACE
@@ -101,67 +101,67 @@ type FB_CMPSTMT_NAMESPACE
 end type
 
 type FB_CMPSTMT_EXTERN
-	lastmang		as FB_MANGLING
+	lastmang        as FB_MANGLING
 end type
 
 type FB_CMPSTMT_SCOPE
-	lastis_scope	as integer
+	lastis_scope    as integer
 end type
 
 type FB_CMPSTMTSTK
-	id			as integer
-	allowmask	as FB_CMPSTMT_MASK
-	scopenode	as ASTNODE ptr
+	id            as integer
+	allowmask    as FB_CMPSTMT_MASK
+	scopenode    as ASTNODE ptr
 	union
-		for		as FB_CMPSTMT_FOR
-		do		as FB_CMPSTMT_DO
-		while	as FB_CMPSTMT_WHILE
-		if		as FB_CMPSTMT_IF
-		proc	as FB_CMPSTMT_PROC
-		select	as FB_CMPSTMT_SELECT
-		with	as FB_CMPSTMT_WITH
-		nspc	as FB_CMPSTMT_NAMESPACE
-		ext		as FB_CMPSTMT_EXTERN
-		scp		as FB_CMPSTMT_SCOPE
+		for        as FB_CMPSTMT_FOR
+		do        as FB_CMPSTMT_DO
+		while    as FB_CMPSTMT_WHILE
+		if        as FB_CMPSTMT_IF
+		proc    as FB_CMPSTMT_PROC
+		select    as FB_CMPSTMT_SELECT
+		with    as FB_CMPSTMT_WITH
+		nspc    as FB_CMPSTMT_NAMESPACE
+		ext        as FB_CMPSTMT_EXTERN
+		scp        as FB_CMPSTMT_SCOPE
 	end union
 end type
 
 type FB_LETSTMT_NODE
-	expr			as ASTNODE ptr
+	expr            as ASTNODE ptr
 end type
 
 type FBPARSER_STMT_LET
-	list			as TLIST					'' of FB_LETSTMT_NODE
+	list            as TLIST                    '' of FB_LETSTMT_NODE
 end type
 
 '' parser context
 type FBPARSER_STMT
-	stk				as TSTACK
-	id				as FB_TOKEN					'' current compound stmt id
+	stk                as TSTACK
+	id                as FB_TOKEN                    '' current compound stmt id
 
-	cnt				as integer		            '' keep track of :'s to help scope break's
+	cnt                as integer                    '' keep track of :'s to help scope break's
 
-	for				as FB_CMPSTMTSTK ptr
-	do				as FB_CMPSTMTSTK ptr
-	while			as FB_CMPSTMTSTK ptr
-	select			as FB_CMPSTMTSTK ptr
-	proc			as FB_CMPSTMTSTK ptr
-	with			as FB_CMPSTMTSTK ptr
-	let				as FBPARSER_STMT_LET
+	for                as FB_CMPSTMTSTK ptr
+	do                as FB_CMPSTMTSTK ptr
+	while            as FB_CMPSTMTSTK ptr
+	select            as FB_CMPSTMTSTK ptr
+	proc            as FB_CMPSTMTSTK ptr
+	with            as FB_CMPSTMTSTK ptr
+	let                as FBPARSER_STMT_LET
 end type
 
 enum FB_PARSEROPT
-	FB_PARSEROPT_NONE			= &h00000000
-	FB_PARSEROPT_PRNTOPT		= &h00000001
-	FB_PARSEROPT_CHKARRAY		= &h00000002	'' used by LEN() to handle expr's and ()-less arrays (while set, there will be "array access, index expected" errors, unsetting allows to have no-index arrays, e.g. as bydesc arguments, or in l/ubound())
-	FB_PARSEROPT_ISEXPR			= &h00000004	'' parsing an expression?
-	FB_PARSEROPT_ISSCOPE		= &h00000008
-	FB_PARSEROPT_ISFUNC			= &h00000010
-	FB_PARSEROPT_OPTONLY		= &h00000020
-	FB_PARSEROPT_HASINSTPTR		= &h00000040
-	FB_PARSEROPT_ISPROPGET		= &h00000080
-	FB_PARSEROPT_EQINPARENSONLY	= &h00000100	'' only check for '=' if inside parentheses
-	FB_PARSEROPT_GTINPARENSONLY	= &h00000200	'' only check for '>' if inside parentheses
+	FB_PARSEROPT_NONE            = &h00000000
+	FB_PARSEROPT_PRNTOPT        = &h00000001
+	FB_PARSEROPT_CHKARRAY        = &h00000002    '' used by LEN() to handle expr's and ()-less arrays (while set, there will be "array access, index expected" errors, unsetting allows to have no-index arrays, e.g. as bydesc arguments, or in l/ubound())
+	FB_PARSEROPT_ISEXPR            = &h00000004    '' parsing an expression?
+	FB_PARSEROPT_ISSCOPE        = &h00000008
+	FB_PARSEROPT_ISFUNC            = &h00000010
+	FB_PARSEROPT_OPTONLY        = &h00000020
+	FB_PARSEROPT_HASINSTPTR        = &h00000040
+	FB_PARSEROPT_ISPROPGET        = &h00000080
+	FB_PARSEROPT_EQINPARENSONLY    = &h00000100    '' only check for '=' if inside parentheses
+	FB_PARSEROPT_GTINPARENSONLY    = &h00000200    '' only check for '>' if inside parentheses
 	FB_PARSEROPT_ISPP               = &h00000400  '' PP expression? (e.g. #if condition)
 	FB_PARSEROPT_EXPLICITBASE       = &h00000800  '' Used to tell cProcArgList() & co about explicit BASE accesses from hBaseMemberAccess() functions
 	FB_PARSEROPT_IDXINPARENSONLY    = &h00001000  '' Only parse array index if inside parentheses (used by REDIM, so it can handle 'expr(1 to 2)', where the expression parser should parse 'expr' but not the '(1 to 2)' part)
@@ -169,51 +169,51 @@ end enum
 
 type PARSERCTX
 	'' stmt recursion
-	stmt			as FBPARSER_STMT
-	nspcrec			as integer					'' namespace recursion
+	stmt            as FBPARSER_STMT
+	nspcrec            as integer                    '' namespace recursion
 
 	'' globals
-	scope			as uinteger					'' current scope (0=main module)
+	scope            as uinteger                    '' current scope (0=main module)
 
-	mangling		as FB_MANGLING				'' current EXTERN's mangling
+	mangling        as FB_MANGLING                '' current EXTERN's mangling
 
-	currproc 		as FBSYMBOL ptr				'' current proc
-	currblock 		as FBSYMBOL ptr				'' current scope block (= proc if outside any block)
+	currproc         as FBSYMBOL ptr                '' current proc
+	currblock         as FBSYMBOL ptr                '' current scope block (= proc if outside any block)
 
-	ovlarglist		as TLIST					'' used to resolve calls to overloaded functions
+	ovlarglist        as TLIST                    '' used to resolve calls to overloaded functions
 
 	'' hacks
-	prntcnt			as integer					'' ()'s count, to allow optional ()'s on SUB's
-	options			as FB_PARSEROPT
+	prntcnt            as integer                    '' ()'s count, to allow optional ()'s on SUB's
+	options            as FB_PARSEROPT
 	ctx_dtype       as integer                  '' used to resolve the address of overloaded procs
-	ctxsym			as FBSYMBOL ptr				'' /
-	have_eq_outside_parens	as integer
+	ctxsym            as FBSYMBOL ptr                '' /
+	have_eq_outside_parens    as integer
 end type
 
 '' cSymbolType flags
 enum FB_SYMBTYPEOPT
-	FB_SYMBTYPEOPT_NONE			= &h00000000
+	FB_SYMBTYPEOPT_NONE            = &h00000000
 
-	FB_SYMBTYPEOPT_CHECKSTRPTR	= &h00000001
-	FB_SYMBTYPEOPT_ALLOWFORWARD	= &h00000002
-	FB_SYMBTYPEOPT_ISBYREF		= &h00000004
+	FB_SYMBTYPEOPT_CHECKSTRPTR    = &h00000001
+	FB_SYMBTYPEOPT_ALLOWFORWARD    = &h00000002
+	FB_SYMBTYPEOPT_ISBYREF        = &h00000004
 
-	FB_SYMBTYPEOPT_DEFAULT		= FB_SYMBTYPEOPT_CHECKSTRPTR
+	FB_SYMBTYPEOPT_DEFAULT        = FB_SYMBTYPEOPT_CHECKSTRPTR
 end enum
 
 '' cIdentifier flags
 enum FB_IDOPT
-	FB_IDOPT_NONE				= &h00000000
+	FB_IDOPT_NONE                = &h00000000
 
-	FB_IDOPT_DONTCHKPERIOD		= &h00000001
-	FB_IDOPT_SHOWERROR			= &h00000002
-	FB_IDOPT_ISDECL				= &h00000004
-	FB_IDOPT_ISOPERATOR			= &h00000008
-	FB_IDOPT_ALLOWSTRUCT		= &h00000010
+	FB_IDOPT_DONTCHKPERIOD        = &h00000001
+	FB_IDOPT_SHOWERROR            = &h00000002
+	FB_IDOPT_ISDECL                = &h00000004
+	FB_IDOPT_ISOPERATOR            = &h00000008
+	FB_IDOPT_ALLOWSTRUCT        = &h00000010
 	FB_IDOPT_CHECKSTATIC        = &h00000020
 	FB_IDOPT_ISVAR              = &h00000040  '' parsing namespace prefix for variable declaration?
 
-	FB_IDOPT_DEFAULT			= FB_IDOPT_SHOWERROR or FB_IDOPT_CHECKSTATIC
+	FB_IDOPT_DEFAULT            = FB_IDOPT_SHOWERROR or FB_IDOPT_CHECKSTATIC
 end enum
 
 '' cInitializer flags
@@ -225,9 +225,9 @@ end enum
 
 '' cProcHeader() flags
 enum FB_PROCOPT
-	FB_PROCOPT_NONE			= &h00000000
-	FB_PROCOPT_ISPROTO		= &h00000001
-	FB_PROCOPT_HASPARENT		= &h00000002
+	FB_PROCOPT_NONE            = &h00000000
+	FB_PROCOPT_ISPROTO        = &h00000001
+	FB_PROCOPT_HASPARENT        = &h00000002
 end enum
 
 '' cVarOrDeref flags
@@ -315,7 +315,8 @@ declare function cSymbolType _
 		byref subtype as FBSYMBOL ptr, _
 		byref lgt as longint = 0, _
 		byref is_fixlenstr as integer = FALSE, _
-		byval options as FB_SYMBTYPEOPT = FB_SYMBTYPEOPT_DEFAULT _
+		byval options as FB_SYMBTYPEOPT = FB_SYMBTYPEOPT_DEFAULT, _
+		byval mode as INTEGER = 0 _                  
 	) as integer
 
 declare function cIdentifier _
@@ -646,12 +647,12 @@ declare function cFunctionCall _
 	) as ASTNODE ptr
 
 declare sub hMethodCallAddInstPtrOvlArg _
-    ( _
-        byval proc as FBSYMBOL ptr, _
-        byval thisexpr as ASTNODE ptr, _
-        byval arg_list as FB_CALL_ARG_LIST ptr, _
-        byval options as FB_PARSEROPT ptr _
-    )
+	( _
+		byval proc as FBSYMBOL ptr, _
+		byval thisexpr as ASTNODE ptr, _
+		byval arg_list as FB_CALL_ARG_LIST ptr, _
+		byval options as FB_PARSEROPT ptr _
+	)
 
 declare function cMaybeIgnoreCallResult( byval expr as ASTNODE ptr ) as integer
 

--- a/src/compiler/rtl-data.bas
+++ b/src/compiler/rtl-data.bas
@@ -185,12 +185,12 @@ function rtlDataRead _
 		byval varexpr as ASTNODE ptr _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
 	dim as integer args = any, dtype = any
-	dim as longint lgt = any
+	dim as ASTNODE ptr lgt = any
 
-    function = FALSE
+	function = FALSE
 
 	f = NULL
 	args = 1
@@ -238,27 +238,27 @@ function rtlDataRead _
 		exit function
 	end select
 
-    if( f = NULL ) then
-    	exit function
-    end if
-
-    proc = astNewCALL( f )
-
-    if( args > 1 ) then
-    	'' always calc len before pushing the param
-		lgt = rtlCalcStrLen( varexpr, dtype )
-	else
-		lgt = 0
+	if( f = NULL ) then
+		exit function
 	end if
 
-    '' byref var as any
-    if( astNewARG( proc, varexpr ) = NULL ) then
+	proc = astNewCALL( f )
+
+	if( args > 1 ) then
+		'' always calc len before pushing the param
+		lgt = rtlCalcStrLen2( varexpr, dtype )
+	else
+		lgt = astNewCONSTi( 0 )
+	end if
+
+	'' byref var as any
+	if( astNewARG( proc, varexpr ) = NULL ) then
  		exit function
  	end if
 
 	if( args > 1 ) then
 		'' byval dst_size as integer
-		if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+		if( astNewARG( proc, lgt ) = NULL ) then
 			exit function
 		end if
 
@@ -270,10 +270,10 @@ function rtlDataRead _
 		end if
 	end if
 
-    ''
-    astAdd( proc )
+	''
+	astAdd( proc )
 
-    function = TRUE
+	function = TRUE
 
 end function
 
@@ -283,12 +283,12 @@ function rtlDataRestore _
 		byval afternode as ASTNODE ptr _
 	) as integer
 
-    dim as ASTNODE ptr proc = any, expr = any
-    dim as FBSYMBOL ptr sym = any
+	dim as ASTNODE ptr proc = any, expr = any
+	dim as FBSYMBOL ptr sym = any
 
-    function = FALSE
+	function = FALSE
 
-    proc = astNewCALL( PROCLOOKUP( DATARESTORE ), NULL )
+	proc = astNewCALL( PROCLOOKUP( DATARESTORE ), NULL )
 
 	'' byval labeladdrs as void ptr
 	if( label = NULL ) then

--- a/src/compiler/rtl-file.bas
+++ b/src/compiler/rtl-file.bas
@@ -1196,12 +1196,12 @@ function rtlFileOpen _
 		byval flen as ASTNODE ptr, _
 		byval fencoding as ASTNODE ptr, _
 		byval isfunc as integer, _
-        byval openkind as FBOPENKIND _
+		byval openkind as FBOPENKIND _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer doencoding = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer doencoding = any
 
 	function = NULL
 
@@ -1217,25 +1217,25 @@ function rtlFileOpen _
 			f = PROCLOOKUP( FILEOPEN_ENCOD )
 		end if
 
-    case FB_FILE_TYPE_CONS
+	case FB_FILE_TYPE_CONS
 		f = PROCLOOKUP( FILEOPEN_CONS )
 
-    case FB_FILE_TYPE_ERR
+	case FB_FILE_TYPE_ERR
 		f = PROCLOOKUP( FILEOPEN_ERR )
 
-    case FB_FILE_TYPE_PIPE
+	case FB_FILE_TYPE_PIPE
 		f = PROCLOOKUP( FILEOPEN_PIPE )
 
-    case FB_FILE_TYPE_SCRN
+	case FB_FILE_TYPE_SCRN
 		f = PROCLOOKUP( FILEOPEN_SCRN )
 
-    case FB_FILE_TYPE_LPT
+	case FB_FILE_TYPE_LPT
 		f = PROCLOOKUP( FILEOPEN_LPT )
 
-    case FB_FILE_TYPE_COM
+	case FB_FILE_TYPE_COM
 		f = PROCLOOKUP( FILEOPEN_COM )
 
-    case else
+	case else
 		assert(openkind = FB_FILE_TYPE_QB)
 		f = PROCLOOKUP( FILEOPEN_QB )
 		doencoding = FALSE
@@ -1307,8 +1307,8 @@ function rtlFileOpenShort _
 		byval isfunc as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
 
 	function = NULL
 
@@ -1359,7 +1359,7 @@ function rtlFileClose _
 		byval isfunc as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
 	function = NULL
 
@@ -1389,13 +1389,13 @@ function rtlFileSeek _
 		byval newpos as ASTNODE ptr _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer pos_dtype = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer pos_dtype = any
 
 	function = FALSE
 
-    pos_dtype = astGetDataType( newpos )
+	pos_dtype = astGetDataType( newpos )
 	assert( typeGetClass( pos_dtype ) = FB_DATACLASS_INTEGER )
 	if( typeGetSize( pos_dtype ) = 8 ) then
 		f = PROCLOOKUP( FILESEEKLARGE )
@@ -1405,13 +1405,13 @@ function rtlFileSeek _
 
 	proc = astNewCALL( f )
 
-    '' byval filenum as integer
-    if( astNewARG( proc, filenum ) = NULL ) then
+	'' byval filenum as integer
+	if( astNewARG( proc, filenum ) = NULL ) then
  		exit function
  	end if
 
-    '' byval newpos as integer
-    if( astNewARG( proc, newpos ) = NULL ) then
+	'' byval newpos as integer
+	if( astNewARG( proc, newpos ) = NULL ) then
  		exit function
  	end if
 
@@ -1425,20 +1425,20 @@ function rtlFileTell _
 		byval filenum as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
-    function = NULL
+	function = NULL
 
 	''
-    proc = astNewCALL( PROCLOOKUP( FILETELL ) )
+	proc = astNewCALL( PROCLOOKUP( FILETELL ) )
 
-    '' byval filenum as integer
-    if( astNewARG( proc, filenum ) = NULL ) then
+	'' byval filenum as integer
+	if( astNewARG( proc, filenum ) = NULL ) then
  		exit function
  	end if
 
-    ''
-    function = proc
+	''
+	function = proc
 
 end function
 
@@ -1452,12 +1452,12 @@ function rtlFilePut _
 		byval isfunc as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any, bytes = any
+	dim as ASTNODE ptr proc = any, bytes = any
 	dim as integer dtype = any, o_dtype = any, isstring = any, islarge = any
-	dim as longint lgt = any
-    dim as FBSYMBOL ptr f = any
+	dim as ASTNODE ptr lgt = any
+	dim as FBSYMBOL ptr f = any
 
-    function = NULL
+	function = NULL
 
 	''
 	dtype    = astGetDataType( src )
@@ -1485,47 +1485,47 @@ function rtlFilePut _
 		end if
 	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    '' byval filenum as integer
-    if( astNewARG( proc, filenum ) = NULL ) then
+	'' byval filenum as integer
+	if( astNewARG( proc, filenum ) = NULL ) then
  		exit function
  	end if
 
-    '' byval offset as integer
-    if( astNewARG( proc, offset ) = NULL ) then
+	'' byval offset as integer
+	if( astNewARG( proc, offset ) = NULL ) then
  		exit function
  	end if
 
-    '' always calc len before pushing the param
-    if( isstring ) then
-    	lgt = rtlCalcStrLen( src, dtype )
-    else
-		lgt = rtlCalcExprLen( src )
-    end if
-
-	if( elements = NULL ) then
-		bytes = astNewCONSTi( lgt )
+	'' always calc len before pushing the param
+	if( isstring ) then
+		lgt = rtlCalcStrLen2( src, dtype )
 	else
-		bytes = astNewBOP( AST_OP_MUL, elements, astNewCONSTi( lgt ) )
+		lgt = rtlCalcExprLen( src )
 	end if
 
-    '' any pointer fields?
-    if( astGetDataType( src ) = FB_DATATYPE_STRUCT ) then
-    	if( symbGetUDTHasPtrField( astGetSubType( src ) ) ) then
+	if( elements = NULL ) then
+		bytes = lgt
+	else
+		bytes = astNewBOP( AST_OP_MUL, elements, lgt )
+	end if
+
+	'' any pointer fields?
+	if( astGetDataType( src ) = FB_DATATYPE_STRUCT ) then
+		if( symbGetUDTHasPtrField( astGetSubType( src ) ) ) then
 			errReportParamWarn( proc->sym, 3, NULL, FB_WARNINGMSG_POINTERFIELDS )
-    	end if
+		end if
 	'' warn if data is pointer
 	elseif( typeIsPtr( astGetDataType( src ) ) ) then
 		errReportParamWarn( proc->sym, 3, NULL, FB_WARNINGMSG_PASSINGPTR )
-    end if
+	end if
 
-    '' value as any | s as string
-    if( astNewARG( proc, src ) = NULL ) then
+	'' value as any | s as string
+	if( astNewARG( proc, src ) = NULL ) then
  		exit function
  	end if
 
-    '' byval bytes as integer
+	'' byval bytes as integer
    	if( astNewARG( proc, bytes ) = NULL ) then
 		exit function
 	end if
@@ -1546,16 +1546,16 @@ function rtlFilePutArray _
 		byval isfunc as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
 	dim as integer o_dtype = any
 
-    function = NULL
+	function = NULL
 
 	if( offset = NULL ) then
 		offset = astNewCONSTi( 0 )
 	end if
-    o_dtype  = astGetDataType( offset )
+	o_dtype  = astGetDataType( offset )
 
 	assert( typeGetClass( o_dtype ) = FB_DATACLASS_INTEGER )
 	if( typeGetSize( o_dtype ) = 8 ) then
@@ -1566,30 +1566,30 @@ function rtlFilePutArray _
 
 	proc = astNewCALL( f )
 
-    '' byval filenum as integer
-    if( astNewARG( proc, filenum ) = NULL ) then
+	'' byval filenum as integer
+	if( astNewARG( proc, filenum ) = NULL ) then
  		exit function
  	end if
 
-    '' byval offset as integer
-    if( astNewARG( proc, offset ) = NULL ) then
+	'' byval offset as integer
+	if( astNewARG( proc, offset ) = NULL ) then
  		exit function
  	end if
 
-    '' any pointer fields?
-    if( astGetDataType( src ) = FB_DATATYPE_STRUCT ) then
-    	if( symbGetUDTHasPtrField( astGetSubType( src ) ) ) then
+	'' any pointer fields?
+	if( astGetDataType( src ) = FB_DATATYPE_STRUCT ) then
+		if( symbGetUDTHasPtrField( astGetSubType( src ) ) ) then
 			errReportParamWarn( proc->sym, 3, NULL, FB_WARNINGMSG_POINTERFIELDS )
-    	end if
+		end if
 	'' warn if data is pointer
 	elseif( typeIsPtr( astGetDataType( src ) ) ) then
 		errReportParamWarn( proc->sym, 3, NULL, FB_WARNINGMSG_PASSINGPTR )
-    end if
+	end if
 
-    '' array() as any
-    if( astNewARG( proc, src ) = NULL ) then
-    	exit function
-    end if
+	'' array() as any
+	if( astNewARG( proc, src ) = NULL ) then
+		exit function
+	end if
 
 	if( isfunc = FALSE ) then
 		astAdd( rtlErrorCheck( proc ) )
@@ -1609,12 +1609,12 @@ function rtlFileGet _
 		byval isfunc as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any, bytes = any
+	dim as ASTNODE ptr proc = any, bytes = any
 	dim as integer dtype = any, o_dtype = any, isstring = any, islarge = any
-	dim as longint lgt = any
-    dim as FBSYMBOL ptr f = any
+	dim as ASTNODE ptr lgt = any
+	dim as FBSYMBOL ptr f = any
 
-    function = NULL
+	function = NULL
 
 	''
 	dtype = astGetDataType( dst )
@@ -1675,48 +1675,48 @@ function rtlFileGet _
 		end if
 	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    '' byval filenum as integer
-    if( astNewARG( proc, filenum ) = NULL ) then
+	'' byval filenum as integer
+	if( astNewARG( proc, filenum ) = NULL ) then
  		exit function
  	end if
 
-    '' byval offset as integer
-    if( astNewARG( proc, offset ) = NULL ) then
+	'' byval offset as integer
+	if( astNewARG( proc, offset ) = NULL ) then
  		exit function
  	end if
 
-    '' always calc len before pushing the param
-    if( isstring ) then
-    	lgt = rtlCalcStrLen( dst, dtype )
-    else
-		lgt = rtlCalcExprLen( dst )
-    end if
-
-	if( elements = NULL ) then
-		bytes = astNewCONSTi( lgt )
+	'' always calc len before pushing the param
+	if( isstring ) then
+		lgt = rtlCalcStrLen2( dst, dtype )
 	else
-		bytes = astNewBOP( AST_OP_MUL, elements, astNewCONSTi( lgt ) )
+		lgt = rtlCalcExprLen( dst )
 	end if
 
-    '' any pointer fields?
-    if( dtype = FB_DATATYPE_STRUCT ) then
-    	if( symbGetUDTHasPtrField( astGetSubType( dst ) ) ) then
+	if( elements = NULL ) then
+		bytes = lgt
+	else
+		bytes = astNewBOP( AST_OP_MUL, elements, lgt )
+	end if
+
+	'' any pointer fields?
+	if( dtype = FB_DATATYPE_STRUCT ) then
+		if( symbGetUDTHasPtrField( astGetSubType( dst ) ) ) then
 			errReportParamWarn( proc->sym, 3, NULL, FB_WARNINGMSG_POINTERFIELDS )
-    	end if
+		end if
 	'' warn if data is pointer
 	elseif( typeIsPtr( astGetDataType( dst ) ) ) then
 		errReportParamWarn( proc->sym, 3, NULL, FB_WARNINGMSG_PASSINGPTR )
-    end if
+	end if
 	
-    '' value as any
-    if( astNewARG( proc, dst ) = NULL ) then
+	'' value as any
+	if( astNewARG( proc, dst ) = NULL ) then
  		exit function
  	end if
 
-    '' byval bytes as integer
-    if( astNewARG( proc, bytes ) = NULL ) then
+	'' byval bytes as integer
+	if( astNewARG( proc, bytes ) = NULL ) then
  		exit function
  	end if
 
@@ -1744,9 +1744,9 @@ function rtlFileGetArray _
 		byval isfunc as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer o_dtype = any, islarge = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer o_dtype = any, islarge = any
 
 	function = NULL
 
@@ -1774,30 +1774,30 @@ function rtlFileGetArray _
 
 	proc = astNewCALL( f )
 
-    '' byval filenum as integer
-    if( astNewARG( proc, filenum ) = NULL ) then
+	'' byval filenum as integer
+	if( astNewARG( proc, filenum ) = NULL ) then
  		exit function
  	end if
 
-    '' byval offset as integer
-    if( astNewARG( proc, offset ) = NULL ) then
+	'' byval offset as integer
+	if( astNewARG( proc, offset ) = NULL ) then
  		exit function
  	end if
 
-    '' any pointer fields?
-    if( astGetDataType( dst ) = FB_DATATYPE_STRUCT ) then
-    	if( symbGetUDTHasPtrField( astGetSubType( dst ) ) ) then
+	'' any pointer fields?
+	if( astGetDataType( dst ) = FB_DATATYPE_STRUCT ) then
+		if( symbGetUDTHasPtrField( astGetSubType( dst ) ) ) then
 			errReportParamWarn( proc->sym, 3, NULL, FB_WARNINGMSG_POINTERFIELDS )
-    	end if
+		end if
 	'' warn if data is pointer
 	elseif( typeIsPtr( astGetDataType( dst ) ) ) then
 		errReportParamWarn( proc->sym, 3, NULL, FB_WARNINGMSG_PASSINGPTR )
-    end if
+	end if
 
-    '' array() as any
-    if( astNewARG( proc, dst ) = NULL ) then
-    	exit function
-    end if
+	'' array() as any
+	if( astNewARG( proc, dst ) = NULL ) then
+		exit function
+	end if
 
 	if( iobytes ) then
 		'' byref iobytes as uinteger
@@ -1820,25 +1820,25 @@ function rtlFileStrInput _
 		byval tk as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
-    function = NULL
+	function = NULL
 
 	proc = astNewCALL( iif( tk = FB_TK_WINPUT, _
 				PROCLOOKUP( FILEWSTRINPUT ), _
 				PROCLOOKUP( FILESTRINPUT ) ) )
 
-    '' byval bytes as integer
-    if( astNewARG( proc, bytesexpr ) = NULL ) then
+	'' byval bytes as integer
+	if( astNewARG( proc, bytesexpr ) = NULL ) then
  		exit function
  	end if
 
-    '' byval filenum as integer
-    if( astNewARG( proc, filenum ) = NULL ) then
+	'' byval filenum as integer
+	if( astNewARG( proc, filenum ) = NULL ) then
  		exit function
  	end if
 
-    function = proc
+	function = proc
 end function
 
 '':::::
@@ -1851,10 +1851,10 @@ function rtlFileLineInput _
 		byval addnewline as integer _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer args = any, dtype = any
-	dim as longint lgt = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer args = any, dtype = any
+	dim as ASTNODE ptr lgt = any
 
 	function = FALSE
 
@@ -1867,28 +1867,28 @@ function rtlFileLineInput _
 		args = 6
 	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    '' "byval filenum as integer" or "text as string "
-    if( (isfile = FALSE) and (expr = NULL) ) then
+	'' "byval filenum as integer" or "text as string "
+	if( (isfile = FALSE) and (expr = NULL) ) then
 		expr = astNewVAR( symbAllocStrConst( "", 0 ) )
 	end if
 
-    if( astNewARG( proc, expr ) = NULL ) then
+	if( astNewARG( proc, expr ) = NULL ) then
  		exit function
  	end if
 
-    '' always calc len before pushing the param
+	'' always calc len before pushing the param
 	dtype = astGetDataType( dstexpr )
-	lgt = rtlCalcStrLen( dstexpr, dtype )
+	lgt = rtlCalcStrLen2( dstexpr, dtype )
 
 	'' dst as any
-    if( astNewARG( proc, dstexpr ) = NULL ) then
+	if( astNewARG( proc, dstexpr ) = NULL ) then
  		exit function
  	end if
 
 	'' byval dstlen as integer
-	if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+	if( astNewARG( proc, lgt ) = NULL ) then
 		exit function
 	end if
 
@@ -1909,9 +1909,9 @@ function rtlFileLineInput _
 		end if
 	end if
 
-    astAdd( proc )
+	astAdd( proc )
 
-    function = TRUE
+	function = TRUE
 
 end function
 
@@ -1925,10 +1925,10 @@ function rtlFileLineInputWstr _
 		byval addnewline as integer _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer args = any, dtype = any
-	dim as longint lgt = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer args = any, dtype = any
+	dim as ASTNODE ptr lgt = any
 
 	function = FALSE
 
@@ -1941,28 +1941,28 @@ function rtlFileLineInputWstr _
 		args = 5
 	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    '' "byval filenum as integer" or "byval text as wstring ptr"
-    if( (isfile = FALSE) and (expr = NULL) ) then
+	'' "byval filenum as integer" or "byval text as wstring ptr"
+	if( (isfile = FALSE) and (expr = NULL) ) then
 		expr = astNewVAR( symbAllocWStrConst( "", 0 ) )
 	end if
 
-    if( astNewARG( proc, expr ) = NULL ) then
+	if( astNewARG( proc, expr ) = NULL ) then
  		exit function
  	end if
 
-    '' always calc len before pushing the param
+	'' always calc len before pushing the param
 	dtype = astGetDataType( dstexpr )
-	lgt = rtlCalcStrLen( dstexpr, dtype )
+	lgt = rtlCalcStrLen2( dstexpr, dtype )
 
 	'' byval dst as wstring ptr
-    if( astNewARG( proc, dstexpr ) = NULL ) then
+	if( astNewARG( proc, dstexpr ) = NULL ) then
  		exit function
  	end if
 
 	'' byval max_chars as integer
-	if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+	if( astNewARG( proc, lgt ) = NULL ) then
 		exit function
 	end if
 
@@ -1978,9 +1978,9 @@ function rtlFileLineInputWstr _
 		end if
 	end if
 
-    astAdd( proc )
+	astAdd( proc )
 
-    function = TRUE
+	function = TRUE
 
 end function
 
@@ -1993,9 +1993,9 @@ function rtlFileInput _
 		byval addnewline as integer _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer args = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer args = any
 
 	function = FALSE
 
@@ -2008,10 +2008,10 @@ function rtlFileInput _
 		args = 3
 	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    '' "byval filenum as integer" or "text as string "
-    if( (isfile = FALSE) and (expr = NULL) ) then
+	'' "byval filenum as integer" or "text as string "
+	if( (isfile = FALSE) and (expr = NULL) ) then
 		expr = astNewVAR( symbAllocStrConst( "", 0 ) )
 	end if
 
@@ -2031,9 +2031,9 @@ function rtlFileInput _
 		end if
 	end if
 
-    astAdd( proc )
+	astAdd( proc )
 
-    function = TRUE
+	function = TRUE
 
 end function
 
@@ -2043,10 +2043,10 @@ function rtlFileInputGet _
 		byval dstexpr as ASTNODE ptr _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer args = any, dtype = any
-	dim as longint lgt = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer args = any, dtype = any
+	dim as ASTNODE ptr lgt = any
 
 	function = FALSE
 
@@ -2094,21 +2094,21 @@ function rtlFileInputGet _
 		exit function
 	end select
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    '' always calc len before pushing the param
-    if( args > 1 ) then
-		lgt = rtlCalcStrLen( dstexpr, dtype )
+	'' always calc len before pushing the param
+	if( args > 1 ) then
+		lgt = rtlCalcStrLen2( dstexpr, dtype )
 	end if
 
-    '' byref dst as any | byval dst as wstring ptr
-    if( astNewARG( proc, dstexpr ) = NULL ) then
+	'' byref dst as any | byval dst as wstring ptr
+	if( astNewARG( proc, dstexpr ) = NULL ) then
  		exit function
  	end if
 
 	if( args > 1 ) then
 		'' byval dstlen as integer
-		if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+		if( astNewARG( proc, lgt ) = NULL ) then
 			exit function
 		end if
 
@@ -2120,9 +2120,9 @@ function rtlFileInputGet _
 		end if
 	end if
 
-    astAdd( proc )
+	astAdd( proc )
 
-    function = TRUE
+	function = TRUE
 
 end function
 
@@ -2135,9 +2135,9 @@ function rtlFileLock _
 		byval endexpr as ASTNODE ptr _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer islarge = any, i_dtype = any, e_dtype = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer islarge = any, i_dtype = any, e_dtype = any
 
 	function = FALSE
 
@@ -2162,26 +2162,26 @@ function rtlFileLock _
 		end if
 	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    '' byval filenum as integer
-    if( astNewARG( proc, filenum ) = NULL ) then
+	'' byval filenum as integer
+	if( astNewARG( proc, filenum ) = NULL ) then
  		exit function
  	end if
 
-    '' byval inipos as integer
-    if( astNewARG( proc, iniexpr ) = NULL ) then
+	'' byval inipos as integer
+	if( astNewARG( proc, iniexpr ) = NULL ) then
  		exit function
  	end if
 
-    '' byval endpos as integer
-    if( astNewARG( proc, endexpr ) = NULL ) then
+	'' byval endpos as integer
+	if( astNewARG( proc, endexpr ) = NULL ) then
  		exit function
  	end if
 
-    astAdd( proc )
+	astAdd( proc )
 
-    function = TRUE
+	function = TRUE
 
 end function
 
@@ -2189,23 +2189,23 @@ end function
 function rtlFileRename _
 	( _
 		byval filename_new as ASTNODE ptr, _
-        byval filename_old as ASTNODE ptr, _
-        byval isfunc as integer _
+		byval filename_old as ASTNODE ptr, _
+		byval isfunc as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
 	function = NULL
 
-    proc = astNewCALL( PROCLOOKUP( FILERENAME ) )
+	proc = astNewCALL( PROCLOOKUP( FILERENAME ) )
 
 	'' byval filename_old as zstring ptr
-    if( astNewARG( proc, filename_old ) = NULL ) then
+	if( astNewARG( proc, filename_old ) = NULL ) then
  		exit function
  	end if
 
 	'' byval filename_new as zstring ptr
-    if( astNewARG( proc, filename_new ) = NULL ) then
+	if( astNewARG( proc, filename_new ) = NULL ) then
  		exit function
  	end if
 
@@ -2221,25 +2221,25 @@ function rtlWidthFile _
 	( _
 		byval fnum as ASTNODE ptr, _
 		byval width_arg as ASTNODE ptr, _
-        byval isfunc as integer _
-    ) as ASTNODE ptr
+		byval isfunc as integer _
+	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
 	function = NULL
 
 	''
-    proc = astNewCALL( PROCLOOKUP( WIDTHFILE ) )
+	proc = astNewCALL( PROCLOOKUP( WIDTHFILE ) )
 
-    '' byval fnum as integer
-    if( astNewARG( proc, fnum ) = NULL ) then
-    	exit function
-    end if
+	'' byval fnum as integer
+	if( astNewARG( proc, fnum ) = NULL ) then
+		exit function
+	end if
 
-    '' byval width_arg as integer
-    if( astNewARG( proc, width_arg ) = NULL ) then
-    	exit function
-    end if
+	'' byval width_arg as integer
+	if( astNewARG( proc, width_arg ) = NULL ) then
+		exit function
+	end if
 
 	if( isfunc = FALSE ) then
 		astAdd( rtlErrorCheck( proc ) )

--- a/src/compiler/rtl-mem.bas
+++ b/src/compiler/rtl-mem.bas
@@ -154,7 +154,7 @@ function rtlNullPtrCheck _
 		byval module as zstring ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
    	function = NULL
 
@@ -173,12 +173,12 @@ function rtlNullPtrCheck _
 		exit function
 	end if
 
-    '' module
+	'' module
 	if( astNewARG( proc, astNewCONSTstr( module ) ) = NULL ) then
-    	exit function
-    end if
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -194,7 +194,7 @@ function rtlMemSwap _
 	dim as ASTNODE ptr proc = astNewCALL( PROCLOOKUP( MEMSWAP ) )
 
 	'' always calc len before pushing the param
-	dim as longint bytes = rtlCalcExprLen( dst )
+	dim as ASTNODE ptr bytes = rtlCalcExprLen( dst )
 
 	'' dst as any
 	if( astNewARG( proc, dst ) = NULL ) then
@@ -207,7 +207,7 @@ function rtlMemSwap _
 	end if
 
 	'' byval bytes as integer
-	if( astNewARG( proc, astNewCONSTi( bytes ) ) = NULL ) then
+	if( astNewARG( proc, bytes ) = NULL ) then
 		exit function
 	end if
 
@@ -225,37 +225,37 @@ function rtlMemCopyClear _
 		byval srclen as longint _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
 	function = FALSE
 
 	''
-    proc = astNewCALL( PROCLOOKUP( MEMCOPYCLEAR ) )
+	proc = astNewCALL( PROCLOOKUP( MEMCOPYCLEAR ) )
 
-    '' dst as any
-    if( astNewARG( proc, dstexpr ) = NULL ) then
-    	exit function
-    end if
+	'' dst as any
+	if( astNewARG( proc, dstexpr ) = NULL ) then
+		exit function
+	end if
 
 	'' byval dstlen as integer
 	if( astNewARG( proc, astNewCONSTi( dstlen ) ) = NULL ) then
 		exit function
 	end if
 
-    '' src as any
-    if( astNewARG( proc, srcexpr ) = NULL ) then
-    	exit function
-    end if
+	'' src as any
+	if( astNewARG( proc, srcexpr ) = NULL ) then
+		exit function
+	end if
 
 	'' byval srclen as integer
 	if( astNewARG( proc, astNewCONSTi( srclen ) ) = NULL ) then
 		exit function
 	end if
 
-    ''
-    astAdd( proc )
+	''
+	astAdd( proc )
 
-    function = TRUE
+	function = TRUE
 
 end function
 

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -2078,39 +2078,39 @@ function rtlStrCompare _
 		byval sdtype2 as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-	dim as longint str1len = any, str2len = any
+	dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr str1len = any, str2len = any
 
 	function = NULL
 
 	''
-    proc = astNewCALL( PROCLOOKUP( STRCOMPARE ) )
+	proc = astNewCALL( PROCLOOKUP( STRCOMPARE ) )
 
    	'' always calc len before pushing the param
-   	str1len = rtlCalcStrLen( str1, sdtype1 )
-	str2len = rtlCalcStrLen( str2, sdtype2 )
+   	str1len = rtlCalcStrLen2( str1, sdtype1 )
+	str2len = rtlCalcStrLen2( str2, sdtype2 )
 
-    '' byref str1 as any
-    if( astNewARG( proc, str1, sdtype1 ) = NULL ) then
-    	exit function
-    end if
+	'' byref str1 as any
+	if( astNewARG( proc, str1, sdtype1 ) = NULL ) then
+		exit function
+	end if
 
 	'' byval str1_len as integer
-	if( astNewARG( proc, astNewCONSTi( str1len ) ) = NULL ) then
+	if( astNewARG( proc, str1len ) = NULL ) then
 		exit function
 	end if
 
-    '' byref str2 as any
-    if( astNewARG( proc, str2, sdtype2 ) = NULL ) then
-    	exit function
-    end if
+	'' byref str2 as any
+	if( astNewARG( proc, str2, sdtype2 ) = NULL ) then
+		exit function
+	end if
 
 	'' byval str2_len as integer
-	if( astNewARG( proc, astNewCONSTi( str2len ) ) = NULL ) then
+	if( astNewARG( proc, str2len ) = NULL ) then
 		exit function
 	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -2121,24 +2121,24 @@ function rtlWstrCompare _
 		byval str2 as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
 	function = NULL
 
 	''
-    proc = astNewCALL( PROCLOOKUP( WSTRCOMPARE ) )
+	proc = astNewCALL( PROCLOOKUP( WSTRCOMPARE ) )
 
-    '' byval str1 as wstring ptr
-    if( astNewARG( proc, str1 ) = NULL ) then
-    	exit function
-    end if
+	'' byval str1 as wstring ptr
+	if( astNewARG( proc, str1 ) = NULL ) then
+		exit function
+	end if
 
-    '' byval str2 as wstring ptr
-    if( astNewARG( proc, str2 ) = NULL ) then
-    	exit function
-    end if
+	'' byval str2 as wstring ptr
+	if( astNewARG( proc, str2 ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -2151,16 +2151,16 @@ function rtlStrConcat _
 		byval sdtype2 as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-	dim as longint str1len = any, str2len = any
-    dim as FBSYMBOL ptr tmp = any
+	dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr str1len = any, str2len = any
+	dim as FBSYMBOL ptr tmp = any
 
 	function = NULL
 
-    proc = astNewCALL( PROCLOOKUP( STRCONCAT ) )
+	proc = astNewCALL( PROCLOOKUP( STRCONCAT ) )
 
-    '' byref dst as string (must be cleaned up due the rtlib assumptions about destine)
-    tmp = symbAddTempVar( FB_DATATYPE_STRING )
+	'' byref dst as string (must be cleaned up due the rtlib assumptions about destine)
+	tmp = symbAddTempVar( FB_DATATYPE_STRING )
 
 	if( astNewARG( proc, _
 		astNewLINK( astBuildTempVarClear( tmp ), _
@@ -2170,30 +2170,30 @@ function rtlStrConcat _
 	end if
 
    	'' always calc len before pushing the param
-   	str1len = rtlCalcStrLen( str1, sdtype1 )
-	str2len = rtlCalcStrLen( str2, sdtype2 )
+   	str1len = rtlCalcStrLen2( str1, sdtype1 )
+	str2len = rtlCalcStrLen2( str2, sdtype2 )
 
-    '' byref str1 as any
-    if( astNewARG( proc, str1, sdtype1 ) = NULL ) then
-    	exit function
-    end if
+	'' byref str1 as any
+	if( astNewARG( proc, str1, sdtype1 ) = NULL ) then
+		exit function
+	end if
 
 	'' byval str1_len as integer
-	if( astNewARG( proc, astNewCONSTi( str1len ) ) = NULL ) then
+	if( astNewARG( proc, str1len ) = NULL ) then
 		exit function
 	end if
 
-    '' byref str2 as any
-    if( astNewARG( proc, str2, sdtype2 ) = NULL ) then
-    	exit function
-    end if
+	'' byref str2 as any
+	if( astNewARG( proc, str2, sdtype2 ) = NULL ) then
+		exit function
+	end if
 
 	'' byval str2_len as integer
-	if( astNewARG( proc, astNewCONSTi( str2len ) ) = NULL ) then
+	if( astNewARG( proc, str2len ) = NULL ) then
 		exit function
 	end if
 
-    function = proc
+	function = proc
 end function
 
 '':::::
@@ -2204,32 +2204,32 @@ function rtlWstrConcatWA _
 		byval sdtype2 as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-	dim as longint str2len = any
+	dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr str2len = any
 
 	function = NULL
 
-    proc = astNewCALL( PROCLOOKUP( WSTRCONCATWA ) )
+	proc = astNewCALL( PROCLOOKUP( WSTRCONCATWA ) )
 
-    '' byval str1 as wstring ptr
-    if( astNewARG( proc, str1 ) = NULL ) then
-    	exit function
-    end if
-
-   	'' always calc len before pushing the param
-   	str2len = rtlCalcStrLen( str2, sdtype2 )
-
-    '' byref str2 as any
-    if( astNewARG( proc, str2, sdtype2 ) = NULL ) then
-    	exit function
-    end if
-
-	'' byval str2_len as integer
-	if( astNewARG( proc, astNewCONSTi( str2len ) ) = NULL ) then
+	'' byval str1 as wstring ptr
+	if( astNewARG( proc, str1 ) = NULL ) then
 		exit function
 	end if
 
-    function = proc
+   	'' always calc len before pushing the param
+   	str2len = rtlCalcStrLen2( str2, sdtype2 )
+
+	'' byref str2 as any
+	if( astNewARG( proc, str2, sdtype2 ) = NULL ) then
+		exit function
+	end if
+
+	'' byval str2_len as integer
+	if( astNewARG( proc, str2len ) = NULL ) then
+		exit function
+	end if
+
+	function = proc
 
 end function
 
@@ -2241,32 +2241,32 @@ function rtlWstrConcatAW _
 		byval str2 as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-	dim as longint str1len = any
+	dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr str1len = any
 
 	function = NULL
 
-    proc = astNewCALL( PROCLOOKUP( WSTRCONCATAW ) )
+	proc = astNewCALL( PROCLOOKUP( WSTRCONCATAW ) )
 
    	'' always calc len before pushing the param
-   	str1len = rtlCalcStrLen( str1, sdtype1 )
+   	str1len = rtlCalcStrLen2( str1, sdtype1 )
 
-    '' byref str1 as any
-    if( astNewARG( proc, str1, sdtype1 ) = NULL ) then
-    	exit function
-    end if
-
-	'' byval str1_len as integer
-	if( astNewARG( proc, astNewCONSTi( str1len ) ) = NULL ) then
+	'' byref str1 as any
+	if( astNewARG( proc, str1, sdtype1 ) = NULL ) then
 		exit function
 	end if
 
-    '' byval str2 as wstring ptr
-    if( astNewARG( proc, str2 ) = NULL ) then
-    	exit function
-    end if
+	'' byval str1_len as integer
+	if( astNewARG( proc, str1len ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	'' byval str2 as wstring ptr
+	if( astNewARG( proc, str2 ) = NULL ) then
+		exit function
+	end if
+
+	function = proc
 
 end function
 
@@ -2279,36 +2279,36 @@ function rtlWstrConcat _
 		byval sdtype2 as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
 	function = NULL
 
 	'' both not wstrings?
-    if( typeGetDtAndPtrOnly( sdtype1 ) <> typeGetDtAndPtrOnly( sdtype2 ) ) then
-    	'' left ?
-    	if( typeGet( sdtype1 ) = FB_DATATYPE_WCHAR ) then
-    		return rtlWstrConcatWA( str1, str2, sdtype2 )
+	if( typeGetDtAndPtrOnly( sdtype1 ) <> typeGetDtAndPtrOnly( sdtype2 ) ) then
+		'' left ?
+		if( typeGet( sdtype1 ) = FB_DATATYPE_WCHAR ) then
+			return rtlWstrConcatWA( str1, str2, sdtype2 )
 
-    	'' right..
-    	else
-    		return rtlWstrConcatAW( str1, sdtype1, str2 )
-    	end if
-    end if
+		'' right..
+		else
+			return rtlWstrConcatAW( str1, sdtype1, str2 )
+		end if
+	end if
 
-    '' both wstrings..
-    proc = astNewCALL( PROCLOOKUP( WSTRCONCAT ) )
+	'' both wstrings..
+	proc = astNewCALL( PROCLOOKUP( WSTRCONCAT ) )
 
-    '' byval str1 as wstring ptr
-    if( astNewARG( proc, str1 ) = NULL ) then
-    	exit function
-    end if
+	'' byval str1 as wstring ptr
+	if( astNewARG( proc, str1 ) = NULL ) then
+		exit function
+	end if
 
-    '' byval str2 as wstring ptr
-    if( astNewARG( proc, str2 ) = NULL ) then
-    	exit function
-    end if
+	'' byval str2 as wstring ptr
+	if( astNewARG( proc, str2 ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -2319,9 +2319,10 @@ function rtlStrConcatAssign _
 		byval src as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 	dim as integer ddtype = any, sdtype = any
-	dim as longint lgt = any
+	dim as ASTNODE ptr lgt = any
+	dim as ASTNODE ptr lgt2 = any
 
 	function = NULL
 
@@ -2330,29 +2331,29 @@ function rtlStrConcatAssign _
    	ddtype = astGetDataType( dst )
 
 	'' always calc len before pushing the param
-	lgt = rtlCalcStrLen( dst, ddtype )
+	lgt = rtlCalcStrLen2( dst, ddtype )
 
 	'' dst as any
 	if( astNewARG( proc, dst, ddtype ) = NULL ) then
-    	exit function
-    end if
+		exit function
+	end if
 
 	'' byval dstlen as integer
-	if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+	if( astNewARG( proc, lgt ) = NULL ) then
 		exit function
 	end if
 
    	'' always calc len before pushing the param
    	sdtype = astGetDataType( src )
-	lgt = rtlCalcStrLen( src, sdtype )
+	lgt2 = rtlCalcStrLen2( src, sdtype )
 
 	'' src as any
 	if( astNewARG( proc, src, sdtype ) = NULL ) then
-    	exit function
-    end if
+		exit function
+	end if
 
 	'' byval srclen as integer
-	if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+	if( astNewARG( proc, lgt2 ) = NULL ) then
 		exit function
 	end if
 
@@ -2373,30 +2374,30 @@ function rtlWstrConcatAssign _
 		byval src as ASTNODE ptr _
 	) as ASTNODE ptr static
 
-    dim as ASTNODE ptr proc
-	dim as longint lgt = any
+	dim as ASTNODE ptr proc
+	dim as ASTNODE ptr lgt = any
 
 	function = NULL
 
 	proc = astNewCALL( PROCLOOKUP( WSTRCONCATASSIGN ) )
 
 	'' always calc len before pushing the param
-	lgt = rtlCalcStrLen( dst, FB_DATATYPE_WCHAR )
+	lgt = rtlCalcStrLen2( dst, FB_DATATYPE_WCHAR )
 
 	'' byval dst as wstring ptr
 	if( astNewARG( proc, dst ) = NULL ) then
-    	exit function
-    end if
+		exit function
+	end if
 
 	'' byval dstlen as integer
-	if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+	if( astNewARG( proc, lgt ) = NULL ) then
 		exit function
 	end if
 
 	'' byval src as wstring ptr
 	if( astNewARG( proc, src ) = NULL ) then
-    	exit function
-    end if
+		exit function
+	end if
 
 	''
 	function = proc
@@ -2411,38 +2412,38 @@ function rtlWstrAssignWA _
 		byval sdtype as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-	dim as longint dstlen = any, srclen = any
+	dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr dstlen = any , srclen = any
 
 	function = NULL
 
 	proc = astNewCALL( PROCLOOKUP( WSTRASSIGNWA ) )
 
    	'' always calc len before pushing the param
-	dstlen = rtlCalcStrLen( dst, FB_DATATYPE_WCHAR )
-	srclen = rtlCalcStrLen( src, sdtype )
+	dstlen = rtlCalcStrLen2( dst, FB_DATATYPE_WCHAR )
+	srclen = rtlCalcStrLen2( src, sdtype )
 
-    '' byval dst as wstring ptr
-    if( astNewARG( proc, dst ) = NULL ) then
-    	exit function
-    end if
+	'' byval dst as wstring ptr
+	if( astNewARG( proc, dst ) = NULL ) then
+		exit function
+	end if
 
 	'' byval dstlen as integer
-	if( astNewARG( proc, astNewCONSTi( dstlen ) ) = NULL ) then
+	if( astNewARG( proc, dstlen ) = NULL ) then
 		exit function
 	end if
 
-    '' byref src as any
-    if( astNewARG( proc, src ) = NULL ) then
-    	exit function
-    end if
+	'' byref src as any
+	if( astNewARG( proc, src ) = NULL ) then
+		exit function
+	end if
 
 	'' byval srclen as integer
-	if( astNewARG( proc, astNewCONSTi( srclen ) ) = NULL ) then
+	if( astNewARG( proc, srclen ) = NULL ) then
 		exit function
 	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -2455,8 +2456,8 @@ function rtlWstrAssignAW _
 		byval is_ini as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-	dim as longint lgt = any
+	dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr lgt = any
 
 	function = NULL
 
@@ -2465,29 +2466,29 @@ function rtlWstrAssignAW _
 				PROCLOOKUP(  WSTRASSIGNAW ) ) )
 
    	'' always calc len before pushing the param
-	lgt = rtlCalcStrLen( dst, ddtype )
+	lgt = rtlCalcStrLen2( dst, ddtype )
 
-    '' byref dst as any
-    if( astNewARG( proc, dst ) = NULL ) then
-    	exit function
-    end if
-
-	'' byval dstlen as integer
-	if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+	'' byref dst as any
+	if( astNewARG( proc, dst ) = NULL ) then
 		exit function
 	end if
 
-    '' byval src as wstring ptr
-    if( astNewARG( proc, src ) = NULL ) then
-    	exit function
-    end if
+	'' byval dstlen as integer
+	if( astNewARG( proc, lgt ) = NULL ) then
+		exit function
+	end if
+
+	'' byval src as wstring ptr
+	if( astNewARG( proc, src ) = NULL ) then
+		exit function
+	end if
 
 	'' byval fillrem as integer
 	if( astNewARG( proc, astNewCONSTi( ddtype = FB_DATATYPE_FIXSTR ) ) = NULL ) then
 		exit function
 	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -2499,23 +2500,24 @@ function rtlStrAssign _
 		byval is_ini as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 	dim as integer ddtype = any, sdtype = any
-	dim as longint lgt = any
+	dim as ASTNODE ptr lgt = any
+	dim as ASTNODE ptr lgt2 = any
 
 	function = NULL
 
-    ddtype = astGetDataType( dst )
-    sdtype = astGetDataType( src )
+	ddtype = astGetDataType( dst )
+	sdtype = astGetDataType( src )
 
 	'' wstring source?
-    if( sdtype = FB_DATATYPE_WCHAR ) then
-    	return rtlWstrAssignAW( dst, ddtype, src, is_ini )
+	if( sdtype = FB_DATATYPE_WCHAR ) then
+		return rtlWstrAssignAW( dst, ddtype, src, is_ini )
 
-    '' destine?
-    elseif( ddtype = FB_DATATYPE_WCHAR ) then
-    	return rtlWstrAssignWA( dst, src, sdtype )
-    end if
+	'' destine?
+	elseif( ddtype = FB_DATATYPE_WCHAR ) then
+		return rtlWstrAssignWA( dst, src, sdtype )
+	end if
 
 	'' both strings
 	proc = astNewCALL( iif( is_ini, _
@@ -2524,28 +2526,28 @@ function rtlStrAssign _
 
 	'' always calc len before pushing the param
 
-	lgt = rtlCalcStrLen( dst, ddtype )
+	lgt = rtlCalcStrLen2( dst, ddtype )
 
 	'' dst as any
 	if( astNewARG( proc, dst, astGetDataType( dst ) ) = NULL ) then
-    	exit function
-    end if
+		exit function
+	end if
 
 	'' byval dstlen as integer
-	if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+	if( astNewARG( proc, lgt ) = NULL ) then
 		exit function
 	end if
 
    	'' always calc len before pushing the param
-	lgt = rtlCalcStrLen( src, sdtype )
+	lgt2 = rtlCalcStrLen2( src, sdtype )
 
 	'' src as any
 	if( astNewARG( proc, src, astGetDataType( src ) ) = NULL ) then
-    	exit function
-    end if
+		exit function
+	end if
 
 	'' byval srclen as integer
-	if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+	if( astNewARG( proc, lgt2 ) = NULL ) then
 		exit function
 	end if
 
@@ -2567,9 +2569,9 @@ function rtlWstrAssign _
 		byval is_ini as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 	dim as integer ddtype = any, sdtype = any
-	dim as longint lgt = any
+	dim as ASTNODE ptr lgt = any
 
 	function = NULL
 
@@ -2591,24 +2593,24 @@ function rtlWstrAssign _
 	proc = astNewCALL( PROCLOOKUP( WSTRASSIGN ) )
 
    	'' always calc len before pushing the param
-	lgt = rtlCalcStrLen( dst, ddtype )
+	lgt = rtlCalcStrLen2( dst, ddtype )
 
-    '' byval dst as wstring ptr
-    if( astNewARG( proc, dst ) = NULL ) then
-    	exit function
-    end if
-
-	'' byval dstlen as integer
-	if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
+	'' byval dst as wstring ptr
+	if( astNewARG( proc, dst ) = NULL ) then
 		exit function
 	end if
 
-    '' byval src as wstring ptr
-    if( astNewARG( proc, src ) = NULL ) then
-    	exit function
-    end if
+	'' byval dstlen as integer
+	if( astNewARG( proc, lgt ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	'' byval src as wstring ptr
+	if( astNewARG( proc, src ) = NULL ) then
+		exit function
+	end if
+
+	function = proc
 
 end function
 
@@ -2654,17 +2656,17 @@ function rtlStrAllocTmpResult _
 		byval strg as ASTNODE ptr _
 	) as ASTNODE ptr static
 
-    dim as ASTNODE ptr proc
+	dim as ASTNODE ptr proc
 
 	function = NULL
 
 	''
-    proc = astNewCALL( PROCLOOKUP( STRALLOCTMPRES ), NULL )
+	proc = astNewCALL( PROCLOOKUP( STRALLOCTMPRES ), NULL )
 
-    '' src as string
-    if( astNewARG( proc, strg, FB_DATATYPE_STRING ) = NULL ) then
-    	exit function
-    end if
+	'' src as string
+	if( astNewARG( proc, strg, FB_DATATYPE_STRING ) = NULL ) then
+		exit function
+	end if
 
 	function = proc
 
@@ -2676,12 +2678,12 @@ function rtlStrAllocTmpDesc	_
 		byval strexpr as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 	dim as integer dtype = any
 	dim as longint lgt = any
-    dim as FBSYMBOL ptr litsym = any
+	dim as FBSYMBOL ptr litsym = any
 
-    function = NULL
+	function = NULL
 
 	''
    	dtype = astGetDataType( strexpr )
@@ -2689,46 +2691,46 @@ function rtlStrAllocTmpDesc	_
 	select case as const dtype
 	case FB_DATATYPE_CHAR
 
-    	'' literal?
-    	litsym = astGetStrLitSymbol( strexpr )
-    	if( litsym = NULL ) then
-    		proc = astNewCALL( PROCLOOKUP( STRALLOCTMPDESCZ ) )
-    	else
-    		proc = astNewCALL( PROCLOOKUP( STRALLOCTMPDESCZEX ) )
-    	end if
+		'' literal?
+		litsym = astGetStrLitSymbol( strexpr )
+		if( litsym = NULL ) then
+			proc = astNewCALL( PROCLOOKUP( STRALLOCTMPDESCZ ) )
+		else
+			proc = astNewCALL( PROCLOOKUP( STRALLOCTMPDESCZEX ) )
+		end if
 
-    	'' byval str as zstring ptr
-    	if( astNewARG( proc, strexpr ) = NULL ) then
-    		exit function
-    	end if
+		'' byval str as zstring ptr
+		if( astNewARG( proc, strexpr ) = NULL ) then
+			exit function
+		end if
 
-    	'' length is known at compile-time
-    	if( litsym <> NULL ) then
-    		lgt = symbGetStrLen( litsym ) - 1	'' less the null-term
+		'' length is known at compile-time
+		if( litsym <> NULL ) then
+			lgt = symbGetStrLen( litsym ) - 1	'' less the null-term
 
 			'' byval len as integer
 			if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
 				exit function
 			end if
-    	end if
+		end if
 
 	case FB_DATATYPE_FIXSTR
-    	proc = astNewCALL( PROCLOOKUP( STRALLOCTMPDESCF ) )
+		proc = astNewCALL( PROCLOOKUP( STRALLOCTMPDESCF ) )
 
-    	'' always calc len before pushing the param
+		'' always calc len before pushing the param
 		lgt = rtlCalcStrLen( strexpr, dtype )
 
-    	'' str as any
-    	if( astNewARG( proc, strexpr ) = NULL ) then
-    		exit function
-    	end if
+		'' str as any
+		if( astNewARG( proc, strexpr ) = NULL ) then
+			exit function
+		end if
 
 		'' byval strlen as integer
 		if( astNewARG( proc, astNewCONSTi( lgt ) ) = NULL ) then
 			exit function
 		end if
 
-    end select
+	end select
 
 	''
 	function = proc
@@ -2741,18 +2743,18 @@ function rtlWstrAlloc _
 		byval lenexpr as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
 	function = NULL
 
-    proc = astNewCALL( PROCLOOKUP( WSTRALLOC ) )
+	proc = astNewCALL( PROCLOOKUP( WSTRALLOC ) )
 
-    '' byval len as integer
-    if( astNewARG( proc, lenexpr ) = NULL ) then
-    	exit function
-    end if
+	'' byval len as integer
+	if( astNewARG( proc, lenexpr ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -2762,18 +2764,18 @@ function rtlWstrToA _
 		byval expr as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
-    function = NULL
+	function = NULL
 
-    proc = astNewCALL( PROCLOOKUP( WSTR2STR ) )
+	proc = astNewCALL( PROCLOOKUP( WSTR2STR ) )
 
-    '' byval str as wstring ptr
-    if( astNewARG( proc, expr ) = NULL ) then
-    	exit function
-    end if
+	'' byval str as wstring ptr
+	if( astNewARG( proc, expr ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -2783,18 +2785,18 @@ function rtlAToWstr _
 		byval expr as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
-    function = NULL
+	function = NULL
 
-    proc = astNewCALL( PROCLOOKUP( STR2WSTR ) )
+	proc = astNewCALL( PROCLOOKUP( STR2WSTR ) )
 
-    '' byval str as zstring ptr
-    if( astNewARG( proc, expr ) = NULL ) then
-    	exit function
-    end if
+	'' byval str as zstring ptr
+	if( astNewARG( proc, expr ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -2805,11 +2807,11 @@ function rtlToStr _
 		byval pad as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any, litsym = any
-    dim as integer dtype = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any, litsym = any
+	dim as integer dtype = any
 
-    function = NULL
+	function = NULL
 
 	dtype = astGetDatatype( expr )
 
@@ -2833,24 +2835,24 @@ function rtlToStr _
 		return astNewCONSTstr( s )
 	end if
 
-    '' wstring literal? convert from unicode at compile-time
-    if( dtype = FB_DATATYPE_WCHAR ) then
-    	litsym = astGetStrLitSymbol( expr )
-    	if( litsym <> NULL ) then
+	'' wstring literal? convert from unicode at compile-time
+	if( dtype = FB_DATATYPE_WCHAR ) then
+		litsym = astGetStrLitSymbol( expr )
+		if( litsym <> NULL ) then
 			if( env.wchar_doconv ) then
 				litsym = symbAllocStrConst( str( *symbGetVarLitTextW( litsym ) ), _
 							   	   	   		symbGetWstrLen( litsym ) - 1 )
 
 				return astNewVAR( litsym )
-    		end if
-    	end if
-    end if
+			end if
+		end if
+	end if
 
 	astTryOvlStringCONV( expr )
 
 	dtype = astGetDataType( expr )
 
-    ''
+	''
 	select case as const astGetDataClass( expr )
 	case FB_DATACLASS_INTEGER
 
@@ -2908,14 +2910,14 @@ function rtlToStr _
 	end select
 
 	''
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    ''
-    if( astNewARG( proc, expr ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, expr ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -2925,30 +2927,30 @@ function rtlToWstr _
 		byval expr as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any, litsym = any
-    dim as integer dtype
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any, litsym = any
+	dim as integer dtype
 
-    function = NULL
+	function = NULL
 
-    dtype = astGetDataType( expr )
+	dtype = astGetDataType( expr )
 
-    '' constant? evaluate
-    if( astIsCONST( expr ) ) then
+	'' constant? evaluate
+	if( astIsCONST( expr ) ) then
 		return astNewCONSTwstr( astConstFlushToWstr( expr ) )
-    end if
+	end if
 
-    '' string literal? convert to unicode at compile-time
-    if( dtype = FB_DATATYPE_CHAR ) then
-    	litsym = astGetStrLitSymbol( expr )
-    	if( litsym <> NULL ) then
+	'' string literal? convert to unicode at compile-time
+	if( dtype = FB_DATATYPE_CHAR ) then
+		litsym = astGetStrLitSymbol( expr )
+		if( litsym <> NULL ) then
 			if( env.wchar_doconv ) then
 				litsym = symbAllocWstrConst( wstr( *symbGetVarLitText( litsym ) ), _
 							 			     symbGetStrLen( litsym ) - 1 )
 				return astNewVAR( litsym )
 			end if
-    	end if
-    end if
+		end if
+	end if
 
 	astTryOvlStringCONV( expr )
 
@@ -3005,14 +3007,14 @@ function rtlToWstr _
 	end select
 
 	''
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    ''
-    if( astNewARG( proc, expr ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, expr ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3023,12 +3025,12 @@ function rtlStrToVal _
 		byval to_dtype as integer _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any, s = any
-    dim as FB_CALL_ARG arg = any
-    dim as FB_ERRMSG err_num = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any, s = any
+	dim as FB_CALL_ARG arg = any
+	dim as FB_ERRMSG err_num = any
 
-    function = NULL
+	function = NULL
 
 	'' Convert pointer to uinteger
 	if( typeIsPtr( to_dtype ) ) then
@@ -3060,7 +3062,7 @@ function rtlStrToVal _
 		end select
 
 	'' UDT's, classes: try cast(to_dtype) op overloading
-	case FB_DATATYPE_STRUCT ', FB_DATATYPE_CLASS
+	case FB_DATATYPE_STRUCT 
 		return astNewCONV( to_dtype, NULL, expr )
 
 	case else
@@ -3073,18 +3075,18 @@ function rtlStrToVal _
 	arg.mode = INVALID
 	arg.next = NULL
 	f = symbFindClosestOvlProc( f, 1, @arg, @err_num )
-    if( f = NULL ) then
-    	exit function
-    end if
+	if( f = NULL ) then
+		exit function
+	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    ''
-    if( astNewARG( proc, expr ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, expr ) = NULL ) then
+		exit function
+	end if
 
-    function = astNewCONV( to_dtype, NULL, proc )
+	function = astNewCONV( to_dtype, NULL, proc )
 
 end function
 
@@ -3096,32 +3098,32 @@ function rtlStrMid _
 		byval expr3 as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
-    function = NULL
+	function = NULL
 
 	astTryOvlStringCONV( expr1 )
 
-    if( astGetDataType( expr1 ) <> FB_DATATYPE_WCHAR ) then
-    	proc = astNewCALL( PROCLOOKUP( STRMID ) )
-    else
-    	proc = astNewCALL( PROCLOOKUP( WSTRMID ) )
-    end if
+	if( astGetDataType( expr1 ) <> FB_DATATYPE_WCHAR ) then
+		proc = astNewCALL( PROCLOOKUP( STRMID ) )
+	else
+		proc = astNewCALL( PROCLOOKUP( WSTRMID ) )
+	end if
 
-    ''
-    if( astNewARG( proc, expr1 ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, expr1 ) = NULL ) then
+		exit function
+	end if
 
-    if( astNewARG( proc, expr2 ) = NULL ) then
-    	exit function
-    end if
+	if( astNewARG( proc, expr2 ) = NULL ) then
+		exit function
+	end if
 
-    if( astNewARG( proc, expr3 ) = NULL ) then
-    	exit function
-    end if
+	if( astNewARG( proc, expr3 ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3134,51 +3136,54 @@ function rtlStrAssignMid _
 		byval expr4 as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-	dim as longint dst_len = any
-
-    function = NULL
+	dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr dst_len = any
+	function = NULL
 
 	astTryOvlStringCONV( expr1 )
 
 	''
-    if( astGetDataType( expr1 ) <> FB_DATATYPE_WCHAR ) then
-    	proc = astNewCALL( PROCLOOKUP( STRASSIGNMID ) )
-    	dst_len = -1
-    else
-    	proc = astNewCALL( PROCLOOKUP( WSTRASSIGNMID ) )
-		'' always calc len before pushing the param
-		dst_len = rtlCalcStrLen( expr1, FB_DATATYPE_WCHAR )
-    end if
+	if( astGetDataType( expr1 ) <> FB_DATATYPE_WCHAR ) then
+		proc = astNewCALL( PROCLOOKUP( STRASSIGNMID ) )
 
-    ''
-    if( astNewARG( proc, expr1 ) = NULL ) then
-    	exit function
-    end if
-
-    ''
-    if( dst_len <> -1 ) then
-		if( astNewARG( proc, astNewCONSTi( dst_len ) ) = NULL ) then
+		if( astNewARG( proc, expr1 ) = NULL ) then
 			exit function
 		end if
-    end if
 
-    if( astNewARG( proc, expr2 ) = NULL ) then
-    	exit function
-    end if
 
-    if( astNewARG( proc, expr3 ) = NULL ) then
-    	exit function
-    end if
+	else
+		proc = astNewCALL( PROCLOOKUP( WSTRASSIGNMID ) )
+		'' always calc len before pushing the param
+		dst_len = rtlCalcStrLen2( expr1, FB_DATATYPE_WCHAR )
 
-    if( astNewARG( proc, expr4 ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, expr1 ) = NULL ) then
+		exit function
+	end if
 
-    ''
-    astAdd( proc )
+		if( astNewARG( proc, dst_len ) = NULL ) then
+			exit function
+		end if
+	end if
 
-    function = proc
+	''
+
+	if( astNewARG( proc, expr2 ) = NULL ) then
+		exit function
+	end if
+
+	if( astNewARG( proc, expr3 ) = NULL ) then
+		exit function
+	end if
+
+	if( astNewARG( proc, expr4 ) = NULL ) then
+		exit function
+	end if
+
+	''
+	astAdd( proc )
+
+	function = proc
 
 end function
 
@@ -3190,9 +3195,9 @@ function rtlStrLRSet _
 		byval is_rset as integer _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
-    function = FALSE
+	function = FALSE
 
 	''
 	if( astGetDataType( dstexpr ) <> FB_DATATYPE_WCHAR ) then
@@ -3205,20 +3210,20 @@ function rtlStrLRSet _
 		                        PROCLOOKUP( WSTRLSET ) ) )
 	end if
 
-    '' dst as string
-    if( astNewARG( proc, dstexpr ) = NULL ) then
-    	exit function
-    end if
+	'' dst as string
+	if( astNewARG( proc, dstexpr ) = NULL ) then
+		exit function
+	end if
 
-    '' src as string
-    if( astNewARG( proc, srcexpr ) = NULL ) then
-    	exit function
-    end if
+	'' src as string
+	if( astNewARG( proc, srcexpr ) = NULL ) then
+		exit function
+	end if
 
-    ''
-    astAdd( proc )
+	''
+	astAdd( proc )
 
-    function = TRUE
+	function = TRUE
 
 end function
 
@@ -3229,10 +3234,10 @@ function rtlStrFill _
 		byval expr2 as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
 
-    function = NULL
+	function = NULL
 
 	select case astGetDataType( expr2 )
 	case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, FB_DATATYPE_CHAR
@@ -3241,18 +3246,18 @@ function rtlStrFill _
 		f = PROCLOOKUP( STRFILL1 )
 	end select
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    ''
-    if( astNewARG( proc, expr1 ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, expr1 ) = NULL ) then
+		exit function
+	end if
 
-    if( astNewARG( proc, expr2 ) = NULL ) then
-    	exit function
-    end if
+	if( astNewARG( proc, expr2 ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3263,10 +3268,10 @@ function rtlWstrFill _
 		byval expr2 as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
 
-    function = NULL
+	function = NULL
 
 	if( astGetDataType( expr2 ) = FB_DATATYPE_WCHAR ) then
 		f = PROCLOOKUP( WSTRFILL2 )
@@ -3274,18 +3279,18 @@ function rtlWstrFill _
 		f = PROCLOOKUP( WSTRFILL1 )
 	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    ''
-    if( astNewARG( proc, expr1 ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, expr1 ) = NULL ) then
+		exit function
+	end if
 
-    if( astNewARG( proc, expr2 ) = NULL ) then
-    	exit function
-    end if
+	if( astNewARG( proc, expr2 ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3335,34 +3340,34 @@ function rtlStrAsc _
 		byval posexpr as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
 	function = NULL
 
 	astTryOvlStringCONV( expr )
 
-    ''
-    if( astGetDataType( expr ) <> FB_DATATYPE_WCHAR ) then
-    	proc = astNewCALL( PROCLOOKUP( STRASC ) )
-    else
-    	proc = astNewCALL( PROCLOOKUP( WSTRASC ) )
-    end if
+	''
+	if( astGetDataType( expr ) <> FB_DATATYPE_WCHAR ) then
+		proc = astNewCALL( PROCLOOKUP( STRASC ) )
+	else
+		proc = astNewCALL( PROCLOOKUP( WSTRASC ) )
+	end if
 
-    '' src as string
-    if( astNewARG( proc, expr ) = NULL ) then
-    	exit function
-    end if
+	'' src as string
+	if( astNewARG( proc, expr ) = NULL ) then
+		exit function
+	end if
 
-    '' byval pos as integer
-    if( posexpr = NULL ) then
+	'' byval pos as integer
+	if( posexpr = NULL ) then
 		posexpr = astNewCONSTi( 1 )
-    end if
+	end if
 
-    if( astNewARG( proc, posexpr ) = NULL ) then
-    	exit function
-    end if
+	if( astNewARG( proc, posexpr ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3379,47 +3384,47 @@ function rtlStrChr _
 
 	function = NULL
 
-    if( is_wstr = FALSE ) then
-    	proc = astNewCALL( PROCLOOKUP( STRCHR ) )
-    else
-    	proc = astNewCALL( PROCLOOKUP( WSTRCHR ) )
-    end if
+	if( is_wstr = FALSE ) then
+		proc = astNewCALL( PROCLOOKUP( STRCHR ) )
+	else
+		proc = astNewCALL( PROCLOOKUP( WSTRCHR ) )
+	end if
 
 	'' byval args as integer
 	if( astNewARG( proc, astNewCONSTi( args ) ) = NULL ) then
 		exit function
 	end if
 
-    '' ...
-    for i as integer = 0 to args-1
-    	expr = exprtb(i)
-    	dtype = astGetDatatype( expr )
+	'' ...
+	for i as integer = 0 to args-1
+		expr = exprtb(i)
+		dtype = astGetDatatype( expr )
 
-    	'' check if non-numeric
-    	if( astGetDataClass( expr ) >= FB_DATACLASS_STRING ) then
-    		errReportEx( FB_ERRMSG_PARAMTYPEMISMATCHAT, "at parameter: " + str( i+1 ) )
-    		exit function
-    	end if
+		'' check if non-numeric
+		if( astGetDataClass( expr ) >= FB_DATACLASS_STRING ) then
+			errReportEx( FB_ERRMSG_PARAMTYPEMISMATCHAT, "at parameter: " + str( i+1 ) )
+			exit function
+		end if
 
-    	'' don't allow w|zstring's either..
-    	select case as const dtype
-    	case FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
-    		errReportEx( FB_ERRMSG_PARAMTYPEMISMATCHAT, "at parameter: " + str( i+1 ) )
-    		exit function
+		'' don't allow w|zstring's either..
+		select case as const dtype
+		case FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
+			errReportEx( FB_ERRMSG_PARAMTYPEMISMATCHAT, "at parameter: " + str( i+1 ) )
+			exit function
 
-    	case FB_DATATYPE_INTEGER
+		case FB_DATATYPE_INTEGER
 
-    	'' convert to int as chr() is a varargs function
-    	case else
-    		expr = astNewCONV( FB_DATATYPE_INTEGER, NULL, expr )
-    	end select
+		'' convert to int as chr() is a varargs function
+		case else
+			expr = astNewCONV( FB_DATATYPE_INTEGER, NULL, expr )
+		end select
 
-    	if( astNewARG( proc, expr, FB_DATATYPE_INTEGER ) = NULL ) then
-    		exit function
-    	end if
-    next
+		if( astNewARG( proc, expr, FB_DATATYPE_INTEGER ) = NULL ) then
+			exit function
+		end if
+	next
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3429,14 +3434,14 @@ function rtlStrInstr _
 		byval nd_start as ASTNODE ptr, _
 		byval nd_text as ASTNODE ptr, _
 		byval nd_pattern as ASTNODE ptr, _
-        byval search_any as integer _
-    ) as ASTNODE ptr
+		byval search_any as integer _
+	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
 	dim as integer dtype = any
 
-    function = NULL
+	function = NULL
 
 	astTryOvlStringCONV( nd_text )
 	if( nd_pattern ) then
@@ -3446,36 +3451,36 @@ function rtlStrInstr _
 	dtype = astGetDataType( nd_text )
 
 	''
-    if( search_any ) then
+	if( search_any ) then
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRINSTRANY )
 		else
 			f = PROCLOOKUP( WSTRINSTRANY )
 		end if
-    else
+	else
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRINSTR )
 		else
 			f = PROCLOOKUP( WSTRINSTR )
 		end if
-    end if
+	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
-    ''
-    if( astNewARG( proc, nd_start ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, nd_start ) = NULL ) then
+		exit function
+	end if
 
-    if( astNewARG( proc, nd_text ) = NULL ) then
-    	exit function
-    end if
+	if( astNewARG( proc, nd_text ) = NULL ) then
+		exit function
+	end if
 
-    if( astNewARG( proc, nd_pattern ) = NULL ) then
-    	exit function
-    end if
+	if( astNewARG( proc, nd_pattern ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3540,14 +3545,14 @@ function rtlStrTrim _
 	( _
 		byval nd_text as ASTNODE ptr, _
 		byval nd_pattern as ASTNODE ptr, _
-        byval is_any as integer _
-    ) as ASTNODE ptr
+		byval is_any as integer _
+	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer dtype = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer dtype = any
 
-    function = NULL
+	function = NULL
 
 	astTryOvlStringCONV( nd_text )
 	if( nd_pattern ) then
@@ -3557,39 +3562,39 @@ function rtlStrTrim _
 	dtype = astGetDataType( nd_text )
 
 	''
-    if( is_any ) then
+	if( is_any ) then
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRTRIMANY )
 		else
 			f = PROCLOOKUP( WSTRTRIMANY )
 		end if
-    elseif( nd_pattern <> NULL ) then
+	elseif( nd_pattern <> NULL ) then
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRTRIMEX )
 		else
 			f = PROCLOOKUP( WSTRTRIMEX )
 		end if
-    else
+	else
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRTRIM )
 		else
 			f = PROCLOOKUP( WSTRTRIM )
 		end if
-    end if
-    proc = astNewCALL( f )
+	end if
+	proc = astNewCALL( f )
 
-    ''
-    if( astNewARG( proc, nd_text ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, nd_text ) = NULL ) then
+		exit function
+	end if
 
-    if( nd_pattern<>NULL or is_any ) then
-        if( astNewARG( proc, nd_pattern ) = NULL ) then
-            exit function
-        end if
-    end if
+	if( nd_pattern<>NULL or is_any ) then
+		if( astNewARG( proc, nd_pattern ) = NULL ) then
+			exit function
+		end if
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3598,14 +3603,14 @@ function rtlStrRTrim _
 	( _
 		byval nd_text as ASTNODE ptr, _
 		byval nd_pattern as ASTNODE ptr, _
-        byval is_any as integer _
-    ) as ASTNODE ptr
+		byval is_any as integer _
+	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer dtype = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer dtype = any
 
-    function = NULL
+	function = NULL
 
 	astTryOvlStringCONV( nd_text )
 	if( nd_pattern ) then
@@ -3615,39 +3620,39 @@ function rtlStrRTrim _
 	dtype = astGetDataType( nd_text )
 
 	''
-    if( is_any ) then
+	if( is_any ) then
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRRTRIMANY )
 		else
 			f = PROCLOOKUP( WSTRRTRIMANY )
 		end if
-    elseif( nd_pattern <> NULL ) then
+	elseif( nd_pattern <> NULL ) then
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRRTRIMEX )
 		else
 			f = PROCLOOKUP( WSTRRTRIMEX )
 		end if
-    else
+	else
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRRTRIM )
 		else
 			f = PROCLOOKUP( WSTRRTRIM )
 		end if
-    end if
-    proc = astNewCALL( f )
+	end if
+	proc = astNewCALL( f )
 
-    ''
-    if( astNewARG( proc, nd_text ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, nd_text ) = NULL ) then
+		exit function
+	end if
 
-    if( nd_pattern<>NULL or is_any ) then
-        if( astNewARG( proc, nd_pattern ) = NULL ) then
-            exit function
-        end if
-    end if
+	if( nd_pattern<>NULL or is_any ) then
+		if( astNewARG( proc, nd_pattern ) = NULL ) then
+			exit function
+		end if
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3656,14 +3661,14 @@ function rtlStrLTrim _
 	( _
 		byval nd_text as ASTNODE ptr, _
 		byval nd_pattern as ASTNODE ptr, _
-        byval is_any as integer _
-    ) as ASTNODE ptr
+		byval is_any as integer _
+	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
-    dim as integer dtype = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
+	dim as integer dtype = any
 
-    function = NULL
+	function = NULL
 
 	astTryOvlStringCONV( nd_text )
 	if( nd_pattern ) then
@@ -3673,39 +3678,39 @@ function rtlStrLTrim _
 	dtype = astGetDataType( nd_text )
 
 	''
-    if( is_any ) then
+	if( is_any ) then
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRLTRIMANY )
 		else
 			f = PROCLOOKUP( WSTRLTRIMANY )
 		end if
-    elseif( nd_pattern <> NULL ) then
+	elseif( nd_pattern <> NULL ) then
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRLTRIMEX )
 		else
 			f = PROCLOOKUP( WSTRLTRIMEX )
 		end if
-    else
+	else
 		if( dtype <> FB_DATATYPE_WCHAR ) then
 			f = PROCLOOKUP( STRLTRIM )
 		else
 			f = PROCLOOKUP( WSTRLTRIM )
 		end if
-    end if
-    proc = astNewCALL( f )
+	end if
+	proc = astNewCALL( f )
 
-    ''
-    if( astNewARG( proc, nd_text ) = NULL ) then
-    	exit function
-    end if
+	''
+	if( astNewARG( proc, nd_text ) = NULL ) then
+		exit function
+	end if
 
-    if( nd_pattern<>NULL or is_any ) then
-        if( astNewARG( proc, nd_pattern ) = NULL ) then
-            exit function
-        end if
-    end if
+	if( nd_pattern<>NULL or is_any ) then
+		if( astNewARG( proc, nd_pattern ) = NULL ) then
+			exit function
+		end if
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -3857,11 +3862,11 @@ function rtlStrSwap _
 
 	'' always calc len before pushing the param
 	var dtype1 = astGetDataType( str1 )
-	var length1 = rtlCalcStrLen( str1, dtype1 )
+	var length1 = rtlCalcStrLen2( str1, dtype1 )
 
 	'' always calc len before pushing the param
 	var dtype2 = astGetDataType( str2 )
-	var length2 = rtlCalcStrLen( str2, dtype2 )
+	var length2 = rtlCalcStrLen2( str2, dtype2 )
 
 	'' byref str1 as any
 	if( astNewARG( proc, str1, FB_DATATYPE_STRING ) = NULL ) then
@@ -3869,7 +3874,7 @@ function rtlStrSwap _
 	end if
 
 	'' byval len1 as integer
-	if( astNewARG( proc, astNewCONSTi( length1 ) ) = NULL ) then
+	if( astNewARG( proc, length1 ) = NULL ) then
 		exit function
 	end if
 
@@ -3884,7 +3889,7 @@ function rtlStrSwap _
 	end if
 
 	'' byval len2 as integer
-	if( astNewARG( proc, astNewCONSTi( length2 ) ) = NULL ) then
+	if( astNewARG( proc, length2 ) = NULL ) then
 		exit function
 	end if
 
@@ -3910,7 +3915,7 @@ function rtlWstrSwap _
 	var proc = astNewCALL( PROCLOOKUP( WSTRSWAP ) )
 
 	'' always calc len before pushing the param
-	var length = rtlCalcStrLen( str1, astGetDataType( str1 ) )
+	var length = rtlCalcStrLen2( str1, astGetDataType( str1 ) )
 
 	'' byval str1 as wstring ptr
 	if( astNewARG( proc, str1 ) = NULL ) then
@@ -3918,12 +3923,12 @@ function rtlWstrSwap _
 	end if
 
 	'' byval len1 as integer
-	if( astNewARG( proc, astNewCONSTi( length ) ) = NULL ) then
+	if( astNewARG( proc, length ) = NULL ) then
 		exit function
 	end if
 
 	'' always calc len before pushing the param
-	length = rtlCalcStrLen( str2, astGetDataType( str2 ) )
+	var length2 = rtlCalcStrLen2( str2, astGetDataType( str2 ) )
 
 	'' byval str2 as wstring ptr
 	if( astNewARG( proc, str2 ) = NULL ) then
@@ -3931,7 +3936,7 @@ function rtlWstrSwap _
 	end if
 
 	'' byval len2 as integer
-	if( astNewARG( proc, astNewCONSTi( length ) ) = NULL ) then
+	if( astNewARG( proc, length2 ) = NULL ) then
 		exit function
 	end if
 

--- a/src/compiler/rtl.bas
+++ b/src/compiler/rtl.bas
@@ -414,17 +414,17 @@ end function
 '':::::
 '' note: this function must be called *before* astNewARG(e) because the
 ''       expression 'e' can be changed inside the former (address-of string's etc)
-function rtlCalcExprLen( byval expr as ASTNODE ptr ) as longint
+function rtlCalcExprLen( byval expr as ASTNODE ptr ) as ASTNODE ptr
 	dim as FBSYMBOL ptr s = any
 	dim as integer dtype = any
 
 	dtype = astGetDataType( expr )
 	select case as const dtype
 	case FB_DATATYPE_FIXSTR, FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
-		function = rtlCalcStrLen( expr, dtype )
+		function = rtlCalcStrLen2( expr, dtype )
 
 	case else
-		function = symbCalcLen( dtype, astGetSubtype( expr ))
+		function = astNewCONSTi( symbCalcLen( dtype, astGetSubtype( expr )))
 	end select
 end function
 

--- a/src/compiler/rtl.bi
+++ b/src/compiler/rtl.bi
@@ -903,7 +903,7 @@ declare function rtlOvlProcCall _
 		byval param2 as ASTNODE ptr = NULL _
 	) as ASTNODE ptr
 
-declare function rtlCalcExprLen( byval expr as ASTNODE ptr ) as longint
+declare function rtlCalcExprLen( byval expr as ASTNODE ptr ) as ASTNODE ptr 
 
 declare FUNCTION bydescStringSize( byval expr as ASTNODE ptr) as ASTNODE ptr
 

--- a/src/compiler/rtl.bi
+++ b/src/compiler/rtl.bi
@@ -817,7 +817,7 @@ enum FB_RTL_IDX
 	FB_RTL_IDX_FTOUL
 	FB_RTL_IDX_DTOUL
 
-    FB_RTL_IDX_THREADCALL
+	FB_RTL_IDX_THREADCALL
 
 	FB_RTL_INDEXES
 end enum
@@ -905,11 +905,20 @@ declare function rtlOvlProcCall _
 
 declare function rtlCalcExprLen( byval expr as ASTNODE ptr ) as longint
 
+declare FUNCTION bydescStringSize( byval expr as ASTNODE ptr) as ASTNODE ptr
+
 declare function rtlCalcStrLen _
 	( _
 		byval expr as ASTNODE ptr, _
 		byval dtype as integer _
 	) as longint
+
+declare function rtlCalcStrLen2 _
+	( _
+		byval expr as ASTNODE ptr, _
+		byval dtype as integer _
+	) as ASTNODE ptr
+
 
 declare function rtlStrCompare _
 	( _
@@ -1742,7 +1751,7 @@ declare function rtlPrinter_cb _
 	( _
 		byval sym as FBSYMBOL ptr _
 	) as integer
-    
+	
 declare function rtlThreadCall(byval callexpr as ASTNODE ptr) as ASTNODE ptr
 
 


### PR DESCRIPTION
This fixes a bug mentioned in https://sourceforge.net/p/fbc/bugs/650/. Passed z/wstring arrays didn´t work properly. The more such arrays are now accepted without "*..." term in procedure definitions (sub foo (array() as zstring)), which is meaningless anyway. Sizeof still doesn´t work as expected

sub foo( array() as zstring )
    print array(0), sizeof( array(0) )
end sub

dim array(0 to 0) as zstring * 32
array(0) = "hello"

print array(0), sizeof( array(0) )
foo( array() )

- added: SIZEOF now works as well, assignment will follow
- added: assignment works, maybe must modify file put/get functions too
- added: data, file functions + mem swap

This pull request is ready now. 