### PR TITLE
Add __FB_EVAL__ built in macro

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,7 +40,7 @@ Version 1.08.0
 - '-w suffix' or '-w pedantic' command line option enabled 'Suffix ignored' warning for built-in in string functions
 - __FB_UNIQUEID_PUSH__(), __FB_UNIQUEID__(), __FB_UNIQUEID_POP__(), __FB_ARG_LEFTOF__(), __FB_ARG_RIGHTOF__(), __FB_JOIN__() builtin macros
 - __FB_ARG_COUNT__() builtin macro
-- __FB_QUOTE__(), __FB_UNQUOTE__() builtin macros
+- __FB_QUOTE__(), __FB_UNQUOTE__(), __FB_EVAL__() builtin macros
 - rtlib: REDIM [PRESERVE] will generate run time error if attempting to resize static (fixed length) arrays.
 
 [fixed]

--- a/inc/fbc-int/array.bi
+++ b/inc/fbc-int/array.bi
@@ -1,9 +1,11 @@
 #ifndef __FBC_INT_ARRAY_BI__ 
 #define __FBC_INT_ARRAY_BI__
 
-# if __FB_LANG__ = "fb"
-namespace FBC
+# if __FB_LANG__ = "qb"
+#     error "include not supported in qb dialect"
 # endif
+
+namespace FBC
 
 '' declarations must follow ./src/rtlib/fb_array.h
 
@@ -44,8 +46,6 @@ extern "rtlib"
 		( array() as const any ) as const FBC.FBARRAY ptr
 end extern
 
-# if __FB_LANG__ = "fb"
 end namespace
-# endif
 
 #endif

--- a/inc/fbc-int/fbcall.bi
+++ b/inc/fbc-int/fbcall.bi
@@ -3,14 +3,16 @@
 
 '' definition for FBCALL
 ''
-'' FBCALL is not a built-in word in fbc as calling convention is only implied as "fbcall"
-'' in the absence of other calling convention specifiers stdcall / cdecl / pascal
-'' or other structures the imply some other default calling convention e.g. EXTERN "C"
+'' FBCALL is not a built-in word.  In fbc, calling convention is only implied as "fbcall"
+'' in the absence of any other calling convention specifiers e.g. stdcall / cdecl / pascal
+'' or some other structure that imply another default calling convention e.g. EXTERN "C"
 '' 
 
-# if __FB_LANG__ = "fb"
-namespace FBC
+# if __FB_LANG__ = "qb"
+#     error "include not supported in qb dialect"
 # endif
+
+namespace FBC
 
 '' declarations must follow:
 ''  ./src/rtlib/fb_config.h
@@ -30,8 +32,6 @@ namespace FBC
 	#define FBCALL cdecl
 #endif
 
-# if __FB_LANG__ = "fb"
 end namespace
-# endif
 
 #endif

--- a/inc/fbc-int/memory.bi
+++ b/inc/fbc-int/memory.bi
@@ -2,7 +2,7 @@
 #define __FBC_INT_MEMORY_BI__
 
 # if __FB_LANG__ = "qb"
-# error not supported in -lang qb dialect
+# error not supported in qb dialect
 # endif
 
 '' WARNING!!! EXPERIMENTAL
@@ -29,18 +29,14 @@
 #undef fb_MemMove
 #undef fb_MemCopyClear
 
-# if __FB_LANG__ = "fb"
 '' must have declaration of "..allocate()" and "..deallocate()"
 '' new, new[], delete, delete[] can't work without these exact names
 extern "C"
 	declare function allocate cdecl alias "malloc" ( byval size as const uinteger ) as any ptr
 	declare sub deallocate cdecl alias "free" ( byval p as const any ptr )
 end extern
-# endif
 
-# if __FB_LANG__ = "fb"
 namespace FBC
-# endif
 
 extern "rtlib"
 	declare function allocate cdecl alias "malloc" ( byval size as const uinteger ) as any ptr
@@ -67,8 +63,6 @@ extern "rtlib"
 
 end extern
 
-# if __FB_LANG__ = "fb"
 end namespace
-# endif
 
 #endif

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -422,7 +422,7 @@ sub fbInit( byval ismain as integer, byval restarts as integer )
 	hashInit( @env.inconcehash, FB_INITINCFILES, FALSE )
 
 	stackNew( @parser.stmt.stk, FB_INITSTMTSTACKNODES, len( FB_CMPSTMTSTK ), FALSE )
-	lexInit( FALSE )
+	lexInit( FALSE, FALSE )
 	parserInit( )
 	rtlInit( )
 
@@ -1452,7 +1452,7 @@ sub fbIncludeFile(byval filename as zstring ptr, byval isonce as integer)
 	'' parse
 	lexPushCtx( )
 
-	lexInit( TRUE )
+	lexInit( TRUE, FALSE )
 
 	cProgram()
 

--- a/src/compiler/lex.bi
+++ b/src/compiler/lex.bi
@@ -155,7 +155,8 @@ end type
 
 declare sub lexInit _
 	( _
-		byval isinclude as integer _
+		byval isinclude as integer, _
+		byval is_fb_eval as integer _
 	)
 
 declare sub lexEnd _

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -583,129 +583,6 @@ private function hDefUnquoteW_cb( byval argtb as LEXPP_ARGTB ptr, byval errnum a
 
 end function
 
-private function ppEval( ) as string
-
-	dim expr as ASTNODE ptr = cExpression( )
-
-	if( expr <> NULL ) then
-		expr = astOptimizeTree( expr )
-
-		if( astIsCONST( expr ) ) then
-			function = astConstFlushToStr( expr )
-		elseif( astIsConstant( expr ) ) then
-			dim res as string
-			res = """" + hReplace( expr->sym->var_.littext, QUOTE, QUOTE + QUOTE ) + """"
-			function = res
-		else
-			astDelTree( expr )
-			errReport( FB_ERRMSG_EXPECTEDCONST )
-			'' error recovery: skip until next line
-			hSkipUntil( FB_TK_EOL, TRUE )
-			function = str(0)
-		end if
-	else
-		errReport( FB_ERRMSG_SYNTAXERROR )
-		'' error recovery: skip until next line
-		hSkipUntil( FB_TK_EOL, TRUE )
-		function = ""
-	end if
-
-end function
-
-private sub lexPushDefCtx()
-
-	'' create a lightweight context push for the lexer
-	'' like an include file, but no include file
-	'' text to expand is to be loaded in LEX.CTX->DEFTEXT[W]
-	'' use the parser to build an AST for the literal result
-
-
-	'' from lexPushCtx()
-
-	lex.ctx += 1
-
-	'' TODO: meld code with lexPushCtx()
-
-	dim as integer i
-	dim as FBTOKEN ptr n
-
-	'' create a circular list
-	lex.ctx->k = 0
-
-	lex.ctx->head = @lex.ctx->tokenTB(0)
-	lex.ctx->tail = lex.ctx->head
-
-	n = lex.ctx->head
-	for i = 0 to FB_LEX_MAXK-1
-		n->next = @lex.ctx->tokenTB(i+1)
-		n = n->next
-	next
-	n->next = lex.ctx->head
-
-	''
-	for i = 0 to FB_LEX_MAXK
-		lex.ctx->tokenTB(i).id = INVALID
-	next
-
-	lex.ctx->currchar = cuint( INVALID )
-	lex.ctx->lahdchar = cuint( INVALID )
-
-
-	'' copy linenumber from parent context for error message reporting
-
-	lex.ctx->linenum = (lex.ctx-1)->linenum
-	lex.ctx->lasttk_id = cuint( INVALID )
-
-	lex.ctx->reclevel = (lex.ctx-1)->reclevel
-	lex.ctx->currmacro = (lex.ctx-1)->currmacro
-
-	''
-	lex.ctx->bufflen = 0
-	lex.ctx->deflen	= 0
-
-	if( env.inf.format = FBFILE_FORMAT_ASCII ) then
-		lex.ctx->buffptr = NULL
-		lex.ctx->defptr = NULL
-		DZstrAllocate( lex.ctx->deftext, 0 )
-	else
-		lex.ctx->buffptrw = NULL
-		lex.ctx->defptrw = NULL
-		DWstrAllocate( lex.ctx->deftextw, 0 )
-	end if
-
-	''
-	lex.ctx->filepos = (lex.ctx-1)->filepos
-	lex.ctx->lastfilepos = (lex.ctx-1)->lastfilepos
-
-
-	'' just empty the current line, deftext[w] will expand on to currline
-
-	DZstrAllocate( lex.ctx->currline, 0 )
-	DZstrConcatAssign( lex.ctx->currline, "" )
-
-	'' lex.insidemacro = FALSE
-
-	lex.ctx->after_space = FALSE
-
-end sub
-
-private sub lexPopDefCtx()
-
-	'' from lexPopCtx()
-
-	DZstrAllocate( lex.ctx->currline, 0 )
-
-	'' free dynamic strings used in macro expansions
-	if( env.inf.format = FBFILE_FORMAT_ASCII ) then
-		DZstrAllocate( lex.ctx->deftext, 0 )
-	else
-		DWstrAllocate( lex.ctx->deftextw, 0 )
-	end if
-
-	lex.ctx -= 1
-
-end sub
-
 private function hDefEval_cb( byval argtb as LEXPP_ARGTB ptr, byval errnum as integer ptr) as string
 
 	'' __FB_EVAL__( arg )
@@ -718,17 +595,41 @@ private function hDefEval_cb( byval argtb as LEXPP_ARGTB ptr, byval errnum as in
 
 	if( arg ) then
 
-		lexPushDefCtx()
+		'' create a lightweight context push for the lexer
+		'' like an include file, but no include file
+		'' text to expand is to be loaded in LEX.CTX->DEFTEXT[W]
+		'' use the parser to build an AST for the literal result
 
-		if( arg ) then
-			DZstrAssign( lex.ctx->deftext, *arg )
-			lex.ctx->defptr = lex.ctx->deftext.data
-			lex.ctx->deflen += len( *arg )
+		lexPushCtx()
+		lexInit( FALSE, TRUE )
+
+		DZstrAssign( lex.ctx->deftext, *arg )
+		lex.ctx->defptr = lex.ctx->deftext.data
+		lex.ctx->deflen += len( *arg )
+
+		dim expr as ASTNODE ptr = cExpression( )
+
+		if( expr <> NULL ) then
+			expr = astOptimizeTree( expr )
+
+			if( astIsCONST( expr ) ) then
+				res = astConstFlushToStr( expr )
+			elseif( astIsConstant( expr ) ) then
+				res = """" + hReplace( expr->sym->var_.littext, QUOTE, QUOTE + QUOTE ) + """"
+			else
+				astDelTree( expr )
+				errReport( FB_ERRMSG_EXPECTEDCONST )
+				'' error recovery: skip until next line
+				hSkipUntil( FB_TK_EOL, TRUE )
+				res = str(0)
+			end if
+		else
+			errReport( FB_ERRMSG_SYNTAXERROR )
+			'' error recovery: skip until next line
+			hSkipUntil( FB_TK_EOL, TRUE )
 		end if
 
-		res = ppEval()
-
-		lexPopDefCtx()
+		lexPopCtx()
 
 	end if
 

--- a/tests/pp/macro-eval.bas
+++ b/tests/pp/macro-eval.bas
@@ -1,0 +1,35 @@
+#include "fbcunit.bi"
+
+SUITE( fbc_tests.pp.macro_eval )
+
+	TEST( direct )
+		CU_ASSERT_EQUAL( 0, __FB_EVAL__( 0 ) )
+		CU_ASSERT_EQUAL( 8, __FB_EVAL__( 3 + 5 ) )
+		CU_ASSERT_EQUAL( "hithere", __FB_EVAL__( "hi" + "there" ) )
+	END_TEST
+
+	TEST( pp_ )
+	    #macro assign( sym, expr )
+		#define tmp __FB_EVAL__( expr )
+		__FB_UNQUOTE__( __FB_EVAL__( "#undef " + sym ) )
+		__FB_UNQUOTE__( __FB_EVAL__( "#define " + sym + " " + __FB_QUOTE__( tmp ) ) )
+		#undef tmp
+		#endmacro
+
+		assign( "x", 1 )
+		CU_ASSERT_EQUAL( x, 1 )
+		
+		assign( "x", x+1 )
+		CU_ASSERT_EQUAL( x, 2 )
+		
+		assign( "x", x*x )  
+		CU_ASSERT_EQUAL( x, 4 ) 
+		
+		assign( "x", "hello" )  
+		CU_ASSERT_EQUAL( x, "hello" )
+		
+		assign( "x", x+x )  
+		CU_ASSERT_EQUAL( x, "hellohello" )
+	END_TEST
+
+END_SUITE


### PR DESCRIPTION
`__FB_EVAL__( arg )` macro evaluates `arg` at compile time.

- `fbc` creates a new lexer context and parses `arg` as an expression.
- `arg` must evaluate to a constant.
- if the expression is invalid, a compile time error is generated
- internally, `__FB_EVAL__` re-uses `lexPushCtx`, `cExpression`, and `lexPopCtx` to obtain the constant folded expression