### PR TITLE
fbc-tests: fix in test-suite for log-tests results discarded

### DIFF
--- a/doc/fbc.1
+++ b/doc/fbc.1
@@ -1,4 +1,4 @@
-.TH FBC 1 "2019-09-07" "FreeBASIC Compiler 1.08.0" "FreeBASIC Compiler"
+.TH FBC 1 "2020-08-16" "FreeBASIC Compiler 1.08.0" "FreeBASIC Compiler"
 .SH NAME
 fbc \- The FreeBASIC compiler
 .SH DESCRIPTION
@@ -194,6 +194,30 @@ Show compiler version
 .TP
 \fB\-w\fR \fBall\fR|\fBpedantic\fR|\fIn\fR
 Set minimum warning level: \fBall\fR, \fBpedantic\fR, or an integer
+.TP
+\fB\-w\fR \fBall\fR
+Enable all warnings
+.TP
+\fB\-w\fR \fBnone\fR
+Disable all warnings
+.TP
+\fB\-w\fR \fBparam\fR
+Enable parameter warnings
+.TP
+\fB\-w\fR \fBescape\fR
+Enable string escape sequence warnings
+.TP
+\fB\-w\fR \fBnext\fR
+Enable next statement warnings
+.TP
+\fB\-w\fR \fBsignedness\fR
+Enable type signedness warnings
+.TP
+\fB\-w\fR \fBconstness\fR
+Enable const type warnings
+.TP
+\fB\-w\fR \fBsuffix\fR
+Enable invalid suffix warnings
 .TP
 \fB\-Wa\fR \fIa,b,c\fR
 Pass options to GAS

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -3539,6 +3539,16 @@ private sub hPrintOptions( byval verbose as integer )
 	print "  -vec <n>         Automatic vectorization level (default: 0)"
 	print "  [-]-version      Show compiler version"
 	print "  -w all|pedantic|<n>  Set min warning level: all, pedantic or a value"
+	if( verbose ) then
+	print "  -w all           Enable all warnings"
+	print "  -w none          Disable all warnings"
+	print "  -w param         Enable parameter warnings"
+	print "  -w escape        Enable string escape sequence warnings"
+	print "  -w next          Enable next statement warnings"
+	print "  -w signedness    Enable type signedness warnings"
+	print "  -w constness     Enable const type warnings"
+	print "  -w suffix        Enable invalid suffix warnings"
+	end if
 	print "  -Wa <a,b,c>      Pass options to 'as'"
 	print "  -Wc <a,b,c>      Pass options to 'gcc' (-gen gcc) or 'llc' (-gen llvm)"
 	print "  -Wl <a,b,c>      Pass options to 'ld'"

--- a/tests/log-tests.mk
+++ b/tests/log-tests.mk
@@ -21,6 +21,7 @@ SED := sed
 ECHO := echo
 CAT := cat
 PRINTF := printf
+TAIL := TAIL
 
 ifndef FBC
 FBC := fbc$(EXEEXT)
@@ -372,7 +373,7 @@ $(LOG_TESTS_LOG_LST) : $(LOG_TESTS_INC)
 #
 #
 $(LOG_TESTS_RESULTS_LOG): $(LOG_TESTS_LOG_LST) $(LOGLIST_ALL)
-	@$(XARGS) -a $(LOG_TESTS_LOG_LST) $(GREP) -i -E '^.*[[:space:]]*:[[:space:]]*RESULT=FAILED' ; true > $@ 
+	@$(XARGS) -a $(LOG_TESTS_LOG_LST) $(GREP) -i -E '^.*[[:space:]]*:[[:space:]]*RESULT=FAILED' | $(TAIL) -n +1 > $@ 
 
 results : $(LOG_TESTS_RESULTS_LOG)
 

--- a/tests/log-tests.mk
+++ b/tests/log-tests.mk
@@ -21,7 +21,7 @@ SED := sed
 ECHO := echo
 CAT := cat
 PRINTF := printf
-TAIL := TAIL
+TAIL := tail
 
 ifndef FBC
 FBC := fbc$(EXEEXT)

--- a/tests/quirk/keyword-suffix.bas
+++ b/tests/quirk/keyword-suffix.bas
@@ -1,4 +1,4 @@
-' TEST_MODE : COMPILE_ONLY_FAIL
+' TEST_MODE : COMPILE_ONLY_OK
 
 if$ 1 then
 end if


### PR DESCRIPTION
fbc-tests: Change an xargs redirection in ./tests/log-tests.mk to properly collect test results (they were previously being discarded).
fbc: Additions for documentation / help on previously committed '-w suffix' change