### PR TITLE
FB_READ_LARGE / FB_WRITE_LARGE functions.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -63,6 +63,7 @@ Version 1.08.0
 - sf.net #908: visibility / access rights of overload For/Next/Step operators not taken into account by for...next statement 
 - sf.net #906: #error on line 2 not reported if immediately following #error on line 1
 - rtlib: ERASE - check for static (fixed length) plain, string, and object arrays passed to ERASE; clear only if array is static, and free memory if dynamic
+- rtlib: allow reading/writing data larger than 2GB with GET # / PUT # [WIP]
 
 
 Version 1.07.0

--- a/src/rtlib/dev_file_read.c
+++ b/src/rtlib/dev_file_read.c
@@ -28,7 +28,7 @@ int fb_DevFileRead( FB_FILE *handle, void *dst, size_t *pLength )
     }
 
     /* do read */
-    rlen = fread( dst, 1, length, fp );
+    rlen = FB_FREAD_LARGE( dst, length, fp );
     /* fill with nulls if at eof */
     if( rlen != length )
         memset( ((char *)dst) + rlen, 0, length - rlen );

--- a/src/rtlib/dev_file_write.c
+++ b/src/rtlib/dev_file_write.c
@@ -16,7 +16,7 @@ int fb_DevFileWrite( FB_FILE *handle, const void* value, size_t valuelen )
 	}
 
 	/* do write */
-	if( fwrite( value, 1, valuelen, fp ) != valuelen ) {
+	if( FB_FWRITE_LARGE( value, valuelen, fp ) != valuelen ) {
 		FB_UNLOCK();
 		return fb_ErrorSetNum( FB_RTERROR_FILEIO );
 	}

--- a/src/rtlib/fb_file.h
+++ b/src/rtlib/fb_file.h
@@ -365,3 +365,68 @@ extern const UTF_8 __fb_utf8_bmarkTb[7];
 
 FBCALL int          fb_FileCopy         ( const char *source, const char *destination );
 FBCALL int          fb_CrtFileCopy      ( const char *source, const char *destination );
+
+
+
+#define FREAD_CHUNK_SIZE 1048576
+#define FWRITE_CHUNK_SIZE 1048576
+
+static __inline__ size_t FB_FREAD_LARGE( void *ptr, size_t nmemb, FILE *stream )
+{
+   size_t total = 0, nread;
+
+   /* if nmemb <1MB, use fread() directly */
+   if (nmemb < FREAD_CHUNK_SIZE) return fread( ptr, 1, nmemb, stream );
+
+   while (nmemb > FREAD_CHUNK_SIZE) {
+      /* read chunk */
+      nread = fread( ptr, 1, FREAD_CHUNK_SIZE, stream );
+      total += nread;
+
+      /* stop early if too few items read */
+      if (nread < FREAD_CHUNK_SIZE) {
+         return total;
+      }
+
+      ptr += FREAD_CHUNK_SIZE;
+      nmemb -= FREAD_CHUNK_SIZE;
+   }
+
+   if (nmemb > 0) {
+      /* read last chunk */
+      nread = fread( ptr, 1, nmemb, stream );
+      total += nread;
+   }
+
+   return total;
+}
+
+static __inline__ size_t FB_FWRITE_LARGE( const void *ptr, size_t nmemb, FILE *stream )
+{
+   size_t total = 0, nwritten;
+
+   /* if nmemb <1MB, use fwrite() directly */
+   if (nmemb < FWRITE_CHUNK_SIZE) return fwrite( ptr, 1, nmemb, stream );
+
+   while (nmemb > FWRITE_CHUNK_SIZE) {
+      /* write chunk */
+      nwritten = fwrite( ptr, 1, FWRITE_CHUNK_SIZE, stream );
+      total += nwritten;
+
+      /* stop early if too few items written */
+      if (nwritten < FWRITE_CHUNK_SIZE) {
+         return total;
+      }
+
+      ptr += FWRITE_CHUNK_SIZE;
+      nmemb -= FWRITE_CHUNK_SIZE;
+   }
+
+   if (nmemb > 0) {
+      /* write last chunk */
+      nwritten = fwrite( ptr, 1, nmemb, stream );
+      total += nwritten;
+   }
+
+   return total;
+}

--- a/src/rtlib/fb_file.h
+++ b/src/rtlib/fb_file.h
@@ -375,9 +375,6 @@ static __inline__ size_t FB_FREAD_LARGE( void *ptr, size_t nbytes, FILE *stream 
 {
    size_t total = 0, nread;
 
-   /* if nbytes <1MB, use fread() directly */
-   if (nbytes < FREAD_CHUNK_SIZE) return fread( ptr, 1, nbytes, stream );
-
    while (nbytes > FREAD_CHUNK_SIZE) {
       /* read chunk */
       nread = fread( ptr, 1, FREAD_CHUNK_SIZE, stream );
@@ -404,9 +401,6 @@ static __inline__ size_t FB_FREAD_LARGE( void *ptr, size_t nbytes, FILE *stream 
 static __inline__ size_t FB_FWRITE_LARGE( const void *ptr, size_t nbytes, FILE *stream )
 {
    size_t total = 0, nwritten;
-
-   /* if nbytes <1MB, use fwrite() directly */
-   if (nbytes < FWRITE_CHUNK_SIZE) return fwrite( ptr, 1, nbytes, stream );
 
    while (nbytes > FWRITE_CHUNK_SIZE) {
       /* write chunk */

--- a/src/rtlib/fb_file.h
+++ b/src/rtlib/fb_file.h
@@ -371,14 +371,14 @@ FBCALL int          fb_CrtFileCopy      ( const char *source, const char *destin
 #define FREAD_CHUNK_SIZE 1048576
 #define FWRITE_CHUNK_SIZE 1048576
 
-static __inline__ size_t FB_FREAD_LARGE( void *ptr, size_t nmemb, FILE *stream )
+static __inline__ size_t FB_FREAD_LARGE( void *ptr, size_t nbytes, FILE *stream )
 {
    size_t total = 0, nread;
 
-   /* if nmemb <1MB, use fread() directly */
-   if (nmemb < FREAD_CHUNK_SIZE) return fread( ptr, 1, nmemb, stream );
+   /* if nbytes <1MB, use fread() directly */
+   if (nbytes < FREAD_CHUNK_SIZE) return fread( ptr, 1, nbytes, stream );
 
-   while (nmemb > FREAD_CHUNK_SIZE) {
+   while (nbytes > FREAD_CHUNK_SIZE) {
       /* read chunk */
       nread = fread( ptr, 1, FREAD_CHUNK_SIZE, stream );
       total += nread;
@@ -389,26 +389,26 @@ static __inline__ size_t FB_FREAD_LARGE( void *ptr, size_t nmemb, FILE *stream )
       }
 
       ptr += FREAD_CHUNK_SIZE;
-      nmemb -= FREAD_CHUNK_SIZE;
+      nbytes -= FREAD_CHUNK_SIZE;
    }
 
-   if (nmemb > 0) {
+   if (nbytes > 0) {
       /* read last chunk */
-      nread = fread( ptr, 1, nmemb, stream );
+      nread = fread( ptr, 1, nbytes, stream );
       total += nread;
    }
 
    return total;
 }
 
-static __inline__ size_t FB_FWRITE_LARGE( const void *ptr, size_t nmemb, FILE *stream )
+static __inline__ size_t FB_FWRITE_LARGE( const void *ptr, size_t nbytes, FILE *stream )
 {
    size_t total = 0, nwritten;
 
-   /* if nmemb <1MB, use fwrite() directly */
-   if (nmemb < FWRITE_CHUNK_SIZE) return fwrite( ptr, 1, nmemb, stream );
+   /* if nbytes <1MB, use fwrite() directly */
+   if (nbytes < FWRITE_CHUNK_SIZE) return fwrite( ptr, 1, nbytes, stream );
 
-   while (nmemb > FWRITE_CHUNK_SIZE) {
+   while (nbytes > FWRITE_CHUNK_SIZE) {
       /* write chunk */
       nwritten = fwrite( ptr, 1, FWRITE_CHUNK_SIZE, stream );
       total += nwritten;
@@ -419,12 +419,12 @@ static __inline__ size_t FB_FWRITE_LARGE( const void *ptr, size_t nmemb, FILE *s
       }
 
       ptr += FWRITE_CHUNK_SIZE;
-      nmemb -= FWRITE_CHUNK_SIZE;
+      nbytes -= FWRITE_CHUNK_SIZE;
    }
 
-   if (nmemb > 0) {
+   if (nbytes > 0) {
       /* write last chunk */
-      nwritten = fwrite( ptr, 1, nmemb, stream );
+      nwritten = fwrite( ptr, 1, nbytes, stream );
       total += nwritten;
    }
 


### PR DESCRIPTION
They differ from fread/fwrite in two main ways:
1. They take only a single parameter for the size, in bytes
2. They read/write in chunks of 1MB, to bypass any multi-gigabyte limits.
1MB chunks should be large enough to avoid significant overhead per chunk,
yet well short of any 32-bit length limits.

Use them in place of fread/fwrite in fbDevFileRead/Write, called eventually
by file GETs/PUTs.

Notes:
I'm not necessarily happy with the location of the functions, they may be better in separate modules, or at least somewhere that changes don't trigger a full rebuild.  I think the main thing at this point is just to submit something that works and let it be refined, otherwise the code is likely to rot on my hard disk.

It may also technically be worth using them inside Bload/Bsave functions, although 2GB images would be pretty rare.  There shouldn't be much overhead on small reads/writes though.