### PR TITLE
Build 1.08 updates

### DIFF
--- a/makefile
+++ b/makefile
@@ -240,7 +240,16 @@ else
     # msys64  mingw32  MINGW32_NT-6.1 x86_64    i686-w64-mingw32
     # msys64  mingw64  MINGW64_NT-6.1 x86_64    x86_64-w64-mingw32
     #
+    # on WinXP...
+    # host    shell    uname -s -m              default gcc target
+    # ------  -------  --------------------     ------------------
+    # mingw   cmd.exe  MINGW32_NT-5.1 i686      mingw32
+    #
     else ifneq ($(findstring MINGW32,$(uname)),)
+      # host is WinXP, then don't include DirectX 10 driver
+      ifneq ($(findstring NT-5,$(uname)),)
+        DISABLE_D3D10 := 1
+      endif
       TARGET_ARCH := x86
     else ifneq ($(findstring MINGW64,$(uname)),)
       TARGET_ARCH := x86_64

--- a/makefile
+++ b/makefile
@@ -105,6 +105,7 @@
 #   -DDISABLE_FFI    build without ffi.h (disables ThreadCall)
 #   -DDISABLE_OPENGL build without OpenGL headers (disables OpenGL gfx drivers)
 #   -DDISABLE_FBDEV  build without Linux framebuffer device headers (disables Linux fbdev gfx driver)
+#   -DDISABLE_D3D10  build without DirectX 10 driver(disable D2D driver in windows)
 #
 # makefile variables may either be set on the make command line,
 # or (in a more permanent way) inside a 'config.mk' file.

--- a/src/gfxlib2/win32/gfx_driver_d2d.c
+++ b/src/gfxlib2/win32/gfx_driver_d2d.c
@@ -4,6 +4,7 @@
 /* This file requires a Windows SDK capable of targeting Windows 7 */
 #define _WIN32_WINNT 0x0601
 
+#ifndef DISABLE_D3D10
 #ifndef HOST_CYGWIN
 
 #include "../fb_gfx.h"
@@ -889,3 +890,4 @@ static int* D2DFetchModes(int depth, int *size)
 }
 
 #endif /* HOST_CYGWIN */
+#endif /* DISABLE_D3D10 */

--- a/src/gfxlib2/win32/gfx_driver_ddraw.c
+++ b/src/gfxlib2/win32/gfx_driver_ddraw.c
@@ -67,7 +67,13 @@ typedef HRESULT (WINAPI *DIRECTDRAWENUMERATEEX)(LPDDENUMCALLBACKEX lpCallback,LP
 /* Unfortunately c_dfDIKeyboard is a required global variable
  * defined in import library LIBDINPUT.A, and as we're not
  * linking with it, we need to define it here...
+ * 
+ * ARRAYSIZE won't be defined for really old gcc  
  */
+#ifndef ARRAYSIZE
+#define ARRAYSIZE(__a) (sizeof(__a)/sizeof(__a[0]))
+#endif
+ 
 static DIOBJECTDATAFORMAT __c_rgodfDIKeyboard[256];
 static const DIDATAFORMAT __c_dfDIKeyboard = { sizeof(__c_dfDIKeyboard), sizeof(*__c_rgodfDIKeyboard),
                                                DIDF_RELAXIS, 256,

--- a/src/gfxlib2/win32/gfx_driver_ddraw.c
+++ b/src/gfxlib2/win32/gfx_driver_ddraw.c
@@ -556,4 +556,4 @@ static int *driver_fetch_modes(int depth, int *size)
 	return modes.data;
 }
 
-#endif
+#endif /* HOST_CYGWIN */

--- a/src/gfxlib2/win32/gfx_driver_opengl.c
+++ b/src/gfxlib2/win32/gfx_driver_opengl.c
@@ -548,4 +548,5 @@ static int *driver_fetch_modes(int depth, int *size)
 	return modes;
 }
 
-#endif
+#endif /* DISABLE_OPENGL */
+

--- a/src/gfxlib2/win32/gfx_win32.c
+++ b/src/gfxlib2/win32/gfx_win32.c
@@ -30,12 +30,12 @@ WIN32DRIVER fb_win32;
 
 const GFXDRIVER *__fb_gfx_drivers_list[] = {
 #ifndef HOST_CYGWIN
-	&fb_gfxDriverDirectDraw,
-#endif
-	&fb_gfxDriverGDI,
-#ifndef HOST_CYGWIN
+#ifndef DISABLE_D3D10
 	&fb_gfxDriverD2D,
-#endif
+#endif /* DISABLE_D3D10 */
+	&fb_gfxDriverDirectDraw,
+#endif /* HOST_CYGWIN */
+	&fb_gfxDriverGDI,
 	&fb_gfxDriverOpenGL,
 	NULL
 };

--- a/src/rtlib/dos/symb_reg.txt
+++ b/src/rtlib/dos/symb_reg.txt
@@ -69,8 +69,8 @@ extern_asm(_fb_StrLen);
 extern_asm(_fb_ErrorSetModName);
 extern_asm(_fb_Time);
 extern_asm(_fb_ArrayAllocTempDesc);
-extern_asm(_fb_WstrConcat);
 extern_asm(_fb_BIN_l);
+extern_asm(_fb_WstrConcat);
 extern_asm(_fb_BINEx_b);
 extern_asm(_fb_PrinterClose);
 extern_asm(_fb_Dir64);
@@ -210,8 +210,8 @@ extern_asm(_fb_PrintUsingLongint);
 extern_asm(_fb_dos_lock_code);
 extern_asm(_fb_PrintBool);
 extern_asm(_fb_IsTypeOf);
-extern_asm(_fb_WstrLeft);
 extern_asm(_fb_Year);
+extern_asm(_fb_WstrLeft);
 extern_asm(_fb_PageSet);
 extern_asm(_fb_InputInt);
 extern_asm(_fb_VALINT);
@@ -325,8 +325,8 @@ extern_asm(_fb_ConsoleLocate_BIOS);
 extern_asm(_fb_DateValue);
 extern_asm(_fb_PrintUInt);
 extern_asm(_fb_DataReadBool);
-extern_asm(_fb_WstrLTrimAny);
 extern_asm(_fb_BIN_i);
+extern_asm(_fb_WstrLTrimAny);
 extern_asm(_fb_SleepEx);
 extern_asm(_fb_WstrOctEx_b);
 extern_asm(_fb_ConReadLine);
@@ -343,8 +343,8 @@ extern_asm(_fb_FileOpenLpt);
 extern_asm(_fb_StrAssign);
 extern_asm(_fb_StrRset);
 extern_asm(_fb_WriteInt);
-extern_asm(_fb_WstrAlloc);
 extern_asm(_fb_MKI);
+extern_asm(_fb_WstrAlloc);
 extern_asm(_fb_WstrTrimEx);
 extern_asm(_fb_WstrFill1);
 extern_asm(_fb_RIGHT);
@@ -634,8 +634,8 @@ extern_asm(_fb_DevScrnClose);
 extern_asm(_fb_hBoolToStr);
 extern_asm(_fb_PrintString);
 extern_asm(_fb_ConsoleSetMouse);
-extern_asm(_fb_WstrBin_b);
 extern_asm(_fb_StrConcat);
+extern_asm(_fb_WstrBin_b);
 extern_asm(_fb_hTimeDecodeSerial);
 extern_asm(_fb_SetPos);
 extern_asm(_fb_hGetWeekOfYear);
@@ -907,8 +907,8 @@ DXE_EXPORT_TABLE (libfb_symbol_table)
     DXE_EXPORT_ASM (_fb_ErrorSetModName)
     DXE_EXPORT_ASM (_fb_Time)
     DXE_EXPORT_ASM (_fb_ArrayAllocTempDesc)
-    DXE_EXPORT_ASM (_fb_WstrConcat)
     DXE_EXPORT_ASM (_fb_BIN_l)
+    DXE_EXPORT_ASM (_fb_WstrConcat)
     DXE_EXPORT_ASM (_fb_BINEx_b)
     DXE_EXPORT_ASM (_fb_PrinterClose)
     DXE_EXPORT_ASM (_fb_Dir64)
@@ -1048,8 +1048,8 @@ DXE_EXPORT_TABLE (libfb_symbol_table)
     DXE_EXPORT_ASM (_fb_dos_lock_code)
     DXE_EXPORT_ASM (_fb_PrintBool)
     DXE_EXPORT_ASM (_fb_IsTypeOf)
-    DXE_EXPORT_ASM (_fb_WstrLeft)
     DXE_EXPORT_ASM (_fb_Year)
+    DXE_EXPORT_ASM (_fb_WstrLeft)
     DXE_EXPORT_ASM (_fb_PageSet)
     DXE_EXPORT_ASM (_fb_InputInt)
     DXE_EXPORT_ASM (_fb_VALINT)
@@ -1163,8 +1163,8 @@ DXE_EXPORT_TABLE (libfb_symbol_table)
     DXE_EXPORT_ASM (_fb_DateValue)
     DXE_EXPORT_ASM (_fb_PrintUInt)
     DXE_EXPORT_ASM (_fb_DataReadBool)
-    DXE_EXPORT_ASM (_fb_WstrLTrimAny)
     DXE_EXPORT_ASM (_fb_BIN_i)
+    DXE_EXPORT_ASM (_fb_WstrLTrimAny)
     DXE_EXPORT_ASM (_fb_SleepEx)
     DXE_EXPORT_ASM (_fb_WstrOctEx_b)
     DXE_EXPORT_ASM (_fb_ConReadLine)
@@ -1181,8 +1181,8 @@ DXE_EXPORT_TABLE (libfb_symbol_table)
     DXE_EXPORT_ASM (_fb_StrAssign)
     DXE_EXPORT_ASM (_fb_StrRset)
     DXE_EXPORT_ASM (_fb_WriteInt)
-    DXE_EXPORT_ASM (_fb_WstrAlloc)
     DXE_EXPORT_ASM (_fb_MKI)
+    DXE_EXPORT_ASM (_fb_WstrAlloc)
     DXE_EXPORT_ASM (_fb_WstrTrimEx)
     DXE_EXPORT_ASM (_fb_WstrFill1)
     DXE_EXPORT_ASM (_fb_RIGHT)
@@ -1472,8 +1472,8 @@ DXE_EXPORT_TABLE (libfb_symbol_table)
     DXE_EXPORT_ASM (_fb_hBoolToStr)
     DXE_EXPORT_ASM (_fb_PrintString)
     DXE_EXPORT_ASM (_fb_ConsoleSetMouse)
-    DXE_EXPORT_ASM (_fb_WstrBin_b)
     DXE_EXPORT_ASM (_fb_StrConcat)
+    DXE_EXPORT_ASM (_fb_WstrBin_b)
     DXE_EXPORT_ASM (_fb_hTimeDecodeSerial)
     DXE_EXPORT_ASM (_fb_SetPos)
     DXE_EXPORT_ASM (_fb_hGetWeekOfYear)

--- a/tests/functions/argv.bas
+++ b/tests/functions/argv.bas
@@ -3,7 +3,7 @@
 ' Test arguments to main().
 ' A better test of COMMAND would be to actually call with some arguments...
 
-#if defined(__FB_WIN32__) or defined(__FB_CYGWIN__) or defined(__FB_DOS__)
+#if defined(__FB_WIN32__) or defined(__FB_CYGWIN__)
 	#include "windows.bi"
 #endif
 
@@ -12,7 +12,7 @@ ASSERT( __FB_ARGC__ = 1 )
 '' Test argv[0] against __FILE__
 dim as string expected_exe_1 = __FILE__
 expected_exe_1 = left( expected_exe_1, len( expected_exe_1 ) - 4 )  ' Remove .bas
-#if defined(__FB_WIN32__) or defined(__FB_CYGWIN__) or defined(__FB_DOS__)
+#if defined(__FB_WIN32__) or defined(__FB_CYGWIN__)
 	expected_exe_1 += ".exe"
 
 	'' Also test argv[0] against full exe path + name
@@ -25,6 +25,17 @@ expected_exe_1 = left( expected_exe_1, len( expected_exe_1 ) - 4 )  ' Remove .ba
 
 	ASSERT( (*__FB_ARGV__[0] = expected_exe_1) or (*__FB_ARGV__[0] = expected_exe_2) )
 	ASSERT( (command( 0 )    = expected_exe_1) or (command( 0 )    = expected_exe_2) )
+#elseif defined( __FB_DOS__ )
+#if ENABLE_CHECK_BUGS
+	'' This depends on what kind of DOS is being run, in a bash like shell, etc.
+	'' On DOS and Win98, should work
+	'' On WinXP, there's confusion between short and long filenames.
+	'' Just skip the test on DOS
+	expected_exe_1 += ".exe"
+
+	ASSERT( right( *__FB_ARGV__[0], len(expected_exe_1) ) = expected_exe_1 )
+	ASSERT( right( command( 0 ), len(expected_exe_1) )    = expected_exe_1 )
+#endif
 #else
 	ASSERT( *__FB_ARGV__[0] = expected_exe_1 )
 	ASSERT( command( 0 )    = expected_exe_1 )


### PR DESCRIPTION
Update of some build options for building on WinXP and win32-mingworg and DOS/DJ.

New DX10 driver for gfxlib2 disabled for win32-mingworg builds.  If `DISABLE_D3D10` is defined when compiling gfxlib2, driver is excluded.  When building on WinXP, try to detect winnt 5.1 and automatically define DISABLE_D3D10.

Fix failing `crt/argv.bas` test on DOS.  When building dos version on WinXP w/DJ, short versus long filenames can cause the test to fail.  Test is disabled with an `ENABLE_CHECK_BUGS` conditional in the test file.

In the `contrib/release/build.sh` release script, the FBSHA1 value was getting lost over separate build steps.  Also, fbc's `makefile` tries to use `git` to determine the FBSHA1 value if it is not set.  This can fail during automated rebuilds when the PATH is modified and `git` no longer available.  Instead, FBSHA1 captured during the checkout from repository and saved for later use by the script.

Update for `SYMB_REG.TXT` on DOS for the rtlib exports (used by the DLL code).

Plus over last days, have tested full release generation plus test-suite on:
- Ubuntu 14.04, 16.04, 18.04, x86
- Ubuntu 14.04, 16.04, 18.04, x86_64, gcc & gas64 backends
- WinXP (win32-mingworg & DOS)
- mingw-w64/mingw32 under win7
- mingw-w64/mingw64 under win7, gcc & gas64 backends
- FYI, my build environment is completely broken on Win98SE.  It was painful on the last release, so I have no plans to fix.

Remaining work (for another time ... not now):
- A new LibFFI 3.3 was released since our 1.07.1 release, so LibFFI should get updated (so we are building our own version again if possible).
- `build.sh` for DOS is still set for old versions of gnu tools so the download paths are incorrect.  Tests were made with cached versions of the downloads, and new versions need to be selected and tested.
- `build.sh` still using gcc 5.2.0 still as default for mingw-w64 and needs to be updated to most recent available and tested.

