### PR TITLE
fbc: sf.net # 882: error on REDIM udt.field(expr) access

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -64,6 +64,7 @@ Version 1.08.0
 - sf.net #906: #error on line 2 not reported if immediately following #error on line 1
 - rtlib: ERASE - check for static (fixed length) plain, string, and object arrays passed to ERASE; clear only if array is static, and free memory if dynamic
 - rtlib: allow reading/writing data larger than 2GB with GET # / PUT # [WIP]
+- sf.net #882: error on REDIM udt.field(expr) if default constructor has no access
 
 
 Version 1.07.0

--- a/src/compiler/rtl-array.bas
+++ b/src/compiler/rtl-array.bas
@@ -607,8 +607,8 @@ function rtlArrayRedim _
 			exit function
 		end if
 	else
-		hCheckDefCtor( ctor, FALSE, FALSE )
-		hCheckDtor( dtor, FALSE, FALSE )
+		hCheckDefCtor( ctor, TRUE, FALSE )
+		hCheckDtor( dtor, TRUE, FALSE )
 
 		'' byval ctor as sub cdecl( )
 		if( astNewARG( proc, hBuildProcPtr( ctor ) ) = NULL ) then

--- a/tests/structs/obj-array-private-defctor-1.bas
+++ b/tests/structs/obj-array-private-defctor-1.bas
@@ -1,0 +1,14 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+type T
+	as integer i
+	private:
+		declare constructor()
+end type
+
+constructor T()
+end constructor
+
+redim as T x(0 to 0)
+
+ 

--- a/tests/structs/obj-array-private-defctor-2.bas
+++ b/tests/structs/obj-array-private-defctor-2.bas
@@ -1,0 +1,17 @@
+' TEST_MODE : COMPILE_ONLY_OK
+
+type T
+	as integer i
+	private:
+		declare constructor()
+		declare sub proc()
+end type
+
+constructor T()
+end constructor
+
+sub T.proc()
+	redim as T x(0 to 0)
+end sub
+
+ 


### PR DESCRIPTION
Add compile time error on access rights when using `REDIM ust.field(expr)`

```
type T
	as integer i
	private:
		declare constructor()
		declare sub proc()
end type

constructor T()
end constructor

sub T.proc()
	redim as T x(0 to 0)  '' OK - have private access to default ctor
end sub

redim as T x(0 to 0)      '' ERROR - no public access to default ctor
```

See https://sourceforge.net/p/fbc/bugs/882/
