### PR TITLE
Leaky realloc fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@ Version 1.08.0
 - sf.net #404: len/sizeof type parsing eats namespace prefix (namespace prefix is now preserved)
 - sf.net #718: len/sizeof type parsing disambiguates between type and variable having same name
 - github #205: fix rtlib realloc memory leaks in 'redim preserve' and 'fb_hGetLocaleInfo' (adeyblue)
+- gitbub #205: fix rtlib realloc memory leaks and malloc null ptrs in utf_conv.bi CharToUTF, 'WCharToUTF, UTFToChar, UTFToWChar, and related functions
 
 
 Version 1.07.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ Version 1.08.0
 - sf.net #718: len/sizeof type parsing disambiguates between type and variable having same name
 - github #205: fix rtlib realloc memory leaks in 'redim preserve' and 'fb_hGetLocaleInfo' (adeyblue)
 - gitbub #205: fix rtlib realloc memory leaks and malloc null ptrs in utf_conv.bi CharToUTF, 'WCharToUTF, UTFToChar, UTFToWChar, and related functions
+- gitbub #205: fix rtlib potential malloc null ptr access in dev file read/write methods
 
 
 Version 1.07.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Version 1.08.0
 - rtlib: potential buffer overflow in sys_getshortpath.c (macko17)
 - sf.net #404: len/sizeof type parsing eats namespace prefix (namespace prefix is now preserved)
 - sf.net #718: len/sizeof type parsing disambiguates between type and variable having same name
+- github #205: fix rtlib realloc memory leaks in 'redim preserve' and 'fb_hGetLocaleInfo' (adeyblue)
 
 
 Version 1.07.0

--- a/src/rtlib/array_redimpresv.c
+++ b/src/rtlib/array_redimpresv.c
@@ -20,6 +20,7 @@ int fb_hArrayRealloc
 	ssize_t lbTB[FB_MAXDIMENSIONS];
 	ssize_t ubTB[FB_MAXDIMENSIONS];
 	unsigned char *this_;
+	void *reallocTemp;
 
 	/* ditto, see fb_hArrayAlloc() */
 	if( (dimensions != array->dimensions) && (array->dimensions != 0) )
@@ -52,10 +53,11 @@ int fb_hArrayRealloc
     size = elements * element_len;
 
 	/* realloc */
-    array->ptr = realloc( array->ptr, size );
-    if( array->ptr == NULL )
+    reallocTemp = realloc( array->ptr, size );
+    if( reallocTemp == NULL )
         return fb_ErrorSetNum( FB_RTERROR_OUTOFMEM );
 
+    array->ptr = reallocTemp;
     /* Have remainder? */
     if( size > array->size ) {
         /* Construct or clear new array elements: */

--- a/src/rtlib/dev_file_read_wstr.c
+++ b/src/rtlib/dev_file_read_wstr.c
@@ -28,9 +28,19 @@ int fb_DevFileReadWstr( FB_FILE *handle, FB_WCHAR *dst, size_t *pchars )
     chars = *pchars;
 
 	if( chars < FB_LOCALBUFF_MAXLEN )
+	{
 		buffer = alloca( chars + 1 );
+		/* note: if out of memory on alloca, it's a stack exception */
+	}
 	else
+	{
 		buffer = malloc( chars + 1 );
+		if( buffer == NULL )
+		{
+			FB_UNLOCK();
+			return fb_ErrorSetNum( FB_RTERROR_OUTOFMEM );
+		}
+	}
 
 	/* do read */
 	chars = fread( buffer, 1, chars, fp );

--- a/src/rtlib/dev_file_write_wstr.c
+++ b/src/rtlib/dev_file_write_wstr.c
@@ -18,9 +18,19 @@ int fb_DevFileWriteWstr( FB_FILE *handle, const FB_WCHAR* src, size_t chars )
 	}
 
 	if( chars < FB_LOCALBUFF_MAXLEN )
+	{
 		buffer = alloca( chars + 1 );
+		/* note: if out of memory on alloca, it's a stack exception */
+	}
 	else
+	{
 		buffer = malloc( chars + 1 );
+		if( buffer == NULL )
+		{
+			FB_UNLOCK();
+			return fb_ErrorSetNum( FB_RTERROR_OUTOFMEM );
+		}
+	}
 
 	/* convert to ascii, file should be opened with the ENCODING option
 	   to allow UTF characters to be written */

--- a/src/rtlib/utf_convfrom_wchar.c
+++ b/src/rtlib/utf_convfrom_wchar.c
@@ -154,7 +154,13 @@ static UTF_16 *hUTF32ToUTF16( const FB_WCHAR *src, ssize_t chars, UTF_16 *dst, s
 			if( *bytes == dst_size )
 			{
 				dst_size += sizeof( UTF_16 ) * 8;
-				buffer = realloc( buffer, dst_size );
+				UTF_16 *newbuffer = realloc( buffer, dst_size );
+				if( newbuffer == NULL )
+				{
+					free( buffer );
+					return NULL;
+				}
+				buffer = newbuffer;
 				dst = (UTF_16 *)buffer;
 			}
 

--- a/src/rtlib/utf_convto_char.c
+++ b/src/rtlib/utf_convto_char.c
@@ -7,6 +7,66 @@
 extern const char __fb_utf8_trailingTb[256];
 extern const UTF_32 __fb_utf8_offsetsTb[6];
 
+/*
+char * fb_hUTF8ToChar( const UTF_8 *src, char *dst, ssize_t *chars )
+char * fb_hUTF16ToChar( const UTF_8 *src, char *dst, ssize_t *chars )
+char * fb_hUTF32ToChar( const UTF_8 *src, char *dst, ssize_t *chars )
+
+if 'dst' is null
+
+	src 
+		- 'src' is the address of the source utf-8 encoded string
+		- must not be null
+		- must have a null terminating character
+
+	dst
+		- ignored
+
+	chars
+		- 'chars' must not be null
+		- 'chars' value is ignored on entry
+		- on return, 'chars' is set to the number of characters 
+		  converted not including the null terminator
+
+	return value
+		- the pointer to the newly allocated (realloc) memory
+		  containing the converted string which includes a
+		  terminating null character, or NULL pointer if
+		  unable to allocate memory
+		- 'chars' contains the number of characters 
+		  converted not including the null terminator
+
+	NOTE: caller is responsible to free the memory
+
+
+if 'dst' is not null
+
+	src
+		- 'src' is the address of the source utf-8 encoded string
+		- must not be null
+		- may have null terminating character
+
+	dst
+		- 'dst' is the destination buffer for the ascii string
+
+	chars
+		- 'chars' must not be null
+		- caller must set 'chars' to the maximum number of
+		  characters to convert which may include the 
+		  terminating null character
+		- on return, 'chars' is set to the number characters
+		  converted not including the terminating null
+		  character
+	
+	NOTE: the caller will not know if a terminating null
+	character was written based on the value of 'chars'.  The 
+	value of 'chars' will be the same if the conversion ended
+	on a terminating null character or the character
+	immediately before it.  In either case, the terminating
+	null character is not written.
+
+*/
+
 char *fb_hUTF8ToChar( const UTF_8 *src, char *dst, ssize_t *chars )
 {
 	UTF_32 c;
@@ -52,7 +112,13 @@ char *fb_hUTF8ToChar( const UTF_8 *src, char *dst, ssize_t *chars )
 			{
 				charsleft = 8;
 				dst_size += charsleft;
-				buffer = realloc( buffer, dst_size );
+				char *newbuffer = realloc( buffer, dst_size );
+				if( newbuffer == NULL )
+				{
+					free( buffer );
+					return NULL;
+				}
+				buffer = newbuffer;
 				dst = buffer + dst_size - charsleft;
 			}
 			
@@ -138,7 +204,13 @@ char *fb_hUTF16ToChar( const UTF_16 *src, char *dst, ssize_t *chars )
 			{
 				charsleft = 8;
 				dst_size += charsleft;
-				buffer = realloc( buffer, dst_size );
+				char *newbuffer = realloc( buffer, dst_size );
+				if( newbuffer == NULL )
+				{
+					free( buffer );
+					return NULL;
+				}
+				buffer = newbuffer;
 				dst = buffer + dst_size - charsleft;
 			}
 			
@@ -199,7 +271,13 @@ char *fb_hUTF32ToChar( const UTF_32 *src, char *dst, ssize_t *chars )
 			{
 				charsleft = 8;
 				dst_size += charsleft;
-				buffer = realloc( buffer, dst_size );
+				char *newbuffer = realloc( buffer, dst_size );
+				if( newbuffer == NULL )
+				{
+					free( buffer );
+					return NULL;
+				}
+				buffer = newbuffer;
 				dst = buffer + dst_size - charsleft;
 			}
 			

--- a/src/rtlib/utf_convto_wchar.c
+++ b/src/rtlib/utf_convto_wchar.c
@@ -59,7 +59,13 @@ static FB_WCHAR *hUTF8ToUTF16( const UTF_8 *src, FB_WCHAR *dst, ssize_t *chars )
 				charsleft = 8;
 				dst_size += charsleft;
 
-				buffer = realloc( buffer, dst_size * sizeof( FB_WCHAR ) );
+				FB_WCHAR *newbuffer = realloc( buffer, dst_size * sizeof( FB_WCHAR ) );
+				if( newbuffer == NULL )
+				{
+					free( buffer );
+					return NULL;
+				}
+				buffer = newbuffer;
 				dst = buffer + dst_size - charsleft;
 			}
 
@@ -179,7 +185,13 @@ static FB_WCHAR *hUTF8ToUTF32( const UTF_8 *src, FB_WCHAR *dst, ssize_t *chars )
 			{
 				charsleft = 8;
 				dst_size += charsleft;
-				buffer = realloc( buffer, dst_size * sizeof( FB_WCHAR ) );
+				FB_WCHAR *newbuffer = realloc( buffer, dst_size * sizeof( FB_WCHAR ) );
+				if( newbuffer == NULL )
+				{
+					free( buffer );
+					return NULL;
+				}
+				buffer = newbuffer;
 				dst = buffer + dst_size - charsleft;
 			}
 			
@@ -269,6 +281,8 @@ static FB_WCHAR *hUTF16ToUTF16( const UTF_16 *src, FB_WCHAR *dst, ssize_t *chars
 		while( src[len] )
 			len++;
 		dst = malloc( (len + 1) * sizeof( UTF_16 ) );
+		if( dst == NULL )
+			return NULL;
 		memcpy( dst, src, (len + 1) * sizeof( UTF_16 ) );
 	} else {
 		while( src[len] && len < *chars )
@@ -305,7 +319,12 @@ static FB_WCHAR *hUTF16ToUTF32( const UTF_16 *src, FB_WCHAR *dst, ssize_t *chars
 			{
 				charsleft = 8;
 				dst_size += charsleft;
-				buffer = realloc( buffer, dst_size * sizeof( FB_WCHAR ) );
+				FB_WCHAR *newbuffer = realloc( buffer, dst_size * sizeof( FB_WCHAR ) );
+				if( newbuffer == NULL ) {
+					free( buffer );
+					return NULL;
+				}
+				buffer = newbuffer;
 				dst = buffer + dst_size - charsleft;
 			}
 			
@@ -388,7 +407,12 @@ static FB_WCHAR *hUTF32ToUTF16( const UTF_32 *src, FB_WCHAR *dst, ssize_t *chars
 				/* Make room for some chars */
 				charsleft = 8;
 				dst_size += charsleft;
-				buffer = realloc( buffer, dst_size * sizeof( FB_WCHAR ) );
+				FB_WCHAR *newbuffer = realloc( buffer, dst_size * sizeof( FB_WCHAR ) );
+				if( newbuffer == NULL ) {
+					free( buffer );
+					return NULL;
+				}
+				buffer = newbuffer;
 				dst = buffer + dst_size - charsleft;
 			}
 			
@@ -450,6 +474,8 @@ static FB_WCHAR *hUTF32ToUTF32( const UTF_32 *src, FB_WCHAR *dst, ssize_t *chars
 		while( src[len] )
 			len++;
 		dst = malloc( (len + 1) * sizeof( UTF_32 ) );
+		if( dst == NULL )
+			return NULL;
 		memcpy( dst, src, (len + 1) * sizeof( UTF_32 ) );
 	} else {
 		while( src[len] && len < *chars )

--- a/src/rtlib/utf_core.c
+++ b/src/rtlib/utf_core.c
@@ -26,6 +26,24 @@ const UTF_32 __fb_utf8_offsetsTb[6] =
 		0x00000000UL, 0x00003080UL, 0x000E2080UL, 0x03C82080UL, 0xFA082080UL, 0x82082080UL
 	};
 
+/*
+	void fb_hCharToUTF8( const char *src, ssize_t chars, char *dst, ssize_t *total_bytes )
+
+		'src' is the address of the source ascii string and must not
+		be null if 'chars' > 0.
+
+		'chars' is  number of ascii characters to convert including
+		embedded or terminating null characters.
+
+		'dst' is the destination buffer for the utf-8 encoded string
+		and must not be null if 'chars' > 0.
+
+		'total_bytes' is set to the total number of bytes written 
+		to 'dst' on return and must not be null if 'chars' > 0.
+
+		no return value
+*/
+
 void fb_hCharToUTF8( const char *src, ssize_t chars, char *dst, ssize_t *total_bytes )
 {
 	UTF_8 c;

--- a/src/rtlib/win32/intl_core.c
+++ b/src/rtlib/win32/intl_core.c
@@ -90,9 +90,12 @@ char *fb_hGetLocaleInfo( LCID Locale, LCTYPE LCType, char *pszBuffer, size_t uiS
         uiSize = 64;
         pszBuffer = NULL;
         for(;;) {
-            pszBuffer = (char*) realloc( pszBuffer, uiSize <<= 1 );
-            if( pszBuffer==NULL )
+            char* pszNewBuffer = (char*) realloc( pszBuffer, uiSize <<= 1 );
+            if( pszNewBuffer==NULL ) {
+                free(pszBuffer);
                 break;
+            }
+            pszBuffer = pszNewBuffer;
             if( GetLocaleInfo( Locale, LCType, pszBuffer, uiSize - 1 )!=0 ) {
                 return pszBuffer;
             }


### PR DESCRIPTION
There are also eight other leaky reallocs in the unicode string conversion like this one:
https://github.com/freebasic/fbc/blob/5e93d69f151172694f98f08376838e90f632d6b9/src/rtlib/utf_convto_char.c#L55
As none of them are checked for failure right now it's above my pay grade to decide what should happen in the failure cases