### PR TITLE
fbc: sf.net bugfix 906 - error on line 2 not shown

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -55,6 +55,7 @@ Version 1.08.0
 - oGLfbGFX: opengl driver was leaking thread handle under 'screencontrol fb.SET_GL_2D_MODE, fb.OGL_2D_AUTO_SYNC'
 - oGLfbGFX: prevent opengl mode and scale from changing until next mode is set
 - sf.net #908: visibility / access rights of overload For/Next/Step operators not taken into account by for...next statement 
+- sf.net #906: #error on line 2 not reported if immediately following #error on line 1
 
 
 Version 1.07.0

--- a/src/compiler/pp.bas
+++ b/src/compiler/pp.bas
@@ -266,6 +266,7 @@ sub ppParse( )
 	case FB_TK_PP_ERROR
 		lexSkipToken( LEXCHECK_POST_SUFFIX )
 		errReportEx( -1, *ppReadLiteral( ) )
+		parser.stmt.cnt += 1
 
 	'' INCLUDE ONCE? LIT_STR
 	case FB_TK_PP_INCLUDE

--- a/tests/pp/include-error.bas
+++ b/tests/pp/include-error.bas
@@ -1,0 +1,3 @@
+' TEST_MODE : COMPILE_ONLY_FAIL 
+
+#include "include-error.bi" 

--- a/tests/pp/include-error.bi
+++ b/tests/pp/include-error.bi
@@ -1,0 +1,3 @@
+#error 1
+#error 2
+#error 3


### PR DESCRIPTION
A small fix, appears to perform OK after several weeks of working with preprocessor codes.

See: https://sourceforge.net/p/fbc/bugs/906/ for more details.

Example:
```
#error message #1
#error message #2
#error message #3
```
Output:
```
jeff@ubuntu:~/fb/misc$ fbc error.bas
error.bas(1) error: message #1
error.bas(3) error: message #3
```
