### PR TITLE
Bug fixes for basic macro built-ins

### DIFF
--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -11,6 +11,7 @@
 #include once "list.bi"
 #include once "lex.bi"
 #include once "hlp.bi"
+#include once "pp.bi"
 
 #include once "datetime.bi"
 #include once "string.bi"
@@ -237,7 +238,12 @@ end function
 
 private function hDefUniqueIdPush_cb( byval argtb as LEXPP_ARGTB ptr, byval errnum as integer ptr ) as string
 
-	'' __FB_UNIQUEID_PUSH__( STACKID )	
+	'' __FB_UNIQUEID_PUSH__( STACKID )
+
+	''  if skipping over code, don't cause side effects
+	if( pp.skipping ) then
+		return ""
+	end if
 
 	var id = hMacro_getArgZ( argtb )
 	if( id = null ) then
@@ -270,6 +276,11 @@ private function hDefUniqueId_cb( byval argtb as LEXPP_ARGTB ptr, byval errnum a
 
 	'' __FB_UNIQUEID__( STACKID )
 
+	''  if skipping over code, don't cause side effects
+	if( pp.skipping ) then
+		return ""
+	end if
+
 	var id = hMacro_getArgZ( argtb )
 	if( id = null ) then
 		*errnum = FB_ERRMSG_ARGCNTMISMATCH
@@ -295,6 +306,11 @@ end function
 private function hDefUniqueIdPop_cb( byval argtb as LEXPP_ARGTB ptr, byval errnum as integer ptr ) as string
 
 	'' __FB_UNIQUEID_POP__( STACKID )
+
+	''  if skipping over code, don't cause side effects
+	if( pp.skipping ) then
+		return ""
+	end if
 
 	var id = hMacro_getArgZ( argtb )
 	if( id = null ) then

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -329,6 +329,8 @@ private function hDefUniqueIdPop_cb( byval argtb as LEXPP_ARGTB ptr, byval errnu
 		else
 			*errnum = FB_ERRMSG_SYNTAXERROR
 		end if
+	else
+		*errnum = FB_ERRMSG_SYNTAXERROR
 	end if
 	
 	function = ""

--- a/tests/pp/macro-uniqueid-pop-1.bas
+++ b/tests/pp/macro-uniqueid-pop-1.bas
@@ -1,0 +1,3 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+__fb_uniqueid_pop__( __undefined__ )

--- a/tests/pp/macro-uniqueid-pop-2.bas
+++ b/tests/pp/macro-uniqueid-pop-2.bas
@@ -1,0 +1,5 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+__fb_uniqueid_push__( __defined__ )
+__fb_uniqueid_pop__( __defined__ )
+__fb_uniqueid_pop__( __defined__ )

--- a/tests/pp/macro-uniqueid.bas
+++ b/tests/pp/macro-uniqueid.bas
@@ -1,0 +1,67 @@
+#include "fbcunit.bi"
+
+SUITE( fbc_tests.pp.macro_uniqueid )
+
+
+	TEST( unused )
+
+		'' before __FB_UNIQUEID_PUSH__() creates a stack
+		'' __FB_UNIQUEID__() should return an empty string
+
+		CU_ASSERT_EQUAL( __FB_QUOTE__( __FB_UNIQUEID__( __unused__ ) ), "" )
+
+	END_TEST
+
+	TEST( not_global )
+
+		CU_ASSERT_EQUAL( __FB_QUOTE__( __FB_UNIQUEID__( __ns__ ) ), "" )
+
+		__FB_UNIQUEID_PUSH__( __ns__ )
+
+		#if defined( __ns__ )
+			CU_FAIL()
+		#endif
+
+		__FB_UNIQUEID_POP__( __ns__ )
+
+	END_TEST
+
+	TEST( direct )
+
+		__FB_UNIQUEID_PUSH__( __direct__ )
+		#define L1 __FB_UNIQUEID__( __direct__ )
+
+		__FB_UNIQUEID_PUSH__( __direct__ )
+		#define L2 __FB_UNIQUEID__( __direct__ )
+
+		__FB_UNIQUEID_PUSH__( __direct__ )
+		#define L3 __FB_UNIQUEID__( __direct__ )
+
+		CU_ASSERT_EQUAL( __FB_QUOTE__( __FB_UNIQUEID__( __direct__ ) ), __FB_QUOTE__( L3 ) )
+		__FB_UNIQUEID_POP__( __direct__ )
+
+		CU_ASSERT_EQUAL( __FB_QUOTE__( __FB_UNIQUEID__( __direct__ ) ), __FB_QUOTE__( L2 ) )
+		__FB_UNIQUEID_POP__( __direct__ )
+
+		CU_ASSERT_EQUAL( __FB_QUOTE__( __FB_UNIQUEID__( __direct__ ) ), __FB_QUOTE__( L1 ) )
+		__FB_UNIQUEID_POP__( __direct__ )
+
+	END_TEST
+
+	TEST( skipping )
+
+		__FB_UNIQUEID_PUSH__( __skip__ )
+		#define L1 __FB_UNIQUEID__( __skip__ )
+
+		#if 0
+			__FB_UNIQUEID__( __skip__ )
+		#endif	
+
+		CU_ASSERT_EQUAL( __FB_QUOTE__( __FB_UNIQUEID__( __skip__ ) ), __FB_QUOTE__( L1 ) )
+		__FB_UNIQUEID_POP__( __skip__ )
+
+	END_TEST
+
+END_SUITE
+
+ 

--- a/tests/pp/macro-uniqueid.bas
+++ b/tests/pp/macro-uniqueid.bas
@@ -12,6 +12,17 @@ SUITE( fbc_tests.pp.macro_uniqueid )
 
 	END_TEST
 
+	TEST( empty )
+
+		'' __FB_UNIQUEID__() should return an empty string if stack is empty
+
+		__FB_UNIQUEID_PUSH__( __empty__ )
+		__FB_UNIQUEID_POP__( __empty__ )
+
+		CU_ASSERT_EQUAL( __FB_QUOTE__( __FB_UNIQUEID__( __empty__ ) ), "" )
+
+	END_TEST
+
 	TEST( not_global )
 
 		CU_ASSERT_EQUAL( __FB_QUOTE__( __FB_UNIQUEID__( __ns__ ) ), "" )


### PR DESCRIPTION
After the initial change for basic macros, some corrections and bug fixes for behaviour:

fbc: basic-macros: error on __fb_uniqueid_pop__ underflow
- log-test for __fb_uniqueid_pop__ stack underflow with undefined stack
- log-test for __fb_uniqueid_pop__ stack underflow with defined stack

fbc: basic-macros: add tests for __fb_uniqueid*() macros

fbc: basic-macros: prevent side effects when skipping statements
- '#if 0' skipping still expands macros, so prevent side effects in __fb_uniqueid*() macros

fbc: basic-macros: fix ICE when accessing unique id stacks
- prevent ICE in __FB_UNIQUEID_POP__() due to stack underflow
- prevent ICE in __FB_UNIQUEID__() due to no stack defined
