### PR TITLE
File2

### DIFF
--- a/inc/file.bi
+++ b/inc/file.bi
@@ -29,13 +29,20 @@ declare function FileExists alias "fb_FileExists" ( byval filename as __zstring 
 declare function FileDateTime alias "fb_FileDateTime" ( byval filename as __zstring __ptr ) as double
 
 #else
-
-declare function FileCopy alias "fb_FileCopy" ( byval source as zstring ptr, byval destination as zstring ptr ) as long
 declare function FileAttr alias "fb_FileAttr" ( byval handle as long, byval returntype as long = 1 ) as integer
-declare function FileLen alias "fb_FileLen" ( byval filename as zstring ptr ) as longint
-declare function FileExists alias "fb_FileExists" ( byval filename as zstring ptr ) as long
-declare function FileDateTime alias "fb_FileDateTime" ( byval filename as zstring ptr ) as double
 
+    #ifdef __FB_WIN32__                               'windows
+        declare function FileCopy alias "fb_FileCopyW" ( byval source as Wstring ptr, byval destination as Wstring ptr ) as long
+        declare function FileLen alias "fb_FileLenW" ( byval filename as wstring ptr ) as longint
+        declare function FileExists alias "fb_FileExistsW" ( byval filename as wstring ptr ) as long
+        declare function FileDateTime alias "fb_FileDateTimeW" ( byval filename as Wstring ptr ) as double
+
+    #else
+        declare function FileCopy alias "fb_FileCopy" ( byval source as zstring ptr, byval destination as zstring ptr ) as long
+        declare function FileLen alias "fb_FileLen" ( byval filename as zstring ptr ) as longint
+        declare function FileExists alias "fb_FileExists" ( byval filename as zstring ptr ) as long
+        declare function FileDateTime alias "fb_FileDateTime" ( byval filename as zstring ptr ) as double
+    #endif
 #endif
 
 #endif

--- a/src/rtlib/win32/file_copy.c
+++ b/src/rtlib/win32/file_copy.c
@@ -1,11 +1,11 @@
-/* file copy */
+/* file copy, support wide string filenames */
 
 #include "../fb.h"
 #include <windows.h>
 
-FBCALL int fb_FileCopy( const char *source, const char *destination )
+FBCALL int fb_FileCopyW( const FB_WCHAR *source, const FB_WCHAR *destination )
 {
 	BOOL res;
-	res = CopyFile( source, destination, FALSE );
+	res = CopyFileW( source, destination, FALSE );
 	return fb_ErrorSetNum( res == FALSE ? FB_RTERROR_ILLEGALFUNCTIONCALL : FB_RTERROR_OK );
 }

--- a/src/rtlib/win32/file_datetime_w.c
+++ b/src/rtlib/win32/file_datetime_w.c
@@ -1,0 +1,19 @@
+/* get file date/time by wide string filename */
+
+#include "../fb.h"
+#include <time.h>
+#include <sys/stat.h>
+
+FBCALL double fb_FileDateTimeW( const FB_WCHAR *filename )
+{
+	struct _stat buf;
+	if( _wstat( filename, &buf ) != 0 )
+		return 0.0;
+
+	struct tm *tm = localtime( &buf.st_mtime );
+	if( tm == NULL )
+		return 0.0;
+
+	return fb_DateSerial( 1900 + tm->tm_year, 1+tm->tm_mon, tm->tm_mday ) +
+	       fb_TimeSerial( tm->tm_hour, tm->tm_min, tm->tm_sec );
+}

--- a/src/rtlib/win32/file_exists_w.c
+++ b/src/rtlib/win32/file_exists_w.c
@@ -1,0 +1,22 @@
+/* file existence testing for wide string filenames*/
+
+#include "../fb.h"
+
+FBCALL int fb_FileExistsW 
+    ( 
+        const FB_WCHAR *filename 
+    )
+{
+    FILE *fp;
+    
+    fp = _wfopen(filename, L"r");
+    if (fp) 
+    {
+        fclose(fp);
+        return FB_TRUE;
+    } 
+    else
+    {
+        return FB_FALSE;
+    }
+}

--- a/src/rtlib/win32/file_len_w.c
+++ b/src/rtlib/win32/file_len_w.c
@@ -1,0 +1,33 @@
+/* get file length by wide filename */
+
+#include "../fb.h"
+
+fb_off_t fb_FileLenExW( const FB_WCHAR *filename )
+{
+    FILE *fp;
+    fb_off_t len;
+    
+    fp = _wfopen( filename, L"rb" );    
+    if( fp != NULL )
+    {
+        if( fseeko( fp, 0, SEEK_END ) == 0 ) 
+        {
+            if( (len = ftello( fp )) != -1 ) 
+            {
+                fclose( fp );
+                fb_ErrorSetNum( FB_RTERROR_OK );
+                return len;
+            }
+        }
+
+        fclose( fp );
+    }
+
+    fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
+    return 0;
+}
+
+FBCALL long long fb_FileLenW( const FB_WCHAR *filename )
+{
+    return fb_FileLenExW( filename );
+}


### PR DESCRIPTION
Make existing functions (FILECOPY, FILEEXISTS, FILEDATETIME and FILELEN) wide string compatible for Windows. 

It isn´t necessary to have two functions, one for in-going ANSI file names and another one for in-going wide string file names. Because of the implicit conversion the wide string version alone will do. 

In terms of performance there is no loss for the ANSI to wide string conversion, because Windows internally only makes use of the ...W APIs and converts all ANSI parameters of ...A APIs to wide strings. So the conversion of ANSI strings is taking place anyway, only the place is different. 

I would propose the same approach (supply only a wide string version) for all file related functions to be made working with wide strings.
 
JK