### PR TITLE
fix problems with overloaded functions: string vs. wstring

### DIFF
--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -990,6 +990,14 @@ declare function symbFindCastOvlProc _
 		byval is_explicit as integer = FALSE _
 	) as FBSYMBOL ptr
 
+declare function symbFindCastOvlProc2 _
+	( _
+		byval to_dtype as integer, _                      'parameter type (to cast to)
+		byval to_subtype as FBSYMBOL ptr, _               'parameter subtype
+		byval l as ASTNODE ptr, _                         'argument (in code to compile)
+		byval err_num as FB_ERRMSG ptr _
+	) as FB_OVLPROC_MATCH_SCORE
+
 declare function symbFindCtorOvlProc _
 	( _
 		byval sym as FBSYMBOL ptr, _


### PR DESCRIPTION
This fixes an annoying problem with overloaded functions accepting string and wstring variable types. In the past an error ("ambigous ...") was reported, because symbFindCastOvlProc returns only a yes or no decision (not a scaled matchscore). So if two or more functions were able to process the passed string data, it wasn´t possible to find the best matching function. Automatic conversion between string and wide string taking place regularily made more than one function a match.

I changed the logic to return a real matchscore for string data too. This resolves existing ambiguities. In order to avoid equal matchscores for string and wstring/ustring, a wstring/ustring match is rated a little bit higher than a string match. While this may lead to unnecessary conversions (string -> wide string and back) sometimes, it doesn´t produce wrong results. An initial conversion wide string -> string and back later isn´t (depending on the data) lossless all the time, the other way round is safe.

Example:
You got a function working for strings and string wide strings accepting two input strings and returning a string
function doit overload (s as string, s2 as string) as string
function doit overload (u as wstring, u2 as wstring) as wstring ptr

So when you pass a string as the first parameter and a wstring as the second parameter (or vice versa), the matchscore for both functions would be equal (-> ambiguos ...), unless wstrings were rated over strings. Now the second function is taken, which at any rate ensures a correct result. The first function could return a wrong result because of a necessary but probably lossy conversion from wide string to string. 