### PR TITLE
GDI Gfxlib Driver Scanline Size Fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@ Version 1.08.0
 - github #205: fix rtlib potential malloc null ptr access in dev file read/write methods
 - default new, new[] operator (allocate) after #undef allocate caused compiler crash
 - default delete, delete[] operator (deallocate) after #undef deallocate caused compiler crash
+- windows GDI gfxlib driver now displays double scanline screen modes correctly (screen 2 & 8), rather than half screen (adeyblue)
 
 
 Version 1.07.0

--- a/src/gfxlib2/win32/gfx_driver_gdi.c
+++ b/src/gfxlib2/win32/gfx_driver_gdi.c
@@ -41,7 +41,9 @@ static void alpha_remover_blitter(unsigned char *dest, int pitch)
 	char *dirty = __fb_gfx->dirty;
 	int x, y;
 
-	for (y = __fb_gfx->h * __fb_gfx->scanline_size; y; y--) {
+	DBG_ASSERT((fb_win32.depth == 32) && (__fb_gfx->scanline_size == 1));
+
+	for (y = __fb_gfx->h; y; y--) {
 		if (*dirty) {
 			s = (unsigned int *)src;
 			d = (unsigned int *)dest;
@@ -165,25 +167,27 @@ static int gdi_init(void)
 	bitmap_info->bmiHeader.biClrUsed = 256;
 	bitmap_info->bmiHeader.biCompression = BI_RGB;
 
-	if ((fb_win32.depth >= 16) || (fb_win32.w & 0x3)) {
-		if (fb_win32.depth == 16) {
-			fb_win32.blitter = fb_hGetBlitter(15, FALSE);
-			if (!fb_win32.blitter)
-				return -1;
-		}
-		else if (fb_win32.w & 0x3) {
-			fb_win32.blitter = fb_hGetBlitter(fb_win32.depth, FALSE);
-			if (!fb_win32.blitter)
-				return -1;
-		}
+	if ((fb_win32.depth >= 16) || (fb_win32.w & 0x3) || (__fb_gfx->scanline_size > 1)) {
 		if (fb_win32.flags & DRIVER_SHAPED_WINDOW)
 		{
 			if( fb_win32.depth == 32 )
 				fb_win32.blitter = alpha_remover_blitter;
 		}
-		buffer = malloc(((fb_win32.w + 3) & ~3) * fb_win32.h * __fb_gfx->bpp);
-		if (!buffer)
-			return -1;
+		else if (fb_win32.depth == 16) {
+			fb_win32.blitter = fb_hGetBlitter(15, FALSE);
+			if (!fb_win32.blitter)
+				return -1;
+		}
+		else if ((fb_win32.w & 0x3) || (__fb_gfx->scanline_size > 1)) {
+			fb_win32.blitter = fb_hGetBlitter(fb_win32.depth, FALSE);
+			if (!fb_win32.blitter)
+				return -1;
+		}
+		if(fb_win32.blitter) {
+			buffer = malloc(((fb_win32.w + 3) & ~3) * fb_win32.h * __fb_gfx->bpp);
+			if (!buffer)
+				return -1;
+		}
 	}
 
 	hdc = GetDC(fb_win32.wnd);
@@ -223,7 +227,7 @@ static DWORD WINAPI gdi_thread( LPVOID param )
 #endif
 {
 	HANDLE running_event = param;
-	int i, y1, y2, h;
+	int i, y1, y2, h, scanline_size;
 	unsigned char *source, keystate[256];
 	HDC hdc;
 	RECT rect;
@@ -239,6 +243,7 @@ static DWORD WINAPI gdi_thread( LPVOID param )
 	while (fb_win32.is_running)
 	{
 		fb_hWin32Lock();
+		scanline_size = __fb_gfx->scanline_size;
 
 		hdc = GetDC(fb_win32.wnd);
 		if (fb_win32.is_palette_changed) {
@@ -255,19 +260,22 @@ static DWORD WINAPI gdi_thread( LPVOID param )
 			fb_win32.is_palette_changed = FALSE;
 		}
 		/* Only do a single SetDIBitsToDevice call per frame */
-		for (y1 = 0; y1 < fb_win32.h; y1++) {
+		for (y1 = 0; y1 < __fb_gfx->h; y1++) {
 			if (__fb_gfx->dirty[y1]) {
-				for (y2 = fb_win32.h - 1; !__fb_gfx->dirty[y2]; y2--)
+				for (y2 = __fb_gfx->h - 1; !__fb_gfx->dirty[y2]; y2--)
 					;
-				h = y2 - y1 + 1;
+
 				if (fb_win32.blitter) {
-					fb_win32.blitter(buffer, (__fb_gfx->pitch + 3) & ~3);
+					y1 *= scanline_size;
+					y2 *= scanline_size;
+					fb_win32.blitter(buffer, (__fb_gfx->pitch + 3) & ~0x3);
 					source = buffer + (y1 * ((__fb_gfx->pitch + 3) & ~0x3));
 				}
 				else
 				{
 					source = __fb_gfx->framebuffer + (y1 * __fb_gfx->pitch);
 				}
+				h = (y2 - y1 + 1);
 
 				SetDIBitsToDevice(hdc, 0, y1, fb_win32.w, h, 0, 0, 0, h, source, bitmap_info, DIB_RGB_COLORS);
 				

--- a/src/gfxlib2/win32/gfx_driver_gdi.c
+++ b/src/gfxlib2/win32/gfx_driver_gdi.c
@@ -169,9 +169,8 @@ static int gdi_init(void)
 	bitmap_info->bmiHeader.biCompression = BI_RGB;
 
 	if ((fb_win32.depth >= 16) || (fb_win32.w & 0x3) || (__fb_gfx->scanline_size > 1)) {
-		if (fb_win32.flags & DRIVER_SHAPED_WINDOW) {
-			if( fb_win32.depth == 32 )
-				fb_win32.blitter = alpha_remover_blitter;
+		if ((fb_win32.flags & DRIVER_SHAPED_WINDOW) && (fb_win32.depth == 32)) {
+			fb_win32.blitter = alpha_remover_blitter;
 		}
 		else if (fb_win32.depth == 16) {
 			fb_win32.blitter = fb_hGetBlitter(15, FALSE);

--- a/src/gfxlib2/win32/gfx_win32.c
+++ b/src/gfxlib2/win32/gfx_win32.c
@@ -30,10 +30,12 @@ WIN32DRIVER fb_win32;
 
 const GFXDRIVER *__fb_gfx_drivers_list[] = {
 #ifndef HOST_CYGWIN
-	&fb_gfxDriverD2D,
 	&fb_gfxDriverDirectDraw,
 #endif
 	&fb_gfxDriverGDI,
+#ifndef HOST_CYGWIN
+	&fb_gfxDriverD2D,
+#endif
 	&fb_gfxDriverOpenGL,
 	NULL
 };


### PR DESCRIPTION
Graphic screens 2 & 8 only render to half the window using the GDI driver since it doesn't take into account the scanline size.  This PR fixes that by using a blitter, and cleans up some other stuff:
a) only allocating the blitter buffer when necessary
b) fixing exit from full screen if window creation fails (the change back depended on the window being created)
c) alpha_remover_blitter was broken in the >1 scanline case it attempted to handle (gfxlib only writes upto __fb_gfx->h, not __fb_gfx->h*scanline_size) - but as alpha_remover_blitter is only used in 32bpp modes, and there are no 32bpp modes with a greater than 1 scanline size, I removed the multiplication and stuck the conditions in an assert.

Example code that this PR now renders correctly:
Screen 2
https://www.freebasic.net/forum/viewtopic.php?t=19967#p175270

Screen 8:
https://www.freebasic.net/forum/viewtopic.php?t=21047#p185975