### PR TITLE
CSIGN/CUNSG preserve size when converting pointers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -72,6 +72,7 @@ Version 1.08.0
 - sf.net #918: pcopy (console) bug when copying large console buffers, windows only (adeyblue)
 - github #216: function getMouse() seems broken on Win10 when using the Console Mode (screen 0), fixed by turn off the QuickEdit console mode during GetMouse (adeyblue)
 - github #258: on windows directx and gdi drivers, only show window after intialization is complete (adeyblue)
+- sf.net #925: CSIGN/CUSGN preserve size when converting pointers on 64-bit and implict conversion of STEP value in FOR...NEXT statement
 
 
 Version 1.07.0

--- a/src/compiler/symb-data.bas
+++ b/src/compiler/symb-data.bas
@@ -224,8 +224,15 @@ function typeToSigned _
 	case FB_DATATYPE_WCHAR
 		return typeToSigned( env.target.wchar )
 
-	case FB_DATATYPE_ULONG, FB_DATATYPE_POINTER
+	case FB_DATATYPE_ULONG
 		nd = FB_DATATYPE_LONG
+
+	case FB_DATATYPE_POINTER
+		if( env.pointersize = 8 ) then
+			nd = FB_DATATYPE_LONGINT	
+		else
+			nd = FB_DATATYPE_LONG
+		end if
 
 	case FB_DATATYPE_ULONGINT
 		nd = FB_DATATYPE_LONGINT
@@ -260,8 +267,15 @@ function typeToUnsigned _
 	case FB_DATATYPE_INTEGER, FB_DATATYPE_ENUM
 		nd = FB_DATATYPE_UINT
 
-	case FB_DATATYPE_LONG, FB_DATATYPE_POINTER
+	case FB_DATATYPE_LONG
 		nd = FB_DATATYPE_ULONG
+
+	case FB_DATATYPE_POINTER
+		if( env.pointersize = 8 ) then
+			nd = FB_DATATYPE_ULONGINT	
+		else
+			nd = FB_DATATYPE_ULONG
+		end if
 
 	case FB_DATATYPE_LONGINT
 		nd = FB_DATATYPE_ULONGINT

--- a/tests/numbers/casting.bas
+++ b/tests/numbers/casting.bas
@@ -57,4 +57,109 @@ SUITE( fbc_tests.numbers.casting )
 		CU_ASSERT( culngint( d ) = 123 )
 	END_TEST
 
+	#macro check_int( typ, s_value, u_value )
+		scope
+			dim s as typ = s_value
+			dim u as unsigned typ = u_value
+
+			'' Sizes match?
+			CU_ASSERT( sizeof( s ) = sizeof( u ) )
+			CU_ASSERT( sizeof( csign( s ) ) = sizeof( s ) )
+			CU_ASSERT( sizeof( cunsg( s ) ) = sizeof( s ) )
+			CU_ASSERT( sizeof( csign( u ) ) = sizeof( u ) )
+			CU_ASSERT( sizeof( cunsg( u ) ) = sizeof( u ) )
+
+			'' values match?
+			CU_ASSERT( csign( s ) = s )
+			CU_ASSERT( csign( u ) = s )
+			CU_ASSERT( cunsg( s ) = u )
+			CU_ASSERT( cunsg( u ) = u )
+
+			'' types match?
+			#assert typeof( csign( s ) ) = typeof( typ )
+			#assert typeof( cunsg( s ) ) = typeof( unsigned typ )
+			#assert typeof( csign( u ) ) = typeof( typ )
+			#assert typeof( cunsg( u ) ) = typeof( unsigned typ )
+
+			'' same value when convert back to original type?
+			dim s2 as typ = csign( u )
+			dim u2 as unsigned typ = cunsg( s )
+			CU_ASSERT( s2 = s )
+			CU_ASSERT( u2 = u )
+
+		end scope
+	#endmacro
+
+	TEST( sign_ints )
+		check_int( byte,    0,   0 )
+		check_int( byte,  127, 127 )
+		check_int( byte, -128, 128 )
+		check_int( byte,   -1, 255 )
+
+		check_int( short,      0,     0 )
+		check_int( short,  32767, 32767 )
+		check_int( short, -32768, 32768 )
+		check_int( short,     -1, 65535 )
+
+		check_int( long,           0ll,          0ull )
+		check_int( long,  2147483647ll, 2147483647ull )
+		check_int( long, -2147483648ll, 2147483648ull )
+		check_int( long,          -1ll, 4294967295ull )
+
+		#ifndef __FB_64BIT__
+			check_int( integer,           0ll,          0ull )
+			check_int( integer,  2147483647ll, 2147483647ull )
+			check_int( integer, -2147483648ll, 2147483648ull )
+			check_int( integer,          -1ll, 4294967295ull )
+		#else
+			check_int( integer,                    0ll,                    0ull )
+			check_int( integer,  9223372036854775807ll,  9223372036854775807ull )
+			check_int( integer, -9223372036854775808ll,  9223372036854775808ull )
+			check_int( integer,                   -1ll, 18446744073709551615ull )
+		#endif
+
+		check_int( longint,                    0ll,                    0ull )
+		check_int( longint,  9223372036854775807ll,  9223372036854775807ull )
+		check_int( longint, -9223372036854775808ll,  9223372036854775808ull )
+		check_int( longint,                   -1ll, 18446744073709551615ull )
+
+	END_TEST
+
+	TEST( sign_ptrs )
+
+		union T
+			p as any ptr
+			i as integer
+		end union
+
+		dim x as T
+
+		#ifndef __FB_64BIT__
+			x.i = &h800000001
+		#else
+			x.i = &h80000000000000001
+		#endif
+
+		CU_ASSERT( sizeof( x.p ) = sizeof( x.i ) )
+		CU_ASSERT( sizeof( csign( x.p ) ) = sizeof( x.p ) )
+		CU_ASSERT( sizeof( cunsg( x.p ) ) = sizeof( x.p ) )
+
+		scope
+			var ni = csign( x.i )
+			var np = csign( x.p )
+			CU_ASSERT( np = ni )
+			var p = cast( any ptr, np )
+			CU_ASSERT( p = x.p )
+		end scope
+
+		scope
+			var ni = cunsg( x.i )
+			var np = cunsg( x.p )
+			CU_ASSERT( np = ni )
+			var p = cast( any ptr, np )
+			CU_ASSERT( p = x.p )
+		end scope
+
+	END_TEST
+
 END_SUITE


### PR DESCRIPTION
fbc: sf.net # 925: CSIGN/CUNSG preserve size when converting pointers

- previously on 64-bit CSIGN was converted to LONG and CUNSG was converted to ULONG, when size should be preserved
- this also was seen in the STEP value of FOR...NEXT statements where STEP value for pointers was also converted to LONG
- this change preserves the size of the pointer when converted to [u]integer
- adds new tests for checking CSIGN and CUNSG

See also: https://sourceforge.net/p/fbc/bugs/925/