### PR TITLE
fix or remove invalid tests in fbc test suite

### DIFF
--- a/inc/crt/stdarg.bi
+++ b/inc/crt/stdarg.bi
@@ -9,6 +9,6 @@
 #ifndef __crt_stdarg_bi__
 #define __crt_stdarg_bi__
 
-type va_list as any ptr
+type va_list as cva_list
 
 #endif

--- a/tests/fbcunit/changelog.txt
+++ b/tests/fbcunit/changelog.txt
@@ -1,3 +1,9 @@
+Version 0.8
+
+[changed]
+- run_tests() returns false (failed) if any one assert fails
+
+
 Version 0.7
 
 [added]

--- a/tests/fbcunit/inc/fbcunit.bi
+++ b/tests/fbcunit/inc/fbcunit.bi
@@ -2,7 +2,7 @@
 #define __FBCUNIT_BI_INCLUDE__ 1
 
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2019 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus
@@ -13,7 +13,7 @@
 ---------------------------------------------------------'/
 
 #define FBCU_VER_MAJOR 0
-#define FBCU_VER_MINOR 7
+#define FBCU_VER_MINOR 8
 
 #inclib "fbcunit"
 

--- a/tests/fbcunit/license.txt
+++ b/tests/fbcunit/license.txt
@@ -1,5 +1,5 @@
 fbcunit - FreeBASIC Compiler Unit Testing Component
-Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+Copyright (C) 2017-2019 Jeffery R. Marshall (coder[at]execulink[dot]com)
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/tests/fbcunit/readme.txt
+++ b/tests/fbcunit/readme.txt
@@ -1,7 +1,7 @@
 	fbcunit - FreeBASIC Compiler Unit Testing Component
-	Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+	Copyright (C) 2017-2019 Jeffery R. Marshall (coder[at]execulink[dot]com)
 
-fbcunit version 0.7
+fbcunit version 0.8
 -------------------
 	Unit testing component for fbc compiler.  Provides macros 
 	and common code for unit testing fbc compiled sources. 

--- a/tests/fbcunit/src/fbcunit.bas
+++ b/tests/fbcunit/src/fbcunit.bas
@@ -607,6 +607,10 @@ namespace fbcu
 
 							fbcu_test_index = .test_index_next
 
+							if( .assert_pass_count <> .assert_count ) then
+								failed = true
+							end if
+
 						end with
 
 					wend

--- a/tests/fbcunit/src/fbcunit.bas
+++ b/tests/fbcunit/src/fbcunit.bas
@@ -1,5 +1,5 @@
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2019 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus

--- a/tests/functions/va_int_and_ptrs.bas
+++ b/tests/functions/va_int_and_ptrs.bas
@@ -1,10 +1,6 @@
 # include "fbcunit.bi"
 
-#if defined( __FB_64BIT__ ) 
-	#if defined( __FB_WIN32__ )
-		#define DOTEST
-	#endif	
-#elseif (__FB_BACKEND__ = "gas")
+#if (__FB_BACKEND__ = "gas")
 	#define DOTEST
 #endif
 

--- a/tests/functions/va_strings.bas
+++ b/tests/functions/va_strings.bas
@@ -1,10 +1,6 @@
 # include "fbcunit.bi"
 
-#if defined( __FB_64BIT__ ) 
-	#if defined( __FB_WIN32__ )
-		#define DOTEST
-	#endif	
-#elseif (__FB_BACKEND__ = "gas")
+#if (__FB_BACKEND__ = "gas")
 	#define DOTEST
 #endif
 

--- a/tests/functions/va_tmpstring.bas
+++ b/tests/functions/va_tmpstring.bas
@@ -1,10 +1,6 @@
 # include "fbcunit.bi"
 
-#if defined( __FB_64BIT__ ) 
-	#if defined( __FB_WIN32__ )
-		#define DOTEST
-	#endif	
-#elseif (__FB_BACKEND__ = "gas")
+#if (__FB_BACKEND__ = "gas")
 	#define DOTEST
 #endif
 

--- a/tests/functions/var_args.bas
+++ b/tests/functions/var_args.bas
@@ -1,10 +1,6 @@
 # include "fbcunit.bi"
 
-#if defined( __FB_64BIT__ ) 
-	#if defined( __FB_WIN32__ )
-		#define DOTEST
-	#endif	
-#elseif (__FB_BACKEND__ = "gas")
+#if (__FB_BACKEND__ = "gas")
 	#define DOTEST
 #endif
 

--- a/tests/udt-zstring/str.bas
+++ b/tests/udt-zstring/str.bas
@@ -78,12 +78,12 @@ SUITE( fbc_tests.udt_zstring_.str_ )
 
 	TEST( default )
 		
-		dim s1 as zstring * 10 = chr(1234)
-		dim s2 as zstring * 10 = chr(1234)
+		dim s1 as zstring * 10 = chr(12)
+		dim s2 as zstring * 10 = chr(12)
 		dim s3 as zstring * 10 = str( s1 )
 
-		dim u1 as ustring = chr(1234)
-		dim u2 as ustring = chr(1234)
+		dim u1 as ustring = chr(12)
+		dim u2 as ustring = chr(12)
 		dim u3 as ustring = str( s1 )
 		dim u4 as ustring = wstr( u1 )
 

--- a/tests/udt-zstring/swap.bas
+++ b/tests/udt-zstring/swap.bas
@@ -112,10 +112,6 @@ SUITE( fbc_tests.udt_zstring_.swap_ )
 		check( "a", "a" )
 		check( "a", "abcdefghi" )
 
-		check( "", !"\u3041\u3043\u3045\u3047\u3049" )
-		check( "abc", !"\u3041\u3043\u3045\u3047\u3049" )
-		check( !"\u3045", !"\u3041\u3043\u3047\u3049" )
-
 	END_TEST 
 
 END_SUITE

--- a/tests/wstring/print.bas
+++ b/tests/wstring/print.bas
@@ -126,7 +126,7 @@ SUITE( fbc_tests.wstring_.print_ )
 		OPEN_FILE( "print_strings.txt" )
 
 		check( "" )
-		check( " " )
+		'' check( " " ) '' can't test whitespace with INPUT
 		check( "0123456789" )
 		check( "ABCDEFGHIJKLMNOP" )
 		check( !"\u3041\u3043\u3045\u3047\u3049" )


### PR DESCRIPTION
Some tests in the test suite are incorrect and fail.

This has occurred because tests/fbc-tests.bas exits with a non-zero exit code only if tests fail to run, or there is a failed internal check.  Failed tests on their own do not produce a non-zero (error) exit code.  

- update fbcunit to version 0.8 and produce a non-zero (error) exit code if any test (assert) fails
- va_list typedef in inc/crt/stdarg.bi should be `type va_list as cva_list`
- some tests for `va_first`, `va_next`, and `va_arg` are enabled for `-gen gcc` in windows.  This is from an older version of varargs updates that allowed these macros for `-gen gcc` in windows, which appear to pass in local testing, but to date, found no documentation that guarantees it would always work.  They are reverted to only be enabled with `-gen gas`
- method for testing space " " in tests/wstring/print.bas is incorrect and will fail
- tests/udt-zstring/swap.bas and tests/udt-zstring/str.bas have some tests that were incorrectly translated from tests/udt-wstring, and fail.
