### PR TITLE
fbc: add array descriptor 'flags' field

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,11 @@
 Version 1.08.0
 
 [changed]
+- array descriptor contains new 'flags' field.  Careful, breaks binary compatibility plus chicken-egg problem to build fbc.
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling
+- array descriptor 'flags' field to track fixed length, fixed dimension, dimTb() size.
 
 [fixed]
 

--- a/inc/fbc-int/array.bi
+++ b/inc/fbc-int/array.bi
@@ -15,17 +15,23 @@ namespace FBC
 		dim as integer ubound        '' dimension upper bound
 	end type
 
+	const FBARRAY_FLAGS_DIMENSIONS = &h0000000f    '' number of entries allocated in dimTb()
+	const FBARRAY_FLAGS_FIXED_DIM  = &h00000010    '' array has fixed number of dimensions
+	const FBARRAY_FLAGS_FIXED_LEN  = &h00000020    '' array points to fixed-length memory
+	const FBARRAY_FLAGS_RESERVED   = &hffffffc0    '' reserved, do not use
+
 	type FBARRAY
 		dim as any ptr index_ptr     '' @array(0, 0, 0, ... )
 		dim as any ptr base_ptr      '' start of memory at array lowest bounds
 		dim as uinteger size         '' byte size of allocated contents
 		dim as uinteger element_len  '' byte size of single element
 		dim as uinteger dimensions   '' number of dimensions
+		dim as uinteger flags        '' FBARRAY_FLAGS_*
 		
 		'' take care with number of dimensions; fbc may allocate
 		'' a smaller descriptor with fewer than FB_MAXDIMENSIONS
 		'' in dimTb() if it is known at compile time that they
-		'' are never needed.  Always respsect number of 
+		'' are never needed.  Always respect number of 
 		'' dimensions when accessing dimTb()
 
 		dim as FBARRAYDIM dimTb(0 to FB_MAXDIMENSIONS-1)

--- a/inc/fbc-int/array.bi
+++ b/inc/fbc-int/array.bi
@@ -5,43 +5,47 @@
 namespace FBC
 # endif
 
-	'' declarations must follow ./src/rtlib/fb_array.h
+'' declarations must follow ./src/rtlib/fb_array.h
 
-	const FB_MAXDIMENSIONS as integer = 8
+const FB_MAXDIMENSIONS as integer = 8
 
-	type FBARRAYDIM
-		dim as uinteger elements     '' number of elements
-		dim as integer lbound        '' dimension lower bound
-		dim as integer ubound        '' dimension upper bound
-	end type
+type FBARRAYDIM
+	dim as uinteger elements     '' number of elements
+	dim as integer lbound        '' dimension lower bound
+	dim as integer ubound        '' dimension upper bound
+end type
 
-	const FBARRAY_FLAGS_DIMENSIONS = &h0000000f    '' number of entries allocated in dimTb()
-	const FBARRAY_FLAGS_FIXED_DIM  = &h00000010    '' array has fixed number of dimensions
-	const FBARRAY_FLAGS_FIXED_LEN  = &h00000020    '' array points to fixed-length memory
-	const FBARRAY_FLAGS_RESERVED   = &hffffffc0    '' reserved, do not use
+const FBARRAY_FLAGS_DIMENSIONS = &h0000000f    '' number of entries allocated in dimTb()
+const FBARRAY_FLAGS_FIXED_DIM  = &h00000010    '' array has fixed number of dimensions
+const FBARRAY_FLAGS_FIXED_LEN  = &h00000020    '' array points to fixed-length memory
+const FBARRAY_FLAGS_RESERVED   = &hffffffc0    '' reserved, do not use
 
-	type FBARRAY
-		dim as any ptr index_ptr     '' @array(0, 0, 0, ... )
-		dim as any ptr base_ptr      '' start of memory at array lowest bounds
-		dim as uinteger size         '' byte size of allocated contents
-		dim as uinteger element_len  '' byte size of single element
-		dim as uinteger dimensions   '' number of dimensions
-		dim as uinteger flags        '' FBARRAY_FLAGS_*
-		
-		'' take care with number of dimensions; fbc may allocate
-		'' a smaller descriptor with fewer than FB_MAXDIMENSIONS
-		'' in dimTb() if it is known at compile time that they
-		'' are never needed.  Always respect number of 
-		'' dimensions when accessing dimTb()
+type FBARRAY
+	dim as any ptr index_ptr     '' @array(0, 0, 0, ... )
+	dim as any ptr base_ptr      '' start of memory at array lowest bounds
+	dim as uinteger size         '' byte size of allocated contents
+	dim as uinteger element_len  '' byte size of single element
+	dim as uinteger dimensions   '' number of dimensions
+	dim as uinteger flags        '' FBARRAY_FLAGS_*
 
-		dim as FBARRAYDIM dimTb(0 to FB_MAXDIMENSIONS-1)
-	end type
+	'' take care with number of dimensions; fbc may allocate
+	'' a smaller descriptor with fewer than FB_MAXDIMENSIONS
+	'' in dimTb() if it is known at compile time that they
+	'' are never needed.  Always respect number of 
+	'' dimensions when accessing dimTb()
+
+	dim as FBARRAYDIM dimTb(0 to FB_MAXDIMENSIONS-1)
+end type
+
+extern "rtlib"
+	declare function ArrayDescriptorPtr alias "fb_ArrayGetDesc" _
+		( array() as any ) as FBC.FBARRAY ptr
+	declare function ArrayConstDescriptorPtr alias "fb_ArrayGetDesc" _
+		( array() as const any ) as const FBC.FBARRAY ptr
+end extern
 
 # if __FB_LANG__ = "fb"
 end namespace
 # endif
-
-declare function fb_ArrayGetDesc alias "fb_ArrayGetDesc" _
-	  ( array() as any ) as FBC.FBARRAY ptr
 
 #endif

--- a/src/compiler/ast-helper.bas
+++ b/src/compiler/ast-helper.bas
@@ -820,7 +820,7 @@ function astBuildArrayDescIniTree _
 	) as ASTNODE ptr
 
     dim as ASTNODE ptr tree = any
-	dim as integer dtype = any, dimensions = any
+	dim as integer dtype = any, dimensions = any, max_dimensions = any, flags = 0
     dim as FBSYMBOL ptr elm = any, dimtb = any, subtype = any
 
 	'' COMMON or EXTERN? Cannot be initialized
@@ -859,6 +859,7 @@ function astBuildArrayDescIniTree _
 			array_expr = astNewVAR( array )
 		end if
 		array_expr = astNewADDROF( array_expr )
+		flags or= FBARRAY_FLAGS_FIXED_LEN
 	end if
 
 	astTypeIniScopeBegin( tree, desc, FALSE )
@@ -900,11 +901,20 @@ function astBuildArrayDescIniTree _
 	if( dimensions = -1 ) then
 		assert( symbDescriptorHasRoomFor( desc, FB_MAXARRAYDIMS ) )
 		dimensions = 0
+		max_dimensions = FB_MAXARRAYDIMS
 	else
 		assert( symbDescriptorHasRoomFor( desc, dimensions ) )
+		max_dimensions = dimensions
+		flags or= FBARRAY_FLAGS_FIXED_DIM
 	end if
 	assert( dimensions >= 0 )
 	astTypeIniAddAssign( tree, astNewCONSTi( dimensions ), elm )
+
+    elm = symbGetNext( elm )
+
+	'' .flags = flags
+	flags or= ( max_dimensions and FBARRAY_FLAGS_DIMENSIONS )
+	astTypeIniAddAssign( tree, astNewCONSTi( flags ), elm )
 
     elm = symbGetNext( elm )
 

--- a/src/compiler/symb-var.bas
+++ b/src/compiler/symb-var.bas
@@ -47,7 +47,7 @@ sub symbVarInit( )
 	symb.fbarray_data  = 0
 	symb.fbarray_ptr   = env.pointersize     '' behind: data
 	symb.fbarray_size  = env.pointersize * 2 '' behind: data, ptr
-	symb.fbarray_dimtb = env.pointersize * 5 '' behind: data, ptr, size, element_len, dimensions
+	symb.fbarray_dimtb = env.pointersize * 6 '' behind: data, ptr, size, element_len, dimensions, flags
 
 	'' FBARRAYDIM
 	symb.fbarraydim_lbound = env.pointersize      '' behind: elements
@@ -96,7 +96,7 @@ function symbGetDescTypeDimensions( byval desctype as FBSYMBOL ptr ) as integer
 	end if
 
 	'' dimensions = sizeof(dimTB) \ sizeof(FBARRAYDIM)
-	dimtbsize = symbGetLen( desctype ) - (env.pointersize * 5)
+	dimtbsize = symbGetLen( desctype ) - (env.pointersize * 6)
 	dimensions = dimtbsize \ (env.pointersize * 3)
 
 	assert( (dimensions > 0) and (dimensions <= FB_MAXARRAYDIMS) )
@@ -197,6 +197,7 @@ function symbAddArrayDescriptorType _
 	symbAddField( sym, "size", 0, dTB(), FB_DATATYPE_INTEGER, NULL, 0, 0, 0 )
 	symbAddField( sym, "element_len", 0, dTB(), FB_DATATYPE_INTEGER, NULL, 0, 0, 0 )
 	symbAddField( sym, "dimensions", 0, dTB(), FB_DATATYPE_INTEGER, NULL, 0, 0, 0 )
+	symbAddField( sym, "flags", 0, dTB(), FB_DATATYPE_INTEGER, NULL, 0, 0, 0 )
 	'' If dimensions are unknown, the descriptor type must have room for
 	'' FB_MAXARRAYDIMS
 	if( dimensions = -1 ) then

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -628,6 +628,13 @@ type FBS_SCOPE
 	emit			as FB_SCOPEEMIT
 end type
 
+enum FBARRAY_FLAGS
+	FBARRAY_FLAGS_DIMENSIONS = &h0000000f      '' number of entries allocated in dimTb()
+	FBARRAY_FLAGS_FIXED_DIM  = &h00000010      '' array points to fixed-length memory
+	FBARRAY_FLAGS_FIXED_LEN  = &h00000020      '' array points to fixed-length memory
+	FBARRAY_FLAGS_RESERVED   = &hffffffc0      '' reserved, do not use
+end enum
+
 '' variable
 type FBS_ARRAY
 	'' 0 = none (not an array),
@@ -2558,8 +2565,8 @@ declare sub symbDump( byval s as FBSYMBOL ptr )
 declare sub symbDumpNamespace( byval ns as FBSYMBOL ptr )
 declare sub symbDumpChain( byval chain_ as FBSYMCHAIN ptr )
 
-'' FBARRAY: 5 pointer/integer fields + the dimTB with 3 integer fields per dimension
-#define symbDescriptorHasRoomFor( sym, dimensions ) (symbGetLen( sym ) = env.pointersize * (((dimensions) * 3) + 5))
+'' FBARRAY: 6 pointer/integer fields + the dimTB with 3 integer fields per dimension
+#define symbDescriptorHasRoomFor( sym, dimensions ) (symbGetLen( sym ) = env.pointersize * (((dimensions) * 3) + 6))
 #endif
 
 declare function symbDumpPrettyToStr( byval sym as FBSYMBOL ptr ) as string

--- a/src/rtlib/array_resetdesc.c
+++ b/src/rtlib/array_resetdesc.c
@@ -1,4 +1,3 @@
-/*!!!REMOVEME!!!*/
 /* descriptor reset, for dynamic local arrays */
 
 #include "fb.h"
@@ -8,5 +7,15 @@ FBCALL void fb_ArrayResetDesc( FBARRAY *array )
 	array->data = NULL;
 	array->ptr = NULL;
 	array->size = 0;
+	/* array->element_len = 0; */
+	/* array->dimensions = 0; */
+
+	/* only keep flags we make decisions on.  These will
+	   will have been set when the array descriptor was
+	   first allocated and must be kept.
+	*/
+	array->flags &= FBARRAY_FLAGS_DIMENSIONS 
+	                | FBARRAY_FLAGS_FIXED_DIM
+	                | FBARRAY_FLAGS_FIXED_LEN;
 	memset( &array->dimTB[0], 0, array->dimensions * sizeof( FBARRAYDIM ) );
 }

--- a/src/rtlib/fb_array.h
+++ b/src/rtlib/fb_array.h
@@ -4,12 +4,20 @@ typedef struct _FBARRAYDIM {
 	ssize_t ubound;
 } FBARRAYDIM;
 
+typedef enum _FBARRAY_FLAGS {
+	FBARRAY_FLAGS_DIMENSIONS = 0x0000000f,
+	FBARRAY_FLAGS_FIXED_DIM  = 0x00000010,
+	FBARRAY_FLAGS_FIXED_LEN  = 0x00000020,
+	FBARRAY_FLAGS_RESERVED   = 0xffffffc0
+} FBARRAY_FLAGS;
+
 typedef struct _FBARRAY {
 	void           *data;        /* ptr + diff, must be at ofs 0! */
 	void           *ptr;
 	size_t          size;
 	size_t          element_len;
 	size_t          dimensions;
+	size_t          flags;       /* FBARRAY_FLAGS */
 	FBARRAYDIM      dimTB[1];    /* dimtb[dimensions] */
 } FBARRAY;
 

--- a/tests/fbc-int/array.bas
+++ b/tests/fbc-int/array.bas
@@ -18,6 +18,16 @@ SUITE( fbc_tests.fbc_int.array )
 		end if
 	#endmacro
 
+	#macro check_flags( ap, max_d, fixed_dim, fixed_len )
+		if( ap ) then
+			CU_ASSERT( (ap->flags and FBARRAY_FLAGS_DIMENSIONS) = max_d )
+			CU_ASSERT( cbool(ap->flags and FBARRAY_FLAGS_FIXED_LEN) = fixed_len )
+			CU_ASSERT( cbool(ap->flags and FBARRAY_FLAGS_FIXED_DIM) = fixed_dim )
+		else
+			CU_FAIL()
+		end if
+	#endmacro
+
 	#macro check_dim( ap, d, e, l, u )
 		if( ap ) then
 			CU_ASSERT( ap->dimTb(d).elements = e )
@@ -31,66 +41,490 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( static_fixed )
 		'' static array will have descriptor because it is passed
 		'' a procedure, in this case, fb_ArrayGetDesc() 
+
+		'' 1 - dimensional
 	
 		static a1(2 to 11) as integer
 		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( a1() )
 		check_array( ap1, @a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, true )
 		check_dim( ap1, 0, 10, 2, 11 )
+
+		'' 2 - dimensional
 		
 		static a2(2 to 6, 3 to 12) as integer
 		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( a2() )
 		check_array( ap2, @a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, true )
 		check_dim( ap2, 0, 5, 2, 6 )
 		check_dim( ap2, 1, 10, 3, 12 )
 	END_TEST
 
    	TEST( static_empty )
-   		'' static array will have descriptor because it is dynamic
+   		'' static array will have descriptor because it is var-len
+
+		'' unknown dimension
 
 		static a0() as integer
 		dim ap0 as FBARRAY ptr = fb_ArrayGetDesc( a0() )
 		check_array( ap0, 0, 0, sizeof(integer), 0 )
+		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
 	
+		redim a0(2 to 11) as integer
+		check_array( ap0, @a0(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_dim( ap0, 0, 10, 2, 11 )
+
+		'' number of dimensions retained after ERASE
+		erase a0
+		check_array( ap0, 0, 0, sizeof(integer), 1 )
+		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+
+		'' 1 - dimensional
+
 		static a1(any) as integer
 		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( a1() )
 		check_array( ap1, 0, 0, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
 		check_dim( ap1, 0, 0, 0, 0 )
+
+		redim a1(2 to 11) as integer
+		check_array( ap1, @a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		erase a1
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 0, 0, 0 )
+
+		'' 2 - dimensional
 
 		static a2(any,any) as integer
 		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( a2() )
 		check_array( ap2, 0, 0, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
 		check_dim( ap2, 0, 0, 0, 0 )
 		check_dim( ap2, 1, 0, 0, 0 )
+
+		redim a2(2 to 6, 3 to 12) as integer
+		check_array( ap2, @a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+		erase a2
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 0, 0, 0 )
+		check_dim( ap2, 1, 0, 0, 0 )
+
 	END_TEST
 
 	TEST( local_fixed )
+		
+		'' 1 dimensional
+		
 		dim a1(2 to 11) as integer
 		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( a1() )
 		check_array( ap1, @a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, true )
 		check_dim( ap1, 0, 10, 2, 11 )
+
+		erase a1
+		check_array( ap1, @a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, true )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		'' 2 dimensional
 
 		dim a2(2 to 6, 3 to 12) as integer
 		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( a2() )
 		check_array( ap2, @a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, true )
 		check_dim( ap2, 0, 5, 2, 6 )
 		check_dim( ap2, 1, 10, 3, 12 )
+
+		erase a2
+		check_array( ap2, @a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, true )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
 	END_TEST
 
 	TEST( local_empty )
+		
+		'' unknown dimension
+		
 		dim a0() as integer
 		dim ap0 as FBARRAY ptr = fb_ArrayGetDesc( a0() )
 		check_array( ap0, 0, 0, sizeof(integer), 0 )
+		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+
+		redim a0(2 to 11) as integer
+		check_array( ap0, @a0(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_dim( ap0, 0, 10, 2, 11 )
+
+		'' number of dimensions retained after ERASE
+		erase a0
+		check_array( ap0, 0, 0, sizeof(integer), 1 )
+		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
 	
+		' 1 dimensional
+
 		dim a1(any) as integer
 		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( a1() )
 		check_array( ap1, 0, 0, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
 		check_dim( ap1, 0, 0, 0, 0 )
+
+		redim a1(2 to 11) as integer
+		check_array( ap1, @a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		erase a1
+		check_array( ap1, 0, 0, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 0, 0, 0 )
+
+		' 2 dimensional
 
 		dim a2(any,any) as integer
 		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( a2() )
 		check_array( ap2, 0, 0, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
 		check_dim( ap2, 0, 0, 0, 0 )
 		check_dim( ap2, 1, 0, 0, 0 )
+
+		redim a2(2 to 6, 3 to 12) as integer
+		check_array( ap2, @a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+		erase a2
+		check_array( ap2, 0, 0, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 0, 0, 0 )
+		check_dim( ap2, 1, 0, 0, 0 )
+		
+	END_TEST
+
+	type T_static_a0
+		__ as integer
+		static a0() as integer
+	end type
+	dim T_static_a0.a0() as integer
+
+	TEST( UDT_static_a0 )
+
+		dim x as T_static_a0
+
+		dim ap0 as FBARRAY ptr = fb_ArrayGetDesc( x.a0() )
+		check_array( ap0, 0, 0, sizeof(integer), 0 )
+		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+	
+		redim x.a0(2 to 11) as integer
+		check_array( ap0, @x.a0(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_dim( ap0, 0, 10, 2, 11 )
+
+		'' number of dimensions retained after ERASE
+		erase x.a0
+		check_array( ap0, 0, 0, sizeof(integer), 1 )
+		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		
+	END_TEST
+
+	type T_static_a1
+		__ as integer
+		static a1(any) as integer
+	end type
+	dim T_static_a1.a1(any) as integer
+
+	TEST( UDT_static_a1 )
+
+		dim x as T_static_a1
+
+		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		check_array( ap1, 0, 0, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 0, 0, 0 )
+
+		redim x.a1(2 to 11) as integer
+		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		erase x.a1
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 0, 0, 0 )
+
+	END_TEST
+
+	type T_static_a1f
+		__ as integer
+		static a1(2 to 11) as integer
+	end type
+	dim T_static_a1f.a1(2 to 11) as integer
+
+	TEST( UDT_static_a1f )
+		dim x as T_static_a1f
+
+		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, true )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		erase x.a1
+		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, true )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+	END_TEST
+
+	type T_static_a2
+		__ as integer
+		static a2(any,any) as integer
+	end type
+	static T_static_a2.a2(any,any) as integer
+
+	TEST( UDT_static_a2 )
+
+		dim x as T_static_a2
+
+		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		check_array( ap2, 0, 0, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 0, 0, 0 )
+		check_dim( ap2, 1, 0, 0, 0 )
+
+		redim x.a2(2 to 6, 3 to 12) as integer
+		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+		erase x.a2
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 0, 0, 0 )
+		check_dim( ap2, 1, 0, 0, 0 )
+
+	END_TEST
+
+	type T_static_a2f
+		__ as integer
+		static a2(2 to 6, 3 to 12) as integer
+	end type
+	static T_static_a2f.a2(2 to 6, 3 to 12) as integer
+
+	TEST( UDT_static_a2f )
+
+		dim x as T_static_a2f
+
+		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, true )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+		erase x.a2
+		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, true )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+	END_TEST
+
+	type T_dim_a1
+		dim a1(any) as integer
+	end type
+
+	TEST( UDT_dim_a1 )
+		dim x as T_dim_a1
+
+		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		check_array( ap1, 0, 0, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 0, 0, 0 )
+
+		redim x.a1(2 to 11) as integer
+		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		erase x.a1
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 0, 0, 0 )
+
+	END_TEST
+
+	type T_dim_a1f
+		dim a1(2 to 11) as integer
+	end type
+
+	TEST( UDT_dim_a1f )
+		dim x as T_dim_a1f
+
+		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, true )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		erase x.a1
+		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, true )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+	END_TEST
+
+	type T_dim_a2
+		dim a2(any,any) as integer
+	end type
+
+	TEST( UDT_dim_a2 )
+		dim x as T_dim_a2
+
+		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		check_array( ap2, 0, 0, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 0, 0, 0 )
+		check_dim( ap2, 1, 0, 0, 0 )
+
+		redim x.a2(2 to 6, 3 to 12) as integer
+		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+		erase x.a2
+		check_array( ap2, 0, 0, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 0, 0, 0 )
+		check_dim( ap2, 1, 0, 0, 0 )
+
+	END_TEST
+
+	type T_dim_a2f
+		dim a2(2 to 6,3 to 12) as integer
+	end type
+
+	TEST( UDT_dim_a2f )
+		dim x as T_dim_a2f
+
+		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, true )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+		erase x.a2
+		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, true )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+	END_TEST
+
+	type T_redim_a1
+		redim a1(any) as integer
+	end type
+
+	TEST( UDT_redim_a1 )
+		dim x as T_redim_a1
+
+		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		check_array( ap1, 0, 0, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 0, 0, 0 )
+
+		redim x.a1(2 to 11) as integer
+		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		erase x.a1
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 0, 0, 0 )
+
+	END_TEST
+
+	type T_redim_a1f
+		redim a1(2 to 11) as integer
+	end type
+
+	TEST( UDT_redim_a1f )
+		dim x as T_redim_a1f
+
+		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		redim x.a1(2 to 11) as integer
+		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 10, 2, 11 )
+
+		erase x.a1
+		check_flags( ap1, 1, true, false )
+		check_dim( ap1, 0, 0, 0, 0 )
+
+	END_TEST
+
+	type T_redim_a2
+		redim a2(any,any) as integer
+	end type
+
+	TEST( UDT_redim_a2 )
+		dim x as T_redim_a2
+
+		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		check_array( ap2, 0, 0, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 0, 0, 0 )
+		check_dim( ap2, 1, 0, 0, 0 )
+
+		redim x.a2(2 to 6, 3 to 12) as integer
+		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+		erase x.a2
+		check_array( ap2, 0, 0, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 0, 0, 0 )
+		check_dim( ap2, 1, 0, 0, 0 )
+
+	END_TEST
+
+	type T_redim_a2f
+		redim a2(2 to 6,3 to 12) as integer
+	end type
+
+	TEST( UDT_redim_a2f )
+		dim x as T_redim_a2f
+
+		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+		redim x.a2(2 to 6, 3 to 12) as integer
+		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 5, 2, 6 )
+		check_dim( ap2, 1, 10, 3, 12 )
+
+		erase x.a2
+		check_array( ap2, 0, 0, sizeof(integer), 2 )
+		check_flags( ap2, 2, true, false )
+		check_dim( ap2, 0, 0, 0, 0 )
+		check_dim( ap2, 1, 0, 0, 0 )
+
 	END_TEST
 
 END_SUITE

--- a/tests/fbc-int/array.bas
+++ b/tests/fbc-int/array.bas
@@ -1,8 +1,6 @@
 #include "fbcunit.bi"
 #include "fbc-int/array.bi"
 
-using FBC
-
 '' tests for array descriptor internals
 
 SUITE( fbc_tests.fbc_int.array )
@@ -20,9 +18,9 @@ SUITE( fbc_tests.fbc_int.array )
 
 	#macro check_flags( ap, max_d, fixed_dim, fixed_len )
 		if( ap ) then
-			CU_ASSERT( (ap->flags and FBARRAY_FLAGS_DIMENSIONS) = max_d )
-			CU_ASSERT( cbool(ap->flags and FBARRAY_FLAGS_FIXED_LEN) = fixed_len )
-			CU_ASSERT( cbool(ap->flags and FBARRAY_FLAGS_FIXED_DIM) = fixed_dim )
+			CU_ASSERT( (ap->flags and FBC.FBARRAY_FLAGS_DIMENSIONS) = max_d )
+			CU_ASSERT( cbool(ap->flags and FBC.FBARRAY_FLAGS_FIXED_LEN) = fixed_len )
+			CU_ASSERT( cbool(ap->flags and FBC.FBARRAY_FLAGS_FIXED_DIM) = fixed_dim )
 		else
 			CU_FAIL()
 		end if
@@ -40,12 +38,12 @@ SUITE( fbc_tests.fbc_int.array )
 	
 	TEST( static_fixed )
 		'' static array will have descriptor because it is passed
-		'' a procedure, in this case, fb_ArrayGetDesc() 
+		'' a procedure, in this case, FBC.ArrayDescriptorPtr() 
 
 		'' 1 - dimensional
 	
 		static a1(2 to 11) as integer
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a1() )
 		check_array( ap1, @a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, true )
 		check_dim( ap1, 0, 10, 2, 11 )
@@ -53,7 +51,7 @@ SUITE( fbc_tests.fbc_int.array )
 		'' 2 - dimensional
 		
 		static a2(2 to 6, 3 to 12) as integer
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a2() )
 		check_array( ap2, @a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, true )
 		check_dim( ap2, 0, 5, 2, 6 )
@@ -66,24 +64,24 @@ SUITE( fbc_tests.fbc_int.array )
 		'' unknown dimension
 
 		static a0() as integer
-		dim ap0 as FBARRAY ptr = fb_ArrayGetDesc( a0() )
+		dim ap0 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a0() )
 		check_array( ap0, 0, 0, sizeof(integer), 0 )
-		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_flags( ap0, FBC.FB_MAXDIMENSIONS, false, false )
 	
 		redim a0(2 to 11) as integer
 		check_array( ap0, @a0(2), sizeof(integer) * 10, sizeof(integer), 1 )
-		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_flags( ap0, FBC.FB_MAXDIMENSIONS, false, false )
 		check_dim( ap0, 0, 10, 2, 11 )
 
 		'' number of dimensions retained after ERASE
 		erase a0
 		check_array( ap0, 0, 0, sizeof(integer), 1 )
-		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_flags( ap0, FBC.FB_MAXDIMENSIONS, false, false )
 
 		'' 1 - dimensional
 
 		static a1(any) as integer
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a1() )
 		check_array( ap1, 0, 0, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, false )
 		check_dim( ap1, 0, 0, 0, 0 )
@@ -100,7 +98,7 @@ SUITE( fbc_tests.fbc_int.array )
 		'' 2 - dimensional
 
 		static a2(any,any) as integer
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a2() )
 		check_array( ap2, 0, 0, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, false )
 		check_dim( ap2, 0, 0, 0, 0 )
@@ -124,7 +122,7 @@ SUITE( fbc_tests.fbc_int.array )
 		'' 1 dimensional
 		
 		dim a1(2 to 11) as integer
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a1() )
 		check_array( ap1, @a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, true )
 		check_dim( ap1, 0, 10, 2, 11 )
@@ -137,7 +135,7 @@ SUITE( fbc_tests.fbc_int.array )
 		'' 2 dimensional
 
 		dim a2(2 to 6, 3 to 12) as integer
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a2() )
 		check_array( ap2, @a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, true )
 		check_dim( ap2, 0, 5, 2, 6 )
@@ -156,24 +154,24 @@ SUITE( fbc_tests.fbc_int.array )
 		'' unknown dimension
 		
 		dim a0() as integer
-		dim ap0 as FBARRAY ptr = fb_ArrayGetDesc( a0() )
+		dim ap0 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a0() )
 		check_array( ap0, 0, 0, sizeof(integer), 0 )
-		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_flags( ap0, FBC.FB_MAXDIMENSIONS, false, false )
 
 		redim a0(2 to 11) as integer
 		check_array( ap0, @a0(2), sizeof(integer) * 10, sizeof(integer), 1 )
-		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_flags( ap0, FBC.FB_MAXDIMENSIONS, false, false )
 		check_dim( ap0, 0, 10, 2, 11 )
 
 		'' number of dimensions retained after ERASE
 		erase a0
 		check_array( ap0, 0, 0, sizeof(integer), 1 )
-		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_flags( ap0, FBC.FB_MAXDIMENSIONS, false, false )
 	
 		' 1 dimensional
 
 		dim a1(any) as integer
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a1() )
 		check_array( ap1, 0, 0, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, false )
 		check_dim( ap1, 0, 0, 0, 0 )
@@ -191,7 +189,7 @@ SUITE( fbc_tests.fbc_int.array )
 		' 2 dimensional
 
 		dim a2(any,any) as integer
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( a2() )
 		check_array( ap2, 0, 0, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, false )
 		check_dim( ap2, 0, 0, 0, 0 )
@@ -221,19 +219,19 @@ SUITE( fbc_tests.fbc_int.array )
 
 		dim x as T_static_a0
 
-		dim ap0 as FBARRAY ptr = fb_ArrayGetDesc( x.a0() )
+		dim ap0 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a0() )
 		check_array( ap0, 0, 0, sizeof(integer), 0 )
-		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_flags( ap0, FBC.FB_MAXDIMENSIONS, false, false )
 	
 		redim x.a0(2 to 11) as integer
 		check_array( ap0, @x.a0(2), sizeof(integer) * 10, sizeof(integer), 1 )
-		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_flags( ap0, FBC.FB_MAXDIMENSIONS, false, false )
 		check_dim( ap0, 0, 10, 2, 11 )
 
 		'' number of dimensions retained after ERASE
 		erase x.a0
 		check_array( ap0, 0, 0, sizeof(integer), 1 )
-		check_flags( ap0, FB_MAXDIMENSIONS, false, false )
+		check_flags( ap0, FBC.FB_MAXDIMENSIONS, false, false )
 		
 	END_TEST
 
@@ -247,7 +245,7 @@ SUITE( fbc_tests.fbc_int.array )
 
 		dim x as T_static_a1
 
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a1() )
 		check_array( ap1, 0, 0, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, false )
 		check_dim( ap1, 0, 0, 0, 0 )
@@ -272,7 +270,7 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( UDT_static_a1f )
 		dim x as T_static_a1f
 
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a1() )
 		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, true )
 		check_dim( ap1, 0, 10, 2, 11 )
@@ -294,7 +292,7 @@ SUITE( fbc_tests.fbc_int.array )
 
 		dim x as T_static_a2
 
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a2() )
 		check_array( ap2, 0, 0, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, false )
 		check_dim( ap2, 0, 0, 0, 0 )
@@ -323,7 +321,7 @@ SUITE( fbc_tests.fbc_int.array )
 
 		dim x as T_static_a2f
 
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a2() )
 		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, true )
 		check_dim( ap2, 0, 5, 2, 6 )
@@ -344,7 +342,7 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( UDT_dim_a1 )
 		dim x as T_dim_a1
 
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a1() )
 		check_array( ap1, 0, 0, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, false )
 		check_dim( ap1, 0, 0, 0, 0 )
@@ -367,7 +365,7 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( UDT_dim_a1f )
 		dim x as T_dim_a1f
 
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a1() )
 		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, true )
 		check_dim( ap1, 0, 10, 2, 11 )
@@ -386,7 +384,7 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( UDT_dim_a2 )
 		dim x as T_dim_a2
 
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a2() )
 		check_array( ap2, 0, 0, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, false )
 		check_dim( ap2, 0, 0, 0, 0 )
@@ -413,7 +411,7 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( UDT_dim_a2f )
 		dim x as T_dim_a2f
 
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a2() )
 		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, true )
 		check_dim( ap2, 0, 5, 2, 6 )
@@ -434,7 +432,7 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( UDT_redim_a1 )
 		dim x as T_redim_a1
 
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a1() )
 		check_array( ap1, 0, 0, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, false )
 		check_dim( ap1, 0, 0, 0, 0 )
@@ -457,7 +455,7 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( UDT_redim_a1f )
 		dim x as T_redim_a1f
 
-		dim ap1 as FBARRAY ptr = fb_ArrayGetDesc( x.a1() )
+		dim ap1 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a1() )
 		check_array( ap1, @x.a1(2), sizeof(integer) * 10, sizeof(integer), 1 )
 		check_flags( ap1, 1, true, false )
 		check_dim( ap1, 0, 10, 2, 11 )
@@ -480,7 +478,7 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( UDT_redim_a2 )
 		dim x as T_redim_a2
 
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a2() )
 		check_array( ap2, 0, 0, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, false )
 		check_dim( ap2, 0, 0, 0, 0 )
@@ -507,7 +505,7 @@ SUITE( fbc_tests.fbc_int.array )
 	TEST( UDT_redim_a2f )
 		dim x as T_redim_a2f
 
-		dim ap2 as FBARRAY ptr = fb_ArrayGetDesc( x.a2() )
+		dim ap2 as FBC.FBARRAY ptr = FBC.ArrayDescriptorPtr( x.a2() )
 		check_array( ap2, @x.a2(2,3), sizeof(integer) * 5 * 10, sizeof(integer), 2 )
 		check_flags( ap2, 2, true, false )
 		check_dim( ap2, 0, 5, 2, 6 )

--- a/tests/structs/dynamic-array-fields.bas
+++ b/tests/structs/dynamic-array-fields.bas
@@ -17,6 +17,7 @@ SUITE( fbc_tests.structs.dynamic_array_fields )
 			size		as uinteger
 			element_len	as uinteger
 			dimensions	as uinteger
+			flags		as uinteger
 			dimTB(0 to (n)-1)	as FBARRAYDIM
 		end type
 	#endmacro


### PR DESCRIPTION
- update ./fbc-int/array.bi with new flags field
- flags field records if array is fixed dimension, fixed length, and max number of dimensions available in dimTb()
- const FBARRAY_FLAGS_DIMENSIONS = &h0000000f    '' number of entries allocated in dimTb()
- const FBARRAY_FLAGS_FIXED_DIM  = &h00000010    '' array has fixed number of dimensions
- const FBARRAY_FLAGS_FIXED_LEN  = &h00000020    '' array points to fixed-length memory
- const FBARRAY_FLAGS_RESERVED   = &hffffffc0    '' reserved, do not use