### PR TITLE
fbc: suffixes, warn instead of error on suffixes in '-lang fb'

### DIFF
--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -2447,8 +2447,8 @@ sub lexCheckToken _
 	#define hStrSuffixChar(c) iif( c, chr(c), "" )
 	#define hTokenDesc() "in '" & *lexGetText() & hStrSuffixChar( lexGetSuffixChar() ) & "'"
 	#define hWarnSuffix() errReportWarn( FB_WARNINGMSG_SUFFIXIGNORED, hTokenDesc(), FB_ERRMSGOPT_NONE )
-	#define hErrSuffix()  errReportNotAllowed( LEXCHECK_POST_LANG_SUFFIX )
-	#define hDropSuffix() lexGetType() = FB_DATATYPE_INVALID : lexGetSuffixChar() = 0
+	#define hErrSuffix()  errReportNotAllowed( FB_LANG_OPT_SUFFIX, FB_ERRMSG_SUFFIXONLYVALIDINLANG )
+	#define hDropSuffix() lexGetType() = FB_DATATYPE_INVALID : lexGetSuffixChar() = CHAR_NULL
 
 	'' suffix?
 	if( lexGetSuffixChar() <> CHAR_NULL ) then
@@ -2473,7 +2473,6 @@ sub lexCheckToken _
 			'' warn on suffix only if the dialect doesn't allow suffix?
 			elseif( (flags and LEXCHECK_POST_LANG_SUFFIX) <> 0 ) then
 				if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then
-					'' errReportNotAllowed( FB_LANG_OPT_SUFFIX, FB_ERRMSG_SUFFIXONLYVALIDINLANG )
 					hWarnSuffix()
 					hDropSuffix()
 				end if
@@ -2481,18 +2480,18 @@ sub lexCheckToken _
 			'' warn on '$' suffix depending if dialect allows suffix.
 			elseif( (flags and LEXCHECK_POST_STRING_SUFFIX) <> 0 ) then
 
-				'' string suffix?
-				if( lexGetSuffixChar() = FB_TK_STRTYPECHAR ) then
-
-					'' warn only '-w suffix' or '-w pedantic' was given
-					if( fbPdCheckIsSet( FB_PDCHECK_SUFFIX ) ) then
+				if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then
+					'' string suffix?
+					if( lexGetSuffixChar() = FB_TK_STRTYPECHAR ) then
+						'' warn only '-w suffix' or '-w pedantic' was given
+						if( fbPdCheckIsSet( FB_PDCHECK_SUFFIX ) ) then
+							hWarnSuffix()
+						end if
+					else
 						hWarnSuffix()
 					end if
-					hDropSuffix()
-
-				'' otherwise warn for any other suffix
-				else
-					hWarnSuffix()
+					'' error recovery: always drop the suffix
+					''     the lang dialect doesn't support it
 					hDropSuffix()
 				end if
 

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -2480,7 +2480,13 @@ sub lexCheckToken _
 			'' warn on '$' suffix depending if dialect allows suffix.
 			elseif( (flags and LEXCHECK_POST_STRING_SUFFIX) <> 0 ) then
 
-				if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then
+				if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) ) then
+					'' not string suffix?
+					if( lexGetSuffixChar() <> FB_TK_STRTYPECHAR ) then
+						hWarnSuffix()
+						hDropSuffix()
+					end if
+				else
 					'' string suffix?
 					if( lexGetSuffixChar() = FB_TK_STRTYPECHAR ) then
 						'' warn only '-w suffix' or '-w pedantic' was given

--- a/src/compiler/parser-comment.bas
+++ b/src/compiler/parser-comment.bas
@@ -91,7 +91,7 @@ private sub cDirective( ) static
 			lexSkipToken( )
 
 			'' ONCE?
-			isonce = hMatchIdOrKw( "ONCE", LEXCHECK_POST_STRING_SUFFIX )
+			isonce = hMatchIdOrKw( "ONCE", LEXCHECK_POST_SUFFIX )
 
 			'' ':'
 			if( hMatch( FB_TK_STMTSEP ) = FALSE ) then

--- a/src/compiler/parser-decl-const.bas
+++ b/src/compiler/parser-decl-const.bas
@@ -90,12 +90,11 @@ private sub cConstAssign _
 		exit sub
 	end select
 
-	suffix = lexGetType( )
 	id = *lexGetText( )
 
-	hCheckSuffix( suffix )
-
 	'' ID
+	lexCheckToken( LEXCHECK_POST_LANG_SUFFIX )
+	suffix = lexGetType( )
 	lexSkipToken( )
 
 	'' not multiple?

--- a/src/compiler/parser-decl-proc-params.bas
+++ b/src/compiler/parser-decl-proc-params.bas
@@ -326,10 +326,10 @@ private function hParamDecl _
 		*id = *lexGetText( )
 		dotpos = lexGetPeriodPos( )
 
+		lexCheckToken( LEXCHECK_POST_LANG_SUFFIX )
 		dtype = lexGetType( )
-		hCheckSuffix( dtype )
-
 		lexSkipToken( )
+
 	else
 		'' no id
 		dtype  = FB_DATATYPE_INVALID

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -565,8 +565,8 @@ private function hGetId _
 	errmsg = hCheckForIdToken( parent )
 	if( errmsg = FB_ERRMSG_OK ) then
 		*id = *lexGetText( )
+		lexCheckToken( LEXCHECK_POST_LANG_SUFFIX )
 		suffix = lexGetType( )
-		hCheckSuffix( suffix )
 
 		'' no parent? read as-is
 		if( parent = NULL ) then
@@ -574,15 +574,18 @@ private function hGetId _
 		else
 			function = symbLookupAt( parent, lexGetText( ), FALSE, is_redim )
 		end if
+
+		lexSkipToken( )
+
 	else
 		errReport( errmsg )
 		'' error recovery: fake an id
 		*id = *symbUniqueLabel( )
 		suffix = FB_DATATYPE_INVALID
 		function = NULL
+		'' don't report on suffix, already have an error
+		lexSkipToken( )
 	end if
-
-	lexSkipToken( )
 
 end function
 

--- a/src/compiler/parser-expr-function.bas
+++ b/src/compiler/parser-expr-function.bas
@@ -116,8 +116,12 @@ function cFunctionEx _
 	) as ASTNODE ptr
 
 	'' ID
-	lexSkipToken( LEXCHECK_POST_LANG_SUFFIX )
-
+	lexSkipToken( _
+		iif( symbIsSuffixed(sym), _
+			iif( symbGetIsRTL(sym), LEXCHECK_POST_STRING_SUFFIX, LEXCHECK_POST_LANG_SUFFIX ), _
+			LEXCHECK_POST_SUFFIX _
+		) )
+	
 	function = cFunctionCall( base_parent, sym, NULL, NULL, options )
 
 end function

--- a/src/compiler/parser-expr-variable.bas
+++ b/src/compiler/parser-expr-variable.bas
@@ -1198,7 +1198,8 @@ function cVariableEx _
 
 	else
 		if( suffix <> FB_DATATYPE_INVALID ) then
-			errReportNotAllowed( FB_LANG_OPT_SUFFIX, FB_ERRMSG_SUFFIXONLYVALIDINLANG )
+			lexCheckToken( LEXCHECK_POST_LANG_SUFFIX )
+			suffix = lexGetType()
 		end if
 
 		sym = symbFindByClass( chain_, FB_SYMBCLASS_VAR )

--- a/src/compiler/parser-proc.bas
+++ b/src/compiler/parser-proc.bas
@@ -360,16 +360,20 @@ private function hGetId _
 	'' Disallow type suffix on SUBs
 	if( is_sub ) then
 		if( *dtype <> FB_DATATYPE_INVALID ) then
+			'' TODO: error message is weird because it reports proc name
+			'' as the invalid character, when it should probably:
+			''    a) a different error message
+			''    b) point to the invalid suffix character
 			errReport( FB_ERRMSG_INVALIDCHARACTER )
+			'' error recovery: invalidate the data type and suffix
 			*dtype = FB_DATATYPE_INVALID
+			lexGetType() = FB_DATATYPE_INVALID
+			lexGetSuffixChar() = CHAR_NULL
 		end if
 	end if
 
-	'' Check whether type suffix is allowed by the -lang mode
-	hCheckSuffix( *dtype )
-
 	'' ID
-	lexSkipToken( )
+	lexSkipToken( LEXCHECK_POST_LANG_SUFFIX )
 
 	function = sym
 end function

--- a/src/compiler/parser-quirk-file.bas
+++ b/src/compiler/parser-quirk-file.bas
@@ -91,12 +91,12 @@ function cPrintStmt  _
 		'' (Expression?|SPC(Expression)|TAB(Expression)
 		isspc = FALSE
 		istab = FALSE
-		if( hMatch( FB_TK_SPC, LEXCHECK_POST_STRING_SUFFIX ) ) then
+		if( hMatch( FB_TK_SPC, LEXCHECK_POST_LANG_SUFFIX ) ) then
 			isspc = TRUE
 			hMatchLPRNT( )
 			hMatchExpressionEx( expr, FB_DATATYPE_INTEGER )
 			hMatchRPRNT( )
-		elseif( hMatch( FB_TK_TAB, LEXCHECK_POST_STRING_SUFFIX ) ) then
+		elseif( hMatch( FB_TK_TAB, LEXCHECK_POST_LANG_SUFFIX ) ) then
 			istab = TRUE
 			hMatchLPRNT( )
 			hMatchExpressionEx( expr, FB_DATATYPE_INTEGER )

--- a/src/compiler/parser-quirk-string.bas
+++ b/src/compiler/parser-quirk-string.bas
@@ -643,7 +643,7 @@ function cStringFunct(byval tk as FB_TOKEN) as ASTNODE ptr
 	'' W|STR '(' Expression{bool|int|float|double|wstring} ')'
 	case FB_TK_STR, FB_TK_WSTR
 		is_wstr = (tk = FB_TK_WSTR)
-		lexSkipToken( LEXCHECK_POST_STRING_SUFFIX )
+		lexSkipToken( iif( is_wstr, LEXCHECK_POST_SUFFIX, LEXCHECK_POST_STRING_SUFFIX ) )
 
 		hMatchLPRNT( )
 		hMatchExpressionEx( expr1, FB_DATATYPE_INTEGER )
@@ -687,7 +687,8 @@ function cStringFunct(byval tk as FB_TOKEN) as ASTNODE ptr
 	'' W|STRING '(' Expression ',' Expression{int|str} ')'
 	case FB_TK_STRING, FB_TK_WSTRING
 		is_wstr = (tk = FB_TK_WSTRING)
-		lexSkipToken( LEXCHECK_POST_STRING_SUFFIX )
+		lexSkipToken( iif( is_wstr, LEXCHECK_POST_SUFFIX, LEXCHECK_POST_STRING_SUFFIX ) )
+
 
 		hMatchLPRNT( )
 		hMatchExpressionEx( expr1, FB_DATATYPE_INTEGER )
@@ -710,7 +711,7 @@ function cStringFunct(byval tk as FB_TOKEN) as ASTNODE ptr
 	'' W|CHR '(' Expression (',' Expression )* ')'
 	case FB_TK_CHR, FB_TK_WCHR
 		is_wstr = (tk = FB_TK_WCHR)
-		lexSkipToken( LEXCHECK_POST_STRING_SUFFIX )
+		lexSkipToken( iif( is_wstr, LEXCHECK_POST_SUFFIX, LEXCHECK_POST_STRING_SUFFIX ) )
 
 		function = cStrCHR(is_wstr)
 

--- a/src/compiler/parser.bi
+++ b/src/compiler/parser.bi
@@ -961,15 +961,6 @@ declare function hIntegerTypeFromBitSize _
 #endmacro
 
 '':::::
-#macro hCheckSuffix(suffix)
-	if( suffix <> FB_DATATYPE_INVALID ) then
-		if( fbLangOptIsSet( FB_LANG_OPT_SUFFIX ) = FALSE ) then
-			errReportNotAllowed( FB_LANG_OPT_SUFFIX, FB_ERRMSG_SUFFIXONLYVALIDINLANG )
-		end if
-	end if
-#endmacro
-
-'':::::
 #macro hEmitCurrLine( )
 	if( env.clopt.debuginfo ) then
 		if( env.includerec = 0 ) then

--- a/tests/warnings/r/dos/suffix-fb.txt
+++ b/tests/warnings/r/dos/suffix-fb.txt
@@ -949,3 +949,9 @@ warning expected
 	Suffix ignored in 'true%'
 warning expected
 	Suffix ignored in 'false%'
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/dos/suffix-fblite.txt
+++ b/tests/warnings/r/dos/suffix-fblite.txt
@@ -95,3 +95,10 @@ parser-quirk-on.bas ----
 	Suffix ignored in 'label1%'
 warning expected
 	Suffix ignored in 'label1%'
+----String Functions ----
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/dos/suffix-qb.txt
+++ b/tests/warnings/r/dos/suffix-qb.txt
@@ -5,3 +5,5 @@ warning expected
 none expected
 warning expected
 	Suffix ignored in 'let%'
+----String Functions ----
+none expected

--- a/tests/warnings/r/linux-x86/suffix-fb.txt
+++ b/tests/warnings/r/linux-x86/suffix-fb.txt
@@ -949,3 +949,9 @@ warning expected
 	Suffix ignored in 'true%'
 warning expected
 	Suffix ignored in 'false%'
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/linux-x86/suffix-fblite.txt
+++ b/tests/warnings/r/linux-x86/suffix-fblite.txt
@@ -95,3 +95,10 @@ parser-quirk-on.bas ----
 	Suffix ignored in 'label1%'
 warning expected
 	Suffix ignored in 'label1%'
+----String Functions ----
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/linux-x86/suffix-qb.txt
+++ b/tests/warnings/r/linux-x86/suffix-qb.txt
@@ -5,3 +5,5 @@ warning expected
 none expected
 warning expected
 	Suffix ignored in 'let%'
+----String Functions ----
+none expected

--- a/tests/warnings/r/linux-x86_64/suffix-fb.txt
+++ b/tests/warnings/r/linux-x86_64/suffix-fb.txt
@@ -949,3 +949,9 @@ warning expected
 	Suffix ignored in 'true%'
 warning expected
 	Suffix ignored in 'false%'
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/linux-x86_64/suffix-fblite.txt
+++ b/tests/warnings/r/linux-x86_64/suffix-fblite.txt
@@ -95,3 +95,10 @@ parser-quirk-on.bas ----
 	Suffix ignored in 'label1%'
 warning expected
 	Suffix ignored in 'label1%'
+----String Functions ----
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/linux-x86_64/suffix-qb.txt
+++ b/tests/warnings/r/linux-x86_64/suffix-qb.txt
@@ -5,3 +5,5 @@ warning expected
 none expected
 warning expected
 	Suffix ignored in 'let%'
+----String Functions ----
+none expected

--- a/tests/warnings/r/win32/suffix-fb.txt
+++ b/tests/warnings/r/win32/suffix-fb.txt
@@ -949,3 +949,9 @@ warning expected
 	Suffix ignored in 'true%'
 warning expected
 	Suffix ignored in 'false%'
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/win32/suffix-fblite.txt
+++ b/tests/warnings/r/win32/suffix-fblite.txt
@@ -95,3 +95,10 @@ parser-quirk-on.bas ----
 	Suffix ignored in 'label1%'
 warning expected
 	Suffix ignored in 'label1%'
+----String Functions ----
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/win32/suffix-qb.txt
+++ b/tests/warnings/r/win32/suffix-qb.txt
@@ -5,3 +5,5 @@ warning expected
 none expected
 warning expected
 	Suffix ignored in 'let%'
+----String Functions ----
+none expected

--- a/tests/warnings/r/win64/suffix-fb.txt
+++ b/tests/warnings/r/win64/suffix-fb.txt
@@ -949,3 +949,9 @@ warning expected
 	Suffix ignored in 'true%'
 warning expected
 	Suffix ignored in 'false%'
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/win64/suffix-fblite.txt
+++ b/tests/warnings/r/win64/suffix-fblite.txt
@@ -95,3 +95,10 @@ parser-quirk-on.bas ----
 	Suffix ignored in 'label1%'
 warning expected
 	Suffix ignored in 'label1%'
+----String Functions ----
+none expected
+4 warnings expected
+	Suffix ignored in 'wchr$'
+	Suffix ignored in 'wstr$'
+	Suffix ignored in 'wstring$'
+	Suffix ignored in 'bin$'

--- a/tests/warnings/r/win64/suffix-qb.txt
+++ b/tests/warnings/r/win64/suffix-qb.txt
@@ -5,3 +5,5 @@ warning expected
 none expected
 warning expected
 	Suffix ignored in 'let%'
+----String Functions ----
+none expected

--- a/tests/warnings/suffix-fb.bas
+++ b/tests/warnings/suffix-fb.bas
@@ -1270,7 +1270,7 @@ WARN( 1 )
 #line% 1000
 
 /'
-	DON'T INCLUDE DEBUG PP STUFF
+	DON'T INCLUDE DEBUG PP STUFF - IT CAN CHANGE OFTEN
 	WARN( 1 )
 	#dump%( 0 )
 	WARN( 1 )
@@ -1287,3 +1287,37 @@ scope
 	WARN( 1 )
 	b = false%
 end scope
+
+WARN( 0 )
+print chr$(0)
+print inkey$
+print str$(0)
+print space$(0)
+print string$(0,0)
+print oct$(0)
+print hex$(0)
+print mks$(0)
+print mkd$(0)
+print mkl$(0)
+print mki$(0)
+print mkshort$(0)
+print mklongint$(0)
+print ltrim$("")
+print rtrim$("")
+print mid$("",0,0)
+print left$("",0)
+print right$("",0)
+print lcase$("")
+print ucase$("")
+print time$
+print date$
+print environ$("")
+print trim$("")
+print input$(0)
+print command$(0)
+
+WARN( 4 )
+print wchr$(0)
+print wstr$(0)
+print wstring$(0,0)
+print bin$(0)

--- a/tests/warnings/suffix-fblite.bas
+++ b/tests/warnings/suffix-fblite.bas
@@ -127,3 +127,39 @@ label%:
 		WARN( 1 )
 		goto label1%
 	end sub
+
+#print ---- String Functions ----
+
+	WARN( 0 )
+	print chr$(0)
+	print inkey$
+	print str$(0)
+	print space$(0)
+	print string$(0,0)
+	print oct$(0)
+	print hex$(0)
+	print mks$(0)
+	print mkd$(0)
+	print mkl$(0)
+	print mki$(0)
+	print mkshort$(0)
+	print mklongint$(0)
+	print ltrim$("")
+	print rtrim$("")
+	print mid$("",0,0)
+	print left$("",0)
+	print right$("",0)
+	print lcase$("")
+	print ucase$("")
+	print time$
+	print date$
+	print environ$("")
+	print trim$("")
+	print input$(0)
+	print command$(0)
+
+	WARN( 4 )
+   	print wchr$(0)
+	print wstr$(0)
+	print wstring$(0,0)
+   	print bin$(0)

--- a/tests/warnings/suffix-qb.bas
+++ b/tests/warnings/suffix-qb.bas
@@ -26,3 +26,31 @@ WARN( 0 )
 dim b%(1 to 2)
 WARN( 1 )
 let% b%(1) = 1
+
+#print ---- String Functions ----
+
+WARN( 0 )
+print chr$(0)
+print inkey$
+print str$(0)
+print space$(0)
+print string$(0,0)
+print oct$(0)
+print hex$(0)
+print mks$(0)
+print mkd$(0)
+print mkl$(0)
+print mki$(0)
+print ltrim$("")
+print rtrim$("")
+print mid$("",0,0)
+print left$("",0)
+print right$("",0)
+print lcase$("")
+print ucase$("")
+print time$
+print date$
+print environ$("")
+print input$(0)
+print command$(0)
+


### PR DESCRIPTION
- also warn if string suffix is expected, but some other suffix was found.

I think this should generally bring the suffix changes to a close for now.