### PR TITLE
Fixes sourceforge bug #918

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -66,6 +66,7 @@ Version 1.08.0
 - rtlib: allow reading/writing data larger than 2GB with GET # / PUT # [WIP]
 - sf.net #882: error on REDIM udt.field(expr) if default constructor has no access
 - github #246: rtlib leaks thread local data, fixed by adding TLS destructors (adeyblue)
+- sf.net #914: pcopy (console) bug when copying large console buffers, windows only (adeyblue)
 
 
 Version 1.07.0

--- a/src/rtlib/win32/io_pcopy.c
+++ b/src/rtlib/win32/io_pcopy.c
@@ -39,16 +39,18 @@ int fb_ConsolePageCopy( int src, int dst )
 	}
 
 	/* do the copy */
-	static COORD pos = { 0, 0 };
 
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
 	GetConsoleScreenBufferInfo( __fb_con.pgHandleTb[src], &csbi );
-	PCHAR_INFO buff = alloca( csbi.dwSize.X * csbi.dwSize.Y * sizeof( CHAR_INFO ) );
+	PCHAR_INFO buff = malloc( csbi.dwSize.X * csbi.dwSize.Y * sizeof( CHAR_INFO ) );
+	if(buff)
+	{
+		COORD pos = { 0, 0 };
+		ReadConsoleOutput( __fb_con.pgHandleTb[src], buff, csbi.dwSize, pos, &csbi.srWindow );
 
-	ReadConsoleOutput( __fb_con.pgHandleTb[src], buff, csbi.dwSize, pos, &csbi.srWindow );
-
-	GetConsoleScreenBufferInfo( __fb_con.pgHandleTb[dst], &csbi );
-	WriteConsoleOutput( __fb_con.pgHandleTb[dst], buff, csbi.dwSize, pos, &csbi.srWindow );
-
-	return fb_ErrorSetNum( FB_RTERROR_OK );
+		GetConsoleScreenBufferInfo( __fb_con.pgHandleTb[dst], &csbi );
+		WriteConsoleOutput( __fb_con.pgHandleTb[dst], buff, csbi.dwSize, pos, &csbi.srWindow );
+		free( buff );
+	}
+	return fb_ErrorSetNum( buff ? FB_RTERROR_OK : FB_RTERROR_OUTOFMEM );
 }


### PR DESCRIPTION
Since GCC doesn't support SEH to catch failing allocas and with malloca being relatively new invention, this seems the path of least resistance.