### PR TITLE
Fix DX and GDI GFX drivers crashing on window creation

### DIFF
--- a/src/gfxlib2/win32/gfx_driver_ddraw.c
+++ b/src/gfxlib2/win32/gfx_driver_ddraw.c
@@ -229,7 +229,7 @@ static int directx_init(void)
 	rect.bottom = fb_win32.h;
 
 	if (fb_win32.flags & DRIVER_FULLSCREEN) {
-		if (fb_hInitWindow(WS_POPUP | WS_VISIBLE, 0, 0, 0, GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN)))
+		if (fb_hInitWindow(WS_POPUP, 0, 0, 0, GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN)))
 			return -1;
 		if (IDirectDraw2_SetCooperativeLevel(lpDD, fb_win32.wnd, DDSCL_ALLOWREBOOT | DDSCL_FULLSCREEN | DDSCL_EXCLUSIVE) != DD_OK)
 			return -1;
@@ -263,9 +263,9 @@ static int directx_init(void)
 		display_offset = ((height - fb_win32.h) >> 1);
 	} else {
 		if (fb_win32.flags & DRIVER_NO_FRAME) {
-			style = WS_POPUP | WS_VISIBLE;
+			style = WS_POPUP;
 		} else {
-			style = (WS_OVERLAPPEDWINDOW & ~WS_THICKFRAME) | WS_VISIBLE;
+			style = (WS_OVERLAPPEDWINDOW & ~WS_THICKFRAME);
 			if (fb_win32.flags & DRIVER_NO_SWITCH)
 				style &= ~WS_MAXIMIZEBOX;
 		}
@@ -346,6 +346,8 @@ static int directx_init(void)
 		return -1;
 	if (IDirectInputDevice_Acquire(lpDID) != DI_OK)
 		return -1;
+
+	ShowWindow(fb_win32.wnd, SW_SHOWNORMAL);
 
 	return 0;
 }

--- a/src/gfxlib2/win32/gfx_driver_gdi.c
+++ b/src/gfxlib2/win32/gfx_driver_gdi.c
@@ -149,7 +149,7 @@ static int gdi_init(void)
 		y = monitor_info.rcMonitor.top;
 	}
 
-	if (fb_hInitWindow(style | WS_VISIBLE, ex_style, x, y, rect.right, rect.bottom))
+	if (fb_hInitWindow(style, ex_style, x, y, rect.right, rect.bottom))
 		return -1;
 	if (fb_win32.flags & DRIVER_SHAPED_WINDOW) {
 		if (!fb_win32.SetLayeredWindowAttributes)
@@ -200,6 +200,8 @@ static int gdi_init(void)
 	free(lp);
 
 	ReleaseDC(fb_win32.wnd, hdc);
+
+	ShowWindow(fb_win32.wnd, SW_SHOWNORMAL);
 
 	return 0;
 }


### PR DESCRIPTION
RE: https://www.freebasic.net/forum/viewtopic.php?f=6&t=28868

Fix DirectX and GDI GFX drivers crashing when something external hooks the window (in this case an IME) and starts doing Windows message related things before we do. As these drivers show the window before they've finished initialisation, any Get/PeekMessage anybody does may cause a WM_PAINT to happen, and when it does the drivers crash /because/ they've not finished initialising.

This PR removes all the visible flags passed to fb_InitWindow and adds a ShowWindow after all the initialisation is complete.