### PR TITLE
rtlib: internal fb_MemCopyClear() argument types changed unsigned

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ Version 1.08.0
 - sf.net #832: warn on suffixes for all built-in keywords.
 - 'Suffix ignored' warning in -lang fb instead of errors
 - macros and defines with parameters can now be invoked without using parentheses around the arguments
+- rtlib: internal fb_MemCopyClear() argument types changed to expect unsigned lengths (UINTEGER => size_t)
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling
@@ -32,7 +33,7 @@ Version 1.08.0
 - gfxlib: added Direct2D driver, preferred driver on newer systems.  DirectX driver is still fallback for older systems (adeyblue)
 - fbc: add builtin function fb_MemMove() alias "memmove"
 - fbc: add builtin function fb_MemCopy() alias "memcpy" (was previously removed in an older version of fbc)
-- ./inc/fbc-int/memory.bi - fbc  API for low level memory operations allocate, callocate, reallocate, deallocate, clear, memcopy, memmove
+- ./inc/fbc-int/memory.bi - fbc  API for low level memory operations allocate, callocate, reallocate, deallocate, clear, memcopy, memmove, copyclear
 - '-w suffix' or '-w pedantic' command line option enabled 'Suffix ignored' warning for built-in in string functions
 - __FB_UNIQUEID_PUSH__(), __FB_UNIQUEID__(), __FB_UNIQUEID_POP__(), __FB_ARG_LEFTOF__(), __FB_ARG_RIGHTOF__(), __FB_JOIN__() builtin macros
 - __FB_ARG_COUNT__() builtin macro

--- a/inc/fbc-int/memory.bi
+++ b/inc/fbc-int/memory.bi
@@ -10,7 +10,7 @@
 ''   1) redefine the builtin low level memory operations in a namespace
 ''      - currently not possible for allocate / deallocate, see below
 ''
-''   2) alternate definition of fb.clear, fb.memmove, fb.memcopy
+''   2) alternate definition of fb.clear, fb.memmove, fb.memcopy, fb.copyclear
 ''      - built-in as defined by the compiler prefers BYREF parameters for source and destination
 ''        to be more aligned with already long existing CLEAR statemnt
 ''      - this header file uses BYVAL AS ANY PTR parameters to be more aligned with actual rtlib
@@ -27,6 +27,7 @@
 #undef deallocate
 #undef fb_MemCopy
 #undef fb_MemMove
+#undef fb_MemCopyClear
 
 # if __FB_LANG__ = "fb"
 '' must have declaration of "..allocate()" and "..deallocate()"
@@ -48,7 +49,7 @@ extern "rtlib"
 	declare sub deallocate cdecl alias "free" ( byval p as const any ptr )
 
 	'' Note differences in the declarations fbc versus implementation:
-	'' fbc's 'clear', 'fb_MemMove', 'fb_MemCopy', are declared to take
+	'' fbc's 'clear', 'fb_MemMove', 'fb_MemCopy', "fb_MemCopyClear", are declared to take
 	'' 'byref as any' parameters for dst/src.
 	'' - fbc declares the functions to the user as 'byref as any'
 	'' - the underlying implementation is a 'byval as any ptr' (char* to be exact)
@@ -57,11 +58,13 @@ extern "rtlib"
 	'' declare function clear cdecl alias "memset" ( byref dst as any, byval value as const long = 0, byval size as const uinteger ) as any ptr
 	'' declare function fb_MemMove cdecl alias "memmove" ( byref dst as any, byref src as const any, byval size as const uinteger ) as any ptr
 	'' declare function fb_MemCopy cdecl alias "memcpy" ( byref dst as any, byref src as const any, byval size as const uinteger ) as any ptr
-	''
+	'' declare sub fb_MemCopyClear alias "fb_MemCopyClear" ( byref dst as any, byval dstlen as const uinteger, byref src as const any, byval srclen as const uinteger )
 
 	declare function clear cdecl alias "memset" ( byval dst as any ptr, byval value as const long = 0, byval size as const uinteger ) as any ptr
 	declare function memmove cdecl alias "memmove" ( byval dst as any ptr, byval src as const any ptr, byval size as const uinteger ) as any ptr
 	declare function memcopy cdecl alias "memcpy" ( byval dst as any ptr, byval src as const any ptr, byval size as const uinteger ) as any ptr
+	declare sub copyclear alias "fb_MemCopyClear" ( byval dst as any ptr, byval dstlen as const uinteger, byval src as const any ptr, byval srclen as const uinteger )
+
 end extern
 
 # if __FB_LANG__ = "fb"

--- a/src/compiler/parser-quirk-string.bas
+++ b/src/compiler/parser-quirk-string.bas
@@ -164,6 +164,9 @@ function cLRSetStmt(byval tk as FB_TOKEN) as integer
 			return TRUE
 		end if
 
+		assert( symbGetLen( dst->subtype ) > 0 )
+		assert( symbGetLen( src->subtype ) > 0 )
+
 		function = rtlMemCopyClear( dstexpr, symbGetLen( dst->subtype ), _
 		                            srcexpr, symbGetLen( src->subtype ) )
 	else

--- a/src/compiler/rtl-mem.bas
+++ b/src/compiler/rtl-mem.bas
@@ -41,9 +41,9 @@
 		/' sub fb_MemCopyClear _
 			( _
 				byref dst as any, _
-				byval dstlen as const integer, _
+				byval dstlen as const uinteger, _
 				byref src as const any, _
-				byval srclen as const integer _
+				byval srclen as const uinteger _
 			) '/ _
 		( _
 			@FB_RTL_MEMCOPYCLEAR, NULL, _
@@ -52,9 +52,9 @@
 			4, _
 			{ _
 				( FB_DATATYPE_VOID, FB_PARAMMODE_BYREF, FALSE, 0, TRUE ), _
-				( typeSetIsConst( FB_DATATYPE_INTEGER ),FB_PARAMMODE_BYVAL, FALSE ), _
+				( typeSetIsConst( FB_DATATYPE_UINT ),FB_PARAMMODE_BYVAL, FALSE ), _
 				( typeSetIsConst( FB_DATATYPE_VOID ), FB_PARAMMODE_BYREF, FALSE, 0, TRUE ), _
-				( typeSetIsConst( FB_DATATYPE_INTEGER ), FB_PARAMMODE_BYVAL, FALSE ) _
+				( typeSetIsConst( FB_DATATYPE_UINT ), FB_PARAMMODE_BYVAL, FALSE ) _
 			} _
 		), _
 		/' function fre( byval mode as const long = 0 ) as uinteger '/ _

--- a/src/rtlib/fb_system.h
+++ b/src/rtlib/fb_system.h
@@ -9,8 +9,8 @@ FBCALL void         fb_MemSwap          ( unsigned char *dst, unsigned char *src
 FBCALL void         fb_StrSwap          ( void *str1, ssize_t size1, int fillrem1,
                                           void *str2, ssize_t size2, int fillrem2 );
 FBCALL void         fb_WstrSwap         ( FB_WCHAR *str1, ssize_t size1, FB_WCHAR *str2, ssize_t size2 );
-FBCALL void         fb_MemCopyClear     ( unsigned char *dst, ssize_t dstlen,
-                                          unsigned char *src, ssize_t srclen );
+FBCALL void         fb_MemCopyClear     ( unsigned char *dst, size_t dstlen,
+                                          unsigned char *src, size_t srclen );
 
        void         fb_hInit            ( void );
        void         fb_hEnd             ( int errlevel );

--- a/src/rtlib/mem_copyclear.c
+++ b/src/rtlib/mem_copyclear.c
@@ -5,20 +5,21 @@
 FBCALL void fb_MemCopyClear
 	(
 		unsigned char *dst,
-		ssize_t dstlen,
+		size_t dstlen,
 		unsigned char *src,
-		ssize_t srclen
+		size_t srclen
 	)
 {
-	ssize_t bytes;
+	size_t bytes;
 
-	if( (dst == NULL) || (src == NULL) || (dstlen <= 0) || (srclen <= 0) )
+	if( (dst == NULL) || (src == NULL) || (dstlen == 0) )
 		return;
 
 	bytes = (dstlen <= srclen? dstlen: srclen);
 	
 	/* move */
-	memcpy( dst, src, bytes );
+	if( bytes > 0 )
+		memcpy( dst, src, bytes );
 
 	/* clear remainder */
 	dstlen -= bytes;


### PR DESCRIPTION
rtlib: internal fb_MemCopyClear() 

- argument types changed to expect unsigned lengths (UINTEGER => size_t)
- is only ever called from LSET for structs (types) which will never have negative lengths
- this allows arguments passed to `fb_MemCopyClear()` to cooperate with the memcpy and memset parameter types
