### PR TITLE
fbc: preserve namespace prefix when parsing len/sizeof (sf.net 404)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Version 1.08.0
 - sf.net #910: cast(string, variable) can cause fbc to segfault (infinite recursion), due to misplaced const & non-const casting
 - sf.net #898: fbc win gfxlib DirectX driver failed to initialize on 64-bit, due to incorrect construction of DIDATAFORMAT for keyboard device (macko17)
 - rtlib: potential buffer overflow in sys_getshortpath.c (macko17)
+- sf.net #404: len/sizeof type parsing eats namespace prefix
 
 
 Version 1.07.0

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -316,9 +316,11 @@ function cTypeOrExpression _
 
 	if( maybe_type ) then
 		'' Parse as type
-		if( cSymbolType( dtype, subtype, lgt, is_fixlenstr, FB_SYMBTYPEOPT_NONE ) ) then
+		assert( parser.nsprefix = NULL )
+		if( cSymbolType( dtype, subtype, lgt, is_fixlenstr, FB_SYMBTYPEOPT_SAVENSPREFIX ) ) then
 			'' Successful -- it's a type, not an expression
 			ambigioussizeof.maybeWarn( tk, TRUE )
+			parser.nsprefix = NULL
 			return NULL
 		end if
 	end if
@@ -328,6 +330,8 @@ function cTypeOrExpression _
 	'' Parse as expression, allowing NIDXARRAYs
 	expr = cExpressionWithNIDXARRAY( TRUE )
 	if( expr = NULL ) then
+		'' was an error, so make sure to discard the namespace prefix
+		parser.nsprefix = NULL
 		errReport( FB_ERRMSG_EXPECTEDEXPRESSION )
 		'' error recovery: fake an expr
 		expr = astNewCONSTi( 0 )
@@ -718,6 +722,17 @@ function cSymbolType _
 			end if
 
 			if( chain_ ) then
+				'' cTypeOrExpression() will expect that the namespace prefix
+				'' will be preserved if we abort and retry as an expression.
+				'' Eventually namespace prefix it gets used in cIdentifier()
+				if( options and FB_SYMBTYPEOPT_SAVENSPREFIX ) then
+					assert( parser.nsprefix = NULL )
+					select case symbGetClass( chain_->sym )
+					case FB_SYMBCLASS_CONST, FB_SYMBCLASS_VAR
+						parser.nsprefix = chain_
+					end select
+				end if
+
 				do
 					dim as FBSYMBOL ptr sym = chain_->sym
 					do
@@ -752,6 +767,13 @@ function cSymbolType _
 
 					chain_ = symbChainGetNext( chain_ )
 				loop while( chain_ <> NULL )
+
+				'' discard the namespace prefix if it won't be needed later
+				if( options and FB_SYMBTYPEOPT_SAVENSPREFIX ) then
+					if( dtype <> FB_DATATYPE_INVALID ) then
+						parser.nsprefix = NULL
+					end if
+				end if
 			end if
 		end if
 

--- a/src/compiler/parser-identifier.bas
+++ b/src/compiler/parser-identifier.bas
@@ -162,7 +162,13 @@ function cIdentifier _
 
     base_parent = NULL
 
-    chain_ = lexGetSymChain( )
+	'' use the saved namespace prefix if cTypeOrExpression() saved it.
+	if( parser.nsprefix ) then
+		chain_ = parser.nsprefix
+		parser.nsprefix = NULL
+	else
+		chain_ = lexGetSymChain( )
+	end if
 
 	if( fbLangOptIsSet( FB_LANG_OPT_NAMESPC ) = FALSE ) then
 	    return chain_

--- a/src/compiler/parser-toplevel.bas
+++ b/src/compiler/parser-toplevel.bas
@@ -37,6 +37,7 @@ sub parserSetCtx( )
 	parser.currblock = NULL
 
 	parser.nspcrec = 0
+	parser.nsprefix = NULL
 
 	parser.mangling = FB_MANGLING_BASIC
 

--- a/src/compiler/parser.bi
+++ b/src/compiler/parser.bi
@@ -171,6 +171,7 @@ type PARSERCTX
 	'' stmt recursion
 	stmt			as FBPARSER_STMT
 	nspcrec			as integer					'' namespace recursion
+	nsprefix		as FBSYMCHAIN ptr			'' used by cTypeOrExpression() & cIdentifier()
 
 	'' globals
 	scope			as uinteger					'' current scope (0=main module)
@@ -197,6 +198,7 @@ enum FB_SYMBTYPEOPT
 	FB_SYMBTYPEOPT_CHECKSTRPTR	= &h00000001
 	FB_SYMBTYPEOPT_ALLOWFORWARD	= &h00000002
 	FB_SYMBTYPEOPT_ISBYREF		= &h00000004
+	FB_SYMBTYPEOPT_SAVENSPREFIX = &h00000008    '' used by cTypeOrExpression() & cIdentifier()
 
 	FB_SYMBTYPEOPT_DEFAULT		= FB_SYMBTYPEOPT_CHECKSTRPTR
 end enum

--- a/tests/quirk/len-sizeof.bas
+++ b/tests/quirk/len-sizeof.bas
@@ -486,4 +486,87 @@ SUITE( fbc_tests.quirk.len_sizeof )
 		END_TEST
 	END_TEST_GROUP
 
+	namespace ns1
+		type T
+			as integer a, b, c, d
+		end type
+		dim shared as integer a
+		const b as integer = 0
+		const s as string = "12345"
+
+		namespace ns2
+			type T
+				as integer a, b, c, d
+			end type
+			dim shared as integer a
+			const b as integer = 0
+			const s as string = "12345"
+		end namespace
+	end namespace
+
+	'' sizeof(type|expression)
+	TEST( sizeofTypeOrExpression )
+		'' This tests len/sizeof's type/expression disambiguation, where
+		'' namespace prefix is given
+
+		'' direct use of namespace
+		
+		CU_ASSERT(   len(ns1.T) = sizeof(ns1.T))
+		CU_ASSERT(sizeof(ns1.T) = sizeof(integer)*4)
+
+		CU_ASSERT(   len(ns1.a) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.a) = sizeof(integer))
+
+		CU_ASSERT(   len(ns1.b) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.b) = sizeof(integer))
+
+		CU_ASSERT(   len(ns1.s) =  len("hello"))
+		CU_ASSERT(sizeof(ns1.s) = (len("hello")+1))
+
+		'' direct use of nested namespace
+
+		CU_ASSERT(   len(ns1.ns2.T) = sizeof(ns1.ns2.T))
+		CU_ASSERT(sizeof(ns1.ns2.T) = sizeof(integer)*4)
+
+		CU_ASSERT(   len(ns1.ns2.a) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.ns2.a) = sizeof(integer))
+
+		CU_ASSERT(   len(ns1.ns2.b) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.ns2.b) = sizeof(integer))
+
+		CU_ASSERT(   len(ns1.ns2.s) =  len("hello"))
+		CU_ASSERT(sizeof(ns1.ns2.s) = (len("hello")+1))
+
+		'' import top-level namespace
+
+		using ns1
+
+		CU_ASSERT(   len(T) = sizeof(T))
+		CU_ASSERT(sizeof(T) = sizeof(integer)*4)
+
+		CU_ASSERT(   len(a) = sizeof(integer))
+		CU_ASSERT(sizeof(a) = sizeof(integer))
+
+		CU_ASSERT(   len(b) = sizeof(integer))
+		CU_ASSERT(sizeof(b) = sizeof(integer))
+
+		CU_ASSERT(   len(s) =  len("hello"))
+		CU_ASSERT(sizeof(s) = (len("hello")+1))
+
+		'' nested namespace
+
+		CU_ASSERT(   len(ns2.T) = sizeof(ns2.T))
+		CU_ASSERT(sizeof(ns2.T) = sizeof(integer)*4)
+
+		CU_ASSERT(   len(ns2.a) = sizeof(integer))
+		CU_ASSERT(sizeof(ns2.a) = sizeof(integer))
+
+		CU_ASSERT(   len(ns2.b) = sizeof(integer))
+		CU_ASSERT(sizeof(ns2.b) = sizeof(integer))
+
+		CU_ASSERT(   len(ns2.s) =  len("hello"))
+		CU_ASSERT(sizeof(ns2.s) = (len("hello")+1))
+
+	END_TEST
+
 END_SUITE


### PR DESCRIPTION
fbc does not remember namespace prefixes when parsing expression in LEN/SIZEOF.  This change should:
- fix len/sizeof type parsing eats namespace prefix
- bug fix for https://sourceforge.net/p/fbc/bugs/404/

Internally, `hLenSizeof()` tries to determine the symbol type, and if that fails, retries as an expression.  Rather than try to restore lexer state (which is hard to do), we save a pointer to the starting point in the symbol tree lookup.  If a partial namespace/symbol type was read, then we expect that the very next call in to the parser is that we will be looking for an identifier.  Maybe not as elegant as separate code paths through the parser, but we are trying to re-use parser code already written.

This allows for code such as:
```
namespace UDT
    dim shared i as integer
end namespace
print sizeof( UDT.i )
```
and several other variations which previously would have failed to compile.

In theory, we are adding allowable syntax that previously did not work, so should not break existing code.

