### PR TITLE
gfxlib: fix sf.net # 898: fbc win gfxlib DirectX driver

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Version 1.08.0
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture
 - sf.net #904; gcc backend: pass '-Wno-format' to prevent format string errors in gcc 9.x (enabled by default with -Wall)
 - sf.net #910: cast(string, variable) can cause fbc to segfault (infinite recursion), due to misplaced const & non-const casting
+- sf.net #898: fbc win gfxlib DirectX driver failed to initialize on 64-bit, due to incorrect construction of DIDATAFORMAT for keyboard device (macko17)
 
 
 Version 1.07.0

--- a/src/gfxlib2/win32/gfx_driver_ddraw.c
+++ b/src/gfxlib2/win32/gfx_driver_ddraw.c
@@ -69,7 +69,9 @@ typedef HRESULT (WINAPI *DIRECTDRAWENUMERATEEX)(LPDDENUMCALLBACKEX lpCallback,LP
  * linking with it, we need to define it here...
  */
 static DIOBJECTDATAFORMAT __c_rgodfDIKeyboard[256];
-static const DIDATAFORMAT __c_dfDIKeyboard = { 24, 16, 0x2, 256, 256, __c_rgodfDIKeyboard };
+static const DIDATAFORMAT __c_dfDIKeyboard = { sizeof(__c_dfDIKeyboard), sizeof(*__c_rgodfDIKeyboard),
+                                               DIDF_RELAXIS, 256,
+                                               ARRAYSIZE(__c_rgodfDIKeyboard), __c_rgodfDIKeyboard };
 static HMODULE dd_library;
 static HMODULE di_library;
 static LPDIRECTDRAW2 lpDD = NULL;


### PR DESCRIPTION
Fix for sf.net # 898 DirectX - Driver not working in FBC x64 (WIN) 
- DirectX fails to initialize on win 64-bit

As corrected by macko17 on freebasic.net: [Need new gfxlib driver for Windows 7, 8, 10](https://www.freebasic.net/forum/viewtopic.php?f=6&t=26799#p265198)
- due to incorrect construction of DIDATAFORMAT for keyboard device