### PR TITLE
fix error with LEN and explicit namespace prefix

### DIFF
--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -316,12 +316,21 @@ function cTypeOrExpression _
 
 	if( maybe_type ) then
 		'' Parse as type
-		if( cSymbolType( dtype, subtype, lgt, is_fixlenstr, FB_SYMBTYPEOPT_NONE ) ) then
+
+        dim as LEX_CTX lex_save
+        lex_save = lex                                '' save lexer status
+
+        '' this might "eat" namespace prefixes, which leads to a "Varaible not declared" error with explicit 
+        '' namespace prefix syntax (namespace.identifier)       
+		if( cSymbolType( dtype, subtype, lgt, is_fixlenstr, FB_SYMBTYPEOPT_NONE ) ) then 
 			'' Successful -- it's a type, not an expression
 			ambigioussizeof.maybeWarn( tk, TRUE )
+
 			return NULL
 		end if
-	end if
+
+        lex = lex_save
+	end if                                            '' restore lexer status, if it wasn´t a symbol
 
 	ambigioussizeof.maybeWarn( tk, FALSE )
 


### PR DESCRIPTION
This fixes an error with LEN and explicit namespace syntax (namespace.identifier). before it was necessary to enclose such syntax in parenthesis to make it an expression, now it works as expected (without extra parenthesis)

Jeff, i hope this is correct!

JK
