### PR TITLE
Select case as const, check jump table size

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -49,6 +49,7 @@ Version 1.07.0
 - sf.net #893: 'Suffixes are only valid in -lang' error message showing incorrect -lang options allowed
 - fbc uses '-march=armv8-a' instead of invalid option '-march=aarch64' when passing options to gcc/LLVM (czsgaba)
 - rtlib: sys/io.h incorrectly included on systems that do not provide it.  It is used only for x86, x86_64 and is unnecessary for all other linux targets (armhf ,arm64, mips ....)
+- SELECT CASE AS CONST checks for ranges that would produce unreasonably large jump tables (greater than 8192 entries)
 
 
 Version 1.06.0

--- a/tests/compound/select-const-large-range-1.bas
+++ b/tests/compound/select-const-large-range-1.bas
@@ -1,0 +1,6 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+dim x as integer
+select case as const x
+case 1 to 8193
+end select

--- a/tests/compound/select-const-large-range-2.bas
+++ b/tests/compound/select-const-large-range-2.bas
@@ -1,0 +1,8 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+dim x as integer
+select case as const x
+case 8192
+case 8193
+case 1
+end select


### PR DESCRIPTION
Check for ranges that would produce unreasonably large jump tables (greater than 8192 entries)

I am confident, due all previous testing, that fbc was already correctly doing the following:
- generating valid jump tables for `select case as const` in the emitter
- check limits on `case from-value to to-value` statements and error on range too large
- check limits on internal record keeping structures, and error on overflow

The main check missing, is an overall range check for the entire `select case as const` ... `end select` compound structure.

This update adds checks to ensure that while parsing the `select case as const` structure, that no `case` statement is out of range + or - 8192 from the first `case` statement range value.  And that overall range is maximum of 8192 upon reaching the `end select` statement.
