### PR TITLE
Len / sizeof udt member

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Version 1.08.0
 - sf.net #910: cast(string, variable) can cause fbc to segfault (infinite recursion), due to misplaced const & non-const casting
 - sf.net #898: fbc win gfxlib DirectX driver failed to initialize on 64-bit, due to incorrect construction of DIDATAFORMAT for keyboard device (macko17)
 - rtlib: potential buffer overflow in sys_getshortpath.c (macko17)
+- sf.net #404: len/sizeof type parsing eats namespace prefix
 
 
 Version 1.07.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Version 1.08.0
 - makefile: '-d FBSHA1="some-sha-1"' compiler option to set the value of '__FB_BUILD_SHA1__' when building fbc
 - rtlib: inc/file.bi:FileFlush() function, usable for file, PIPE, CONS, and ERR streams opened for BINARY, RANDOM, OUTPUT, APPEND.
 - rtlib: inc/file.bi;FileSetEof() function, to adjust size of open file
+- sf.net feature request #293: allow len/sizeof/typeof for UDT members without expression
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,7 +28,8 @@ Version 1.08.0
 - sf.net #910: cast(string, variable) can cause fbc to segfault (infinite recursion), due to misplaced const & non-const casting
 - sf.net #898: fbc win gfxlib DirectX driver failed to initialize on 64-bit, due to incorrect construction of DIDATAFORMAT for keyboard device (macko17)
 - rtlib: potential buffer overflow in sys_getshortpath.c (macko17)
-- sf.net #404: len/sizeof type parsing eats namespace prefix
+- sf.net #404: len/sizeof type parsing eats namespace prefix (namespace prefix is now preserved)
+- sf.net #718: len/sizeof type parsing disambiguates between type and variable having same name
 
 
 Version 1.07.0

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -355,6 +355,8 @@ sub cTypeOf _
 
 	'' Was it a type?
 	if( expr = NULL ) then
+		'' check for member field
+		cUdtTypeMember( dtype, subtype, lgt, is_fixlenstr )
 		exit sub
 	end if
 
@@ -718,7 +720,9 @@ function cSymbolType _
 			end if
 
 			if( check_id ) then
-				chain_ = cIdentifier( base_parent, FB_IDOPT_DEFAULT or FB_IDOPT_ALLOWSTRUCT )
+				chain_ = cIdentifier( base_parent, _
+					iif( options and FB_SYMBTYPEOPT_SAVENSPREFIX, FB_IDOPT_NONE, FB_IDOPT_DEFAULT or FB_IDOPT_ALLOWSTRUCT ) _
+					)
 			end if
 
 			if( chain_ ) then
@@ -728,7 +732,7 @@ function cSymbolType _
 				if( options and FB_SYMBTYPEOPT_SAVENSPREFIX ) then
 					assert( parser.nsprefix = NULL )
 					select case symbGetClass( chain_->sym )
-					case FB_SYMBCLASS_CONST, FB_SYMBCLASS_VAR
+					case FB_SYMBCLASS_CONST, FB_SYMBCLASS_VAR, FB_SYMBCLASS_FIELD
 						parser.nsprefix = chain_
 					end select
 				end if

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -316,9 +316,11 @@ function cTypeOrExpression _
 
 	if( maybe_type ) then
 		'' Parse as type
-		if( cSymbolType( dtype, subtype, lgt, is_fixlenstr, FB_SYMBTYPEOPT_NONE ) ) then
+		assert( parser.nsprefix = NULL )
+		if( cSymbolType( dtype, subtype, lgt, is_fixlenstr, FB_SYMBTYPEOPT_SAVENSPREFIX ) ) then
 			'' Successful -- it's a type, not an expression
 			ambigioussizeof.maybeWarn( tk, TRUE )
+			parser.nsprefix = NULL
 			return NULL
 		end if
 	end if
@@ -328,6 +330,8 @@ function cTypeOrExpression _
 	'' Parse as expression, allowing NIDXARRAYs
 	expr = cExpressionWithNIDXARRAY( TRUE )
 	if( expr = NULL ) then
+		'' was an error, so make sure to discard the namespace prefix
+		parser.nsprefix = NULL
 		errReport( FB_ERRMSG_EXPECTEDEXPRESSION )
 		'' error recovery: fake an expr
 		expr = astNewCONSTi( 0 )
@@ -718,6 +722,17 @@ function cSymbolType _
 			end if
 
 			if( chain_ ) then
+				'' cTypeOrExpression() will expect that the namespace prefix
+				'' will be preserved if we abort and retry as an expression.
+				'' Eventually namespace prefix it gets used in cIdentifier()
+				if( options and FB_SYMBTYPEOPT_SAVENSPREFIX ) then
+					assert( parser.nsprefix = NULL )
+					select case symbGetClass( chain_->sym )
+					case FB_SYMBCLASS_CONST, FB_SYMBCLASS_VAR
+						parser.nsprefix = chain_
+					end select
+				end if
+
 				do
 					dim as FBSYMBOL ptr sym = chain_->sym
 					do
@@ -752,6 +767,13 @@ function cSymbolType _
 
 					chain_ = symbChainGetNext( chain_ )
 				loop while( chain_ <> NULL )
+
+				'' discard the namespace prefix if it won't be needed later
+				if( options and FB_SYMBTYPEOPT_SAVENSPREFIX ) then
+					if( dtype <> FB_DATATYPE_INVALID ) then
+						parser.nsprefix = NULL
+					end if
+				end if
 			end if
 		end if
 

--- a/src/compiler/parser-identifier.bas
+++ b/src/compiler/parser-identifier.bas
@@ -162,7 +162,13 @@ function cIdentifier _
 
     base_parent = NULL
 
-    chain_ = lexGetSymChain( )
+	'' use the saved namespace prefix if cTypeOrExpression() saved it.
+	if( parser.nsprefix ) then
+		chain_ = parser.nsprefix
+		parser.nsprefix = NULL
+	else
+		chain_ = lexGetSymChain( )
+	end if
 
 	if( fbLangOptIsSet( FB_LANG_OPT_NAMESPC ) = FALSE ) then
 	    return chain_

--- a/src/compiler/parser-quirk-math.bas
+++ b/src/compiler/parser-quirk-math.bas
@@ -127,6 +127,27 @@ private function hLenSizeof( byval tk as integer, byval isasm as integer ) as AS
 			tk = FB_TK_SIZEOF
 			expr = astRemoveNIDXARRAY( expr )
 		end if
+
+	'' then must be a type
+	elseif( tk = FB_TK_SIZEOF ) then
+		dim is_fixlenstr as integer
+		cUdtTypeMember( dtype, subtype, lgt, is_fixlenstr )
+
+	elseif( tk = FB_TK_LEN ) then
+		dim is_fixlenstr as integer
+		cUdtTypeMember( dtype, subtype, lgt, is_fixlenstr )
+
+		if( is_fixlenstr ) then
+			'' assume that constant string has no embedded nulls
+			select case typeGetDtAndPtrOnly( dtype )
+			case FB_DATATYPE_CHAR, FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR
+				lgt -= typeGetSize( FB_DATATYPE_CHAR )
+				lgt /= typeGetSize( FB_DATATYPE_CHAR )
+			case FB_DATATYPE_WCHAR
+				lgt -= typeGetSize( FB_DATATYPE_WCHAR )
+				lgt /= typeGetSize( FB_DATATYPE_WCHAR )
+			end select
+		end if
 	end if
 
 	'' ')'

--- a/src/compiler/parser-toplevel.bas
+++ b/src/compiler/parser-toplevel.bas
@@ -37,6 +37,7 @@ sub parserSetCtx( )
 	parser.currblock = NULL
 
 	parser.nspcrec = 0
+	parser.nsprefix = NULL
 
 	parser.mangling = FB_MANGLING_BASIC
 

--- a/src/compiler/parser.bi
+++ b/src/compiler/parser.bi
@@ -688,6 +688,14 @@ declare function cUdtMember _
 		byval options as FB_PARSEROPT = 0 _
 	) as ASTNODE ptr
 
+declare sub cUdtTypeMember _
+	( _
+		byref dtype as integer, _
+		byref subtype as FBSYMBOL ptr, _
+		byref lgt as longint, _
+		byref is_fixlenstr as integer _
+	)
+
 declare function cMemberAccess _
 	( _
 		byval dtype as integer, _

--- a/src/compiler/parser.bi
+++ b/src/compiler/parser.bi
@@ -171,6 +171,7 @@ type PARSERCTX
 	'' stmt recursion
 	stmt			as FBPARSER_STMT
 	nspcrec			as integer					'' namespace recursion
+	nsprefix		as FBSYMCHAIN ptr			'' used by cTypeOrExpression() & cIdentifier()
 
 	'' globals
 	scope			as uinteger					'' current scope (0=main module)
@@ -197,6 +198,7 @@ enum FB_SYMBTYPEOPT
 	FB_SYMBTYPEOPT_CHECKSTRPTR	= &h00000001
 	FB_SYMBTYPEOPT_ALLOWFORWARD	= &h00000002
 	FB_SYMBTYPEOPT_ISBYREF		= &h00000004
+	FB_SYMBTYPEOPT_SAVENSPREFIX = &h00000008    '' used by cTypeOrExpression() & cIdentifier()
 
 	FB_SYMBTYPEOPT_DEFAULT		= FB_SYMBTYPEOPT_CHECKSTRPTR
 end enum

--- a/tests/quirk/len-sizeof-udt-member.bas
+++ b/tests/quirk/len-sizeof-udt-member.bas
@@ -1,0 +1,72 @@
+#include "fbcunit.bi"
+
+SUITE( fbc_tests.quirk.len_sizeof_udt_member )
+
+	#define STRCONST "hello"
+
+	type U
+		x(0 to 15) as byte
+	end type
+
+	type T
+		sb as byte
+		ub as ubyte
+		ss as short
+		us as ushort
+		sl as long
+		ul as ulong
+		si as integer
+		ui as uinteger
+		sli as longint
+		uli as ulongint
+		const zs = STRCONST
+		const ws = wstr( STRCONST )
+		z as zstring * 10
+		w as wstring * 10
+		s as string
+		p as any ptr
+		udt as U
+	end type
+
+	TEST( members )
+
+		CU_ASSERT( sizeof( T.sb ) = sizeof( byte ) )
+		CU_ASSERT( sizeof( T.ub ) = sizeof( ubyte ) )
+		CU_ASSERT( sizeof( T.ss ) = sizeof( short ) )
+		CU_ASSERT( sizeof( T.us ) = sizeof( ushort ) )
+		CU_ASSERT( sizeof( T.sl ) = sizeof( long ) )
+		CU_ASSERT( sizeof( T.ul ) = sizeof( ulong ) )
+		CU_ASSERT( sizeof( T.si ) = sizeof( integer ) )
+		CU_ASSERT( sizeof( T.ui ) = sizeof( uinteger ) )
+		CU_ASSERT( sizeof( T.sli ) = sizeof( longint ) )
+		CU_ASSERT( sizeof( T.uli ) = sizeof( ulongint ) )
+		CU_ASSERT( sizeof( T.zs ) = sizeof( STRCONST ) )
+		CU_ASSERT( sizeof( T.ws ) = sizeof( wstr( STRCONST ) ) )
+		CU_ASSERT( sizeof( T.z ) = sizeof( zstring * 10 ) )
+		CU_ASSERT( sizeof( T.w ) = sizeof( wstring * 10 ) )
+		CU_ASSERT( sizeof( T.s ) = sizeof( string ) )
+		CU_ASSERT( sizeof( T.p ) = sizeof( any ptr ) )
+		CU_ASSERT( sizeof( T.udt ) = sizeof( U ) )
+
+		CU_ASSERT( len( T.sb ) = len( byte ) )
+		CU_ASSERT( len( T.ub ) = len( ubyte ) )
+		CU_ASSERT( len( T.ss ) = len( short ) )
+		CU_ASSERT( len( T.us ) = len( ushort ) )
+		CU_ASSERT( len( T.sl ) = len( long ) )
+		CU_ASSERT( len( T.ul ) = len( ulong ) )
+		CU_ASSERT( len( T.si ) = len( integer ) )
+		CU_ASSERT( len( T.ui ) = len( uinteger ) )
+		CU_ASSERT( len( T.sli ) = len( longint ) )
+		CU_ASSERT( len( T.uli ) = len( ulongint ) )
+		CU_ASSERT( len( T.zs ) = len( STRCONST ) )
+		CU_ASSERT( len( T.ws ) = len( wstr( STRCONST ) ) )
+		CU_ASSERT( len( T.z ) = len( zstring * 10 ) )
+		CU_ASSERT( len( T.w ) = len( wstring * 10 ) )
+		CU_ASSERT( len( T.s ) = len( string ) )
+		CU_ASSERT( len( T.p ) = len( any ptr ) )
+		CU_ASSERT( len( T.udt ) = len( U ) )
+
+	END_TEST
+
+END_SUITE
+ 

--- a/tests/quirk/len-sizeof-udt-member.bas
+++ b/tests/quirk/len-sizeof-udt-member.bas
@@ -68,5 +68,31 @@ SUITE( fbc_tests.quirk.len_sizeof_udt_member )
 
 	END_TEST
 
+	type T2
+		s as string
+	end type
+
+	TEST( strings )
+
+		CU_ASSERT( len( T2.s ) = sizeof( string ) )
+		CU_ASSERT( sizeof( T2.s ) = sizeof( string ) )
+
+		dim x as T2
+		x.s = STRCONST
+
+		CU_ASSERT( len( x.s ) = len( STRCONST ) )
+		CU_ASSERT( sizeof( x.s ) = sizeof( string ) )
+		CU_ASSERT( len( (x).s ) = len( STRCONST ) )
+		CU_ASSERT( sizeof( (x).s ) = sizeof( string ) )
+
+		dim t2 as T2
+		t2.s = "hello"
+
+		CU_ASSERT( len( t2.s ) = sizeof( string ) )
+		CU_ASSERT( sizeof( t2.s ) = sizeof( string ) )
+		CU_ASSERT( len( (t2).s ) = len( STRCONST ) )
+		CU_ASSERT( sizeof( (t2).s ) = sizeof( string ) )
+
+	END_TEST
+
 END_SUITE
- 

--- a/tests/quirk/len-sizeof.bas
+++ b/tests/quirk/len-sizeof.bas
@@ -493,6 +493,9 @@ SUITE( fbc_tests.quirk.len_sizeof )
 		dim shared as integer a
 		const b as integer = 0
 		const s as string = "12345"
+		enum e1
+			e11, e12, e13
+		end enum
 
 		namespace ns2
 			type T
@@ -501,6 +504,9 @@ SUITE( fbc_tests.quirk.len_sizeof )
 			dim shared as integer a
 			const b as integer = 0
 			const s as string = "12345"
+			enum e2
+				e21, e22, e23
+			end enum
 		end namespace
 	end namespace
 
@@ -523,6 +529,9 @@ SUITE( fbc_tests.quirk.len_sizeof )
 		CU_ASSERT(   len(ns1.s) =  len("hello"))
 		CU_ASSERT(sizeof(ns1.s) = (len("hello")+1))
 
+		CU_ASSERT(   len(ns1.e1.e11) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.e1.e11) = sizeof(integer))
+
 		'' direct use of nested namespace
 
 		CU_ASSERT(   len(ns1.ns2.T) = sizeof(ns1.ns2.T))
@@ -536,6 +545,9 @@ SUITE( fbc_tests.quirk.len_sizeof )
 
 		CU_ASSERT(   len(ns1.ns2.s) =  len("hello"))
 		CU_ASSERT(sizeof(ns1.ns2.s) = (len("hello")+1))
+
+		CU_ASSERT(   len(ns1.ns2.e2.e21) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.ns2.e2.e21) = sizeof(integer))
 
 		'' import top-level namespace
 
@@ -553,6 +565,12 @@ SUITE( fbc_tests.quirk.len_sizeof )
 		CU_ASSERT(   len(s) =  len("hello"))
 		CU_ASSERT(sizeof(s) = (len("hello")+1))
 
+		CU_ASSERT(   len(e1.e11) = sizeof(integer))
+		CU_ASSERT(sizeof(e1.e11) = sizeof(integer))
+
+		CU_ASSERT(   len(e11) = sizeof(integer))
+		CU_ASSERT(sizeof(e11) = sizeof(integer))
+
 		'' nested namespace
 
 		CU_ASSERT(   len(ns2.T) = sizeof(ns2.T))
@@ -566,6 +584,9 @@ SUITE( fbc_tests.quirk.len_sizeof )
 
 		CU_ASSERT(   len(ns2.s) =  len("hello"))
 		CU_ASSERT(sizeof(ns2.s) = (len("hello")+1))
+
+		CU_ASSERT(   len(ns2.e2.e21) = sizeof(integer))
+		CU_ASSERT(sizeof(ns2.e2.e21) = sizeof(integer))
 
 	END_TEST
 

--- a/tests/quirk/len-sizeof.bas
+++ b/tests/quirk/len-sizeof.bas
@@ -486,4 +486,87 @@ SUITE( fbc_tests.quirk.len_sizeof )
 		END_TEST
 	END_TEST_GROUP
 
+	namespace ns1
+		type T
+			as integer a, b, c, d
+		end type
+		dim shared as integer a
+		const b as integer = 0
+		const s as string = "12345"
+
+		namespace ns2
+			type T
+				as integer a, b, c, d
+			end type
+			dim shared as integer a
+			const b as integer = 0
+			const s as string = "12345"
+		end namespace
+	end namespace
+
+	'' sizeof(type|expression)
+	TEST( sizeofTypeOrExpression )
+		'' This tests len/sizeof's type/expression disambiguation, where
+		'' namespace prefix is given
+
+		'' direct use of namespace
+		
+		CU_ASSERT(   len(ns1.T) = sizeof(ns1.T))
+		CU_ASSERT(sizeof(ns1.T) = sizeof(integer)*4)
+
+		CU_ASSERT(   len(ns1.a) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.a) = sizeof(integer))
+
+		CU_ASSERT(   len(ns1.b) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.b) = sizeof(integer))
+
+		CU_ASSERT(   len(ns1.s) =  len("hello"))
+		CU_ASSERT(sizeof(ns1.s) = (len("hello")+1))
+
+		'' direct use of nested namespace
+
+		CU_ASSERT(   len(ns1.ns2.T) = sizeof(ns1.ns2.T))
+		CU_ASSERT(sizeof(ns1.ns2.T) = sizeof(integer)*4)
+
+		CU_ASSERT(   len(ns1.ns2.a) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.ns2.a) = sizeof(integer))
+
+		CU_ASSERT(   len(ns1.ns2.b) = sizeof(integer))
+		CU_ASSERT(sizeof(ns1.ns2.b) = sizeof(integer))
+
+		CU_ASSERT(   len(ns1.ns2.s) =  len("hello"))
+		CU_ASSERT(sizeof(ns1.ns2.s) = (len("hello")+1))
+
+		'' import top-level namespace
+
+		using ns1
+
+		CU_ASSERT(   len(T) = sizeof(T))
+		CU_ASSERT(sizeof(T) = sizeof(integer)*4)
+
+		CU_ASSERT(   len(a) = sizeof(integer))
+		CU_ASSERT(sizeof(a) = sizeof(integer))
+
+		CU_ASSERT(   len(b) = sizeof(integer))
+		CU_ASSERT(sizeof(b) = sizeof(integer))
+
+		CU_ASSERT(   len(s) =  len("hello"))
+		CU_ASSERT(sizeof(s) = (len("hello")+1))
+
+		'' nested namespace
+
+		CU_ASSERT(   len(ns2.T) = sizeof(ns2.T))
+		CU_ASSERT(sizeof(ns2.T) = sizeof(integer)*4)
+
+		CU_ASSERT(   len(ns2.a) = sizeof(integer))
+		CU_ASSERT(sizeof(ns2.a) = sizeof(integer))
+
+		CU_ASSERT(   len(ns2.b) = sizeof(integer))
+		CU_ASSERT(sizeof(ns2.b) = sizeof(integer))
+
+		CU_ASSERT(   len(ns2.s) =  len("hello"))
+		CU_ASSERT(sizeof(ns2.s) = (len("hello")+1))
+
+	END_TEST
+
 END_SUITE


### PR DESCRIPTION
Allow len/sizeof/typeof for UDT members without expression (sf.net feature request # 293)
- See https://sourceforge.net/p/fbc/feature-requests/293/

Allows exception for `len|sizeof|typeof(UDT.member)` which was not previously available.

Some tests have been added to the fbc test suite.  What we are looking for is additional tests where the new syntax allowed might fail.  For example, with complex macro expansions or expressions not yet conceived of.  In theory, this change allows syntax not previously available so should not break existing code.
