### PR TITLE
oGLfbgfx driver for windows OpenGL, Manual and Auto Sync

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -42,6 +42,7 @@ Version 1.08.0
 - default delete, delete[] operator (deallocate) after #undef deallocate caused compiler crash
 - windows GDI gfxlib driver now displays double scanline screen modes correctly (screen 2 & 8), rather than half screen (adeyblue)
 - sf.net #921: gfxlib: horizontal line drawing on 8-bit image was using wrong bpp
+- opengl driver was leaking thread handle under 'screencontrol fb.SET_GL_2D_MODE, fb.OGL_2D_AUTO_SYNC'
 
 
 Version 1.07.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -42,7 +42,8 @@ Version 1.08.0
 - default delete, delete[] operator (deallocate) after #undef deallocate caused compiler crash
 - windows GDI gfxlib driver now displays double scanline screen modes correctly (screen 2 & 8), rather than half screen (adeyblue)
 - sf.net #921: gfxlib: horizontal line drawing on 8-bit image was using wrong bpp
-- opengl driver was leaking thread handle under 'screencontrol fb.SET_GL_2D_MODE, fb.OGL_2D_AUTO_SYNC'
+- oGLfbGFX: opengl driver was leaking thread handle under 'screencontrol fb.SET_GL_2D_MODE, fb.OGL_2D_AUTO_SYNC'
+- oGLfbGFX: prevent opengl mode and scale from changing until next mode is set
 
 
 Version 1.07.0

--- a/inc/fbgfx.bi
+++ b/inc/fbgfx.bi
@@ -48,8 +48,8 @@ namespace FB
 	'Constants for OpenGL 2D render
 	const as integer OGL_2D_NONE        		= 0, _
 					 OGL_2D_MANUAL_SYNC			= 1, _
-                     OGL_2D_AUTO_SYNC			= 2
-					 
+					 OGL_2D_AUTO_SYNC			= 2
+
 	'' Constants accepted by ScreenControl
 	''
 	'' Getters:

--- a/src/gfxlib2/fb_gfx.h
+++ b/src/gfxlib2/fb_gfx.h
@@ -68,7 +68,6 @@
 #define DRIVER_OGL_2D_MANUAL_SYNC   1
 #define DRIVER_OGL_2D_AUTO_SYNC     2
 
-
 #define LINE_TYPE_LINE		0
 #define LINE_TYPE_B		1
 #define LINE_TYPE_BF		2

--- a/src/gfxlib2/fb_gfx_gl.h
+++ b/src/gfxlib2/fb_gfx_gl.h
@@ -51,12 +51,11 @@ typedef void (APIENTRY *GLPIXELTRANSFERI)(GLenum, GLint);
 typedef void (APIENTRY *GLPIXELMAPFV)(GLenum, GLsizei, const GLfloat *);
 
 
-
 typedef struct FB_GL {
 	GLENABLE					Enable;
 	GLDISABLE					Disable;
-	GLENABLECLIENTSTATE				EnableClientState;
-	GLDISABLECLIENTSTATE				DisableClientState;
+	GLENABLECLIENTSTATE			EnableClientState;
+	GLDISABLECLIENTSTATE		DisableClientState;
 	GLGETSTRING					GetString;
 	GLVIEWPORT					Viewport;
 	GLMATRIXMODE				MatrixMode;
@@ -76,9 +75,9 @@ typedef struct FB_GL {
 	GLTEXCOORDPOINTER			TexCoordPointer;
 	GLDRAWARRAYS				DrawArrays;
 	GLPUSHMATRIX				PushMatrix;
-	GLPOPMATRIX				PopMatrix;
+	GLPOPMATRIX					PopMatrix;
 	GLPUSHATTRIB				PushAttrib;
-	GLPOPATTRIB				PopAttrib;
+	GLPOPATTRIB					PopAttrib;
 	GLPUSHCLIENTATTRIB			PushClientAttrib;
 	GLPOPCLIENTATTRIB			PopClientAttrib;
 	GLPIXELSTOREI				PixelStorei;
@@ -102,7 +101,6 @@ typedef struct FB_GL_PARAMS {
 	int accum_blue_bits;
 	int accum_alpha_bits;
 	int num_samples;
-
 	int mode_2d;
 	int scale;
 	void (*callback)(void);

--- a/src/gfxlib2/fb_gfx_gl.h
+++ b/src/gfxlib2/fb_gfx_gl.h
@@ -101,7 +101,9 @@ typedef struct FB_GL_PARAMS {
 	int accum_blue_bits;
 	int accum_alpha_bits;
 	int num_samples;
+	int init_mode_2d;
 	int mode_2d;
+	int init_scale;
 	int scale;
 	void (*callback)(void);
 } FB_GL_PARAMS;

--- a/src/gfxlib2/gfx_control.c
+++ b/src/gfxlib2/gfx_control.c
@@ -237,10 +237,16 @@ FBCALL void fb_GfxControl_i( int what, ssize_t *param1, ssize_t *param2, ssize_t
 		break;
 
 	case SET_GL_2D_MODE:
+		/* set the initial 2d mode only; we don't want to
+		   change the active mode in use.  The activie mode
+		   only gets set in driver_init() */
 		__fb_gl_params.init_mode_2d = *param1;
 		break;
 
 	case SET_GL_SCALE:
+		/* set the initial scale only; we don't want to
+		   change the active scale in use.  The activie scale
+		   only gets set in driver_init() */
 		__fb_gl_params.init_scale = *param1;
 		break;
 #endif

--- a/src/gfxlib2/gfx_control.c
+++ b/src/gfxlib2/gfx_control.c
@@ -237,11 +237,11 @@ FBCALL void fb_GfxControl_i( int what, ssize_t *param1, ssize_t *param2, ssize_t
 		break;
 
 	case SET_GL_2D_MODE:
-		__fb_gl_params.mode_2d = *param1;
+		__fb_gl_params.init_mode_2d = *param1;
 		break;
 
 	case SET_GL_SCALE:
-		__fb_gl_params.scale = *param1;
+		__fb_gl_params.init_scale = *param1;
 		break;
 #endif
 

--- a/src/gfxlib2/gfx_opengl.c
+++ b/src/gfxlib2/gfx_opengl.c
@@ -25,7 +25,7 @@ FBCALL void *fb_GfxGetGLProcAddress(const char *proc)
 #endif
 
 FB_GL __fb_gl;
-FB_GL_PARAMS __fb_gl_params = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, NULL };
+FB_GL_PARAMS __fb_gl_params = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, NULL };
 static GLfloat texcoords[8];
 static GLuint ScreenTex;
 static GLfloat map_r[256], map_g[256], map_b[256];

--- a/src/gfxlib2/gfx_opengl.c
+++ b/src/gfxlib2/gfx_opengl.c
@@ -24,14 +24,11 @@ FBCALL void *fb_GfxGetGLProcAddress(const char *proc)
 #define GL_UNSIGNED_SHORT_5_6_5           0x8363
 #endif
 
-
 FB_GL __fb_gl;
 FB_GL_PARAMS __fb_gl_params = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, NULL };
 static GLfloat texcoords[8];
 static GLuint ScreenTex;
-
 static GLfloat map_r[256], map_g[256], map_b[256];
-
 
 static int next_pow2(int n)
 {
@@ -245,7 +242,6 @@ int fb_hGL_Init(FB_DYLIB lib, char *os_extensions)
 }
 
 
-
 void fb_hGL_SetPalette(int index, int r, int g, int b){
 	map_r[index]=(float)r/256.0;
 	map_g[index]=(float)g/256.0;
@@ -255,6 +251,22 @@ void fb_hGL_SetPalette(int index, int r, int g, int b){
 
 void fb_hGL_SetupProjection(void)
 {
+	/*
+	INFO ONLY: Prior to oGLfbgfx changes, this is the projection set-up
+
+	__fb_gl.Viewport(0, 0, __fb_gfx->w, __fb_gfx->h);
+	__fb_gl.MatrixMode(GL_PROJECTION);
+	__fb_gl.LoadIdentity();
+	__fb_gl.Ortho(-0.325, __fb_gfx->w - 0.325, __fb_gfx->h - 0.325, -0.325, -1.0, 1.0);
+	__fb_gl.MatrixMode(GL_MODELVIEW);
+	__fb_gl.LoadIdentity();
+	__fb_gl.ShadeModel(GL_FLAT);
+	__fb_gl.Disable(GL_DEPTH_TEST);
+	__fb_gl.DepthMask(GL_FALSE);
+	__fb_gl.ClearColor(0.0, 0.0, 0.0, 1.0);
+	__fb_gl.Clear(GL_COLOR_BUFFER_BIT);
+	*/
+
 	const GLfloat vert[] = {-1,-1,-1,1,1,1,1,-1};
 
 	__fb_gl.PushClientAttrib(GL_CLIENT_ALL_ATTRIB_BITS);
@@ -313,7 +325,6 @@ void fb_hGL_SetupProjection(void)
 	__fb_gl.PopMatrix();
 	__fb_gl.PopAttrib();
 	__fb_gl.PopClientAttrib();
-
 
 }
 

--- a/src/gfxlib2/unix/gfx_driver_opengl_x11.c
+++ b/src/gfxlib2/unix/gfx_driver_opengl_x11.c
@@ -216,7 +216,10 @@ static int driver_init(char *title, int w, int h, int depth, int refresh_rate, i
 		return -1;
 	}
 
-	if (__fb_gl_params.scale>1){
+	__fb_gl_params.mode_2d = __fb_gl_params.init_mode_2d;
+
+	if (__fb_gl_params.init_scale>1){
+		__fb_gl_params.init_scale = __fb_gl_params.init_scale;
 		free(__fb_gfx->dirty);
 		__fb_gfx->dirty = (char *)calloc(1, __fb_gfx->h * __fb_gfx->scanline_size* __fb_gl_params.scale);
 	}

--- a/src/gfxlib2/unix/gfx_driver_opengl_x11.c
+++ b/src/gfxlib2/unix/gfx_driver_opengl_x11.c
@@ -57,8 +57,6 @@ static FB_DYLIB gl_lib = NULL;
 static GLXFUNCS __fb_glX = { NULL, NULL, NULL, NULL, NULL };
 static GLXContext context;
 
-
-
 void *fb_hGL_GetProcAddress(const char *proc)
 {
 	void *addr;
@@ -239,10 +237,10 @@ static int driver_init(char *title, int w, int h, int depth, int refresh_rate, i
 	if ((samples_attrib) && (*samples_attrib > 0))
 		__fb_gl.Enable(GL_MULTISAMPLE_ARB);
 
-	if (__fb_gl_params.mode_2d!=0)
+	if (__fb_gl_params.mode_2d != DRIVER_OGL_2D_NONE)
 		fb_hGL_ScreenCreate();
 
-	if (__fb_gl_params.mode_2d==2){
+	if (__fb_gl_params.mode_2d == DRIVER_OGL_2D_AUTO_SYNC){
 		__fb_glX.MakeCurrent(fb_x11.display, None, NULL);
 		fb_x11.update = opengl_window_update;
 	}
@@ -263,7 +261,7 @@ static void driver_exit(void)
 static void driver_flip(void)
 {
 	fb_hX11Lock();
-	if (__fb_gl_params.mode_2d==1)
+	if (__fb_gl_params.mode_2d == DRIVER_OGL_2D_MANUAL_SYNC)
 		fb_hGL_SetupProjection();
 
 	__fb_glX.SwapBuffers(fb_x11.display, fb_x11.window);

--- a/src/gfxlib2/win32/gfx_driver_opengl.c
+++ b/src/gfxlib2/win32/gfx_driver_opengl.c
@@ -388,13 +388,15 @@ static DWORD WINAPI opengl_thread( LPVOID param )
 
 	while (fb_win32.is_running)
 	{
-
-		FB_GRAPHICS_LOCK( );
+		fb_hWin32Lock();
+		/* FB_GRAPHICS_LOCK( ); */
+		fb_wgl.MakeCurrent(hdc, hglrc);
 		fb_hGL_SetupProjection();
 		SwapBuffers(hdc);
+		fb_wgl.MakeCurrent(NULL, NULL);
 		driver_poll_events();
-		FB_GRAPHICS_UNLOCK( );
-
+		/* FB_GRAPHICS_UNLOCK( ); */
+		fb_hWin32Unlock();
 		Sleep(10);
 	}
 
@@ -465,10 +467,20 @@ static void driver_exit(void)
 
 static void driver_lock(void)
 {
+	if (__fb_gl_params.mode_2d == DRIVER_OGL_2D_AUTO_SYNC){
+		fb_hWin32Lock();
+		fb_wgl.MakeCurrent(hdc, hglrc);
+		fb_hGL_SetupProjection();
+	}
 }
 
 static void driver_unlock(void)
 {
+	if (__fb_gl_params.mode_2d == DRIVER_OGL_2D_AUTO_SYNC){
+		SwapBuffers(hdc);
+		fb_wgl.MakeCurrent(NULL, NULL);
+		fb_hWin32Unlock();
+	}
 }
 
 static void driver_flip(void)

--- a/src/gfxlib2/win32/gfx_driver_opengl.c
+++ b/src/gfxlib2/win32/gfx_driver_opengl.c
@@ -222,7 +222,6 @@ static int opengl_init(void)
 	rect.right = fb_win32.w;
 	rect.bottom = fb_win32.h;
 	if (!(fb_win32.flags & DRIVER_FULLSCREEN)) {
-		
 		AdjustWindowRect(&rect, style, FALSE);
 		if (monitor_info.szDevice[0]) {
 			x = monitor_info.rcMonitor.left + ((monitor_info.rcMonitor.right - monitor_info.rcMonitor.left - rect.right) >> 1);

--- a/src/gfxlib2/win32/gfx_driver_opengl.c
+++ b/src/gfxlib2/win32/gfx_driver_opengl.c
@@ -426,7 +426,10 @@ static int driver_init(char *title, int w, int h, int depth_arg, int refresh_rat
 	fb_win32.paint = opengl_paint;
 	fb_win32.thread = NULL;
 
-	if (__fb_gl_params.scale>1){
+	__fb_gl_params.mode_2d = __fb_gl_params.init_mode_2d;
+
+	if (__fb_gl_params.init_scale>1){
+		__fb_gl_params.scale = __fb_gl_params.init_scale;
 		free(__fb_gfx->dirty);
 		__fb_gfx->dirty = (char *)calloc(1, __fb_gfx->h * __fb_gfx->scanline_size * __fb_gl_params.scale);
 		w *= __fb_gl_params.scale;

--- a/src/gfxlib2/win32/gfx_driver_opengl.c
+++ b/src/gfxlib2/win32/gfx_driver_opengl.c
@@ -241,7 +241,9 @@ static int GL_common_init()
 	/* setup pixel format */
 
 	if (__fb_gl_params.mode_2d != DRIVER_OGL_2D_AUTO_SYNC){
-		// flags??!!!
+		/* flags?  This logic of not calling fb_hGL_NormalizeParameters()
+		   when mode_2d is DRIVER_OGL_2D_AUTO_SYNC is kept from a
+		   previous version. */
 		fb_hGL_NormalizeParameters( fb_win32.flags);
 	}
 
@@ -258,7 +260,9 @@ static int GL_common_init()
 	}
 	if (!pf) {
 		if (__fb_gl_params.mode_2d != DRIVER_OGL_2D_AUTO_SYNC){
-			// flags??!!!
+			/* flags?  This logic of not excluding HAS_MULTISAMPLE
+			   when mode_2d is DRIVER_OGL_2D_AUTO_SYNC is kept from a
+			   previous version. */
 			fb_win32.flags &= ~HAS_MULTISAMPLE;
 		}
 		pf = ChoosePixelFormat(hdc, &pfd);
@@ -384,6 +388,7 @@ static DWORD WINAPI opengl_thread( LPVOID param )
 		return 1;
 	}
 
+	/* thread initialization complete, so release the thread creation lock */
 	SetEvent((HANDLE)param);
 
 	while (fb_win32.is_running)
@@ -435,6 +440,10 @@ static int driver_init(char *title, int w, int h, int depth_arg, int refresh_rat
 		w *= __fb_gl_params.scale;
 		h *= __fb_gl_params.scale;
 	}
+
+	/*  Initialize the graphics window only.  Creation of the window
+	    is handled in next fb_hWin32Init() or GL_common_init()
+	 */
 
 	if( fb_hWin32Init(title, w, h, depth, refresh_rate, flags) ) {
 		return -1;

--- a/src/gfxlib2/win32/gfx_win32.c
+++ b/src/gfxlib2/win32/gfx_win32.c
@@ -613,7 +613,7 @@ int fb_hWin32Init(char *title, int w, int h, int depth, int refresh_rate, int fl
 	keyconv_clear( &keyconv1 );
 	keyconv_clear( &keyconv2 );
 
-	if (!(flags & DRIVER_OPENGL)) {
+	if (fb_win32.thread != NULL) {
 		InitializeCriticalSection(&update_lock);
 
 		events[0] = CreateEvent( NULL, FALSE, FALSE, NULL );


### PR DESCRIPTION
Refactors some common code for OpenGL driver

Following fixes:
- oGLfbGFX: opengl driver was leaking thread handle under 'screencontrol fb.SET_GL_2D_MODE, fb.OGL_2D_AUTO_SYNC'
- oGLfbGFX: prevent opengl 2d mode and scale from changing until next mode is set

Following additions:
- `screenlock` and `screenunlock` will acquire and release the opengl context respectively when using fb.OGL_2D_AUTO_SYNC mode
