### PR TITLE
Threadsafe RANDOMIZE & RND using mutex

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Version 1.08.0
 - rtlib: internal removal of unused / legacy functions: fb_ArraySetDesc(), temporay descriptor functions and structs
 - github #256: gfxlib2: enable frame buffer on linux-arm targets
 - gfxlib2: X11 driver - set the window title for both the frame window and the client window
+- rtlib: RANDOMIZE RND_REAL for real random number generator now fills a buffer (624 ulongs) and RND iterates the buffer
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling
@@ -46,6 +47,7 @@ Version 1.08.0
 - rtlib: REDIM [PRESERVE] will generate run time error if attempting to resize static (fixed length) arrays.
 - gas64 emitter for x86_64 (SARG), added '-gen gas64' command line option to select
 - github #256: gfxlib2: add vga16_blitter for linux-arm targets to pack 2 pixels per byte and write to linear frame buffer
+- ./inc/fbc-int/math.bi - fbc API for rnd, rnd32, randomize, expose some random number generator internals
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture
@@ -75,6 +77,7 @@ Version 1.08.0
 - github #258: on windows directx and gdi drivers, only show window after intialization is complete (adeyblue)
 - sf.net #925: CSIGN/CUNSG preserve size when converting pointers on 64-bit and implict conversion of STEP value in FOR...NEXT statement
 - github #122: gfxlib2: linux GFX_NO_FRAME + GFX_OPENGL freezing at exit due to a dead lock between exit routines
+- sf.net #914: threadsafe RND() and RANDOMIZE() by adding a mutex
 
 
 Version 1.07.0

--- a/inc/fbc-int/math.bi
+++ b/inc/fbc-int/math.bi
@@ -1,0 +1,68 @@
+#ifndef __FBC_INT_MATH_BI__ 
+#define __FBC_INT_MATH_BI__
+
+# if __FB_LANG__ = "qb"
+# error not supported in qb dialect
+# endif
+
+'' DISCLAIMER!!!
+''
+''   1) this header documents runtime library internals and is subject to change without notice
+''
+
+'' declarations must follow ./src/rtlib/fb_math.h
+''                          ./src/rtlib/fb_rnd.c
+
+'' move built-ins out of the global namespace
+#undef rnd
+#undef randomize
+
+#if defined( __FB_CYGWIN__) or defined(__FB_WIN32__)
+#inclib "advapi32"
+#endif
+
+namespace FBC
+
+enum FB_RND_ALGORITHMS
+	FB_RND_AUTO
+	FB_RND_CRT
+	FB_RND_FAST
+	FB_RND_MTWIST
+	FB_RND_QB
+	FB_RND_REAL
+end enum
+
+type FB_RNDINTERNALS
+	dim algorithm as ulong           '' algorithm number see FB_RND_ALGORITHMS
+	dim length as ulong              '' length Mersennse Twister states in (number of ulongs)
+	dim stateblock as ulong ptr      '' Mersenne Twister state (pointer array)
+	dim stateindex as ulong ptr ptr  '' Mersenne Twister current index
+	dim iseed as ulong ptr           '' Current state for FB_RND_FAST & FB_RND_QB
+
+	'' function pointer for internal proc called by fb_Rnd()
+	dim rndproc as function( byval n as single ) as double
+
+	'' function pointer for internal proc called by fb_Rnd32()
+	dim rndproc32 as function( ) as ulong
+end type
+
+extern "rtlib"
+	
+	declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB_RND_AUTO )
+	declare function rnd alias "fb_Rnd" ( byval n as single = 1.0 ) as double
+	declare function rnd32 alias "fb_Rnd32" ( ) as ulong
+
+	declare sub rndGetInternals alias "fb_RndGetInternals" ( byval info as FB_RNDINTERNALS ptr )
+
+	#if __FB_MT__
+
+	declare sub mathLock alias "fb_MathLock" ()
+	declare sub mathUnlock alias "fb_MathUnlock" ()
+
+	#endif
+
+end extern
+
+end namespace
+
+#endif

--- a/inc/fbc-int/math.bi
+++ b/inc/fbc-int/math.bi
@@ -34,20 +34,20 @@ end enum
 
 type FB_RNDINTERNALS
 	dim algorithm as ulong           '' algorithm number see FB_RND_ALGORITHMS
-	dim length as ulong              '' length Mersennse Twister states in (number of ulongs)
+	dim length as ulong              '' length of Mersennse Twister states in (number of ulongs)
 	dim stateblock as ulong ptr      '' Mersenne Twister state (pointer array)
 	dim stateindex as ulong ptr ptr  '' Mersenne Twister current index
 	dim iseed as ulong ptr           '' Current state for FB_RND_FAST & FB_RND_QB
 
 	'' function pointer for internal proc called by fb_Rnd()
-	dim rndproc as function( byval n as single ) as double
+	dim rndproc as function cdecl ( byval n as single = 1.0 ) as double
 
 	'' function pointer for internal proc called by fb_Rnd32()
-	dim rndproc32 as function( ) as ulong
+	dim rndproc32 as function cdecl ( ) as ulong
 end type
 
 extern "rtlib"
-	
+
 	declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB_RND_AUTO )
 	declare function rnd alias "fb_Rnd" ( byval n as single = 1.0 ) as double
 	declare function rnd32 alias "fb_Rnd32" ( ) as ulong

--- a/src/rtlib/dos/hinit.c
+++ b/src/rtlib/dos/hinit.c
@@ -15,12 +15,15 @@ char *__fb_startup_cwd;
 	static pthread_mutex_t __fb_global_mutex;
 	static pthread_mutex_t __fb_string_mutex;
 	static pthread_mutex_t __fb_graphics_mutex;
+	static pthread_mutex_t __fb_math_mutex;
 	FBCALL void fb_Lock     ( void ) { pthread_mutex_lock  ( &__fb_global_mutex ); }
 	FBCALL void fb_Unlock   ( void ) { pthread_mutex_unlock( &__fb_global_mutex ); }
 	FBCALL void fb_StrLock  ( void ) { pthread_mutex_lock  ( &__fb_string_mutex ); }
 	FBCALL void fb_StrUnlock( void ) { pthread_mutex_unlock( &__fb_string_mutex ); }
 	FBCALL void fb_GraphicsLock  ( void ) { pthread_mutex_lock  ( &__fb_graphics_mutex ); }
 	FBCALL void fb_GraphicsUnlock( void ) { pthread_mutex_unlock( &__fb_graphics_mutex ); }
+	FBCALL void fb_MathLock  ( void ) { pthread_mutex_lock  ( &__fb_math_mutex ); }
+	FBCALL void fb_MathUnlock( void ) { pthread_mutex_unlock( &__fb_math_mutex ); }
 #endif
 
 void fb_hInit( void )
@@ -48,6 +51,7 @@ void fb_hInit( void )
 		pthread_mutex_init(&__fb_global_mutex, &attr);
 		pthread_mutex_init(&__fb_string_mutex, &attr);
 		pthread_mutex_init(&__fb_graphics_mutex, &attr);
+		pthread_mutex_init(&__fb_math_mutex, &attr);
 	#endif
 
 }
@@ -60,6 +64,7 @@ void fb_hEnd( int unused )
 	pthread_mutex_destroy(&__fb_global_mutex);
 	pthread_mutex_destroy(&__fb_string_mutex);
 	pthread_mutex_destroy(&__fb_graphics_mutex);
+	pthread_mutex_destroy(&__fb_math_mutex);
 #endif
 
 }

--- a/src/rtlib/fb.h
+++ b/src/rtlib/fb.h
@@ -109,6 +109,8 @@
 	FBCALL void fb_StrUnlock( void );
 	FBCALL void fb_GraphicsLock  ( void );
 	FBCALL void fb_GraphicsUnlock( void );
+	FBCALL void fb_MathLock  ( void );
+	FBCALL void fb_MathUnlock( void );
 	/* NOTE: if both locks are acquired, FB_LOCK() must be called before
            FB_STRLOCK() in order to avoid deadlocking */
 	#define FB_LOCK()      fb_Lock()
@@ -119,6 +121,8 @@
            required. See bug #885 */
 	#define FB_GRAPHICS_LOCK()   fb_GraphicsLock()
 	#define FB_GRAPHICS_UNLOCK() fb_GraphicsUnlock()
+	#define FB_MATH_LOCK()   fb_MathLock()
+	#define FB_MATH_UNLOCK() fb_MathUnlock()
 #else
 	#define FB_LOCK()
 	#define FB_UNLOCK()
@@ -126,6 +130,8 @@
 	#define FB_STRUNLOCK()
 	#define FB_GRAPHICS_LOCK()
 	#define FB_GRAPHICS_UNLOCK()
+	#define FB_MATH_LOCK()
+	#define FB_MATH_UNLOCK()
 #endif
 
 /* CPU-dependent macros and inline functions */

--- a/src/rtlib/fb_math.h
+++ b/src/rtlib/fb_math.h
@@ -1,4 +1,17 @@
+typedef struct _FB_RNDINTERNALS {
+	uint32_t algorithm;
+	uint32_t length;
+	uint32_t *stateblock;
+	uint32_t **stateindex;
+	uint32_t *iseed;
+	double   ( *rndproc )( float n );
+	uint32_t ( *rndproc32 )( void );
+} FB_RNDINTERNALS;
+
 FBCALL double       fb_Rnd              ( float n );
+FBCALL uint32_t     fb_Rnd32            ( void );
+FBCALL void         fb_GetRndInternals  ( FB_RNDINTERNALS *info );
+
 FBCALL void         fb_Randomize        ( double seed, int algorithm );
 FBCALL int          fb_SGNSingle        ( float x );
 FBCALL int          fb_SGNDouble        ( double x );

--- a/src/rtlib/math_rnd.c
+++ b/src/rtlib/math_rnd.c
@@ -83,7 +83,7 @@ static double hRnd_CRT ( float n )
 		return last_num;
 
 	/* return between 0 and 1 (but never 1) */
-	return (double)rand( ) * ( 1.0 / ( (double)RAND_MAX + 1.0 ) );
+	return (double)hRnd_CRT32( ) * ( 1.0 / ( (double)RAND_MAX + 1.0 ) );
 }
 
 static uint32_t hRnd_FAST32 ( void )
@@ -273,6 +273,8 @@ FBCALL void fb_Randomize ( double seed, int algorithm )
 		}
 	}
 
+	FB_MATH_LOCK();
+
 	if( seed == -1.0 )
 	{
 		/* Take value of Timer to ensure a non-constant seed.  The seeding
@@ -282,8 +284,6 @@ FBCALL void fb_Randomize ( double seed, int algorithm )
 		dtoi.d = fb_Timer( );
 		seed = (double)(dtoi.i[0] ^ dtoi.i[1]);
 	}
-
-	FB_MATH_LOCK();
 
 	generator = algorithm;
 

--- a/src/rtlib/math_rnd.c
+++ b/src/rtlib/math_rnd.c
@@ -95,13 +95,12 @@ static uint32_t hRnd_FAST32 ( void )
 
 static double hRnd_FAST ( float n )
 {
-	/* Constants from 'Numerical recipes in C' chapter 7.1 */
-	/* return between 0 and 1 (but never 1) */
-	iseed = ( ( 1664525 * iseed ) + 1013904223 );
-	if( n != 0.0 )
-		hRnd_FAST32();
+	/* return last value if argument is 0.0 */
+	if( n == 0.0 )
+		return (double)iseed / (double)4294967296ULL;
 
-	return (double)iseed / (double)4294967296ULL;
+	/* return between 0 and 1 (but never 1) */
+	return (double)hRnd_FAST32() / (double)4294967296ULL;
 }
 
 static uint32_t hRnd_MTWIST32 ( void )
@@ -145,7 +144,7 @@ static double hRnd_MTWIST ( float n )
 	return (double)hRnd_MTWIST32() / (double)4294967296ULL;
 }
 
-static inline uint32_t hRnd_QB32 ( void )
+static uint32_t hRnd_QB32 ( void )
 {
 	iseed = ( ( iseed * 0xFD43FD ) + 0xC39EC3 ) & 0xFFFFFF;
 	return iseed;
@@ -158,15 +157,16 @@ static double hRnd_QB ( float n )
 		uint32_t i;
 	} ftoi;
 
-	if( n != 0.0 ) {
-		if( n < 0.0 ) {
-			ftoi.f = n;
-			uint32_t s = ftoi.i;
-			iseed = s + ( s >> 24 );
-		}
-		iseed = ( ( iseed * 0xFD43FD ) + 0xC39EC3 ) & 0xFFFFFF;
+	if( n == 0.0 )
+		return (float)iseed / (float)0x1000000;
+
+	if( n < 0.0 ) {
+		ftoi.f = n;
+		uint32_t s = ftoi.i;
+		iseed = s + ( s >> 24 );
 	}
-	return (float)iseed / (float)0x1000000;
+
+	return (float)hRnd_QB32() / (float)0x1000000;
 }
 
 #if defined HOST_WIN32 || defined HOST_LINUX

--- a/src/rtlib/unix/hinit.c
+++ b/src/rtlib/unix/hinit.c
@@ -46,12 +46,15 @@ extern int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int kind);
 static pthread_mutex_t __fb_global_mutex;
 static pthread_mutex_t __fb_string_mutex;
 static pthread_mutex_t __fb_graphics_mutex;
+static pthread_mutex_t __fb_math_mutex;
 FBCALL void fb_Lock     ( void ) { pthread_mutex_lock  ( &__fb_global_mutex ); }
 FBCALL void fb_Unlock   ( void ) { pthread_mutex_unlock( &__fb_global_mutex ); }
 FBCALL void fb_StrLock  ( void ) { pthread_mutex_lock  ( &__fb_string_mutex ); }
 FBCALL void fb_StrUnlock( void ) { pthread_mutex_unlock( &__fb_string_mutex ); }
 FBCALL void fb_GraphicsLock  ( void ) { pthread_mutex_lock  ( &__fb_graphics_mutex ); }
 FBCALL void fb_GraphicsUnlock( void ) { pthread_mutex_unlock( &__fb_graphics_mutex ); }
+FBCALL void fb_MathLock  ( void ) { pthread_mutex_lock  ( &__fb_math_mutex ); }
+FBCALL void fb_mathUnlock( void ) { pthread_mutex_unlock( &__fb_math_mutex ); }
 #endif
 
 static void *bg_thread(void *arg)
@@ -470,6 +473,7 @@ static void hInit( void )
 	pthread_mutex_init(&__fb_global_mutex, &attr);
 	pthread_mutex_init(&__fb_string_mutex, &attr);
 	pthread_mutex_init(&__fb_graphics_mutex, &attr);
+	pthread_mutex_init(&__fb_math_mutex, &attr);
 #endif
 
 	pthread_mutex_init(&__fb_bg_mutex, &attr);
@@ -572,5 +576,6 @@ void fb_hEnd( int unused )
 	pthread_mutex_destroy(&__fb_global_mutex);
 	pthread_mutex_destroy(&__fb_string_mutex);
 	pthread_mutex_destroy(&__fb_graphics_mutex);
+	pthread_mutex_destroy(&__fb_math_mutex);
 #endif
 }

--- a/src/rtlib/unix/hinit.c
+++ b/src/rtlib/unix/hinit.c
@@ -54,7 +54,7 @@ FBCALL void fb_StrUnlock( void ) { pthread_mutex_unlock( &__fb_string_mutex ); }
 FBCALL void fb_GraphicsLock  ( void ) { pthread_mutex_lock  ( &__fb_graphics_mutex ); }
 FBCALL void fb_GraphicsUnlock( void ) { pthread_mutex_unlock( &__fb_graphics_mutex ); }
 FBCALL void fb_MathLock  ( void ) { pthread_mutex_lock  ( &__fb_math_mutex ); }
-FBCALL void fb_mathUnlock( void ) { pthread_mutex_unlock( &__fb_math_mutex ); }
+FBCALL void fb_MathUnlock( void ) { pthread_mutex_unlock( &__fb_math_mutex ); }
 #endif
 
 static void *bg_thread(void *arg)

--- a/src/rtlib/win32/hinit.c
+++ b/src/rtlib/win32/hinit.c
@@ -9,6 +9,7 @@ static CRITICAL_SECTION __fb_global_mutex;
 static CRITICAL_SECTION __fb_string_mutex;
 static CRITICAL_SECTION __fb_mtcore_mutex;
 static CRITICAL_SECTION __fb_graphics_mutex;
+static CRITICAL_SECTION __fb_math_mutex;
 FBCALL void fb_Lock( void )      { EnterCriticalSection( &__fb_global_mutex ); }
 FBCALL void fb_Unlock( void )    { LeaveCriticalSection( &__fb_global_mutex ); }
 FBCALL void fb_StrLock( void )   { EnterCriticalSection( &__fb_string_mutex ); }
@@ -17,6 +18,8 @@ FBCALL void fb_MtLock( void )    { EnterCriticalSection( &__fb_mtcore_mutex ); }
 FBCALL void fb_MtUnlock( void )  { LeaveCriticalSection( &__fb_mtcore_mutex ); }
 FBCALL void fb_GraphicsLock  ( void ) { EnterCriticalSection( &__fb_graphics_mutex ); }
 FBCALL void fb_GraphicsUnlock( void ) { LeaveCriticalSection( &__fb_graphics_mutex ); }
+FBCALL void fb_MathLock  ( void ) { EnterCriticalSection( &__fb_math_mutex ); }
+FBCALL void fb_MathUnlock( void ) { LeaveCriticalSection( &__fb_math_mutex ); }
 #endif
 
 FB_CONSOLE_CTX __fb_con /* not initialized */;
@@ -51,6 +54,7 @@ _CRTIMP unsigned int __cdecl __MINGW_NOTHROW _controlfp (unsigned int unNew, uns
 	InitializeCriticalSection(&__fb_string_mutex);
 	InitializeCriticalSection(&__fb_mtcore_mutex);
 	InitializeCriticalSection(&__fb_graphics_mutex);
+	InitializeCriticalSection(&__fb_math_mutex);
 #endif
 
 	memset( &__fb_con, 0, sizeof( FB_CONSOLE_CTX ) );
@@ -63,5 +67,6 @@ void fb_hEnd( int unused )
 	DeleteCriticalSection(&__fb_string_mutex);
 	DeleteCriticalSection(&__fb_mtcore_mutex);
 	DeleteCriticalSection(&__fb_graphics_mutex);
+	DeleteCriticalSection(&__fb_math_mutex);
 #endif
 }

--- a/src/rtlib/xbox/hinit.c
+++ b/src/rtlib/xbox/hinit.c
@@ -6,12 +6,15 @@
 static CRITICAL_SECTION __fb_global_mutex;
 static CRITICAL_SECTION __fb_string_mutex;
 static CRITICAL_SECTION __fb_graphics_mutex;
+static CRITICAL_SECTION __fb_math_mutex;
 FBCALL void fb_Lock( void )      { EnterCriticalSection( &__fb_global_mutex ); }
 FBCALL void fb_Unlock( void )    { LeaveCriticalSection( &__fb_global_mutex ); }
 FBCALL void fb_StrLock( void )   { EnterCriticalSection( &__fb_string_mutex ); }
 FBCALL void fb_StrUnlock( void ) { LeaveCriticalSection( &__fb_string_mutex ); }
 FBCALL void fb_GraphicsLock  ( void ) { EnterCriticalSection( &__fb_graphics_mutex ); }
 FBCALL void fb_GraphicsUnlock( void ) { LeaveCriticalSection( &__fb_graphics_mutex ); }
+FBCALL void fb_MathLock  ( void ) { EnterCriticalSection( &__fb_math_mutex ); }
+FBCALL void fb_MathUnlock( void ) { LeaveCriticalSection( &__fb_math_mutex ); }
 #endif
 
 void fb_hInit( void )
@@ -31,6 +34,7 @@ void fb_hInit( void )
 	InitializeCriticalSection(&__fb_global_mutex);
 	InitializeCriticalSection(&__fb_string_mutex);
 	InitializeCriticalSection(&__fb_graphics_mutex);
+	InitializeCriticalSection(&__fb_math_mutex);
 #endif
 }
 
@@ -40,5 +44,6 @@ void fb_hEnd( int unused )
 	DeleteCriticalSection(&__fb_global_mutex);
 	DeleteCriticalSection(&__fb_string_mutex);
 	DeleteCriticalSection(&__fb_graphics_mutex);
+	DeleteCriticalSection(&__fb_math_mutex);
 #endif
 }

--- a/tests/fbc-int/math-rnd.bas
+++ b/tests/fbc-int/math-rnd.bas
@@ -1,0 +1,49 @@
+#include "fbcunit.bi"
+#include "fbc-int/math.bi"
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+'' tests for random number generator internals
+
+SUITE( fbc_tests.fbc_int.math_rnd )
+
+	TEST( direct )
+
+		fbc.randomize 1, FBC.FB_RND_FAST
+
+		CU_ASSERT_EQUAL( fbc.rnd32(), 1015568748 )
+		CU_ASSERT_EQUAL( fbc.rnd32(), 1586005467 )
+		CU_ASSERT_EQUAL( fbc.rnd32(), 2165703038 )
+		CU_ASSERT_EQUAL( fbc.rnd32(), 3027450565 )
+		CU_ASSERT_EQUAL( fbc.rnd32(), 217083232 )
+		
+		dim info as FBC.FB_RNDINTERNALS
+		fbc.rndGetInternals( @info )
+
+		CU_ASSERT( info.algorithm = FBC.FB_RND_FAST )
+		CU_ASSERT( info.rndproc <> NULL )
+		CU_ASSERT( info.rndproc32 <> NULL )
+
+	END_TEST
+
+	TEST( using_fbc )
+	
+		'' essentially, a compile test only
+		using fbc
+
+		randomize
+		randomize , FB_RND_MTWIST
+
+		var x = rnd
+		var y = rnd32
+
+		dim info as FB_RNDINTERNALS
+		rndGetInternals( @info )
+
+		CU_PASS()
+		
+	END_TEST
+
+END_SUITE


### PR DESCRIPTION
Address the bug reported at https://sourceforge.net/p/fbc/bugs/914/ indicating that RND is not thread-safe.

RND is not thread safe due to the rtlib implementation in that the random number generators have a single instance of state in the rtlib.  And when RND is used in a multithread program, updates to the state are not serialized across multiple threads.

To address this, a mutex is added to serialize access to the random number generator state.  The advantage is that rtlib will be doing-the-right-thing by default.  The disadvantage is that there is now new overhead for having a mutex on mutlithreaded programs.

For single threaded programs (non-multithreaded) there is no change compared to previous versions because there is no mutex locking & unlocking by the rtlib.

So to allow for some new capabilities when working with FB's random number generators, a header file `'./inc/fbc-int/math.bi'` is added that exposes some internals of the rtlib in the `FBC` namespace.

In `'./inc/fbc-int/math.bi'`:
Enumeration of the generators:
```
	enum FB_RND_ALGORITHMS
		FB_RND_AUTO
		FB_RND_CRT
		FB_RND_FAST
		FB_RND_MTWIST
		FB_RND_QB
		FB_RND_REAL
	end enum
```
Declarations of existing `RANDOMIZE` & `RND`:
```
	declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB_RND_AUTO )
	declare function rnd alias "fb_Rnd" ( byval n as single = 1.0 ) as double
```
New entry point to return the 32-bit random value (avoids one branch and one division)
```
	declare function rnd32 alias "fb_Rnd32" ( ) as ulong
```
Structure and API function for retriecing the internals of the RNG state:
```
	type FB_RNDINTERNALS
		dim algorithm as ulong           '' algorithm number see FB_RND_ALGORITHMS
		dim length as ulong              '' length of Mersennse Twister states in (number of ulongs)
		dim stateblock as ulong ptr      '' Mersenne Twister state (pointer array)
		dim stateindex as ulong ptr ptr  '' Mersenne Twister current index
		dim iseed as ulong ptr           '' Current state for FB_RND_FAST & FB_RND_QB

		'' function pointer for internal proc called by fb_Rnd()
		dim rndproc as function cdecl ( byval n as single = 1.0 ) as double

		'' function pointer for internal proc called by fb_Rnd32()
		dim rndproc32 as function cdecl ( ) as ulong
	end type

	declare sub rndGetInternals alias "fb_RndGetInternals" ( byval info as FB_RNDINTERNALS ptr )
```
Declarations to access the new mutex from user code:
```
	#if __FB_MT__
	declare sub mathLock alias "fb_MathLock" ()
	declare sub mathUnlock alias "fb_MathUnlock" ()
	#endif
```

Additionally, the `FB_RND_REAL` generator has been modified to fill the buffer (624 ulongs) that would normally be used by `FB_RND_MTWIST`, and then `RND` iterates over the buffer.  When the entire buffer has been used, it is filled again with the `FB_RND_REAL` algorithm.


