### PR TITLE
Enable vga16 blitter for linux-arm targets

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,7 +20,7 @@ Version 1.08.0
 - rtlib: internal changes to API: fb_ArrayErase(), fb_ArrayClear(), fb_ArrayClearObj()
 - rtlib: internal removal of unused / legacy functions: fb_ArrayRedim(), fb_ArrayRedimPresv()
 - rtlib: internal removal of unused / legacy functions: fb_ArraySetDesc(), temporay descriptor functions and structs
-- gfxlib2: enable frame buffer on linux-arm targets, but disable vga16_blitter
+- gfxlib2: enable frame buffer on linux-arm targets
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling
@@ -44,6 +44,7 @@ Version 1.08.0
 - __FB_QUOTE__(), __FB_UNQUOTE__(), __FB_EVAL__() builtin macros
 - rtlib: REDIM [PRESERVE] will generate run time error if attempting to resize static (fixed length) arrays.
 - gas64 emitter for x86_64 (SARG), added '-gen gas64' command line option to select
+- gfxlib2: add vga16_blitter for linux-arm targets to pack 2 pixels per byte and write to linear frame buffer
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Version 1.08.0
 - rtlib: internal changes to API: fb_ArrayErase(), fb_ArrayClear(), fb_ArrayClearObj()
 - rtlib: internal removal of unused / legacy functions: fb_ArrayRedim(), fb_ArrayRedimPresv()
 - rtlib: internal removal of unused / legacy functions: fb_ArraySetDesc(), temporay descriptor functions and structs
+- gfxlib2: enable frame buffer on linux-arm targets, but disable vga16_blitter
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling

--- a/src/gfxlib2/linux/fb_gfx_linux.h
+++ b/src/gfxlib2/linux/fb_gfx_linux.h
@@ -3,11 +3,6 @@
 #ifndef __FB_GFX_LINUX_H__
 #define __FB_GFX_LINUX_H__
 
-/* Disable fbdev driver on ARM, because it currently uses x86 inline asm */
-#if !defined HOST_X86 && !defined HOST_X86_64
-	#define DISABLE_FBDEV
-#endif
-
 #ifndef DISABLE_FBDEV
 
 #define DOUBLE_CLICK_TIME		250

--- a/src/gfxlib2/linux/gfx_driver_fbdev.c
+++ b/src/gfxlib2/linux/gfx_driver_fbdev.c
@@ -17,8 +17,11 @@
 #define FB_AUX_VGA_PLANES_VGA4	0
 #endif
 
+#if defined HOST_X86 || defined HOST_X86_64
 #define OUTB(port,value)	{ __asm__ __volatile__ ("outb %b0, %w1" : : "a"(value), "Nd"(port)); }
-
+#else
+#define OUTB(port,value)
+#endif
 
 typedef struct FBDEVDRIVER
 {
@@ -86,8 +89,6 @@ static pthread_t thread;
 static pthread_mutex_t mutex;
 static pthread_cond_t cond;
 
-#if defined HOST_X86 || defined HOST_X86_64
-
 static void vga16_blitter(unsigned char *dest, int pitch)
 {
 	unsigned int color;
@@ -141,7 +142,6 @@ static void vga16_blitter(unsigned char *dest, int pitch)
 		source += __fb_gfx->pitch;
 	}
 }
-#endif
 
 static void *driver_thread(void *arg)
 {
@@ -451,13 +451,9 @@ got_mode:
 	fb_hMemSet(framebuffer, 0, device_info.smem_len);
 
 	if (mode.bits_per_pixel == 4) {
-#if defined HOST_X86 || defined HOST_X86_64
 		palette_len = 16;
 		framebuffer_offset = (((mode.yres - h) >> 1) * (mode.xres >> 3)) + ((mode.xres - w) >> 4);
 		blitter = vga16_blitter;
-#else
-		return -1;
-#endif
 	} else {
 		palette_len = 256;
 		framebuffer_offset = (((mode.yres - h) >> 1) * device_info.line_length) +

--- a/src/gfxlib2/linux/gfx_driver_fbdev.c
+++ b/src/gfxlib2/linux/gfx_driver_fbdev.c
@@ -86,6 +86,8 @@ static pthread_t thread;
 static pthread_mutex_t mutex;
 static pthread_cond_t cond;
 
+#if defined HOST_X86 || defined HOST_X86_64
+
 static void vga16_blitter(unsigned char *dest, int pitch)
 {
 	unsigned int color;
@@ -139,6 +141,7 @@ static void vga16_blitter(unsigned char *dest, int pitch)
 		source += __fb_gfx->pitch;
 	}
 }
+#endif
 
 static void *driver_thread(void *arg)
 {
@@ -448,9 +451,13 @@ got_mode:
 	fb_hMemSet(framebuffer, 0, device_info.smem_len);
 
 	if (mode.bits_per_pixel == 4) {
+#if defined HOST_X86 || defined HOST_X86_64
 		palette_len = 16;
 		framebuffer_offset = (((mode.yres - h) >> 1) * (mode.xres >> 3)) + ((mode.xres - w) >> 4);
 		blitter = vga16_blitter;
+#else
+		return -1;
+#endif
 	} else {
 		palette_len = 256;
 		framebuffer_offset = (((mode.yres - h) >> 1) * device_info.line_length) +


### PR DESCRIPTION
As reported in #193, #196, & #197 and issue #192 the framebuffer driver was disabled on non-x86 targets due to x86 assembler in the sources and x86 assumptions about vga hardware.  However, the framebuffer driver can work on Raspberry Pi / linux-arm.

Following changes:
- gfxlib2: enable frame buffer on linux-arm targets
- gfxlib2: add vga16_blitter for linux-arm targets to pack 2 pixels per byte and write to linear frame buffer

This addition works for me as tested on actual RPi hardware - with a monitor connected via HDMI on /dev/fb0.  No special configuration of the framebuffer, and appears to work as expected for example with `screen 12`.  Palette shifting also appears to work.

The vga16 blitter for non-x86 targets added was based on existing vga16 blitter for x86 for the 4-bits per pixel modes.  The added blitter packs pairs of gfxlib2 pixels which are stored one pixel per byte, in to two pixels per byte for the frame buffer.  No-reordering for vga planes and the packed pixels are written linearly (left to right), but packed.
