### PR TITLE
fbc-tests: update fbcunit to version 0.9

### DIFF
--- a/tests/fbc-tests.bas
+++ b/tests/fbc-tests.bas
@@ -9,6 +9,8 @@
 dim opt_help as boolean = false
 dim opt_verbose as boolean = false
 dim opt_show_summary as boolean = true
+dim opt_brief_summary as boolean = false
+dim opt_hide_cases as boolean = false
 dim opt_xml_report as boolean = false
 dim opt_xml_filename as string = ""
 dim opt_no_error as boolean = false
@@ -40,6 +42,12 @@ while command(i) > ""
 	case "--no-summary"
 		opt_show_summary = false
 
+	case "--brief-summary"
+		opt_brief_summary = true
+
+	case "--hide-cases"
+		opt_hide_cases = true
+
 	case else
 		print "Unrecognized option '" & command(i) & "'"
 		end 1
@@ -59,6 +67,8 @@ if( opt_help ) then
 	print "   --xml filename       write test results to xml format for filename"
 	print "   --no-summary         don't show the summary (default is to show it)"
 	print "   --no-error           don't exit with error code even if tests failed"
+	print "   --brief-summary      only show failures in the summary"
+	print "   --hide-cases         don't show the failed cases"
 	print
 
 	'' exit with an error code
@@ -77,6 +87,9 @@ if( fbcu.check_internal_state() = false ) then
 	end 1
 end if
 
+'' set extra options
+fbcu.setBriefSummary( opt_brief_summary )
+fbcu.setHideCases( opt_hide_cases )
 
 '' run the tests
 passed = fbcu.run_tests( opt_show_summary, opt_verbose )

--- a/tests/fbcunit/changelog.txt
+++ b/tests/fbcunit/changelog.txt
@@ -1,3 +1,15 @@
+Version 0.9
+
+[added]
+- fbcu.setBriefSummary( true|false ) method to choose brief summary (true), otherwise full summary (false, default)
+- fbcu.setHideCases( true|false ) method to prevent cases (failed asserts) from printing (true), otherwise show all (false, default)
+- fbcu.getHideCases() as boolean to return current setting for "hide-cases" option
+
+[fixed]
+- added missing fbcunit_qb.bas:fbcu_check_internal_state() stub
+- added missing fbcunit_qb.bas:fbcu_write_report_xml() stub
+
+
 Version 0.8
 
 [changed]

--- a/tests/fbcunit/inc/fbcunit.bi
+++ b/tests/fbcunit/inc/fbcunit.bi
@@ -2,7 +2,7 @@
 #define __FBCUNIT_BI_INCLUDE__ 1
 
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2019 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus
@@ -13,7 +13,7 @@
 ---------------------------------------------------------'/
 
 #define FBCU_VER_MAJOR 0
-#define FBCU_VER_MINOR 8
+#define FBCU_VER_MINOR 9
 
 #inclib "fbcunit"
 
@@ -534,6 +534,20 @@
 		( _
 			byval filename as const __zstring __ptr _
 		) as __boolean
+
+	declare sub fbcu.setBriefSummary alias "fbcu_setBriefSummary_qb" _
+		( _
+			byval briefSummary as __boolean _
+		)
+
+	declare sub fbcu.setHideCases alias "fbcu_setHideCases_qb" _
+		( _
+			byval hideCases as __boolean _
+		)
+
+	declare function fbcu.getHideCases alias "fbcu_getHideCases_qb" _
+		( _
+		) as __boolean
 	
 	declare function fbcu.run_tests alias "fbcu_run_tests_qb" _
 		( _
@@ -661,6 +675,20 @@ namespace fbcu
 	declare function write_report_xml _
 		( _
 			byval filename as const zstring ptr _
+		) as boolean
+
+	declare sub setBriefSummary _
+		( _
+			byval briefSummary as boolean _
+		)
+
+	declare sub setHideCases _
+		( _
+			byval hideCases as boolean _
+		)
+
+	declare function getHideCases _
+		( _
 		) as boolean
 
 	declare function run_tests _

--- a/tests/fbcunit/license.txt
+++ b/tests/fbcunit/license.txt
@@ -1,5 +1,5 @@
 fbcunit - FreeBASIC Compiler Unit Testing Component
-Copyright (C) 2017-2019 Jeffery R. Marshall (coder[at]execulink[dot]com)
+Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/tests/fbcunit/readme.txt
+++ b/tests/fbcunit/readme.txt
@@ -1,7 +1,7 @@
 	fbcunit - FreeBASIC Compiler Unit Testing Component
-	Copyright (C) 2017-2019 Jeffery R. Marshall (coder[at]execulink[dot]com)
+	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 
-fbcunit version 0.8
+fbcunit version 0.9
 -------------------
 	Unit testing component for fbc compiler.  Provides macros 
 	and common code for unit testing fbc compiled sources. 

--- a/tests/fbcunit/src/fbcunit.bas
+++ b/tests/fbcunit/src/fbcunit.bas
@@ -1,5 +1,5 @@
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2019 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus
@@ -63,6 +63,9 @@ dim shared fbcu_cases_count as integer = 0
 dim shared fbcu_suite_default_index as integer = INVALID_INDEX
 dim shared fbcu_suite_index as integer = INVALID_INDEX
 dim shared fbcu_test_index as integer = INVALID_INDEX
+
+dim shared fbcu_hide_cases as boolean = false
+dim shared fbcu_brief_summary as boolean = false
 
 '' --------------------
 '' console output
@@ -528,6 +531,29 @@ namespace fbcu
 	end function
 
 	''
+	sub setBriefSummary _
+		( _
+			byval briefSummary as boolean _
+		)
+		fbcu_brief_summary = briefSummary
+	end sub
+
+	''
+	sub setHideCases _
+		( _
+			byval hideCases as boolean _
+		)
+		fbcu_hide_cases = hideCases
+	end sub
+
+	''
+	function getHideCases _
+		( _
+		) as boolean
+		function = fbcu_hide_cases
+	end function
+
+	''
 	function run_tests _
 		( _
 			byval show_summary as boolean = true, _
@@ -654,7 +680,11 @@ namespace fbcu
 		dim x as string = ""
 
 		print_output( )
-		print_output( "SUMMARY" )
+		if( fbcu_brief_summary ) then
+			print_output( "SUMMARY (brief: failures only)" )
+		else
+			print_output( "SUMMARY" )
+		end if
 		print_output( )
 		print_output( " Asserts    Passed    Failed  Suite                                      Tests" )
 		print_output( "--------  --------  --------  --------------------------------------  --------" )
@@ -668,6 +698,13 @@ namespace fbcu
 				t_assert_pass_count += .assert_pass_count
 				t_assert_fail_count += .assert_fail_count
 				t_test_fail_count += .test_fail_count
+
+				'' brief summary? only show non-zero results
+				if( fbcu_brief_summary ) then
+					if( ( .assert_fail_count = 0) and (.test_fail_count = 0) ) then
+						continue for
+					end if
+				end if
 
 				x = ""
 				x &= rjust( "" & .assert_count, 8 )
@@ -905,7 +942,9 @@ namespace fbcu
 		)
 
 		if( value = false ) then
-			print_output( "      " & *fil & "(" & lin & ") : error : " & *fun & " " & *msg )
+			if( not fbcu_hide_cases ) then
+				print_output( "      " & *fil & "(" & lin & ") : error : " & *fun & " " & *msg )
+			end if
 		end if
 
 		add_case( value, fil, lin, fun, msg )

--- a/tests/fbcunit/src/fbcunit_console.bas
+++ b/tests/fbcunit/src/fbcunit_console.bas
@@ -1,5 +1,5 @@
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus

--- a/tests/fbcunit/src/fbcunit_console.bi
+++ b/tests/fbcunit/src/fbcunit_console.bi
@@ -2,7 +2,7 @@
 #define __FBCUNIT_CONSOLE_BI_INCLUDE__ 1
 
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus

--- a/tests/fbcunit/src/fbcunit_qb.bas
+++ b/tests/fbcunit/src/fbcunit_qb.bas
@@ -1,5 +1,5 @@
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus
@@ -54,6 +54,54 @@ sub fbcu_add_test_qb alias "fbcu_add_test_qb" _
 	fbcu.add_test( suite_name, test_name, test_proc, is_global )
 
 end sub
+
+''
+function fbcu_check_internal_state alias "fbcu_check_internal_state_qb" _
+	( _
+	) as boolean
+
+	function = fbcu.check_internal_state()
+
+end function
+
+''
+function fbcu_write_report_xml alias "fbcu_write_report_xml_qb" _
+	( _
+		byval filename as const zstring ptr _
+	) as boolean
+
+	function = fbcu.write_report_xml( filename )
+
+end function
+
+''
+sub fbcu_setBriefSummary alias "fbcu_setBriefSummary_qb" _
+	( _
+		byval briefSummary as boolean _
+	)
+
+	fbcu.setBriefSummary( briefSummary )
+
+end sub
+
+''
+sub fbcu_setHideCases alias "fbcu_setHideCases_qb" _
+	( _
+		byval hideCases as boolean _
+	)
+
+	fbcu.setHideCases( hideCases )
+
+end sub
+
+''
+function fbcu_getHideCases alias "fbcu_getHideCases_qb" _
+	( _
+	) as boolean
+
+	function = fbcu.getHideCases()
+
+end function
 
 ''
 function fbcu_run_tests_qb alias "fbcu_run_tests_qb" _

--- a/tests/fbcunit/src/fbcunit_report.bas
+++ b/tests/fbcunit/src/fbcunit_report.bas
@@ -1,5 +1,5 @@
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus

--- a/tests/fbcunit/src/fbcunit_report.bi
+++ b/tests/fbcunit/src/fbcunit_report.bi
@@ -2,7 +2,7 @@
 #define __FBCUNIT_REPORT_BI_INCLUDE__ 1
 
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus

--- a/tests/fbcunit/src/fbcunit_types.bi
+++ b/tests/fbcunit/src/fbcunit_types.bi
@@ -2,7 +2,7 @@
 #define __FBCUNIT_TYPES_BI_INCLUDE__ 1
 
 ''  fbcunit - FreeBASIC Compiler Unit Testing Component
-''	Copyright (C) 2017-2018 Jeffery R. Marshall (coder[at]execulink[dot]com)
+''	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 ''
 ''  License: GNU Lesser General Public License 
 ''           version 2.1 (or any later version) plus

--- a/tests/fbcunit/tests/tests.bas
+++ b/tests/fbcunit/tests/tests.bas
@@ -19,8 +19,11 @@
 dim opt_help as boolean = false
 dim opt_verbose as boolean = false
 dim opt_show_summary as boolean = true
+dim opt_brief_summary as boolean = false
+dim opt_hide_cases as boolean = false
 dim opt_xml_report as boolean = false
 dim opt_xml_filename as string = ""
+dim opt_no_error as boolean = false
 
 dim i as integer = 1
 
@@ -32,6 +35,9 @@ while command(i) > ""
 
 	case "-v", "--verbose"
 		opt_verbose = true
+
+	case "--no-error"
+		opt_no_error = true
 
 	case "--xml"
 		i += 1
@@ -45,6 +51,12 @@ while command(i) > ""
 
 	case "--no-summary"
 		opt_show_summary = false
+
+	case "--brief-summary"
+		opt_brief_summary = true
+
+	case "--hide-cases"
+		opt_hide_cases = true
 
 	case else
 		print "Unrecognized option '" & command(i) & "'"
@@ -64,6 +76,9 @@ if( opt_help ) then
 	print "   -v, --verbose        be verbose"
 	print "   --xml filename       write test results to xml format for filename"
 	print "   --no-summary         don't show the summary (default is to show it)"
+	print "   --no-error           don't exit with error code even if tests failed"
+	print "   --short-summary      only show failures in the summary"
+	print "   --hide-cases         don't show the failed cases"
 	print
 
 	'' exit with an error code
@@ -82,6 +97,9 @@ if( fbcu.check_internal_state() = false ) then
 	end 1
 end if
 
+'' set extra options
+fbcu.setBriefSummary( opt_brief_summary )
+fbcu.setHideCases( opt_hide_cases )
 
 '' run the tests
 passed = fbcu.run_tests( opt_show_summary, opt_verbose )
@@ -98,7 +116,8 @@ end if
 
 
 '' only return exit code = 0 if all tests passed and no other errors
-if( passed ) then
+'' or if the '-no-error' option was given, suspress the error code
+if( passed or opt_no_error ) then
 	end 0
 end if
 


### PR DESCRIPTION
When making broad development changes to fbc & rtlib there are scenarios where many cases in fbc test suite will fail during the normal course of development.  This can make using ./tests/fbc-tests unwieldly to use as a verification tool if it prints out thousands of cases that have failed.  Similarly, if only a few test cases have failed, it is also often useful to get the failed test cases in detail and just a brief report of the failed test suites.

fbcunit version 0.9 adds options to hide the reporting of failed tests cases and create a brief summary showing only the failed test suites.

./tests/fbc-tests.bas is updated to accept new options (see `fbc-tests --help`):
```
   --brief-summary      only show failures in the summary
   --hide-cases         don't show the failed cases
```

fbcunit: update to version 0.9
- fbcu.setBriefSummary( true|false ) method to choose brief summary (true), otherwise full summary (false, default)
- fbcu.setHideCases( true|false ) method to prevent cases (failed asserts) from printing (true), otherwise show all (false, default)
- fbcu.getHideCases() as boolean to return current setting for "hide-cases" option
- added missing fbcunit_qb.bas:fbcu_check_internal_state() stub
- added missing fbcunit_qb.bas:fbcu_write_report_xml() stub
- update copyright to 2020
