### PR TITLE
update sqlite 3 headers to v3.30.0 + fix example

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 1.08.0
 [changed]
 - array descriptor contains new 'flags' field.  Careful, breaks binary compatibility plus chicken-egg problem to build fbc.
 - fbc '-version' reports build date in yyyy-mm-dd format (aka build date iso)
+- updated SQLite headers for binding to SQLite 3.30.0 (2019-10-04)
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling

--- a/examples/database/sqlite3_test.bas
+++ b/examples/database/sqlite3_test.bas
@@ -14,10 +14,10 @@ declare sub showusage( )
 declare function callback cdecl _
 	( _
 		byval NotUsed as any ptr, _
-		byval argc as integer, _
+		byval argc as long, _
 		byval argv as zstring ptr ptr, _
 		byval colName as zstring ptr ptr _
-	) as integer
+	) as long
 
 	dim as sqlite3 ptr db
 	dim as zstring ptr errMsg 
@@ -59,10 +59,10 @@ declare function callback cdecl _
 function callback cdecl _
 	( _
 		byval NotUsed as any ptr, _
-		byval argc as integer, _
+		byval argc as long, _
 		byval argv as zstring ptr ptr, _
 		byval colName as zstring ptr ptr _
-	) as integer
+	) as long
   
 	dim as integer i 
 	dim as string text

--- a/inc/sqlite3.bi
+++ b/inc/sqlite3.bi
@@ -1,7 +1,7 @@
-'' FreeBASIC binding for SQLite 3.8.11.1
+'' FreeBASIC binding for SQLite 3.30.0
 ''
 '' based on the C header files:
-''   * 2001 September 15
+''   * 2001-09-15
 ''   *
 ''   * The author disclaims copyright to this source code.  In place of
 ''   * a legal notice, here is a blessing:
@@ -33,20 +33,21 @@
 ''   * part of the build process.
 ''
 '' translated to FreeBASIC by:
-''   Copyright © 2015 FreeBASIC development team
+''   Copyright © 2019 FreeBASIC development team
 
 #pragma once
 
 #inclib "sqlite3"
 
+#include once "crt/long.bi"
 #include once "crt/stdarg.bi"
 
 extern "C"
 
-#define _SQLITE3_H_
-#define SQLITE_VERSION "3.8.11.1"
-const SQLITE_VERSION_NUMBER = 3008011
-#define SQLITE_SOURCE_ID "2015-07-29 20:00:57 cf538e2783e468bbc25e7cb2a9ee64d3e0e80b2f"
+#define SQLITE3_H
+#define SQLITE_VERSION "3.30.0"
+const SQLITE_VERSION_NUMBER = 3030000
+#define SQLITE_SOURCE_ID "2019-10-04 15:03:17 c20a35336432025445f9f7e289d0cc3e4003fb17f45a4ce74c6269c407c6e09f"
 extern __sqlite3_version alias "sqlite3_version" as const byte
 #define sqlite3_version (*cptr(const zstring ptr, @__sqlite3_version))
 
@@ -98,6 +99,9 @@ const SQLITE_NOTICE = 27
 const SQLITE_WARNING = 28
 const SQLITE_ROW = 100
 const SQLITE_DONE = 101
+const SQLITE_ERROR_MISSING_COLLSEQ = SQLITE_ERROR or (1 shl 8)
+const SQLITE_ERROR_RETRY = SQLITE_ERROR or (2 shl 8)
+const SQLITE_ERROR_SNAPSHOT = SQLITE_ERROR or (3 shl 8)
 const SQLITE_IOERR_READ = SQLITE_IOERR or (1 shl 8)
 const SQLITE_IOERR_SHORT_READ = SQLITE_IOERR or (2 shl 8)
 const SQLITE_IOERR_WRITE = SQLITE_IOERR or (3 shl 8)
@@ -124,18 +128,28 @@ const SQLITE_IOERR_DELETE_NOENT = SQLITE_IOERR or (23 shl 8)
 const SQLITE_IOERR_MMAP = SQLITE_IOERR or (24 shl 8)
 const SQLITE_IOERR_GETTEMPPATH = SQLITE_IOERR or (25 shl 8)
 const SQLITE_IOERR_CONVPATH = SQLITE_IOERR or (26 shl 8)
+const SQLITE_IOERR_VNODE = SQLITE_IOERR or (27 shl 8)
+const SQLITE_IOERR_AUTH = SQLITE_IOERR or (28 shl 8)
+const SQLITE_IOERR_BEGIN_ATOMIC = SQLITE_IOERR or (29 shl 8)
+const SQLITE_IOERR_COMMIT_ATOMIC = SQLITE_IOERR or (30 shl 8)
+const SQLITE_IOERR_ROLLBACK_ATOMIC = SQLITE_IOERR or (31 shl 8)
 const SQLITE_LOCKED_SHAREDCACHE = SQLITE_LOCKED or (1 shl 8)
+const SQLITE_LOCKED_VTAB = SQLITE_LOCKED or (2 shl 8)
 const SQLITE_BUSY_RECOVERY = SQLITE_BUSY or (1 shl 8)
 const SQLITE_BUSY_SNAPSHOT = SQLITE_BUSY or (2 shl 8)
 const SQLITE_CANTOPEN_NOTEMPDIR = SQLITE_CANTOPEN or (1 shl 8)
 const SQLITE_CANTOPEN_ISDIR = SQLITE_CANTOPEN or (2 shl 8)
 const SQLITE_CANTOPEN_FULLPATH = SQLITE_CANTOPEN or (3 shl 8)
 const SQLITE_CANTOPEN_CONVPATH = SQLITE_CANTOPEN or (4 shl 8)
+const SQLITE_CANTOPEN_DIRTYWAL = SQLITE_CANTOPEN or (5 shl 8)
 const SQLITE_CORRUPT_VTAB = SQLITE_CORRUPT or (1 shl 8)
+const SQLITE_CORRUPT_SEQUENCE = SQLITE_CORRUPT or (2 shl 8)
 const SQLITE_READONLY_RECOVERY = SQLITE_READONLY or (1 shl 8)
 const SQLITE_READONLY_CANTLOCK = SQLITE_READONLY or (2 shl 8)
 const SQLITE_READONLY_ROLLBACK = SQLITE_READONLY or (3 shl 8)
 const SQLITE_READONLY_DBMOVED = SQLITE_READONLY or (4 shl 8)
+const SQLITE_READONLY_CANTINIT = SQLITE_READONLY or (5 shl 8)
+const SQLITE_READONLY_DIRECTORY = SQLITE_READONLY or (6 shl 8)
 const SQLITE_ABORT_ROLLBACK = SQLITE_ABORT or (2 shl 8)
 const SQLITE_CONSTRAINT_CHECK = SQLITE_CONSTRAINT or (1 shl 8)
 const SQLITE_CONSTRAINT_COMMITHOOK = SQLITE_CONSTRAINT or (2 shl 8)
@@ -151,6 +165,7 @@ const SQLITE_NOTICE_RECOVER_WAL = SQLITE_NOTICE or (1 shl 8)
 const SQLITE_NOTICE_RECOVER_ROLLBACK = SQLITE_NOTICE or (2 shl 8)
 const SQLITE_WARNING_AUTOINDEX = SQLITE_WARNING or (1 shl 8)
 const SQLITE_AUTH_USER = SQLITE_AUTH or (1 shl 8)
+const SQLITE_OK_LOAD_PERMANENTLY = SQLITE_OK or (1 shl 8)
 const SQLITE_OPEN_READONLY = &h00000001
 const SQLITE_OPEN_READWRITE = &h00000002
 const SQLITE_OPEN_CREATE = &h00000004
@@ -185,6 +200,7 @@ const SQLITE_IOCAP_SEQUENTIAL = &h00000400
 const SQLITE_IOCAP_UNDELETABLE_WHEN_OPEN = &h00000800
 const SQLITE_IOCAP_POWERSAFE_OVERWRITE = &h00001000
 const SQLITE_IOCAP_IMMUTABLE = &h00002000
+const SQLITE_IOCAP_BATCH_ATOMIC = &h00004000
 const SQLITE_LOCK_NONE = 0
 const SQLITE_LOCK_SHARED = 1
 const SQLITE_LOCK_RESERVED = 2
@@ -246,6 +262,16 @@ const SQLITE_FCNTL_WIN32_SET_HANDLE = 23
 const SQLITE_FCNTL_WAL_BLOCK = 24
 const SQLITE_FCNTL_ZIPVFS = 25
 const SQLITE_FCNTL_RBU = 26
+const SQLITE_FCNTL_VFS_POINTER = 27
+const SQLITE_FCNTL_JOURNAL_POINTER = 28
+const SQLITE_FCNTL_WIN32_GET_HANDLE = 29
+const SQLITE_FCNTL_PDB = 30
+const SQLITE_FCNTL_BEGIN_ATOMIC_WRITE = 31
+const SQLITE_FCNTL_COMMIT_ATOMIC_WRITE = 32
+const SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE = 33
+const SQLITE_FCNTL_LOCK_TIMEOUT = 34
+const SQLITE_FCNTL_DATA_VERSION = 35
+const SQLITE_FCNTL_SIZE_LIMIT = 36
 const SQLITE_GET_LOCKPROXYFILE = SQLITE_FCNTL_GET_LOCKPROXYFILE
 const SQLITE_SET_LOCKPROXYFILE = SQLITE_FCNTL_SET_LOCKPROXYFILE
 const SQLITE_LAST_ERRNO = SQLITE_FCNTL_LAST_ERRNO
@@ -327,12 +353,31 @@ const SQLITE_CONFIG_MMAP_SIZE = 22
 const SQLITE_CONFIG_WIN32_HEAPSIZE = 23
 const SQLITE_CONFIG_PCACHE_HDRSZ = 24
 const SQLITE_CONFIG_PMASZ = 25
+const SQLITE_CONFIG_STMTJRNL_SPILL = 26
+const SQLITE_CONFIG_SMALL_MALLOC = 27
+const SQLITE_CONFIG_SORTERREF_SIZE = 28
+const SQLITE_CONFIG_MEMDB_MAXSIZE = 29
+const SQLITE_DBCONFIG_MAINDBNAME = 1000
 const SQLITE_DBCONFIG_LOOKASIDE = 1001
 const SQLITE_DBCONFIG_ENABLE_FKEY = 1002
 const SQLITE_DBCONFIG_ENABLE_TRIGGER = 1003
+const SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER = 1004
+const SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION = 1005
+const SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE = 1006
+const SQLITE_DBCONFIG_ENABLE_QPSG = 1007
+const SQLITE_DBCONFIG_TRIGGER_EQP = 1008
+const SQLITE_DBCONFIG_RESET_DATABASE = 1009
+const SQLITE_DBCONFIG_DEFENSIVE = 1010
+const SQLITE_DBCONFIG_WRITABLE_SCHEMA = 1011
+const SQLITE_DBCONFIG_LEGACY_ALTER_TABLE = 1012
+const SQLITE_DBCONFIG_DQS_DML = 1013
+const SQLITE_DBCONFIG_DQS_DDL = 1014
+const SQLITE_DBCONFIG_ENABLE_VIEW = 1015
+const SQLITE_DBCONFIG_MAX = 1015
 
 declare function sqlite3_extended_result_codes(byval as sqlite3 ptr, byval onoff as long) as long
 declare function sqlite3_last_insert_rowid(byval as sqlite3 ptr) as sqlite3_int64
+declare sub sqlite3_set_last_insert_rowid(byval as sqlite3 ptr, byval as sqlite3_int64)
 declare function sqlite3_changes(byval as sqlite3 ptr) as long
 declare function sqlite3_total_changes(byval as sqlite3 ptr) as long
 declare sub sqlite3_interrupt(byval as sqlite3 ptr)
@@ -393,9 +438,14 @@ const SQLITE_FUNCTION = 31
 const SQLITE_SAVEPOINT = 32
 const SQLITE_COPY = 0
 const SQLITE_RECURSIVE = 33
-
 declare function sqlite3_trace(byval as sqlite3 ptr, byval xTrace as sub(byval as any ptr, byval as const zstring ptr), byval as any ptr) as any ptr
 declare function sqlite3_profile(byval as sqlite3 ptr, byval xProfile as sub(byval as any ptr, byval as const zstring ptr, byval as sqlite3_uint64), byval as any ptr) as any ptr
+const SQLITE_TRACE_STMT = &h01
+const SQLITE_TRACE_PROFILE = &h02
+const SQLITE_TRACE_ROW = &h04
+const SQLITE_TRACE_CLOSE = &h08
+
+declare function sqlite3_trace_v2(byval as sqlite3 ptr, byval uMask as ulong, byval xCallback as function(byval as ulong, byval as any ptr, byval as any ptr, byval as any ptr) as long, byval pCtx as any ptr) as long
 declare sub sqlite3_progress_handler(byval as sqlite3 ptr, byval as long, byval as function(byval as any ptr) as long, byval as any ptr)
 declare function sqlite3_open(byval filename as const zstring ptr, byval ppDb as sqlite3 ptr ptr) as long
 declare function sqlite3_open16(byval filename as const any ptr, byval ppDb as sqlite3 ptr ptr) as long
@@ -422,16 +472,23 @@ const SQLITE_LIMIT_LIKE_PATTERN_LENGTH = 8
 const SQLITE_LIMIT_VARIABLE_NUMBER = 9
 const SQLITE_LIMIT_TRIGGER_DEPTH = 10
 const SQLITE_LIMIT_WORKER_THREADS = 11
+const SQLITE_PREPARE_PERSISTENT = &h01
+const SQLITE_PREPARE_NORMALIZE = &h02
+const SQLITE_PREPARE_NO_VTAB = &h04
 type sqlite3_stmt as sqlite3_stmt_
 
 declare function sqlite3_prepare(byval db as sqlite3 ptr, byval zSql as const zstring ptr, byval nByte as long, byval ppStmt as sqlite3_stmt ptr ptr, byval pzTail as const zstring ptr ptr) as long
 declare function sqlite3_prepare_v2(byval db as sqlite3 ptr, byval zSql as const zstring ptr, byval nByte as long, byval ppStmt as sqlite3_stmt ptr ptr, byval pzTail as const zstring ptr ptr) as long
+declare function sqlite3_prepare_v3(byval db as sqlite3 ptr, byval zSql as const zstring ptr, byval nByte as long, byval prepFlags as ulong, byval ppStmt as sqlite3_stmt ptr ptr, byval pzTail as const zstring ptr ptr) as long
 declare function sqlite3_prepare16(byval db as sqlite3 ptr, byval zSql as const any ptr, byval nByte as long, byval ppStmt as sqlite3_stmt ptr ptr, byval pzTail as const any ptr ptr) as long
 declare function sqlite3_prepare16_v2(byval db as sqlite3 ptr, byval zSql as const any ptr, byval nByte as long, byval ppStmt as sqlite3_stmt ptr ptr, byval pzTail as const any ptr ptr) as long
+declare function sqlite3_prepare16_v3(byval db as sqlite3 ptr, byval zSql as const any ptr, byval nByte as long, byval prepFlags as ulong, byval ppStmt as sqlite3_stmt ptr ptr, byval pzTail as const any ptr ptr) as long
 declare function sqlite3_sql(byval pStmt as sqlite3_stmt ptr) as const zstring ptr
+declare function sqlite3_expanded_sql(byval pStmt as sqlite3_stmt ptr) as zstring ptr
+declare function sqlite3_normalized_sql(byval pStmt as sqlite3_stmt ptr) as const zstring ptr
 declare function sqlite3_stmt_readonly(byval pStmt as sqlite3_stmt ptr) as long
+declare function sqlite3_stmt_isexplain(byval pStmt as sqlite3_stmt ptr) as long
 declare function sqlite3_stmt_busy(byval as sqlite3_stmt ptr) as long
-type sqlite3_value as Mem
 declare function sqlite3_bind_blob(byval as sqlite3_stmt ptr, byval as long, byval as const any ptr, byval n as long, byval as sub(byval as any ptr)) as long
 declare function sqlite3_bind_blob64(byval as sqlite3_stmt ptr, byval as long, byval as const any ptr, byval as sqlite3_uint64, byval as sub(byval as any ptr)) as long
 declare function sqlite3_bind_double(byval as sqlite3_stmt ptr, byval as long, byval as double) as long
@@ -441,7 +498,9 @@ declare function sqlite3_bind_null(byval as sqlite3_stmt ptr, byval as long) as 
 declare function sqlite3_bind_text(byval as sqlite3_stmt ptr, byval as long, byval as const zstring ptr, byval as long, byval as sub(byval as any ptr)) as long
 declare function sqlite3_bind_text16(byval as sqlite3_stmt ptr, byval as long, byval as const any ptr, byval as long, byval as sub(byval as any ptr)) as long
 declare function sqlite3_bind_text64(byval as sqlite3_stmt ptr, byval as long, byval as const zstring ptr, byval as sqlite3_uint64, byval as sub(byval as any ptr), byval encoding as ubyte) as long
+type sqlite3_value as sqlite3_value_
 declare function sqlite3_bind_value(byval as sqlite3_stmt ptr, byval as long, byval as const sqlite3_value ptr) as long
+declare function sqlite3_bind_pointer(byval as sqlite3_stmt ptr, byval as long, byval as any ptr, byval as const zstring ptr, byval as sub(byval as any ptr)) as long
 declare function sqlite3_bind_zeroblob(byval as sqlite3_stmt ptr, byval as long, byval n as long) as long
 declare function sqlite3_bind_zeroblob64(byval as sqlite3_stmt ptr, byval as long, byval as sqlite3_uint64) as long
 declare function sqlite3_bind_parameter_count(byval as sqlite3_stmt ptr) as long
@@ -470,21 +529,22 @@ const SQLITE_TEXT = 3
 const SQLITE3_TEXT = 3
 
 declare function sqlite3_column_blob(byval as sqlite3_stmt ptr, byval iCol as long) as const any ptr
-declare function sqlite3_column_bytes(byval as sqlite3_stmt ptr, byval iCol as long) as long
-declare function sqlite3_column_bytes16(byval as sqlite3_stmt ptr, byval iCol as long) as long
 declare function sqlite3_column_double(byval as sqlite3_stmt ptr, byval iCol as long) as double
 declare function sqlite3_column_int(byval as sqlite3_stmt ptr, byval iCol as long) as long
 declare function sqlite3_column_int64(byval as sqlite3_stmt ptr, byval iCol as long) as sqlite3_int64
 declare function sqlite3_column_text(byval as sqlite3_stmt ptr, byval iCol as long) as const ubyte ptr
 declare function sqlite3_column_text16(byval as sqlite3_stmt ptr, byval iCol as long) as const any ptr
-declare function sqlite3_column_type(byval as sqlite3_stmt ptr, byval iCol as long) as long
 declare function sqlite3_column_value(byval as sqlite3_stmt ptr, byval iCol as long) as sqlite3_value ptr
+declare function sqlite3_column_bytes(byval as sqlite3_stmt ptr, byval iCol as long) as long
+declare function sqlite3_column_bytes16(byval as sqlite3_stmt ptr, byval iCol as long) as long
+declare function sqlite3_column_type(byval as sqlite3_stmt ptr, byval iCol as long) as long
 declare function sqlite3_finalize(byval pStmt as sqlite3_stmt ptr) as long
 declare function sqlite3_reset(byval pStmt as sqlite3_stmt ptr) as long
 type sqlite3_context as sqlite3_context_
 declare function sqlite3_create_function(byval db as sqlite3 ptr, byval zFunctionName as const zstring ptr, byval nArg as long, byval eTextRep as long, byval pApp as any ptr, byval xFunc as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xStep as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xFinal as sub(byval as sqlite3_context ptr)) as long
 declare function sqlite3_create_function16(byval db as sqlite3 ptr, byval zFunctionName as const any ptr, byval nArg as long, byval eTextRep as long, byval pApp as any ptr, byval xFunc as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xStep as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xFinal as sub(byval as sqlite3_context ptr)) as long
 declare function sqlite3_create_function_v2(byval db as sqlite3 ptr, byval zFunctionName as const zstring ptr, byval nArg as long, byval eTextRep as long, byval pApp as any ptr, byval xFunc as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xStep as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xFinal as sub(byval as sqlite3_context ptr), byval xDestroy as sub(byval as any ptr)) as long
+declare function sqlite3_create_window_function(byval db as sqlite3 ptr, byval zFunctionName as const zstring ptr, byval nArg as long, byval eTextRep as long, byval pApp as any ptr, byval xStep as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xFinal as sub(byval as sqlite3_context ptr), byval xValue as sub(byval as sqlite3_context ptr), byval xInverse as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xDestroy as sub(byval as any ptr)) as long
 
 const SQLITE_UTF8 = 1
 const SQLITE_UTF16LE = 2
@@ -492,7 +552,9 @@ const SQLITE_UTF16BE = 3
 const SQLITE_UTF16 = 4
 const SQLITE_ANY = 5
 const SQLITE_UTF16_ALIGNED = 8
-const SQLITE_DETERMINISTIC = &h800
+const SQLITE_DETERMINISTIC = &h000000800
+const SQLITE_DIRECTONLY = &h000080000
+const SQLITE_SUBTYPE = &h000100000
 
 declare function sqlite3_aggregate_count(byval as sqlite3_context ptr) as long
 declare function sqlite3_expired(byval as sqlite3_stmt ptr) as long
@@ -501,17 +563,21 @@ declare function sqlite3_global_recover() as long
 declare sub sqlite3_thread_cleanup()
 declare function sqlite3_memory_alarm(byval as sub(byval as any ptr, byval as sqlite3_int64, byval as long), byval as any ptr, byval as sqlite3_int64) as long
 declare function sqlite3_value_blob(byval as sqlite3_value ptr) as const any ptr
-declare function sqlite3_value_bytes(byval as sqlite3_value ptr) as long
-declare function sqlite3_value_bytes16(byval as sqlite3_value ptr) as long
 declare function sqlite3_value_double(byval as sqlite3_value ptr) as double
 declare function sqlite3_value_int(byval as sqlite3_value ptr) as long
 declare function sqlite3_value_int64(byval as sqlite3_value ptr) as sqlite3_int64
+declare function sqlite3_value_pointer(byval as sqlite3_value ptr, byval as const zstring ptr) as any ptr
 declare function sqlite3_value_text(byval as sqlite3_value ptr) as const ubyte ptr
 declare function sqlite3_value_text16(byval as sqlite3_value ptr) as const any ptr
 declare function sqlite3_value_text16le(byval as sqlite3_value ptr) as const any ptr
 declare function sqlite3_value_text16be(byval as sqlite3_value ptr) as const any ptr
+declare function sqlite3_value_bytes(byval as sqlite3_value ptr) as long
+declare function sqlite3_value_bytes16(byval as sqlite3_value ptr) as long
 declare function sqlite3_value_type(byval as sqlite3_value ptr) as long
 declare function sqlite3_value_numeric_type(byval as sqlite3_value ptr) as long
+declare function sqlite3_value_nochange(byval as sqlite3_value ptr) as long
+declare function sqlite3_value_frombind(byval as sqlite3_value ptr) as long
+declare function sqlite3_value_subtype(byval as sqlite3_value ptr) as ulong
 declare function sqlite3_value_dup(byval as const sqlite3_value ptr) as sqlite3_value ptr
 declare sub sqlite3_value_free(byval as sqlite3_value ptr)
 declare function sqlite3_aggregate_context(byval as sqlite3_context ptr, byval nBytes as long) as any ptr
@@ -539,8 +605,10 @@ declare sub sqlite3_result_text16(byval as sqlite3_context ptr, byval as const a
 declare sub sqlite3_result_text16le(byval as sqlite3_context ptr, byval as const any ptr, byval as long, byval as sub(byval as any ptr))
 declare sub sqlite3_result_text16be(byval as sqlite3_context ptr, byval as const any ptr, byval as long, byval as sub(byval as any ptr))
 declare sub sqlite3_result_value(byval as sqlite3_context ptr, byval as sqlite3_value ptr)
+declare sub sqlite3_result_pointer(byval as sqlite3_context ptr, byval as any ptr, byval as const zstring ptr, byval as sub(byval as any ptr))
 declare sub sqlite3_result_zeroblob(byval as sqlite3_context ptr, byval n as long)
 declare function sqlite3_result_zeroblob64(byval as sqlite3_context ptr, byval n as sqlite3_uint64) as long
+declare sub sqlite3_result_subtype(byval as sqlite3_context ptr, byval as ulong)
 declare function sqlite3_create_collation(byval as sqlite3 ptr, byval zName as const zstring ptr, byval eTextRep as long, byval pArg as any ptr, byval xCompare as function(byval as any ptr, byval as long, byval as const any ptr, byval as long, byval as const any ptr) as long) as long
 declare function sqlite3_create_collation_v2(byval as sqlite3 ptr, byval zName as const zstring ptr, byval eTextRep as long, byval pArg as any ptr, byval xCompare as function(byval as any ptr, byval as long, byval as const any ptr, byval as long, byval as const any ptr) as long, byval xDestroy as sub(byval as any ptr)) as long
 declare function sqlite3_create_collation16(byval as sqlite3 ptr, byval zName as const any ptr, byval eTextRep as long, byval pArg as any ptr, byval xCompare as function(byval as any ptr, byval as long, byval as const any ptr, byval as long, byval as const any ptr) as long) as long
@@ -549,6 +617,11 @@ declare function sqlite3_collation_needed16(byval as sqlite3 ptr, byval as any p
 declare function sqlite3_sleep(byval as long) as long
 extern sqlite3_temp_directory as zstring ptr
 extern sqlite3_data_directory as zstring ptr
+declare function sqlite3_win32_set_directory(byval type as culong, byval zValue as any ptr) as long
+declare function sqlite3_win32_set_directory8(byval type as culong, byval zValue as const zstring ptr) as long
+declare function sqlite3_win32_set_directory16(byval type as culong, byval zValue as const any ptr) as long
+const SQLITE_WIN32_DATA_DIRECTORY_TYPE = 1
+const SQLITE_WIN32_TEMP_DIRECTORY_TYPE = 2
 declare function sqlite3_get_autocommit(byval as sqlite3 ptr) as long
 declare function sqlite3_db_handle(byval as sqlite3_stmt ptr) as sqlite3 ptr
 declare function sqlite3_db_filename(byval db as sqlite3 ptr, byval zDbName as const zstring ptr) as const zstring ptr
@@ -597,6 +670,7 @@ type sqlite3_module
 	xSavepoint as function(byval pVTab as sqlite3_vtab ptr, byval as long) as long
 	xRelease as function(byval pVTab as sqlite3_vtab ptr, byval as long) as long
 	xRollbackTo as function(byval pVTab as sqlite3_vtab ptr, byval as long) as long
+	xShadowName as function(byval as const zstring ptr) as long
 end type
 
 type sqlite3_index_constraint
@@ -628,16 +702,30 @@ type sqlite3_index_info_
 	orderByConsumed as long
 	estimatedCost as double
 	estimatedRows as sqlite3_int64
+	idxFlags as long
+	colUsed as sqlite3_uint64
 end type
 
+const SQLITE_INDEX_SCAN_UNIQUE = 1
 const SQLITE_INDEX_CONSTRAINT_EQ = 2
 const SQLITE_INDEX_CONSTRAINT_GT = 4
 const SQLITE_INDEX_CONSTRAINT_LE = 8
 const SQLITE_INDEX_CONSTRAINT_LT = 16
 const SQLITE_INDEX_CONSTRAINT_GE = 32
 const SQLITE_INDEX_CONSTRAINT_MATCH = 64
+const SQLITE_INDEX_CONSTRAINT_LIKE = 65
+const SQLITE_INDEX_CONSTRAINT_GLOB = 66
+const SQLITE_INDEX_CONSTRAINT_REGEXP = 67
+const SQLITE_INDEX_CONSTRAINT_NE = 68
+const SQLITE_INDEX_CONSTRAINT_ISNOT = 69
+const SQLITE_INDEX_CONSTRAINT_ISNOTNULL = 70
+const SQLITE_INDEX_CONSTRAINT_ISNULL = 71
+const SQLITE_INDEX_CONSTRAINT_IS = 72
+const SQLITE_INDEX_CONSTRAINT_FUNCTION = 150
+
 declare function sqlite3_create_module(byval db as sqlite3 ptr, byval zName as const zstring ptr, byval p as const sqlite3_module ptr, byval pClientData as any ptr) as long
 declare function sqlite3_create_module_v2(byval db as sqlite3 ptr, byval zName as const zstring ptr, byval p as const sqlite3_module ptr, byval pClientData as any ptr, byval xDestroy as sub(byval as any ptr)) as long
+declare function sqlite3_drop_modules(byval db as sqlite3 ptr, byval azKeep as const zstring ptr ptr) as long
 
 type sqlite3_vtab_
 	pModule as const sqlite3_module ptr
@@ -717,17 +805,40 @@ const SQLITE_TESTCTRL_RESERVE = 14
 const SQLITE_TESTCTRL_OPTIMIZATIONS = 15
 const SQLITE_TESTCTRL_ISKEYWORD = 16
 const SQLITE_TESTCTRL_SCRATCHMALLOC = 17
+const SQLITE_TESTCTRL_INTERNAL_FUNCTIONS = 17
 const SQLITE_TESTCTRL_LOCALTIME_FAULT = 18
 const SQLITE_TESTCTRL_EXPLAIN_STMT = 19
+const SQLITE_TESTCTRL_ONCE_RESET_THRESHOLD = 19
 const SQLITE_TESTCTRL_NEVER_CORRUPT = 20
 const SQLITE_TESTCTRL_VDBE_COVERAGE = 21
 const SQLITE_TESTCTRL_BYTEORDER = 22
 const SQLITE_TESTCTRL_ISINIT = 23
 const SQLITE_TESTCTRL_SORTER_MMAP = 24
 const SQLITE_TESTCTRL_IMPOSTER = 25
-const SQLITE_TESTCTRL_LAST = 25
+const SQLITE_TESTCTRL_PARSER_COVERAGE = 26
+const SQLITE_TESTCTRL_RESULT_INTREAL = 27
+const SQLITE_TESTCTRL_PRNG_SEED = 28
+const SQLITE_TESTCTRL_EXTRA_SCHEMA_CHECKS = 29
+const SQLITE_TESTCTRL_LAST = 29
+
+declare function sqlite3_keyword_count() as long
+declare function sqlite3_keyword_name(byval as long, byval as const zstring ptr ptr, byval as long ptr) as long
+declare function sqlite3_keyword_check(byval as const zstring ptr, byval as long) as long
+type sqlite3_str as sqlite3_str_
+declare function sqlite3_str_new(byval as sqlite3 ptr) as sqlite3_str ptr
+declare function sqlite3_str_finish(byval as sqlite3_str ptr) as zstring ptr
+declare sub sqlite3_str_appendf(byval as sqlite3_str ptr, byval zFormat as const zstring ptr, ...)
+declare sub sqlite3_str_vappendf(byval as sqlite3_str ptr, byval zFormat as const zstring ptr, byval as va_list)
+declare sub sqlite3_str_append(byval as sqlite3_str ptr, byval zIn as const zstring ptr, byval N as long)
+declare sub sqlite3_str_appendall(byval as sqlite3_str ptr, byval zIn as const zstring ptr)
+declare sub sqlite3_str_appendchar(byval as sqlite3_str ptr, byval N as long, byval C as byte)
+declare sub sqlite3_str_reset(byval as sqlite3_str ptr)
+declare function sqlite3_str_errcode(byval as sqlite3_str ptr) as long
+declare function sqlite3_str_length(byval as sqlite3_str ptr) as long
+declare function sqlite3_str_value(byval as sqlite3_str ptr) as zstring ptr
 declare function sqlite3_status(byval op as long, byval pCurrent as long ptr, byval pHighwater as long ptr, byval resetFlag as long) as long
 declare function sqlite3_status64(byval op as long, byval pCurrent as sqlite3_int64 ptr, byval pHighwater as sqlite3_int64 ptr, byval resetFlag as long) as long
+
 const SQLITE_STATUS_MEMORY_USED = 0
 const SQLITE_STATUS_PAGECACHE_USED = 1
 const SQLITE_STATUS_PAGECACHE_OVERFLOW = 2
@@ -750,12 +861,17 @@ const SQLITE_DBSTATUS_CACHE_HIT = 7
 const SQLITE_DBSTATUS_CACHE_MISS = 8
 const SQLITE_DBSTATUS_CACHE_WRITE = 9
 const SQLITE_DBSTATUS_DEFERRED_FKS = 10
-const SQLITE_DBSTATUS_MAX = 10
+const SQLITE_DBSTATUS_CACHE_USED_SHARED = 11
+const SQLITE_DBSTATUS_CACHE_SPILL = 12
+const SQLITE_DBSTATUS_MAX = 12
 declare function sqlite3_stmt_status(byval as sqlite3_stmt ptr, byval op as long, byval resetFlg as long) as long
 const SQLITE_STMTSTATUS_FULLSCAN_STEP = 1
 const SQLITE_STMTSTATUS_SORT = 2
 const SQLITE_STMTSTATUS_AUTOINDEX = 3
 const SQLITE_STMTSTATUS_VM_STEP = 4
+const SQLITE_STMTSTATUS_REPREPARE = 5
+const SQLITE_STMTSTATUS_RUN = 6
+const SQLITE_STMTSTATUS_MEMUSED = 99
 
 type sqlite3_pcache_page
 	pBuf as any ptr
@@ -804,6 +920,7 @@ declare function sqlite3_unlock_notify(byval pBlocked as sqlite3 ptr, byval xNot
 declare function sqlite3_stricmp(byval as const zstring ptr, byval as const zstring ptr) as long
 declare function sqlite3_strnicmp(byval as const zstring ptr, byval as const zstring ptr, byval as long) as long
 declare function sqlite3_strglob(byval zGlob as const zstring ptr, byval zStr as const zstring ptr) as long
+declare function sqlite3_strlike(byval zGlob as const zstring ptr, byval zStr as const zstring ptr, byval cEsc as ulong) as long
 declare sub sqlite3_log(byval iErrCode as long, byval zFormat as const zstring ptr, ...)
 declare function sqlite3_wal_hook(byval as sqlite3 ptr, byval as function(byval as any ptr, byval as sqlite3 ptr, byval as const zstring ptr, byval as long) as long, byval as any ptr) as any ptr
 declare function sqlite3_wal_autocheckpoint(byval db as sqlite3 ptr, byval N as long) as long
@@ -816,7 +933,11 @@ const SQLITE_CHECKPOINT_RESTART = 2
 const SQLITE_CHECKPOINT_TRUNCATE = 3
 declare function sqlite3_vtab_config(byval as sqlite3 ptr, byval op as long, ...) as long
 const SQLITE_VTAB_CONSTRAINT_SUPPORT = 1
+
 declare function sqlite3_vtab_on_conflict(byval as sqlite3 ptr) as long
+declare function sqlite3_vtab_nochange(byval as sqlite3_context ptr) as long
+declare function sqlite3_vtab_collation(byval as sqlite3_index_info ptr, byval as long) as const zstring ptr
+
 const SQLITE_ROLLBACK = 1
 const SQLITE_FAIL = 3
 const SQLITE_REPLACE = 5
@@ -826,8 +947,28 @@ const SQLITE_SCANSTAT_EST = 2
 const SQLITE_SCANSTAT_NAME = 3
 const SQLITE_SCANSTAT_EXPLAIN = 4
 const SQLITE_SCANSTAT_SELECTID = 5
+
 declare function sqlite3_stmt_scanstatus(byval pStmt as sqlite3_stmt ptr, byval idx as long, byval iScanStatusOp as long, byval pOut as any ptr) as long
 declare sub sqlite3_stmt_scanstatus_reset(byval as sqlite3_stmt ptr)
+declare function sqlite3_db_cacheflush(byval as sqlite3 ptr) as long
+declare function sqlite3_system_errno(byval as sqlite3 ptr) as long
+
+type sqlite3_snapshot
+	hidden(0 to 47) as ubyte
+end type
+
+declare function sqlite3_snapshot_get(byval db as sqlite3 ptr, byval zSchema as const zstring ptr, byval ppSnapshot as sqlite3_snapshot ptr ptr) as long
+declare function sqlite3_snapshot_open(byval db as sqlite3 ptr, byval zSchema as const zstring ptr, byval pSnapshot as sqlite3_snapshot ptr) as long
+declare sub sqlite3_snapshot_free(byval as sqlite3_snapshot ptr)
+declare function sqlite3_snapshot_cmp(byval p1 as sqlite3_snapshot ptr, byval p2 as sqlite3_snapshot ptr) as long
+declare function sqlite3_snapshot_recover(byval db as sqlite3 ptr, byval zDb as const zstring ptr) as long
+declare function sqlite3_serialize(byval db as sqlite3 ptr, byval zSchema as const zstring ptr, byval piSize as sqlite3_int64 ptr, byval mFlags as ulong) as ubyte ptr
+const SQLITE_SERIALIZE_NOCOPY = &h001
+declare function sqlite3_deserialize(byval db as sqlite3 ptr, byval zSchema as const zstring ptr, byval pData as ubyte ptr, byval szDb as sqlite3_int64, byval szBuf as sqlite3_int64, byval mFlags as ulong) as long
+
+const SQLITE_DESERIALIZE_FREEONCLOSE = 1
+const SQLITE_DESERIALIZE_RESIZEABLE = 2
+const SQLITE_DESERIALIZE_READONLY = 4
 #define _SQLITE3RTREE_H_
 type sqlite3_rtree_dbl as double
 type sqlite3_rtree_geometry as sqlite3_rtree_geometry_
@@ -866,5 +1007,59 @@ end type
 const NOT_WITHIN = 0
 const PARTLY_WITHIN = 1
 const FULLY_WITHIN = 2
+#define _FTS5_H
+
+type Fts5ExtensionApi as Fts5ExtensionApi_
+type Fts5Context as Fts5Context_
+type fts5_extension_function as sub(byval pApi as const Fts5ExtensionApi ptr, byval pFts as Fts5Context ptr, byval pCtx as sqlite3_context ptr, byval nVal as long, byval apVal as sqlite3_value ptr ptr)
+
+type Fts5PhraseIter
+	a as const ubyte ptr
+	b as const ubyte ptr
+end type
+
+type Fts5ExtensionApi_
+	iVersion as long
+	xUserData as function(byval as Fts5Context ptr) as any ptr
+	xColumnCount as function(byval as Fts5Context ptr) as long
+	xRowCount as function(byval as Fts5Context ptr, byval pnRow as sqlite3_int64 ptr) as long
+	xColumnTotalSize as function(byval as Fts5Context ptr, byval iCol as long, byval pnToken as sqlite3_int64 ptr) as long
+	xTokenize as function(byval as Fts5Context ptr, byval pText as const zstring ptr, byval nText as long, byval pCtx as any ptr, byval xToken as function(byval as any ptr, byval as long, byval as const zstring ptr, byval as long, byval as long, byval as long) as long) as long
+	xPhraseCount as function(byval as Fts5Context ptr) as long
+	xPhraseSize as function(byval as Fts5Context ptr, byval iPhrase as long) as long
+	xInstCount as function(byval as Fts5Context ptr, byval pnInst as long ptr) as long
+	xInst as function(byval as Fts5Context ptr, byval iIdx as long, byval piPhrase as long ptr, byval piCol as long ptr, byval piOff as long ptr) as long
+	xRowid as function(byval as Fts5Context ptr) as sqlite3_int64
+	xColumnText as function(byval as Fts5Context ptr, byval iCol as long, byval pz as const zstring ptr ptr, byval pn as long ptr) as long
+	xColumnSize as function(byval as Fts5Context ptr, byval iCol as long, byval pnToken as long ptr) as long
+	xQueryPhrase as function(byval as Fts5Context ptr, byval iPhrase as long, byval pUserData as any ptr, byval as function(byval as const Fts5ExtensionApi ptr, byval as Fts5Context ptr, byval as any ptr) as long) as long
+	xSetAuxdata as function(byval as Fts5Context ptr, byval pAux as any ptr, byval xDelete as sub(byval as any ptr)) as long
+	xGetAuxdata as function(byval as Fts5Context ptr, byval bClear as long) as any ptr
+	xPhraseFirst as function(byval as Fts5Context ptr, byval iPhrase as long, byval as Fts5PhraseIter ptr, byval as long ptr, byval as long ptr) as long
+	xPhraseNext as sub(byval as Fts5Context ptr, byval as Fts5PhraseIter ptr, byval piCol as long ptr, byval piOff as long ptr)
+	xPhraseFirstColumn as function(byval as Fts5Context ptr, byval iPhrase as long, byval as Fts5PhraseIter ptr, byval as long ptr) as long
+	xPhraseNextColumn as sub(byval as Fts5Context ptr, byval as Fts5PhraseIter ptr, byval piCol as long ptr)
+end type
+
+type Fts5Tokenizer as Fts5Tokenizer_
+
+type fts5_tokenizer
+	xCreate as function(byval as any ptr, byval azArg as const zstring ptr ptr, byval nArg as long, byval ppOut as Fts5Tokenizer ptr ptr) as long
+	xDelete as sub(byval as Fts5Tokenizer ptr)
+	xTokenize as function(byval as Fts5Tokenizer ptr, byval pCtx as any ptr, byval flags as long, byval pText as const zstring ptr, byval nText as long, byval xToken as function(byval pCtx as any ptr, byval tflags as long, byval pToken as const zstring ptr, byval nToken as long, byval iStart as long, byval iEnd as long) as long) as long
+end type
+
+const FTS5_TOKENIZE_QUERY = &h0001
+const FTS5_TOKENIZE_PREFIX = &h0002
+const FTS5_TOKENIZE_DOCUMENT = &h0004
+const FTS5_TOKENIZE_AUX = &h0008
+const FTS5_TOKEN_COLOCATED = &h0001
+
+type fts5_api
+	iVersion as long
+	xCreateTokenizer as function(byval pApi as fts5_api ptr, byval zName as const zstring ptr, byval pContext as any ptr, byval pTokenizer as fts5_tokenizer ptr, byval xDestroy as sub(byval as any ptr)) as long
+	xFindTokenizer as function(byval pApi as fts5_api ptr, byval zName as const zstring ptr, byval ppContext as any ptr ptr, byval pTokenizer as fts5_tokenizer ptr) as long
+	xCreateFunction as function(byval pApi as fts5_api ptr, byval zName as const zstring ptr, byval pContext as any ptr, byval xFunction as fts5_extension_function, byval xDestroy as sub(byval as any ptr)) as long
+end type
 
 end extern

--- a/inc/sqlite3ext.bi
+++ b/inc/sqlite3ext.bi
@@ -1,4 +1,4 @@
-'' FreeBASIC binding for SQLite 3.8.11.1
+'' FreeBASIC binding for SQLite 3.30.0
 ''
 '' based on the C header files:
 ''   * 2006 June 7
@@ -18,7 +18,7 @@
 ''   * sqlite3.h.
 ''
 '' translated to FreeBASIC by:
-''   Copyright © 2015 FreeBASIC development team
+''   Copyright © 2019 FreeBASIC development team
 
 #pragma once
 
@@ -26,7 +26,7 @@
 
 extern "C"
 
-#define _SQLITE3EXT_H_
+#define SQLITE3EXT_H
 
 type sqlite3_api_routines
 	aggregate_context as function(byval as sqlite3_context ptr, byval nBytes as long) as any ptr
@@ -122,7 +122,7 @@ type sqlite3_api_routines
 	rollback_hook as function(byval as sqlite3 ptr, byval as sub(byval as any ptr), byval as any ptr) as any ptr
 	set_authorizer as function(byval as sqlite3 ptr, byval as function(byval as any ptr, byval as long, byval as const zstring ptr, byval as const zstring ptr, byval as const zstring ptr, byval as const zstring ptr) as long, byval as any ptr) as long
 	set_auxdata as sub(byval as sqlite3_context ptr, byval as long, byval as any ptr, byval as sub(byval as any ptr))
-	snprintf as function(byval as long, byval as zstring ptr, byval as const zstring ptr, ...) as zstring ptr
+	xsnprintf as function(byval as long, byval as zstring ptr, byval as const zstring ptr, ...) as zstring ptr
 	step as function(byval as sqlite3_stmt ptr) as long
 	table_column_metadata as function(byval as sqlite3 ptr, byval as const zstring ptr, byval as const zstring ptr, byval as const zstring ptr, byval as const zstring ptr ptr, byval as const zstring ptr ptr, byval as long ptr, byval as long ptr, byval as long ptr) as long
 	thread_cleanup as sub()
@@ -219,7 +219,7 @@ type sqlite3_api_routines
 	uri_boolean as function(byval as const zstring ptr, byval as const zstring ptr, byval as long) as long
 	uri_int64 as function(byval as const zstring ptr, byval as const zstring ptr, byval as sqlite3_int64) as sqlite3_int64
 	uri_parameter as function(byval as const zstring ptr, byval as const zstring ptr) as const zstring ptr
-	vsnprintf as function(byval as long, byval as zstring ptr, byval as const zstring ptr, byval as va_list) as zstring ptr
+	xvsnprintf as function(byval as long, byval as zstring ptr, byval as const zstring ptr, byval as va_list) as zstring ptr
 	wal_checkpoint_v2 as function(byval as sqlite3 ptr, byval as const zstring ptr, byval as long, byval as long ptr, byval as long ptr) as long
 	auto_extension as function(byval as sub()) as long
 	bind_blob64 as function(byval as sqlite3_stmt ptr, byval as long, byval as const any ptr, byval as sqlite3_uint64, byval as sub(byval as any ptr)) as long
@@ -237,8 +237,45 @@ type sqlite3_api_routines
 	value_free as sub(byval as sqlite3_value ptr)
 	result_zeroblob64 as function(byval as sqlite3_context ptr, byval as sqlite3_uint64) as long
 	bind_zeroblob64 as function(byval as sqlite3_stmt ptr, byval as long, byval as sqlite3_uint64) as long
+	value_subtype as function(byval as sqlite3_value ptr) as ulong
+	result_subtype as sub(byval as sqlite3_context ptr, byval as ulong)
+	status64 as function(byval as long, byval as sqlite3_int64 ptr, byval as sqlite3_int64 ptr, byval as long) as long
+	strlike as function(byval as const zstring ptr, byval as const zstring ptr, byval as ulong) as long
+	db_cacheflush as function(byval as sqlite3 ptr) as long
+	system_errno as function(byval as sqlite3 ptr) as long
+	trace_v2 as function(byval as sqlite3 ptr, byval as ulong, byval as function(byval as ulong, byval as any ptr, byval as any ptr, byval as any ptr) as long, byval as any ptr) as long
+	expanded_sql as function(byval as sqlite3_stmt ptr) as zstring ptr
+	set_last_insert_rowid as sub(byval as sqlite3 ptr, byval as sqlite3_int64)
+	prepare_v3 as function(byval as sqlite3 ptr, byval as const zstring ptr, byval as long, byval as ulong, byval as sqlite3_stmt ptr ptr, byval as const zstring ptr ptr) as long
+	prepare16_v3 as function(byval as sqlite3 ptr, byval as const any ptr, byval as long, byval as ulong, byval as sqlite3_stmt ptr ptr, byval as const any ptr ptr) as long
+	bind_pointer as function(byval as sqlite3_stmt ptr, byval as long, byval as any ptr, byval as const zstring ptr, byval as sub(byval as any ptr)) as long
+	result_pointer as sub(byval as sqlite3_context ptr, byval as any ptr, byval as const zstring ptr, byval as sub(byval as any ptr))
+	value_pointer as function(byval as sqlite3_value ptr, byval as const zstring ptr) as any ptr
+	vtab_nochange as function(byval as sqlite3_context ptr) as long
+	value_nochange as function(byval as sqlite3_value ptr) as long
+	vtab_collation as function(byval as sqlite3_index_info ptr, byval as long) as const zstring ptr
+	keyword_count as function() as long
+	keyword_name as function(byval as long, byval as const zstring ptr ptr, byval as long ptr) as long
+	keyword_check as function(byval as const zstring ptr, byval as long) as long
+	str_new as function(byval as sqlite3 ptr) as sqlite3_str ptr
+	str_finish as function(byval as sqlite3_str ptr) as zstring ptr
+	str_appendf as sub(byval as sqlite3_str ptr, byval zFormat as const zstring ptr, ...)
+	str_vappendf as sub(byval as sqlite3_str ptr, byval zFormat as const zstring ptr, byval as va_list)
+	str_append as sub(byval as sqlite3_str ptr, byval zIn as const zstring ptr, byval N as long)
+	str_appendall as sub(byval as sqlite3_str ptr, byval zIn as const zstring ptr)
+	str_appendchar as sub(byval as sqlite3_str ptr, byval N as long, byval C as byte)
+	str_reset as sub(byval as sqlite3_str ptr)
+	str_errcode as function(byval as sqlite3_str ptr) as long
+	str_length as function(byval as sqlite3_str ptr) as long
+	str_value as function(byval as sqlite3_str ptr) as zstring ptr
+	create_window_function as function(byval as sqlite3 ptr, byval as const zstring ptr, byval as long, byval as long, byval as any ptr, byval xStep as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xFinal as sub(byval as sqlite3_context ptr), byval xValue as sub(byval as sqlite3_context ptr), byval xInv as sub(byval as sqlite3_context ptr, byval as long, byval as sqlite3_value ptr ptr), byval xDestroy as sub(byval as any ptr)) as long
+	normalized_sql as function(byval as sqlite3_stmt ptr) as const zstring ptr
+	stmt_isexplain as function(byval as sqlite3_stmt ptr) as long
+	value_frombind as function(byval as sqlite3_value ptr) as long
+	drop_modules as function(byval as sqlite3 ptr, byval as const zstring ptr ptr) as long
 end type
 
+type sqlite3_loadext_entry as function(byval db as sqlite3 ptr, byval pzErrMsg as zstring ptr ptr, byval pThunk as const sqlite3_api_routines ptr) as long
 #undef sqlite3_aggregate_context
 #define sqlite3_aggregate_context sqlite3_api->aggregate_context
 #undef sqlite3_aggregate_count
@@ -432,7 +469,7 @@ end type
 #undef sqlite3_set_auxdata
 #define sqlite3_set_auxdata sqlite3_api->set_auxdata
 #undef sqlite3_snprintf
-#define sqlite3_snprintf sqlite3_api->snprintf
+#define sqlite3_snprintf sqlite3_api->xsnprintf
 #undef sqlite3_step
 #define sqlite3_step sqlite3_api->step
 #undef sqlite3_table_column_metadata
@@ -475,6 +512,8 @@ end type
 #define sqlite3_value_type sqlite3_api->value_type
 #undef sqlite3_vmprintf
 #define sqlite3_vmprintf sqlite3_api->vmprintf
+#undef sqlite3_vsnprintf
+#define sqlite3_vsnprintf sqlite3_api->xvsnprintf
 #undef sqlite3_overload_function
 #define sqlite3_overload_function sqlite3_api->overload_function
 #undef sqlite3_prepare_v2
@@ -624,7 +663,7 @@ end type
 #undef sqlite3_uri_parameter
 #define sqlite3_uri_parameter sqlite3_api->uri_parameter
 #undef sqlite3_uri_vsnprintf
-#define sqlite3_uri_vsnprintf sqlite3_api->vsnprintf
+#define sqlite3_uri_vsnprintf sqlite3_api->xvsnprintf
 #undef sqlite3_wal_checkpoint_v2
 #define sqlite3_wal_checkpoint_v2 sqlite3_api->wal_checkpoint_v2
 #undef sqlite3_auto_extension
@@ -659,6 +698,78 @@ end type
 #define sqlite3_result_zeroblob64 sqlite3_api->result_zeroblob64
 #undef sqlite3_bind_zeroblob64
 #define sqlite3_bind_zeroblob64 sqlite3_api->bind_zeroblob64
+#undef sqlite3_value_subtype
+#define sqlite3_value_subtype sqlite3_api->value_subtype
+#undef sqlite3_result_subtype
+#define sqlite3_result_subtype sqlite3_api->result_subtype
+#undef sqlite3_status64
+#define sqlite3_status64 sqlite3_api->status64
+#undef sqlite3_strlike
+#define sqlite3_strlike sqlite3_api->strlike
+#undef sqlite3_db_cacheflush
+#define sqlite3_db_cacheflush sqlite3_api->db_cacheflush
+#undef sqlite3_system_errno
+#define sqlite3_system_errno sqlite3_api->system_errno
+#undef sqlite3_trace_v2
+#define sqlite3_trace_v2 sqlite3_api->trace_v2
+#undef sqlite3_expanded_sql
+#define sqlite3_expanded_sql sqlite3_api->expanded_sql
+#undef sqlite3_set_last_insert_rowid
+#define sqlite3_set_last_insert_rowid sqlite3_api->set_last_insert_rowid
+#undef sqlite3_prepare_v3
+#define sqlite3_prepare_v3 sqlite3_api->prepare_v3
+#undef sqlite3_prepare16_v3
+#define sqlite3_prepare16_v3 sqlite3_api->prepare16_v3
+#undef sqlite3_bind_pointer
+#define sqlite3_bind_pointer sqlite3_api->bind_pointer
+#undef sqlite3_result_pointer
+#define sqlite3_result_pointer sqlite3_api->result_pointer
+#undef sqlite3_value_pointer
+#define sqlite3_value_pointer sqlite3_api->value_pointer
+#undef sqlite3_vtab_nochange
+#define sqlite3_vtab_nochange sqlite3_api->vtab_nochange
+#undef sqlite3_value_nochange
+#define sqlite3_value_nochange sqlite3_api->value_nochange
+#undef sqlite3_vtab_collation
+#define sqlite3_vtab_collation sqlite3_api->vtab_collation
+#undef sqlite3_keyword_count
+#define sqlite3_keyword_count sqlite3_api->keyword_count
+#undef sqlite3_keyword_name
+#define sqlite3_keyword_name sqlite3_api->keyword_name
+#undef sqlite3_keyword_check
+#define sqlite3_keyword_check sqlite3_api->keyword_check
+#undef sqlite3_str_new
+#define sqlite3_str_new sqlite3_api->str_new
+#undef sqlite3_str_finish
+#define sqlite3_str_finish sqlite3_api->str_finish
+#undef sqlite3_str_appendf
+#define sqlite3_str_appendf sqlite3_api->str_appendf
+#undef sqlite3_str_vappendf
+#define sqlite3_str_vappendf sqlite3_api->str_vappendf
+#undef sqlite3_str_append
+#define sqlite3_str_append sqlite3_api->str_append
+#undef sqlite3_str_appendall
+#define sqlite3_str_appendall sqlite3_api->str_appendall
+#undef sqlite3_str_appendchar
+#define sqlite3_str_appendchar sqlite3_api->str_appendchar
+#undef sqlite3_str_reset
+#define sqlite3_str_reset sqlite3_api->str_reset
+#undef sqlite3_str_errcode
+#define sqlite3_str_errcode sqlite3_api->str_errcode
+#undef sqlite3_str_length
+#define sqlite3_str_length sqlite3_api->str_length
+#undef sqlite3_str_value
+#define sqlite3_str_value sqlite3_api->str_value
+#undef sqlite3_create_window_function
+#define sqlite3_create_window_function sqlite3_api->create_window_function
+#undef sqlite3_normalized_sql
+#define sqlite3_normalized_sql sqlite3_api->normalized_sql
+#undef sqlite3_stmt_isexplain
+#define sqlite3_stmt_isexplain sqlite3_api->isexplain
+#undef sqlite3_value_frombind
+#define sqlite3_value_frombind sqlite3_api->frombind
+#undef sqlite3_drop_modules
+#define sqlite3_drop_modules sqlite3_api->drop_modules
 #define SQLITE_EXTENSION_INIT1 dim shared as const sqlite3_api_routines ptr sqlite3_api = 0
 #define SQLITE_EXTENSION_INIT2(v) sqlite3_api = v
 #define SQLITE_EXTENSION_INIT3 extern as const sqlite3_api_routines ptr sqlite3_api


### PR DESCRIPTION
Updated SQLite headers to v.3.30.0 using the headers from https://www.sqlite.org/2019/sqlite-amalgamation-3300000.zip

Fixed compiler warning and possible 64-bit compatibility issue in the SQLite example program.