### PR TITLE
Fix some potential buffer overflows in rtlib

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ Version 1.08.0
 - sf.net #904; gcc backend: pass '-Wno-format' to prevent format string errors in gcc 9.x (enabled by default with -Wall)
 - sf.net #910: cast(string, variable) can cause fbc to segfault (infinite recursion), due to misplaced const & non-const casting
 - sf.net #898: fbc win gfxlib DirectX driver failed to initialize on 64-bit, due to incorrect construction of DIDATAFORMAT for keyboard device (macko17)
+- rtlib: potential buffer overflow in sys_getshortpath.c (macko17)
 
 
 Version 1.07.0

--- a/src/rtlib/dos/sys_dylib.c
+++ b/src/rtlib/dos/sys_dylib.c
@@ -19,9 +19,9 @@ FBCALL void *fb_DylibLoad( FBSTRING *library )
 		FirstDyLibCall = 1;
 	}
 
-	libname[MAX_PATH-1] = '\0';
 	if( (library) && (library->data) ) {
 		snprintf( libname, MAX_PATH-1, libnameformat, library->data );
+		libname[MAX_PATH-1] = '\0';
 		fb_hConvertPath( libname );
 		res = dlopen( libname, RTLD_GLOBAL + RTLD_LAZY);
 	}

--- a/src/rtlib/dos/sys_execex.c
+++ b/src/rtlib/dos/sys_execex.c
@@ -4,7 +4,7 @@
 
 FBCALL int fb_ExecEx( FBSTRING *program, FBSTRING *args, int do_fork )
 {
-	char buffer[MAX_PATH+1], *arguments, **argv, *p;
+	char buffer[MAX_PATH], *arguments, **argv, *p;
 	int i, argc = 0, res = 0;
 	ssize_t len_arguments;
 

--- a/src/rtlib/dos/sys_getshortpath.c
+++ b/src/rtlib/dos/sys_getshortpath.c
@@ -3,7 +3,8 @@
 char *fb_hGetShortPath( char *src, char *dst, ssize_t maxlen )
 {
 	if( strchr( src, 32 ) == NULL ) {
-		strcpy( dst, src );
+		strncpy( dst, src, maxlen );
+		dst[maxlen-1] = '\0';
     } else {
         /* FIXME: SPC is only allowed when using LFNs provided by a Windows
          * environment. So I guess that we have to use the following INT
@@ -24,7 +25,7 @@ char *fb_hGetShortPath( char *src, char *dst, ssize_t maxlen )
          *      AX = error code
          *
          */
-        strncpy( dst, src, maxlen-1 );
+        strncpy( dst, src, maxlen );
         dst[maxlen-1] = 0;
 	}
 

--- a/src/rtlib/unix/file_dir.c
+++ b/src/rtlib/unix/file_dir.c
@@ -111,7 +111,8 @@ static char *find_next ( int *attrib )
 			return NULL;
 		}
 		name = entry->d_name;
-		strcpy( buffer, ctx->dirname );
+		strncpy( buffer, ctx->dirname, MAX_PATH );
+		buffer[MAX_PATH-1] = '\0';
 		strncat( buffer, name, MAX_PATH - strlen( buffer ) - 1 );
 		buffer[MAX_PATH-1] = '\0';
 

--- a/src/rtlib/unix/sys_execex.c
+++ b/src/rtlib/unix/sys_execex.c
@@ -4,7 +4,7 @@
 
 FBCALL int fb_ExecEx( FBSTRING *program, FBSTRING *args, int do_fork )
 {
-	char buffer[MAX_PATH+1], *arguments, **argv, *p;
+	char buffer[MAX_PATH], *arguments, **argv, *p;
 	int i, argc = 0, res = -1, status;
 	ssize_t len_arguments;
 	pid_t pid;

--- a/src/rtlib/win32/sys_getexepath.c
+++ b/src/rtlib/win32/sys_getexepath.c
@@ -3,6 +3,9 @@
 #include "../fb.h"
 #include <windows.h>
 
+/* maxlen is the size of the buffer including the null terminator 
+   and must be >= 1 */
+
 char *fb_hGetExePath( char *dst, ssize_t maxlen )
 {
 	GetModuleFileName( GetModuleHandle( NULL ), dst, maxlen );

--- a/src/rtlib/win32/sys_getshortpath.c
+++ b/src/rtlib/win32/sys_getshortpath.c
@@ -4,7 +4,8 @@
 char *fb_hGetShortPath( char *src, char *dst, ssize_t maxlen )
 {
 	if( strchr( src, 32 ) == NULL ) {
-		strcpy( dst, src );
+		strncpy( dst, src, maxlen );
+		dst[maxlen-1] = '\0';
 	} else {
 	 	GetShortPathName( src, dst, maxlen );
 	}

--- a/src/rtlib/xbox/file_dir.c
+++ b/src/rtlib/xbox/file_dir.c
@@ -111,7 +111,8 @@ static char *find_next ( int *attrib )
 			return NULL;
 		}
 		name = entry->d_name;
-		strcpy( buffer, ctx->dirname );
+		strncpy( buffer, ctx->dirname, MAX_PATH );
+		buffer[MAX_PATH-1] = '\0';
 		strncat( buffer, name, MAX_PATH - strlen( buffer ) - 1 );
 		buffer[MAX_PATH-1] = '\0';
 


### PR DESCRIPTION
There is potential for buffer overflow in `sys_getshortpath.c` since the `strcpy` does not respect maxlen, as pointed out by macko17 on freebasic.net forums.

Audited the rtlib code grepping for other uses of `strcpy` and `strncpy`.