### PR TITLE
fb build date in ISO format, and source code sha-1 version information

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Version 1.08.0
 - array descriptor 'flags' field to track fixed length, fixed dimension, dimTb() size.
 
 [fixed]
+- makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture
 
 
 Version 1.07.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,11 @@ Version 1.08.0
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling
 - array descriptor 'flags' field to track fixed length, fixed dimension, dimTb() size.
 - __FB_BUILD_DATE_ISO__ intrinsic define to return fbc build date in 'yyyy-mm-dd' format
+- __FB_BUILD_SHA1__ intrinsic define to return the compiler's source code commit sha-1, (if known)
+- '-print sha-1' to print the compiler's source code commit sha-1, (if known)
+- makefile: 'FBSHA1=1' makefile configuration option to determine the current repo commit sha-1 from git
+- makefile: 'FBSHA1=some-sha-1' makefile configuration option to explicit set the repo commit sha-1
+- makefile: '-d FBSHA1="some-sha-1"' compiler option to set the value of '__FB_BUILD_SHA1__' when building fbc
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Version 1.08.0
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling
 - array descriptor 'flags' field to track fixed length, fixed dimension, dimTb() size.
+- __FB_BUILD_DATE_ISO__ intrinsic define to return fbc build date in 'yyyy-mm-dd' format
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 1.08.0
 
 [changed]
 - array descriptor contains new 'flags' field.  Careful, breaks binary compatibility plus chicken-egg problem to build fbc.
+- fbc '-version' reports build date in yyyy-mm-dd format (aka build date iso)
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling

--- a/doc/fbc.1
+++ b/doc/fbc.1
@@ -1,4 +1,4 @@
-.TH FBC 1 "2019-08-26" "FreeBASIC Compiler 1.08.0" "FreeBASIC Compiler"
+.TH FBC 1 "2019-09-07" "FreeBASIC Compiler 1.08.0" "FreeBASIC Compiler"
 .SH NAME
 fbc \- The FreeBASIC compiler
 .SH DESCRIPTION
@@ -146,6 +146,9 @@ Display host/target system name
 .TP
 \fB\-print\fR \fBx\fR
 Display output binary/library file name (if known)
+.TP
+\fB\-print\fR \fBsha-1\fR
+Display compiler's source code commit sha-1 (if known)
 .TP
 \fB\-profile\fR
 Enable function profiling

--- a/makefile
+++ b/makefile
@@ -83,6 +83,8 @@
 #   ENABLE_LIB64=1         use prefix/lib64/ instead of prefix/lib/ for 64bit libs (non-standalone only)
 #   ENABLE_STRIPALL=1      use "-d ENABLE_STRIPALL" with all targets
 #   ENABLE_STRIPALL=0      disable "-d ENABLE_STRIPALL" with all targets
+#   FBSHA1=1               determine the sha-1 of the current commit in repo and store it in the compiler
+#   FBSHA1=some-sha-1      explicitly indicate the sha-1 to store in the compiler
 #   FBPACKAGE     bindist: The package/archive file name without path or extension
 #   FBPACKSUFFIX  bindist: Allows adding a custom suffix to the normal package name (and the toplevel dir in the archive)
 #   FBMANIFEST    bindist: The manifest file name without path or extension
@@ -95,6 +97,7 @@
 #   -d ENABLE_PREFIX=/some/path   hard-code specific $(prefix) into fbc
 #   -d ENABLE_LIB64          use prefix/lib64/ instead of prefix/lib/ for 64bit libs (non-standalone only)
 #   -d ENABLE_STRIPALL       configure fbc to pass down '--strip-all' to linker by default
+#   -d FBSHA1=some-sha-1     store 'some-sha-1' in the compiler for version information
 #
 # rtlib/gfxlib2 source code configuration (CFLAGS):
 #   -DDISABLE_X11    build without X11 headers (disables X11 gfx driver)
@@ -441,6 +444,13 @@ endif
 # Pass the configuration defines on to the compiler source code
 ifdef ENABLE_STANDALONE
   ALLFBCFLAGS += -d ENABLE_STANDALONE
+endif
+ifdef FBSHA1
+  ifeq ($(FBSHA1),1)
+    ALLFBCFLAGS += -d 'FBSHA1="$(shell git rev-parse HEAD)"'
+  else
+    ALLFBCFLAGS += -d 'FBSHA1="$(FBSHA1)"'
+  endif
 endif
 ifdef ENABLE_SUFFIX
   ALLFBCFLAGS += -d 'ENABLE_SUFFIX="$(ENABLE_SUFFIX)"'

--- a/makefile
+++ b/makefile
@@ -206,7 +206,7 @@ else
       TARGET_OS := linux
     else ifneq ($(findstring MINGW,$(uname)),)
       TARGET_OS := win32
-	else ifneq ($(findstring MSYS_NT,$(uname)),)
+    else ifneq ($(findstring MSYS_NT,$(uname)),)
       TARGET_OS := win32
     else ifeq ($(uname),MS-DOS)
       TARGET_OS := dos
@@ -223,6 +223,25 @@ else
     # For DJGPP, always use x86 (DJGPP's uname -m returns just "pc")
     ifeq ($(TARGET_OS),dos)
       TARGET_ARCH := x86
+
+    # For MSYS2, use default compilers (uname -m returns MSYS2's shell
+    #  architecture).  For example, from win 7:
+    #
+    # host    shell    uname -s -m              default gcc target
+    # ------  -------  --------------------     ------------------
+    # msys32  msys2    MSYS_NT-6.1-WOW i686     n/a          
+    # msys32  mingw32  MINGW32_NT-6.1-WOW i686  i686-w64-mingw32                 
+    # msys32  mingw64  MINGW64_NT-6.1-WOW i686  x86_64-w64-mingw32
+    # msys64  msys2    MSYS_NT-6.1 x86_64       n/a
+    # msys64  mingw32  MINGW32_NT-6.1 x86_64    i686-w64-mingw32    
+    # msys64  mingw64  MINGW64_NT-6.1 x86_64    x86_64-w64-mingw32
+    #
+    else ifneq ($(findstring MINGW32,$(uname)),)
+      TARGET_ARCH := x86
+    else ifneq ($(findstring MINGW64,$(uname)),)
+      TARGET_ARCH := x86_64
+
+    # anything, trust 'uname -m', we have no other choice
     else
       TARGET_ARCH = $(shell uname -m)
     endif

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -9,6 +9,12 @@ const FB_BUILD_DATE = __DATE__
 const FB_BUILD_DATE_ISO = __DATE_ISO__
 const FB_SIGN       = "FreeBASIC " + FB_VERSION
 
+#ifdef FBSHA1
+const FB_BUILD_SHA1 = FBSHA1
+#else
+const FB_BUILD_SHA1 = ""
+#endif
+
 #define QUOTE !"\""
 #if defined( __FB_WIN32__ ) or defined( __FB_CYGWIN__ ) or defined( __FB_DOS__ )
 	#define NEWLINE !"\r\n"

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -6,6 +6,7 @@ const FB_VER_MINOR  = "08"
 const FB_VER_PATCH  = "0"
 const FB_VERSION    = FB_VER_MAJOR + "." + FB_VER_MINOR + "." + FB_VER_PATCH
 const FB_BUILD_DATE = __DATE__
+const FB_BUILD_DATE_ISO = __DATE_ISO__
 const FB_SIGN       = "FreeBASIC " + FB_VERSION
 
 #define QUOTE !"\""

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -3559,6 +3559,10 @@ private sub hPrintVersion( byval verbose as integer )
 	if( len( config ) > 0 ) then
 		print config
 	end if
+
+	if( verbose ) then
+		fbcPrintTargetInfo( )
+	end if
 end sub
 
 	fbcInit( )

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -21,6 +21,7 @@ enum
 	PRINT_TARGET
 	PRINT_X
 	PRINT_FBLIBDIR
+	PRINT_SHA1
 end enum
 
 type FBC_EXTOPT
@@ -1773,6 +1774,7 @@ private sub handleOpt(byval optid as integer, byref arg as string)
 		case "target" : fbc.print = PRINT_TARGET
 		case "x"      : fbc.print = PRINT_X
 		case "fblibdir" : fbc.print = PRINT_FBLIBDIR
+		case "sha-1"  : fbc.print = PRINT_SHA1
 		case else
 			hFatalInvalidOption( arg )
 		end select
@@ -3501,6 +3503,9 @@ private sub hPrintOptions( byval verbose as integer )
 	print "  -print host|target  Display host/target system name"
 	print "  -print fblibdir  Display the compiler's lib/ path"
 	print "  -print x         Display output binary/library file name (if known)"
+	if( verbose ) then
+	print "  -print sha-1     Display compiler's source code commit sha-1 (if known)"
+	end if
 	print "  -profile         Enable function profiling"
 	print "  -r               Write out .asm/.c/.ll (-gen gas/gcc/llvm) only"
 	print "  -rr              Write out the final .asm only"
@@ -3562,6 +3567,9 @@ private sub hPrintVersion( byval verbose as integer )
 
 	if( verbose ) then
 		fbcPrintTargetInfo( )
+		if( FB_BUILD_SHA1 > "" ) then
+			print "source sha-1: " & FB_BUILD_SHA1
+		end if
 	end if
 end sub
 
@@ -3624,6 +3632,8 @@ end sub
 			print fbc.outname
 		case PRINT_FBLIBDIR
 			print fbc.libpath
+		case PRINT_SHA1
+			print FB_BUILD_SHA1
 		end select
 		fbcEnd( 0 )
 	end if

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -3550,7 +3550,7 @@ private sub hPrintVersion( byval verbose as integer )
 	dim as string config
 
 	print "FreeBASIC Compiler - Version " + FB_VERSION + _
-		" (" + FB_BUILD_DATE + "), built for " + fbGetHostId( ) + " (" & fbGetHostBits( ) & "bit)"
+		" (" + FB_BUILD_DATE_ISO + "), built for " + fbGetHostId( ) + " (" & fbGetHostBits( ) & "bit)"
 	print "Copyright (C) 2004-2019 The FreeBASIC development team."
 
 	#ifdef ENABLE_STANDALONE

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -211,6 +211,7 @@ dim shared defTb(0 to ...) as SYMBDEF => _
 	(@"__FB_VER_MINOR__"      , @FB_VER_MINOR     , 0                  , NULL           ), _
 	(@"__FB_VER_PATCH__"      , @FB_VER_PATCH     , 0                  , NULL           ), _
 	(@"__FB_SIGNATURE__"      , @FB_SIGN          , FB_DEFINE_FLAGS_STR, NULL           ), _
+	(@"__FB_BUILD_SHA1__"     , @FB_BUILD_SHA1    , FB_DEFINE_FLAGS_STR, NULL           ), _
 	(@"__FB_MT__"             , NULL          , 0                  , @hDefMultithread_cb), _
 	(@"__FILE__"              , NULL          , FB_DEFINE_FLAGS_STR, @hDefFile_cb       ), _
 	(@"__FILE_NQ__"           , NULL          , 0                  , @hDefFile_cb       ), _

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -204,12 +204,13 @@ end function
 dim shared defTb(0 to ...) as SYMBDEF => _
 { _
 	_ '' name                     constant value  flags                callback (if value isn't constant)
-	(@"__FB_VERSION__"        , @FB_VERSION   , FB_DEFINE_FLAGS_STR, NULL               ), _
-	(@"__FB_BUILD_DATE__"     , @FB_BUILD_DATE, FB_DEFINE_FLAGS_STR, NULL               ), _
-	(@"__FB_VER_MAJOR__"      , @FB_VER_MAJOR , 0                  , NULL               ), _
-	(@"__FB_VER_MINOR__"      , @FB_VER_MINOR , 0                  , NULL               ), _
-	(@"__FB_VER_PATCH__"      , @FB_VER_PATCH , 0                  , NULL               ), _
-	(@"__FB_SIGNATURE__"      , @FB_SIGN      , FB_DEFINE_FLAGS_STR, NULL               ), _
+	(@"__FB_VERSION__"        , @FB_VERSION       , FB_DEFINE_FLAGS_STR, NULL           ), _
+	(@"__FB_BUILD_DATE__"     , @FB_BUILD_DATE    , FB_DEFINE_FLAGS_STR, NULL           ), _
+	(@"__FB_BUILD_DATE_ISO__" , @FB_BUILD_DATE_ISO, FB_DEFINE_FLAGS_STR, NULL           ), _
+	(@"__FB_VER_MAJOR__"      , @FB_VER_MAJOR     , 0                  , NULL           ), _
+	(@"__FB_VER_MINOR__"      , @FB_VER_MINOR     , 0                  , NULL           ), _
+	(@"__FB_VER_PATCH__"      , @FB_VER_PATCH     , 0                  , NULL           ), _
+	(@"__FB_SIGNATURE__"      , @FB_SIGN          , FB_DEFINE_FLAGS_STR, NULL           ), _
 	(@"__FB_MT__"             , NULL          , 0                  , @hDefMultithread_cb), _
 	(@"__FILE__"              , NULL          , FB_DEFINE_FLAGS_STR, @hDefFile_cb       ), _
 	(@"__FILE_NQ__"           , NULL          , 0                  , @hDefFile_cb       ), _
@@ -237,7 +238,7 @@ dim shared defTb(0 to ...) as SYMBDEF => _
 	(@"__FB_FPU__"            , NULL          , FB_DEFINE_FLAGS_STR, @hDefFpu_cb        ), _
 	(@"__FB_FPMODE__"         , NULL          , FB_DEFINE_FLAGS_STR, @hDefFpmode_cb     ), _
 	(@"__FB_GCC__"            , NULL          , 0                  , @hDefGcc_cb        ), _
-	(@"__FB_GUI__"            , NULL          , 0                  , @hDefGui_cb    )  _
+	(@"__FB_GUI__"            , NULL          , 0                  , @hDefGui_cb        )  _
 }
 
 sub symbDefineInit _


### PR DESCRIPTION
New features for fbc compiler version tracking:

`__FB_BUILD_DATE_ISO__` intrinsic define:

fbc traditionally has reported the build date in "mm-dd-yyyy" format (on all targets comparable to `date()` function).  As discussed on forums, [`__FB_BUILD_DATE__` should be changed to ISO-Date](https://www.freebasic.net/forum/viewtopic.php?f=17&t=27841) this pull request adds a new intrinsic define `__FB_BUILD_DATE_ISO__` to return the date in "yyyy-mm-dd" ISO format.  Also, build date reported by fbc from `fbc -version` also changed to report in ISO format.

`__FB_BUILD_SHA1__` intrinsic define:

With multiple versions, targets, and builds of the fbc compiler, it would be very useful to know the repository commit sha-1 identifier for the specific version of source code used to build the compiler.  `__FB_BUILD_SHA1__` will return a string for value set at compile time through the `-d FBSHA1="some-sha-1"` compiler makefile option.

`makefile` update:

- A minor patch to detect TARGET_ARCH under msys2.  This update uses the default target architecture of the shell instead of the host's architecture.
- add 'FBSHA1=1' makefile configuration option to determine the current repo commit sha-1 from git
- add 'FBSHA1=some-sha-1' makefile configuration option to explicit set the repo commit sha-1
- add '-d FBSHA1="some-sha-1"' compiler option to set the value of '__FB_BUILD_SHA1__' when building fbc
