### PR TITLE
Disable vga16 blitter on ARM because it uses x86 asm (as opposed to disabling the whole fbdev driver)

### DIFF
--- a/src/gfxlib2/linux/fb_gfx_linux.h
+++ b/src/gfxlib2/linux/fb_gfx_linux.h
@@ -3,11 +3,6 @@
 #ifndef __FB_GFX_LINUX_H__
 #define __FB_GFX_LINUX_H__
 
-/* Disable fbdev driver on ARM, because it currently uses x86 inline asm */
-#if !defined HOST_X86 && !defined HOST_X86_64
-	#define DISABLE_FBDEV
-#endif
-
 #ifndef DISABLE_FBDEV
 
 #define DOUBLE_CLICK_TIME		250

--- a/src/gfxlib2/linux/gfx_driver_fbdev.c
+++ b/src/gfxlib2/linux/gfx_driver_fbdev.c
@@ -86,6 +86,8 @@ static pthread_t thread;
 static pthread_mutex_t mutex;
 static pthread_cond_t cond;
 
+#if defined HOST_X86 || defined HOST_X86_64
+
 static void vga16_blitter(unsigned char *dest, int pitch)
 {
 	unsigned int color;
@@ -139,6 +141,7 @@ static void vga16_blitter(unsigned char *dest, int pitch)
 		source += __fb_gfx->pitch;
 	}
 }
+#endif
 
 static void *driver_thread(void *arg)
 {
@@ -448,9 +451,13 @@ got_mode:
 	fb_hMemSet(framebuffer, 0, device_info.smem_len);
 
 	if (mode.bits_per_pixel == 4) {
+#if defined HOST_X86 || defined HOST_X86_64
 		palette_len = 16;
 		framebuffer_offset = (((mode.yres - h) >> 1) * (mode.xres >> 3)) + ((mode.xres - w) >> 4);
 		blitter = vga16_blitter;
+#else
+		return -1;
+#endif
 	} else {
 		palette_len = 256;
 		framebuffer_offset = (((mode.yres - h) >> 1) * device_info.line_length) +


### PR DESCRIPTION
Drive-by patch for Issue #192.
Completely untested.