### PR TITLE
Update fb_gfx_linux.h

### DIFF
--- a/src/gfxlib2/linux/fb_gfx_linux.h
+++ b/src/gfxlib2/linux/fb_gfx_linux.h
@@ -3,11 +3,6 @@
 #ifndef __FB_GFX_LINUX_H__
 #define __FB_GFX_LINUX_H__
 
-/* Disable fbdev driver on ARM, because it currently uses x86 inline asm */
-#if !defined HOST_X86 && !defined HOST_X86_64
-	#define DISABLE_FBDEV
-#endif
-
 #ifndef DISABLE_FBDEV
 
 #define DOUBLE_CLICK_TIME		250


### PR DESCRIPTION
fbdev can be enabled on arm platform. the only issue is that the vga16 blitter must be disabled in this case. So i propose to remove the macro  #define DISABLE_FBDEV when we are not on a X86 platform
instead of this, ce could add a directive in the vga16_blitter code 