### PR TITLE
Pass '-Wno-format' to gcc backend to prevent string format errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ Version 1.08.0
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture
+- gcc backend: pass '-Wno-format' to prevent format string errors in gcc 9.x (enabled by default with -Wall)
 
 
 Version 1.07.0

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -2939,6 +2939,13 @@ private function hCompileStage2Module( byval module as FBCIOFILE ptr ) as intege
 		'' Avoid gcc exception handling bloat
 		ln += "-fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables "
 
+		'' Prevent format string errors on gcc 9.x. (enabled by default with '-Wall')
+		'' TODO: fbc currently emits the ZSTRING type as 'uint8' when it
+		'' should probably preserve the 'char' type.  In C, there are 3 
+		'' distinct types, 'char', 'unsigned char', 'signed char'.
+		'' See ir-hlc.bas:hEmitType()
+		ln += "-Wno-format "
+
 		if( fbGetOption( FB_COMPOPT_DEBUGINFO ) ) then
 			ln += "-g "
 		end if


### PR DESCRIPTION
As reported in [#904 gcc 9 doesn't support CRT formatting functions like printf ](https://sourceforge.net/p/fbc/bugs/904/), proposed fix is to pass '-Wno-format' to prevent format string errors in gcc 9.x (enabled by default with -Wall).

This should solve the immediate problem.  We may see something similar or related resurface in other ways, as explained in this note added along with the `-Wno-format` option:
```
'' prevent format string errors on gcc 9.x. (enabled by default with '-Wall')
'' TODO: fbc currently emits the ZSTRING type as 'uint8' when it should probably preserve the 'char' type.
'' In C, there are 3 distinct types, 'char', 'unsigned char', 'signed char'.  See ir-hlc.bas:hEmitType()
ln += "-Wno-format "
```
