### PR TITLE
bugfix 921 - horizontal line drawing on 8-bit image was using wrong bpp

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ Version 1.08.0
 - default new, new[] operator (allocate) after #undef allocate caused compiler crash
 - default delete, delete[] operator (deallocate) after #undef deallocate caused compiler crash
 - windows GDI gfxlib driver now displays double scanline screen modes correctly (screen 2 & 8), rather than half screen (adeyblue)
+- sf.net #921: gfxlib: horizontal line drawing on 8-bit image was using wrong bpp
 
 
 Version 1.07.0

--- a/src/gfxlib2/gfx_line.c
+++ b/src/gfxlib2/gfx_line.c
@@ -85,7 +85,7 @@ void fb_GfxDrawLine(FB_GFXCTX *context, int x1, int y1, int x2, int y2, unsigned
 		bit = 0x8000 >> (rot & 0xF );
 
 		if (style == 0xFFFF)
-			context->pixel_set(context->line[y1] + (x1 * __fb_gfx->bpp), color, x2 - x1 + 1);
+			context->pixel_set(context->line[y1] + (x1 * context->target_bpp), color, x2 - x1 + 1);
 		else {
 			for (x = x1; x <= x2; x++) {
 				if (style & bit)


### PR DESCRIPTION
referring to https://sourceforge.net/p/fbc/bugs/921/

The bug is on line
https://sourceforge.net/p/fbc/code/ci/master/tree/src/gfxlib2/gfx_line.c#l88

It's using the screen bpp instead of the target bpp. Circle command indirectly uses Line command (horizontal lines) for filled circles.

When bug is fixed, all this should work:
```
#include once "fbgfx.bi"

'' 32-bit mode screen
screenres 600,300,32

'' create a 32 bit and 8 bit image - OK
dim img4 as fb.image ptr = ImageCreate( 100, 100, 0, 32 )
dim img1 as fb.image ptr = ImageCreate( 100, 100, 0, 8 )

'' green circle on a white background 32-bit
line img4,(0,0)-(100,100),rgb(255,255,255),bf
circle img4, ( 50, 50 ), 40, rgb(0,200,0),,,,f

'' draw a pattern and test clipping in 8 bit image - OK
line img1,(-10,-10)-(110,110),255,bf
for x as integer = -310 to 600 step 25
    circle img1, (x,50), 25, 92,,,,f
    line img1, ( -100, -100 ) - ( x, 400 ), 188
    line img1, ( -100, x ) - ( 200, x ), 188
    line img1, ( x, -100 ) - ( x, 200 ), 188
next

'' modify 32 bit image with 8 bit alpha channel
put img4, (0,0), img1, alpha

'' draw some background
for y as integer = 0 to 300 step 20
    line (300,0)-(0,y),rgb(255,127,127)
    line (600,0)-(300,y),rgb(255,127,127)
next

'' let's see it in 32-bit
put (50,50),img4, pset
put (350,50),img4, alpha

sleep

'' 8-bit mode screen
screenres 300,300,8

'' look at the 8-bit alpha as palette image
put( 50, 50 ), img1, pset
sleep

'' grayscale
for i as integer = 0 to 255
    palette i, i, i, i
next

ImageDestroy img1
ImageDestroy img4

sleep
```