### PR TITLE
Fix a cast(string, variable) issue that can cause fbc to segfault

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,8 @@ Version 1.08.0
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture
-- gcc backend: pass '-Wno-format' to prevent format string errors in gcc 9.x (enabled by default with -Wall)
+- sf.net #904; gcc backend: pass '-Wno-format' to prevent format string errors in gcc 9.x (enabled by default with -Wall)
+- sf.net #910: cast(string, variable) can cause fbc to segfault (infinite recursion), due to misplaced const & non-const casting
 
 
 Version 1.07.0

--- a/src/compiler/ast-node-arg.bas
+++ b/src/compiler/ast-node-arg.bas
@@ -290,7 +290,14 @@ private sub hCheckByrefParam _
 	dim as ASTNODE ptr t = any
 
 	'' skip any casting if they won't do any conversion
-	t = astSkipNoConvCAST( n->l )
+	'' TODO: astSkipConstCASTs() will skip over any CONST conversions
+	'' This is OK when generating the final AST, as we probably no longer care
+	'' about CONST.  However, if we ever get here and we expect PARSER/AST to
+	'' return an error, or preserve the CONST conversion as part of the
+	'' translation, this may introduce undesired behaviour.  Need to verify.
+	'' Specifically, using astSkipConstCASTs() instead of astSkipNoConvCAST()
+	'' allows us to fix the fbc crash as reported in sf.net bug #910
+	t = astSkipConstCASTs( n->l )
 
 	'' If it's a CALL returning a STRING, it actually returns a pointer,
 	'' which can be passed to the BYREF param as-is

--- a/src/compiler/ast-node-conv.bas
+++ b/src/compiler/ast-node-conv.bas
@@ -724,6 +724,15 @@ function astLoadCONV _
 
 end function
 
+function astSkipConstCASTs( byval n as ASTNODE ptr ) as ASTNODE ptr
+	function = n
+	if( n->class = AST_NODECLASS_CONV ) then
+		if( n->cast.doconv = FALSE ) then
+			function = n->l
+		end if
+	end if
+end function
+
 function astSkipNoConvCAST( byval n as ASTNODE ptr ) as ASTNODE ptr
 	function = n
 	if( n->class = AST_NODECLASS_CONV ) then

--- a/src/compiler/ast.bi
+++ b/src/compiler/ast.bi
@@ -561,6 +561,7 @@ declare sub astUpdateCONVFD2FS _
 		byval is_expr as integer _
 	)
 
+declare function astSkipConstCASTs( byval n as ASTNODE ptr ) as ASTNODE ptr
 declare function astSkipNoConvCAST( byval n as ASTNODE ptr ) as ASTNODE ptr
 declare function astRemoveNoConvCAST( byval n as ASTNODE ptr ) as ASTNODE ptr
 declare function astSkipCASTs( byval n as ASTNODE ptr ) as ASTNODE ptr

--- a/src/compiler/parser-expr-unary.bas
+++ b/src/compiler/parser-expr-unary.bas
@@ -488,7 +488,13 @@ private function hVarPtrBody _
 	end if
 
 	'' skip any casting if they won't do any conversion
-	dim as ASTNODE ptr t = astSkipNoConvCAST( expr )
+	'' TODO: replace astSkipNoConvCast() with astSkipConstCASTs()
+	'' where applicable.  Need to verify.  On one hand, we
+	'' probably don't care about CONST anymore, on the other
+	'' hand, we need to make sure we don't prematurely optimize
+	'' the CONST specifier away in the event that it is needed
+	'' to be known with AST type checking later.
+	dim as ASTNODE ptr t = astSkipConstCASTs( expr )
 
 	select case as const astGetClass( t )
 	case AST_NODECLASS_VAR, AST_NODECLASS_IDX, AST_NODECLASS_DEREF, _

--- a/src/compiler/rtl-string.bas
+++ b/src/compiler/rtl-string.bas
@@ -2539,8 +2539,8 @@ function rtlStrAssign _
    	'' always calc len before pushing the param
 	lgt = rtlCalcStrLen( src, sdtype )
 
-	'' src as any
-	if( astNewARG( proc, src, astGetDataType( src ) ) = NULL ) then
+	'' src as const any
+	if( astNewARG( proc, src ) = NULL ) then
     	exit function
     end if
 

--- a/tests/warnings/const-discard.bas
+++ b/tests/warnings/const-discard.bas
@@ -1040,3 +1040,72 @@ sub const_udt_array( byref s as const shape )
 	WARN(0)
 	print s.points(0).x
 end sub
+
+'' --------------------------------------------------------
+
+'' from https://www.freebasic.net/forum/viewtopic.php?f=17&t=27692
+'' and  https://sourceforge.net/p/fbc/bugs/910/
+
+#print "---- Regression Checks"
+
+sub const_cast_string1( byval s as string )
+end sub 
+sub const_cast_string2( byref s as const string )
+	WARN(1)
+    const_cast_string1( cast(string, s) )
+end sub
+
+scope
+	dim x as const string = "test"
+	dim y as string
+	WARN(1)
+	y = cast(string, x )
+	WARN(0)
+	y = cast(const string, x )
+end scope
+
+type T_integer
+	__ as integer
+end type
+
+sub const_cast_proc1i( byval i as integer ptr )
+end sub 
+sub const_cast_proc2i( byval i as const integer ptr )
+end sub
+
+sub const_cast_proc1t( byval x as T_integer ptr )
+end sub 
+sub const_cast_proc2t( byval x as const T_integer ptr )
+end sub 
+
+scope
+	dim i as const integer = 1
+	WARN(1)
+	const_cast_proc1i( @cast(integer, i) )
+	WARN(0)
+	const_cast_proc2i( @cast(const integer, i) )
+end scope
+
+scope
+	dim i as integer = 1
+	WARN(1)
+	const_cast_proc2i( @cast(const integer, i) )
+	WARN(0)
+	const_cast_proc2i( @cast(integer, i) )
+end scope
+
+scope
+	dim x as const T_integer = ( 1 )
+	WARN(1)
+	const_cast_proc1t( @cast(T_integer, x) )
+	WARN(0)
+	const_cast_proc2t( @cast(const T_integer, x) )
+end scope
+
+scope
+	dim x as T_integer = ( 1 )
+	WARN(1)
+	const_cast_proc2t( @cast(const T_integer,x) )
+	WARN(0)
+	const_cast_proc2t( @cast(T_integer,x) )
+end scope

--- a/tests/warnings/r/dos/const-discard.txt
+++ b/tests/warnings/r/dos/const-discard.txt
@@ -420,3 +420,21 @@ none expected
 none expected
 none expected
 none expected
+---- Regression Checks
+warning expected
+	CONST qualifier discarded
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected

--- a/tests/warnings/r/linux-x86/const-discard.txt
+++ b/tests/warnings/r/linux-x86/const-discard.txt
@@ -420,3 +420,21 @@ none expected
 none expected
 none expected
 none expected
+---- Regression Checks
+warning expected
+	CONST qualifier discarded
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected

--- a/tests/warnings/r/linux-x86_64/const-discard.txt
+++ b/tests/warnings/r/linux-x86_64/const-discard.txt
@@ -420,3 +420,21 @@ none expected
 none expected
 none expected
 none expected
+---- Regression Checks
+warning expected
+	CONST qualifier discarded
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected

--- a/tests/warnings/r/win32/const-discard.txt
+++ b/tests/warnings/r/win32/const-discard.txt
@@ -420,3 +420,21 @@ none expected
 none expected
 none expected
 none expected
+---- Regression Checks
+warning expected
+	CONST qualifier discarded
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected

--- a/tests/warnings/r/win64/const-discard.txt
+++ b/tests/warnings/r/win64/const-discard.txt
@@ -420,3 +420,21 @@ none expected
 none expected
 none expected
 none expected
+---- Regression Checks
+warning expected
+	CONST qualifier discarded
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected
+warning expected
+	CONST qualifier discarded
+none expected


### PR DESCRIPTION
As reported in [#910 cast(string, variable) can cause fbc to segfault (infinite recursion)](https://sourceforge.net/p/fbc/bugs/910/)

Demonstrated in this example:
```
dim x as const string = "test"
dim y as string
y = cast(string, x )
```

cast(string, variable) can cause fbc to segfault due to infinite recursion, and misplaced const & non-const casting handling with fbc source.

This fix adjusts how _some_ casts are handled.  This issue needs further investigation, as indicated by the `TODO` notes added to the compiler source.

Only simply tested, is that `CAST` when used to modify constness should now be more permissive in some situations, however, should still give warning when used with `-w constness` warning check.
