### PR TITLE
fbc: revert '-lang fb' suffix handling to fbc 1.05 behaviour

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,9 @@ Version 1.08.0
 - updated PostgreSQL headers for binding to PostgreSQL 12.0
 - updated curl headers for binding to curl 7.66.0
 - warning level for all warnings is increased by 1.  Default warning level is 1.  Previously, default warning level was 0 and some warnings had level of -1.
-- sf.net #909: reverted changes due sf.net #893: invalid suffixes due to '-lang fb' are now pedantic warning only specified with '-w pedantic' or '-w suffix'
+- reverted changes due sf.net #893: invalid suffixes due to '-lang fb'
+- reverted changes due sf.net #832: Fix bug allowing QB style suffixes on all keywords, regardless of -lang
+- suffixes in '-lang fb' reverted to fbc-1.05.0 behaviours
 - sf.net #908: check visibility for overloaded operators FOR, NEXT, and STEP
 
 [added]

--- a/src/compiler/error.bas
+++ b/src/compiler/error.bas
@@ -85,9 +85,7 @@ declare function hMakeParamDesc _
 		( /'FB_WARNINGMSG_CONSTQUALIFIERDISCARDED   '/ 0, @"CONST qualifier discarded" ), _
 		( /'FB_WARNINGMSG_RETURNTYPEMISMATCH        '/ 0, @"Return type mismatch" ), _
 		( /'FB_WARNINGMSG_CALLINGCONVMISMATCH       '/ 0, @"Calling convention mismatch" ), _
-		( /'FB_WARNINGMSG_ARGCNTMISMATCH            '/ 0, @"Argument count mismatch" ), _
-		( /'FB_WARNINGMSG_ONLYVALIDINLANG           '/ 1, @"Only valid in -lang" ), _
-		( /'FB_WARNINGMSG_SUFFIXONLYVALIDINLANG     '/ 1, @"Suffixes are only valid in -lang" ) _
+		( /'FB_WARNINGMSG_ARGCNTMISMATCH            '/ 0, @"Argument count mismatch" ) _
 	}
 
 	dim shared errorMsgs( 1 to FB_ERRMSGS-1 ) as const zstring ptr => _
@@ -785,20 +783,6 @@ private function getNotAllowedMsg _
 	return msg
 
 end function
-
-'':::::
-sub errReportWarnNotAllowed _
-	( _
-		byval opt as FB_LANG_OPT, _
-		byval msgnum as integer = FB_WARNINGMSG_ONLYVALIDINLANG, _
-		byval msgex as zstring ptr = NULL _
-	)
-
-	dim msg as string = getNotAllowedMsg( opt, msgex )
-
-	errReportWarnEx( msgnum, msg, lexLineNum( ) )
-
-end sub
 
 '':::::
 sub errReportNotAllowed _

--- a/src/compiler/error.bi
+++ b/src/compiler/error.bi
@@ -376,8 +376,6 @@ enum FB_WARNINGMSG
 	FB_WARNINGMSG_RETURNTYPEMISMATCH
 	FB_WARNINGMSG_CALLINGCONVMISMATCH
 	FB_WARNINGMSG_ARGCNTMISMATCH
-	FB_WARNINGMSG_ONLYVALIDINLANG
-	FB_WARNINGMSG_SUFFIXONLYVALIDINLANG
 
 	FB_WARNINGMSGS
 end enum
@@ -439,13 +437,6 @@ declare sub errReportWarnEx _
 		byval linenum as integer = 0, _
 		byval options as FB_ERRMSGOPT = FB_ERRMSGOPT_DEFAULT, _
 		byval customText as const zstring ptr = NULL _
-	)
-
-declare sub errReportWarnNotAllowed _
-	( _
-		byval opt as FB_LANG_OPT, _
-		byval msgnum as integer = FB_WARNINGMSG_ONLYVALIDINLANG, _
-		byval msgex as zstring ptr = NULL _
 	)
 
 declare sub errReportParam _

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -386,14 +386,6 @@ private sub hReadIdentifier _
 		byval flags as LEXCHECK _
 	)
 
-	#macro hCheckIdentifierSuffix()
-		if( fbPdCheckIsSet( FB_PDCHECK_SUFFIX ) ) then
-			if( (fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE) and ((flags and LEXCHECK_ALLOWSUFFIX) = 0) ) then
-				errReportWarnNotAllowed( FB_LANG_OPT_SUFFIX, FB_WARNINGMSG_SUFFIXONLYVALIDINLANG )
-			end if
-		end if
-	#endmacro
-
 	dim as integer skipchar = any
 
 	'' (ALPHA | '_' )
@@ -454,19 +446,16 @@ private sub hReadIdentifier _
 		select case as const lexCurrentChar( )
 		'' '%'?
 		case FB_TK_INTTYPECHAR
-			hCheckIdentifierSuffix()
 			dtype = env.lang.integerkeyworddtype
 			lexEatChar( )
 
 		'' '&'?
 		case FB_TK_LNGTYPECHAR
-			hCheckIdentifierSuffix()
 			dtype = FB_DATATYPE_LONG
 			lexEatChar( )
 
 		'' '!'?
 		case FB_TK_SGNTYPECHAR
-			hCheckIdentifierSuffix()
 			dtype = FB_DATATYPE_SINGLE
 			lexEatChar( )
 
@@ -474,14 +463,12 @@ private sub hReadIdentifier _
 		case FB_TK_DBLTYPECHAR
 			'' isn't it a '##'?
 			if( lexGetLookAheadChar( ) <> FB_TK_DBLTYPECHAR ) then
-				hCheckIdentifierSuffix()
 				dtype = FB_DATATYPE_DOUBLE
 				lexEatChar( )
 			end if
 
 		'' '$'?
 		case FB_TK_STRTYPECHAR
-			hCheckIdentifierSuffix()
 			dtype = FB_DATATYPE_STRING
 			lexEatChar( )
 		end select


### PR DESCRIPTION
This change is to restart the try at dealing with the suffix handling in '-lang fb'.  Or at least get back to a point where older source codes can be compiled and we have a little easier time moving between dialects.

Changes as follows:
- reverted fix reported in sf.net # 908: suffixes on keywords 
- reverted fix reported in sf.net # 893: invalid suffixes due to '-lang fb'
- reverted fix reported in sf.net # 832: Fix bug allowing QB style suffixes on all keywords, regardless of -lang
- therefore suffixes in '-lang fb' reverted to fbc-1.05.0 behaviours

It's a deeper issue for a couple of reasons:
- suffixes are generally a type specifier and not part of an identifiers name.  This is to aid in the internal tracking of same named symbols, for example either due to shadowing or overloading.
- lexer generally expects and reads in a suffix on identifiers, in all dialects, I think primarily to keep the grammar at least at the lexical level somewhat consistent if working in multiple dialects.
- The meaningfulness of an identifier suffix typically depends on context.  That it the parser needs to to read the token and look at it before it can fully decide what it is and what to do with the suffix.

Re-opened the original sf.net bug report 832
