### PR TITLE
TLS Data Destructors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -65,6 +65,7 @@ Version 1.08.0
 - rtlib: ERASE - check for static (fixed length) plain, string, and object arrays passed to ERASE; clear only if array is static, and free memory if dynamic
 - rtlib: allow reading/writing data larger than 2GB with GET # / PUT # [WIP]
 - sf.net #882: error on REDIM udt.field(expr) if default constructor has no access
+- github #246: rtlib leaks thread local data, fixed by adding TLS destructors (adeyblue)
 
 
 Version 1.07.0

--- a/src/gfxlib2/gfx_core.c
+++ b/src/gfxlib2/gfx_core.c
@@ -32,6 +32,12 @@ void fb_hPostEvent(EVENT *e)
 
 void fb_hPostEvent_code_end(void) { }
 
+void fb_GFXCTX_Destructor(void* data)
+{
+	FB_GFXCTX *context = (FB_GFXCTX *)data;
+	free( context->line );
+}
+
 /* Caller is expected to hold FB_GRAPHICSLOCK() */
 FB_GFXCTX *fb_hGetContext(void)
 {

--- a/src/rtlib/dos/file_dir.c
+++ b/src/rtlib/dos/file_dir.c
@@ -11,6 +11,8 @@ typedef struct {
 	struct ffblk f;
 } FB_DIRCTX;
 
+#define fb_DIRCTX_Destructor NULL
+
 static char *find_next ( int *out_attrib )
 {
 	FB_DIRCTX *ctx = FB_TLSGETCTX( DIR );

--- a/src/rtlib/fb_error.h
+++ b/src/rtlib/fb_error.h
@@ -32,6 +32,8 @@ typedef struct _FB_ERRORCTX {
 	void         *resnxt_lbl;
 } FB_ERRORCTX;
 
+#define fb_ERRORCTX_Destructor NULL
+
 #define FB_ERRMSG_SIZE 1024
 extern char __fb_errmsg[FB_ERRMSG_SIZE];
 

--- a/src/rtlib/fb_file.h
+++ b/src/rtlib/fb_file.h
@@ -123,6 +123,8 @@ typedef struct {
     int     		index;
 } FB_INPUTCTX;
 
+void	fb_INPUTCTX_Destructor( void* );
+
 
 #define FB_FILE_TO_HANDLE_VALID( index ) \
 	((FB_FILE *)(__fb_ctx.fileTB + (index) - 1 + FB_RESERVED_FILES))

--- a/src/rtlib/fb_thread.h
+++ b/src/rtlib/fb_thread.h
@@ -39,7 +39,15 @@ enum {
 	FB_TLSKEYS
 };
 
-FBCALL void             *fb_TlsGetCtx   ( int index, size_t len );
+typedef void ( *FB_TLS_DESTRUCTOR )( void* tlsData );
+
+typedef struct _FB_TLS_CTX_HEADER {
+
+    FB_TLS_DESTRUCTOR destructor;
+
+} FB_TLS_CTX_HEADER;
+
+FBCALL void             *fb_TlsGetCtx   ( int index, size_t len, FB_TLS_DESTRUCTOR destructor );
 FBCALL void              fb_TlsDelCtx   ( int index );
 FBCALL void              fb_TlsFreeCtxTb( void );
 #ifdef ENABLE_MT
@@ -47,4 +55,4 @@ FBCALL void              fb_TlsFreeCtxTb( void );
        void              fb_TlsExit     ( void );
 #endif
 
-#define FB_TLSGETCTX(id) ((FB_##id##CTX *)fb_TlsGetCtx( FB_TLSKEY_##id, sizeof( FB_##id##CTX ) ))
+#define FB_TLSGETCTX(id) ((FB_##id##CTX *)fb_TlsGetCtx( FB_TLSKEY_##id, sizeof( FB_##id##CTX ), fb_##id##CTX_Destructor ))

--- a/src/rtlib/file_input_file.c
+++ b/src/rtlib/file_input_file.c
@@ -7,7 +7,7 @@ FBCALL int fb_FileInput( int fnum )
     FB_INPUTCTX *ctx;
     FB_FILE *handle = NULL;
 
-	FB_LOCK();
+    FB_LOCK();
 
     handle = FB_FILE_TO_HANDLE(fnum);
     if( !FB_HANDLE_USED(handle) )
@@ -23,7 +23,14 @@ FBCALL int fb_FileInput( int fnum )
     fb_StrDelete( &ctx->str );
     ctx->index	= 0;
 
-	FB_UNLOCK();
+    FB_UNLOCK();
 
-	return fb_ErrorSetNum( FB_RTERROR_OK );
+    return fb_ErrorSetNum( FB_RTERROR_OK );
+}
+
+void fb_INPUTCTX_Destructor( void* data )
+{
+    FB_INPUTCTX *ctx = (FB_INPUTCTX *)data;
+    fb_StrDelete( &ctx->str );
+    /* The file handle is closed by the program, it's not ours to clean up */
 }

--- a/src/rtlib/io_printusg.c
+++ b/src/rtlib/io_printusg.c
@@ -9,6 +9,8 @@ typedef struct {
 	FBSTRING  fmtstr;
 } FB_PRINTUSGCTX;
 
+#define fb_PRINTUSGCTX_Destructor NULL
+
 #define BUFFERLEN 2048
 #define MIN_EXPDIGS 3
 #define MAX_EXPDIGS 5

--- a/src/rtlib/unix/file_dir.c
+++ b/src/rtlib/unix/file_dir.c
@@ -22,7 +22,7 @@ void fb_DIRCTX_Destructor ( void* data )
 {
 	FB_DIRCTX *ctx = (FB_DIRCTX *)data;
 	if( ctx->in_use )
-		close_dir_internal( ctx->dir );
+		close_dir_internal( ctx );
 }
 
 static void close_dir ( void )

--- a/src/rtlib/unix/file_dir.c
+++ b/src/rtlib/unix/file_dir.c
@@ -12,12 +12,23 @@ typedef struct _FB_DIRCTX {
 	char dirname[MAX_PATH];
 } FB_DIRCTX;
 
+static void close_dir_internal ( FB_DIRCTX *ctx )
+{
+	closedir( ctx->dir );
+	ctx->in_use = FALSE;
+}
+
+void fb_DIRCTX_Destructor ( void* data )
+{
+	FB_DIRCTX *ctx = (FB_DIRCTX *)data;
+	if( ctx->in_use )
+		close_dir_internal( ctx->dir );
+}
+
 static void close_dir ( void )
 {
 	FB_DIRCTX *ctx = FB_TLSGETCTX( DIR );
-
-	closedir( ctx->dir );
-	ctx->in_use = FALSE;
+	close_dir_internal( ctx );
 }
 
 static int get_attrib ( char *name, struct stat *info )

--- a/src/rtlib/win32/file_dir.c
+++ b/src/rtlib/win32/file_dir.c
@@ -18,15 +18,27 @@ typedef struct {
 #endif
 } FB_DIRCTX;
 
+static void close_dir_internal ( FB_DIRCTX *ctx )
+{
+#ifdef HOST_MINGW
+	_findclose( ctx->handle );
+#else
+	FindClose( ctx->handle );
+#endif
+	ctx->in_use = FALSE;
+}
+
+void fb_DIRCTX_Destructor ( void* data )
+{
+	FB_DIRCTX *ctx = ( FB_DIRCTX *)data;
+	if( ctx->in_use )
+		close_dir_internal( ctx );
+}
+
 static void close_dir ( void )
 {
 	FB_DIRCTX *ctx = FB_TLSGETCTX( DIR );
-#ifdef HOST_MINGW
-    _findclose( ctx->handle );
-#else
-    FindClose( ctx->handle );
-#endif
-	ctx->in_use = FALSE;
+	close_dir_internal( ctx );
 }
 
 static char *find_next ( int *attrib )

--- a/src/rtlib/xbox/file_dir.c
+++ b/src/rtlib/xbox/file_dir.c
@@ -22,7 +22,7 @@ void fb_DIRCTX_Destructor ( void* data )
 {
 	FB_DIRCTX *ctx = (FB_DIRCTX *)data;
 	if( ctx->in_use )
-		close_dir_internal( ctx->dir );
+		close_dir_internal( ctx );
 }
 
 static void close_dir ( void )

--- a/src/rtlib/xbox/file_dir.c
+++ b/src/rtlib/xbox/file_dir.c
@@ -12,12 +12,23 @@ typedef struct _FB_DIRCTX {
 	char dirname[MAX_PATH];
 } FB_DIRCTX;
 
+static void close_dir_internal ( FB_DIRCTX *ctx )
+{
+	closedir( ctx->dir );
+	ctx->in_use = FALSE;
+}
+
+void fb_DIRCTX_Destructor ( void* data )
+{
+	FB_DIRCTX *ctx = (FB_DIRCTX *)data;
+	if( ctx->in_use )
+		close_dir_internal( ctx->dir );
+}
+
 static void close_dir ( void )
 {
 	FB_DIRCTX *ctx = FB_TLSGETCTX( DIR );
-
-	closedir( ctx->dir );
-	ctx->in_use = FALSE;
+	close_dir_internal( ctx );
 }
 
 static int get_attrib ( char *name, struct stat *info )


### PR DESCRIPTION
This is a fix for #246. Somebody already noticed thread local data leaking was a problem with the special case freeing of the GFX thread data in src/rtlib/thread_core.c, but the problem extends to Dir and Input which may also have things to cleanup.

This PR generalises the special case so that a destructor function is passed when the thread local data is requested/allocated. Now when the thread stops, any destructors present are called to release the outstanding resources.

It's not tested in *nix or Dos