### PR TITLE
makefile: use '-d ENABLE_STRIPALL' by default on dos/win32 builds

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,10 @@ Version 1.07.0
 - github #133: fbc makefile supports bootstrap-minimal target to build a bootstrap fbc with only the minimal features necessary to build another fbc. (William Breathitt Gray)
 - github #141: introduced '-strip'/'-nostrip' options to control symbol stripping of output files (William Breathitt Gray)
 - github #141: fbc will default to stripping symbols if '-d ENABLE_STRIPALL' is passed in FBCFLAGS (William Breathitt Gray)
-- github #141: makefile option 'ENABLE_STRIPALL=1' introduced to pass '-d ENABLE_STRIPALL' via FBCFLAGS by default for dos/win32 targets (William Breathitt Gray)
+- github #141: makefile option 'ENABLE_STRIPALL=1' introduced to pass '-d ENABLE_STRIPALL' via FBCFLAGS (William Breathitt Gray)
+- makefile: 'ENABLE_STRIPALL=1' passes '-d ENABLE_STRIPALL' via FBCFLAGS on all targets
+- makefile: 'ENABLE_STRIPALL=0' disables passing '-d ENABLE_STRIPALL' via FBCFLAGS on all targets
+- makefile: '-d ENABLE_STRIPALL' passed by default for dos/win32 targets when 'ENABLE_STRIPALL=0' not explicitly given
 - 'TYPE udt EXTENDS Z|WSTRING' allowed to specify that UDT is a kind of Z|WSTRING
 - LTRIM/RTRIM/TRIM will accept UDT as Z|WSTRING
 - LCASE/UCASE will accept UDT as Z|WSTRING

--- a/makefile
+++ b/makefile
@@ -81,7 +81,8 @@
 #   ENABLE_SUFFIX=-0.24    append a string like "-0.24" to fbc/FB dir names,
 #                          and use "-d ENABLE_SUFFIX=$(ENABLE_SUFFIX)" (non-standalone only)
 #   ENABLE_LIB64=1         use prefix/lib64/ instead of prefix/lib/ for 64bit libs (non-standalone only)
-#   ENABLE_STRIPALL=1      use "-d ENABLE_STRIPALL" with select targets
+#   ENABLE_STRIPALL=1      use "-d ENABLE_STRIPALL" with all targets
+#   ENABLE_STRIPALL=0      disable "-d ENABLE_STRIPALL" with all targets
 #   FBPACKAGE     bindist: The package/archive file name without path or extension
 #   FBPACKSUFFIX  bindist: Allows adding a custom suffix to the normal package name (and the toplevel dir in the archive)
 #   FBMANIFEST    bindist: The manifest file name without path or extension
@@ -432,6 +433,11 @@ ifdef ENABLE_LIB64
   ALLFBCFLAGS += -d ENABLE_LIB64
 endif
 ifdef ENABLE_STRIPALL
+  ifneq ($(ENABLE_STRIPALL),0)
+    ALLFBCFLAGS += -d ENABLE_STRIPALL
+  endif
+else
+  # by default dos and windows use --strip-all
   ifneq ($(filter dos win32,$(TARGET_OS)),)
     ALLFBCFLAGS += -d ENABLE_STRIPALL
   endif


### PR DESCRIPTION
fbc makefile logic changed as follows:

- 'ENABLE_STRIPALL=1' passes '-d ENABLE_STRIPALL' via FBCFLAGS on all targets
- 'ENABLE_STRIPALL=0' disables passing '-d ENABLE_STRIPALL' via FBCFLAGS on all targets
- '-d ENABLE_STRIPALL' passed by default for dos/win32 targets when 'ENABLE_STRIPALL=0' not explicitly given