### PR TITLE
fbmath.bi header for new PRNGs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Version 1.08.0
 - github #256: gfxlib2: enable frame buffer on linux-arm targets
 - gfxlib2: X11 driver - set the window title for both the frame window and the client window
 - rtlib: RANDOMIZE RND_REAL for real random number generator now fills a buffer (624 ulongs) and RND iterates the buffer
+- rtlib: refactor math_rnd.c internals for readability
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling
@@ -48,6 +49,7 @@ Version 1.08.0
 - gas64 emitter for x86_64 (SARG), added '-gen gas64' command line option to select
 - github #256: gfxlib2: add vga16_blitter for linux-arm targets to pack 2 pixels per byte and write to linear frame buffer
 - ./inc/fbc-int/math.bi - fbc API for rnd, rnd32, randomize, expose some random number generator internals
+- ./inc/fbmath.bi - add random number generators fb.rndfast32, fb.rndmsws32, fb.rndsquares32, fb.rndpcg32, fb.rndxoroshiro128
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture

--- a/inc/fbc-int/math.bi
+++ b/inc/fbc-int/math.bi
@@ -13,13 +13,11 @@
 '' declarations must follow ./src/rtlib/fb_math.h
 ''                          ./src/rtlib/fb_rnd.c
 
-'' move built-ins out of the global namespace
-#undef rnd
-#undef randomize
-
-#if defined( __FB_CYGWIN__) or defined(__FB_WIN32__)
-#inclib "advapi32"
-#endif
+'' fbmath.bi provides definitions for:
+'' - FB.FB_RND_ALGORTITMS
+'' - fb.RANDOMIZE
+'' - fb.RND
+'' - fb.RND32
 
 #include once "fbmath.bi"
 

--- a/inc/fbc-int/math.bi
+++ b/inc/fbc-int/math.bi
@@ -21,16 +21,9 @@
 #inclib "advapi32"
 #endif
 
-namespace FBC
+#include once "fbmath.bi"
 
-enum FB_RND_ALGORITHMS
-	FB_RND_AUTO
-	FB_RND_CRT
-	FB_RND_FAST
-	FB_RND_MTWIST
-	FB_RND_QB
-	FB_RND_REAL
-end enum
+namespace FBC
 
 type FB_RNDINTERNALS
 	dim algorithm as ulong           '' algorithm number see FB_RND_ALGORITHMS
@@ -48,7 +41,7 @@ end type
 
 extern "rtlib"
 
-	declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB_RND_AUTO )
+	declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB.FB_RND_AUTO )
 	declare function rnd alias "fb_Rnd" ( byval n as single = 1.0 ) as double
 	declare function rnd32 alias "fb_Rnd32" ( ) as ulong
 

--- a/inc/fbc-int/math.bi
+++ b/inc/fbc-int/math.bi
@@ -5,6 +5,11 @@
 # error not supported in qb dialect
 # endif
 
+'' fbmath.bi provides definitions for:
+'' - FB.FB_RND_ALGORTITMS
+
+#include once "fbmath.bi"
+
 '' DISCLAIMER!!!
 ''
 ''   1) this header documents runtime library internals and is subject to change without notice
@@ -13,13 +18,19 @@
 '' declarations must follow ./src/rtlib/fb_math.h
 ''                          ./src/rtlib/fb_rnd.c
 
-'' fbmath.bi provides definitions for:
-'' - FB.FB_RND_ALGORTITMS
-'' - fb.RANDOMIZE
-'' - fb.RND
-'' - fb.RND32
+'' Remove RANDOMIZE & RND from the global namespace 
+'' otherwise 'using fb' won't work with new declarations
+'' in the fb namespace
+#if defined( ..RANDOMIZE )
+	#undef ..RANDOMIZE
+#endif
+#if defined( ..RND )
+	#undef ..RND
+#endif
 
-#include once "fbmath.bi"
+#if defined( __FB_CYGWIN__) or defined(__FB_WIN32__)
+#inclib "advapi32"
+#endif
 
 namespace FBC
 
@@ -48,27 +59,13 @@ end type
 
 extern "rtlib"
 
-	'' built-in RANDOMIZE & RND & RND32
+	'' declare built-in RANDOMIZE, RND, & RND32 in the FB namespace
 	declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB.FB_RND_AUTO )
 	declare function rnd alias "fb_Rnd" ( byval n as single = 1.0 ) as double
 	declare function rnd32 alias "fb_Rnd32" ( ) as ulong
 
 	'' get a pointer to the internal global state for RND()
 	declare function rndGetState alias "fb_RndGetState" ( ) as FB_RNDSTATE ptr
-
-	'' generic procedure to initialize a built-in PRNG with user allocated FB_RNDSTATE
-	declare sub rndCtxInit cdecl alias "fb_RndCtxInit" _
-		( _
-			byval seed as ulongint = 0, _
-			byval algorithm as long = FB.FB_RND_AUTO _
-		)
-
-	'' procedures to initialize a user allocated FB_RNDSTATE for a specific generator
-	declare sub rndCtxInitCRT32 cdecl alias "fb_RndCtxInitCRT32" ( byval seed as ulongint = 0 )
-	declare sub rndCtxInitFAST32 cdecl alias "fb_RndCtxInitFAST32" ( byval seed as ulongint = 0 )
-	declare sub rndCtxInitMTWIST32 cdecl alias "fb_RndCtxInitMTWIST32" ( byval seed as ulongint = 0 )
-	declare sub rndCtxInitQB32 cdecl alias "fb_RndCtxInitQB32" ( byval seed as ulongint = 0 )
-	declare sub rndCtxInitREAL32 cdecl alias "fb_RndCtxInitREAL32" ( byval seed as ulongint = 0 )
 
 	#if __FB_MT__
 

--- a/inc/fbc-int/math.bi
+++ b/inc/fbc-int/math.bi
@@ -25,7 +25,7 @@
 
 namespace FBC
 
-type FB_RNDINTERNALS
+type FB_RNDSTATE
 	dim algorithm as ulong           '' algorithm number see FB_RND_ALGORITHMS
 	dim length as ulong              '' length of Mersennse Twister states in (number of ulongs)
 	dim stateblock as ulong ptr      '' Mersenne Twister state (pointer array)
@@ -41,11 +41,12 @@ end type
 
 extern "rtlib"
 
+	'' built-in RANDOMIZE & RND & RND32
 	declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB.FB_RND_AUTO )
 	declare function rnd alias "fb_Rnd" ( byval n as single = 1.0 ) as double
 	declare function rnd32 alias "fb_Rnd32" ( ) as ulong
 
-	declare sub rndGetInternals alias "fb_RndGetInternals" ( byval info as FB_RNDINTERNALS ptr )
+	declare sub rndGetState alias "fb_RndGetState" ( byval info as FB_RNDSTATE ptr )
 
 	#if __FB_MT__
 

--- a/inc/fbc-int/math.bi
+++ b/inc/fbc-int/math.bi
@@ -58,6 +58,20 @@ extern "rtlib"
 	'' get a pointer to the internal global state for RND()
 	declare function rndGetState alias "fb_RndGetState" ( ) as FB_RNDSTATE ptr
 
+	'' generic procedure to initialize a built-in PRNG with user allocated FB_RNDSTATE
+	declare sub rndCtxInit cdecl alias "fb_RndCtxInit" _
+		( _
+			byval seed as ulongint = 0, _
+			byval algorithm as long = FB.FB_RND_AUTO _
+		)
+
+	'' procedures to initialize a user allocated FB_RNDSTATE for a specific generator
+	declare sub rndCtxInitCRT32 cdecl alias "fb_RndCtxInitCRT32" ( byval seed as ulongint = 0 )
+	declare sub rndCtxInitFAST32 cdecl alias "fb_RndCtxInitFAST32" ( byval seed as ulongint = 0 )
+	declare sub rndCtxInitMTWIST32 cdecl alias "fb_RndCtxInitMTWIST32" ( byval seed as ulongint = 0 )
+	declare sub rndCtxInitQB32 cdecl alias "fb_RndCtxInitQB32" ( byval seed as ulongint = 0 )
+	declare sub rndCtxInitREAL32 cdecl alias "fb_RndCtxInitREAL32" ( byval seed as ulongint = 0 )
+
 	#if __FB_MT__
 
 	declare sub mathLock alias "fb_MathLock" ()

--- a/inc/fbmath.bi
+++ b/inc/fbmath.bi
@@ -5,20 +5,6 @@
 # error not supported in qb dialect
 # endif
 
-'' Remove RANDOMIZE & RND from the global namespace 
-'' otherwise 'using fb' won't work with new declarations
-'' in the fb namespace
-#if defined( ..RANDOMIZE )
-	#undef ..RANDOMIZE
-#endif
-#if defined( ..RND )
-	#undef ..RND
-#endif
-
-#if defined( __FB_CYGWIN__) or defined(__FB_WIN32__)
-#inclib "advapi32"
-#endif
-
 namespace FB
 
 	''
@@ -34,13 +20,6 @@ namespace FB
 		FB_RND_QB
 		FB_RND_REAL
 	end enum
-
-	extern "rtlib"
-		'' declare built-in RANDOMIZE, RND, & RND32 in the FB namespace
-		declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB.FB_RND_AUTO )
-		declare function rnd alias "fb_Rnd" ( byval n as single = 1.0 ) as double
-		declare function rnd32 alias "fb_Rnd32" ( ) as ulong
-	end extern
 
 	''
 	'' "FAST" PRNG from 'Numerical recipes in C' chapter 7.1

--- a/inc/fbmath.bi
+++ b/inc/fbmath.bi
@@ -42,6 +42,134 @@ namespace FB
 		declare function rnd32 alias "fb_Rnd32" ( ) as ulong
 	end extern
 
+	''
+	'' "FAST" PRNG from 'Numerical recipes in C' chapter 7.1
+	''
+	type RndFAST32
+		iseed as ulong = 327680
+		declare function rnd() as double
+		declare function rnd32() as ulong
+	end type
+
+	private function RndFAST32.rnd32() as ulong
+		this.iseed = this.iseed * 1664525 + 1013904223
+		return this.iseed
+	end function
+
+	private function RndFAST32.rnd() as double
+		return this.rnd32()/cdbl(4294967296ull)
+	end function
+
+	''
+	'' Middle Square Weyl Sequence PRNG / Bernard Widynski / 20 May 2020
+	'' https://arxiv.org/abs/1704.00358v5
+	'' 
+	''
+	type RndMSWS32
+		s as ulongint = &hb5ad4eceda1ce2a9ull
+		w as ulongint
+		x as ulongint
+		declare function rnd() as double
+		declare function rnd32() as ulong
+	end type
+
+	private function RndMSWS32.rnd32() as ulong
+		with this
+			.x *= .x
+			.w += .s
+			.x += .w
+			.x = ( .x shl 32 ) or ( .x shr 32 )
+			return .x
+		end with
+	end function
+
+	private function RndMSWS32.rnd() as double
+		return this.rnd32()/cdbl(4294967296ull)
+	end function
+
+	''
+	'' Squares: A Fast Counter Based PRNG / Bernard Widynski / 5 May 2020
+	'' https://arxiv.org/abs/2004.06278
+	''
+	type RndSquares32
+		key as ulongint = &hb5ad4eceda1ce2a9ull
+		ctr as ulongint
+		declare function rnd() as double
+		declare function rnd32() as ulong
+	end type
+
+	private function RndSquares32.rnd32() as ulong
+		dim as ulongint x = this.key * this.ctr
+		dim as ulongint y = x
+		dim as ulongint z = y + key
+		x = x * x + y
+		x = ( x shr 32 ) or ( x shl 32 )
+		x = x * x + z
+		x = ( x shr 32 ) or ( x shl 32 )
+		this.ctr += 1
+		return (x * x + y) shr 32
+	end function
+
+	private function RndSquares32.rnd() as double
+		return this.rnd32()/cdbl(4294967296ull)
+	end function
+
+	''
+	'' *Really* minimal PCG32 code / (c) 2014 M.E. O'Neill / pcg-random.org
+	'' Licensed under Apache License 2.0 (NO WARRANTY, etc. see website)
+	''
+	type RndPCG32
+		state as ulongint
+		inc_ as ulongint
+		declare function rnd() as double
+		declare function rnd32() as ulong
+	end type
+
+	private function RndPCG32.rnd32() as ulong
+		with this
+			var oldstate = this.state
+			'' Advance internal state
+			.state = oldstate * 6364136223846793005ULL + ( .inc_ or 1 )
+			'' Calculate output function (XSH RR), uses old state for max ILP
+			dim as ulong xorshifted = ((oldstate shr 18u) xor oldstate) shr 27u
+			dim as ulong rot = oldstate shr 59u
+			return (xorshifted shr rot) or (xorshifted shl ((-rot) and 31))
+		end with
+	end function
+
+	private function RndPCG32.rnd() as double
+		return this.rnd32()/cdbl(4294967296ull)
+	end function
+
+	''
+	'' xoroshiro128** Written in 2018 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+	'' http://prng.di.unimi.it/xoroshiro128starstar.c
+	''
+	'' Note the extra outer parentheses
+	'' also note: #define's won't respect namespaces
+	#define __FB_ROTL__(x,k) ( (x shl k) or (x shr(64-k)) ) 
+ 
+	type Rndxoroshiro128
+		as ulongint s(0 To 1) = { 1, 0 }
+		declare function rnd() as double
+		declare function rnd64() as ulongint
+	end type
+ 
+	private function Rndxoroshiro128.rnd64() as ulongint
+		dim as ulongint s0, s1, result
+		s0 = this.s(0)
+		s1 = this.s(1)
+		result = __FB_ROTL__(s0*5,7)*9
+		s1 xor= s0
+		this.s(0) = __FB_ROTL__(s0,24) xor s1 xor (s1 shl 16)
+		this.s(1) = __FB_ROTL__(s1,37)
+		return result
+	end function
+ 
+	private function Rndxoroshiro128.rnd() as double
+		return cdbl(this.rnd64() shr 11)/cdbl(2^53)
+	end function
+
 end namespace
 
 #endif '' __FBMATH_BI__

--- a/inc/fbmath.bi
+++ b/inc/fbmath.bi
@@ -5,6 +5,20 @@
 # error not supported in qb dialect
 # endif
 
+'' Remove RANDOMIZE & RND from the global namespace 
+'' otherwise 'using fb' won't work with new declarations
+'' in the fb namespace
+#if defined( ..RANDOMIZE )
+	#undef ..RANDOMIZE
+#endif
+#if defined( ..RND )
+	#undef ..RND
+#endif
+
+#if defined( __FB_CYGWIN__) or defined(__FB_WIN32__)
+#inclib "advapi32"
+#endif
+
 namespace FB
 
 	''
@@ -20,6 +34,13 @@ namespace FB
 		FB_RND_QB
 		FB_RND_REAL
 	end enum
+
+	extern "rtlib"
+		'' declare built-in RANDOMIZE, RND, & RND32 in the FB namespace
+		declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB.FB_RND_AUTO )
+		declare function rnd alias "fb_Rnd" ( byval n as single = 1.0 ) as double
+		declare function rnd32 alias "fb_Rnd32" ( ) as ulong
+	end extern
 
 end namespace
 

--- a/inc/fbmath.bi
+++ b/inc/fbmath.bi
@@ -1,0 +1,26 @@
+#ifndef __FBMATH_BI__ 
+#define __FBMATH_BI__
+
+# if __FB_LANG__ = "qb"
+# error not supported in qb dialect
+# endif
+
+namespace FB
+
+	''
+	'' built-in random number generators
+	'' to be used with:
+	''    RANDOMIZE seed, algorithm
+	''
+	enum FB_RND_ALGORITHMS
+		FB_RND_AUTO
+		FB_RND_CRT
+		FB_RND_FAST
+		FB_RND_MTWIST
+		FB_RND_QB
+		FB_RND_REAL
+	end enum
+
+end namespace
+
+#endif '' __FBMATH_BI__

--- a/src/rtlib/fb_math.h
+++ b/src/rtlib/fb_math.h
@@ -34,6 +34,23 @@ typedef struct _FB_RNDSTATE {
 
 FBCALL FB_RNDSTATE *fb_RndGetState ( void );
 
+       void         fb_RndCtxInit           ( uint64_t seed, int algorithm );
+       void         fb_RndCtxInitCRT32      ( uint64_t seed );
+       void         fb_RndCtxInitFAST32     ( uint64_t seed );
+       void         fb_RndCtxInitMTWIST32   ( uint64_t seed );
+       void         fb_RndCtxInitQB32       ( uint64_t seed );
+       void         fb_RndCtxInitREAL32     ( uint64_t seed );
+
+/* Constants from 'Numerical recipes in C' chapter 7.1 */
+#define FBRNDFAST32(arg) ( ( (arg) * 1664525 ) + 1013904223 )
+
+static __inline__ void hRnd_FillFAST32 ( uint32_t *buffer, uint32_t length32, uint32_t iseed32 )
+{
+	buffer[0] = iseed32;
+	for( uint32_t i = 1; i < length32; i++ ) {
+		buffer[i] = FBRNDFAST32( buffer[i - 1] );
+	}
+}
 
 FBCALL int          fb_SGNSingle        ( float x );
 FBCALL int          fb_SGNDouble        ( double x );

--- a/src/rtlib/fb_math.h
+++ b/src/rtlib/fb_math.h
@@ -7,21 +7,34 @@ typedef enum _FB_RND_ALGORITHMS {
 	FB_RND_REAL
 } FB_RND_ALGORITHMS;
 
-typedef struct _FB_RNDSTATE {
-	uint32_t algorithm;
-	uint32_t length;
-	uint32_t *stateblock;
-	uint32_t **stateindex;
-	uint32_t *iseed;
-	double   ( *rndproc )( float n );
-	uint32_t ( *rndproc32 )( void );
-} FB_RNDSTATE;
-
+/* single instance global state */
+FBCALL void         fb_Randomize        ( double seed, int algorithm );
 FBCALL double       fb_Rnd              ( float n );
 FBCALL uint32_t     fb_Rnd32            ( void );
-FBCALL void         fb_RndGetState      ( FB_RNDSTATE *info );
 
-FBCALL void         fb_Randomize        ( double seed, int algorithm );
+#define FB_RND_MAX_STATE 624
+
+typedef struct _FB_RNDSTATE {
+	uint32_t algorithm;        /* see FB_RND_ALGORITHMS */
+	uint32_t length;           /* length of state vector (# of uint32_t) */
+
+	/* function pointers to internal rnd() and rnd32() called by fb_Rnd() and fb_Rnd32() */
+	double   ( *rndproc )( float n );
+	uint32_t ( *rndproc32 )( void );
+
+	union {
+		uint32_t iseed64;      /* initial seed and state 64-bit */
+		uint32_t iseed32;      /* initial seed and state 32-bit */
+	};
+	uint32_t *index32;         /* pointer to index in state vector, if length != 0 */
+	
+	/* state vector */
+	uint32_t state32[FB_RND_MAX_STATE];
+} FB_RNDSTATE;
+
+FBCALL FB_RNDSTATE *fb_RndGetState ( void );
+
+
 FBCALL int          fb_SGNSingle        ( float x );
 FBCALL int          fb_SGNDouble        ( double x );
 FBCALL float        fb_FIXSingle        ( float x );

--- a/src/rtlib/fb_math.h
+++ b/src/rtlib/fb_math.h
@@ -7,7 +7,7 @@ typedef enum _FB_RND_ALGORITHMS {
 	FB_RND_REAL
 } FB_RND_ALGORITHMS;
 
-typedef struct _FB_RNDINTERNALS {
+typedef struct _FB_RNDSTATE {
 	uint32_t algorithm;
 	uint32_t length;
 	uint32_t *stateblock;
@@ -15,11 +15,11 @@ typedef struct _FB_RNDINTERNALS {
 	uint32_t *iseed;
 	double   ( *rndproc )( float n );
 	uint32_t ( *rndproc32 )( void );
-} FB_RNDINTERNALS;
+} FB_RNDSTATE;
 
 FBCALL double       fb_Rnd              ( float n );
 FBCALL uint32_t     fb_Rnd32            ( void );
-FBCALL void         fb_GetRndInternals  ( FB_RNDINTERNALS *info );
+FBCALL void         fb_RndGetState      ( FB_RNDSTATE *info );
 
 FBCALL void         fb_Randomize        ( double seed, int algorithm );
 FBCALL int          fb_SGNSingle        ( float x );

--- a/src/rtlib/fb_math.h
+++ b/src/rtlib/fb_math.h
@@ -1,3 +1,12 @@
+typedef enum _FB_RND_ALGORITHMS {
+	FB_RND_AUTO = 0,
+	FB_RND_CRT,
+	FB_RND_FAST,
+	FB_RND_MTWIST,
+	FB_RND_QB,
+	FB_RND_REAL
+} FB_RND_ALGORITHMS;
+
 typedef struct _FB_RNDINTERNALS {
 	uint32_t algorithm;
 	uint32_t length;

--- a/src/rtlib/fb_math.h
+++ b/src/rtlib/fb_math.h
@@ -34,13 +34,6 @@ typedef struct _FB_RNDSTATE {
 
 FBCALL FB_RNDSTATE *fb_RndGetState ( void );
 
-       void         fb_RndCtxInit           ( uint64_t seed, int algorithm );
-       void         fb_RndCtxInitCRT32      ( uint64_t seed );
-       void         fb_RndCtxInitFAST32     ( uint64_t seed );
-       void         fb_RndCtxInitMTWIST32   ( uint64_t seed );
-       void         fb_RndCtxInitQB32       ( uint64_t seed );
-       void         fb_RndCtxInitREAL32     ( uint64_t seed );
-
 /* Constants from 'Numerical recipes in C' chapter 7.1 */
 #define FBRNDFAST32(arg) ( ( (arg) * 1664525 ) + 1013904223 )
 

--- a/src/rtlib/math_rnd.c
+++ b/src/rtlib/math_rnd.c
@@ -9,19 +9,12 @@
 	#include <fcntl.h>
 #endif
 
-#define RND_AUTO		0
-#define RND_CRT			1
-#define RND_FAST		2
-#define RND_MTWIST		3
-#define RND_QB			4
-#define RND_REAL		5
-
 #define INITIAL_SEED	327680
 
 #define MAX_STATE		624
 #define PERIOD			397
 
-static uint32_t generator = RND_AUTO;
+static uint32_t generator = FB_RND_AUTO;
 
 static double hRnd_Startup( float n );
 static double hRnd_CRT ( float n );
@@ -43,14 +36,14 @@ static void hStartup( void )
 {
 	switch( __fb_ctx.lang ) {
 	case FB_LANG_QB:
-		generator = RND_QB;
+		generator = FB_RND_QB;
 		rnd_func = hRnd_QB;
 		rnd_func32 = hRnd_QB32;
 		iseed = INITIAL_SEED;
 		break;
 	case FB_LANG_FB_FBLITE:
 	case FB_LANG_FB_DEPRECATED:
-		generator = RND_CRT;
+		generator = FB_RND_CRT;
 		rnd_func = hRnd_CRT;
 		rnd_func32 = hRnd_CRT32;
 		break;
@@ -109,7 +102,7 @@ static uint32_t hRnd_MTWIST32 ( void )
 
 	if( !p ) {
 		/* initialize state starting with an initial seed */
-		fb_Randomize( INITIAL_SEED, RND_MTWIST );
+		fb_Randomize( INITIAL_SEED, FB_RND_MTWIST );
 	}
 
 	if( p >= state + MAX_STATE ) {
@@ -199,7 +192,7 @@ static uint32_t hRnd_REAL32( void )
 	if( p == ( state + MAX_STATE ) ) {
 		/* get new random numbers, if not available, redirect to MTwist as per docs */
 		if( hRefillRealRndNumber( ) == 0 ) {
-			fb_Randomize( -1.0, RND_MTWIST );
+			fb_Randomize( -1.0, FB_RND_MTWIST );
 			return fb_Rnd32( );
 		}
 	}
@@ -242,13 +235,13 @@ FBCALL void fb_Randomize ( double seed, int algorithm )
 		uint32_t i[2];
 	} dtoi;
 
-	if( algorithm == RND_AUTO ) {
+	if( algorithm == FB_RND_AUTO ) {
 		switch( __fb_ctx.lang ) {
-		case FB_LANG_QB:			algorithm = RND_QB;		break;
+		case FB_LANG_QB:			algorithm = FB_RND_QB;		break;
 		case FB_LANG_FB_FBLITE:
-		case FB_LANG_FB_DEPRECATED:	algorithm = RND_CRT;	break;
+		case FB_LANG_FB_DEPRECATED:	algorithm = FB_RND_CRT;	break;
 		default:
-		case FB_LANG_FB:			algorithm = RND_MTWIST; break;
+		case FB_LANG_FB:			algorithm = FB_RND_MTWIST; break;
 		}
 	}
 
@@ -267,20 +260,20 @@ FBCALL void fb_Randomize ( double seed, int algorithm )
 	generator = algorithm;
 
 	switch( algorithm ) {
-	case RND_CRT:
+	case FB_RND_CRT:
 		rnd_func = hRnd_CRT;
 		rnd_func32 = hRnd_CRT32;
 		srand( (unsigned int)seed );
 		rand( );
 		break;
 
-	case RND_FAST:
+	case FB_RND_FAST:
 		rnd_func = hRnd_FAST;
 		rnd_func32 = hRnd_FAST32;
 		iseed = (uint32_t)seed;
 		break;
 
-	case RND_QB:
+	case FB_RND_QB:
 		rnd_func = hRnd_QB;
 		rnd_func32 = hRnd_QB32;
 		dtoi.d = seed;
@@ -291,7 +284,7 @@ FBCALL void fb_Randomize ( double seed, int algorithm )
 		break;
 
 #if defined HOST_WIN32 || defined HOST_LINUX
-	case RND_REAL:
+	case FB_RND_REAL:
 		rnd_func = hRnd_REAL;
 		rnd_func32 = hRnd_REAL32;
 		state[0] = (unsigned int)seed;
@@ -302,7 +295,7 @@ FBCALL void fb_Randomize ( double seed, int algorithm )
 #endif
 
 	default:
-	case RND_MTWIST:
+	case FB_RND_MTWIST:
 		rnd_func = hRnd_MTWIST;
 		rnd_func32 = hRnd_MTWIST32;
 		state[0] = (unsigned int)seed;

--- a/src/rtlib/math_rnd.c
+++ b/src/rtlib/math_rnd.c
@@ -33,15 +33,16 @@ static FB_RNDSTATE ctx = {
 	hRnd_Startup32,    /* fb_Rnd32() */
 	{0},               /* iseed64 */
 	NULL,              /* index pointer */
-
 	/* state32[] - state for FB_RND_MTWIST 
-	   and buffer for FB_RND_REAL follows 
-	   immediately follow
-	 */
+	   and buffer for FB_RND_REAL follows */
 	 {0}
 };
 
-/* last number as returned by RND(0.0) is never reset */
+/* last number as returned by RND(0.0) 
+	- is updated by fb_Rnd() only
+	- is never reset
+	- is not updated by fb_Rnd32() or any of the other PRNG procedures
+ */
 static double last_num = 0.0;
 
 /* FB_RND_CRT */
@@ -56,15 +57,25 @@ static double hRnd_CRT ( float n )
 		return last_num;
 
 	/* return between 0 and 1 (but never 1) */
-	return (double)hRnd_CRT32( ) * ( 1.0 / ( (double)RAND_MAX + 1.0 ) );
+	return (double)hRnd_CRT32() * ( 1.0 / ( (double)RAND_MAX + 1.0 ) );
+}
+
+void fb_RndCtxInitCRT32 ( uint64_t seed )
+{
+	ctx.algorithm = FB_RND_CRT;
+	ctx.length = 0;
+	ctx.index32 = NULL;
+	/* ctx.iseed32 = (uint32_t)seed; */
+	ctx.rndproc = hRnd_CRT;
+	ctx.rndproc32 = hRnd_CRT32;
+
+	srand( (unsigned int)seed );
 }
 
 /* FB_RND_FAST */
 static uint32_t hRnd_FAST32 ( void )
 {
-	/* Constants from 'Numerical recipes in C' chapter 7.1 */
-	ctx.iseed32 = ( ( 1664525 * ctx.iseed32 ) + 1013904223 );
-	return ctx.iseed32;
+	return ctx.iseed32 = FBRNDFAST32( ctx.iseed32 );
 }
 
 static double hRnd_FAST ( float n )
@@ -77,14 +88,24 @@ static double hRnd_FAST ( float n )
 	return (double)hRnd_FAST32() / (double)4294967296ULL;
 }
 
-/* rnd# function for FB_RND_MTWIST */
+void fb_RndCtxInitFAST32 ( uint64_t seed )
+{
+	ctx.algorithm = FB_RND_FAST;
+	ctx.length = 0;
+	ctx.index32 = NULL;
+	ctx.iseed32 = (uint32_t)seed;
+	ctx.rndproc = hRnd_FAST;
+	ctx.rndproc32 = hRnd_FAST32;
+}
+
+/* FB_RND_MTWIST */
 static uint32_t hRnd_MTWIST32 ( void )
 {
 	uint32_t i, v, xor_mask[2] = { 0, 0x9908B0DF };
 
 	if( !ctx.index32 ) {
 		/* initialize state starting with an initial seed */
-		fb_Randomize( INITIAL_SEED, FB_RND_MTWIST );
+		fb_RndCtxInitMTWIST32( INITIAL_SEED );
 	}
 
 	if( ctx.index32 >= ctx.state32 + MAX_STATE ) {
@@ -118,6 +139,19 @@ static double hRnd_MTWIST ( float n )
 
 	return (double)hRnd_MTWIST32() / (double)4294967296ULL;
 }
+
+void fb_RndCtxInitMTWIST32 ( uint64_t seed )
+{
+	ctx.algorithm = FB_RND_MTWIST;
+	ctx.length = MAX_STATE;
+	ctx.index32 = ctx.state32 + MAX_STATE;
+	/* ctx.iseed32 = seed; */
+	ctx.rndproc = hRnd_MTWIST;
+	ctx.rndproc32 = hRnd_MTWIST32;
+
+	hRnd_FillFAST32( ctx.state32, MAX_STATE, (uint32_t)seed );
+}
+
 /* FB_RND_QB */
 static uint32_t hRnd_QB32 ( void )
 {
@@ -144,10 +178,20 @@ static double hRnd_QB ( float n )
 	return (float)hRnd_QB32() / (float)0x1000000;
 }
 
+void fb_RndCtxInitQB32 ( uint64_t seed )
+{
+	ctx.algorithm = FB_RND_QB;
+	ctx.length = 0;
+	ctx.index32 = NULL;
+	ctx.iseed32 = (uint32_t)seed;
+	ctx.rndproc = hRnd_QB;
+	ctx.rndproc32 = hRnd_QB32;
+}
+
 /* FB_RND_REAL */
 
 #if defined HOST_WIN32 || defined HOST_LINUX
-static int hRefillRealRndNumber( )
+static int hRefillRealRndNumber( void )
 {
 	int success = 0;
 #if defined HOST_WIN32
@@ -175,9 +219,9 @@ static uint32_t hRnd_REAL32( void )
 	uint32_t v;
 	if( ctx.index32 == ( ctx.state32 + MAX_STATE ) ) {
 		/* get new random numbers, if not available, redirect to MTwist as per docs */
-		if( hRefillRealRndNumber( ) == 0 ) {
+		if( hRefillRealRndNumber() == 0 ) {
 			fb_Randomize( -1.0, FB_RND_MTWIST );
-			return fb_Rnd32( );
+			return hRnd_MTWIST32();
 		}
 	}
 	v = *(ctx.index32++);
@@ -193,23 +237,33 @@ static double hRnd_REAL( float n )
 }
 #endif
 
+void fb_RndCtxInitREAL32 ( uint64_t seed )
+{
+	ctx.algorithm = FB_RND_REAL;
+	ctx.length = MAX_STATE;
+	ctx.index32 = ctx.state32 + MAX_STATE;
+	/* ctx.iseed64 = seed; */
+	ctx.rndproc = hRnd_REAL;
+	ctx.rndproc32 = hRnd_REAL32;
+
+	/* initialize starting state - used by hRefillRealRndNumber() */
+	hRnd_FillFAST32( ctx.state32, MAX_STATE, (uint32_t)seed );
+}
+
+/* RND Startup code */
+
 static void hStartup( void )
 {
 	switch( __fb_ctx.lang ) {
 	case FB_LANG_QB:
-		ctx.algorithm = FB_RND_QB;
-		ctx.rndproc = hRnd_QB;
-		ctx.rndproc32 = hRnd_QB32;
-		ctx.iseed32 = INITIAL_SEED;
+		fb_RndCtxInitQB32( INITIAL_SEED );
 		break;
 	case FB_LANG_FB_FBLITE:
 	case FB_LANG_FB_DEPRECATED:
-		ctx.algorithm = FB_RND_CRT;
-		ctx.rndproc = hRnd_CRT;
-		ctx.rndproc32 = hRnd_CRT32;
+		fb_RndCtxInitCRT32( 1 );
 		break;
 	default:
-		fb_Randomize( 0.0, 0 );
+		fb_Randomize( 0.0, FB_RND_AUTO );
 		break;
 	}
 }
@@ -224,23 +278,6 @@ static double hRnd_Startup ( float n )
 {
 	hStartup();
 	return fb_Rnd( n );
-}
-
-FBCALL double fb_Rnd ( float n )
-{
-	FB_MATH_LOCK();
-	last_num = ctx.rndproc( n );
-	FB_MATH_UNLOCK();
-	return last_num;
-}
-
-FBCALL uint32_t fb_Rnd32 ( void )
-{
-	uint32_t result;
-	FB_MATH_LOCK();
-	result = ctx.rndproc32( );
-	FB_MATH_UNLOCK();
-	return result;
 }
 
 static int getAlogrithm( int algorithm )
@@ -264,57 +301,42 @@ union {
 
 void fb_RndCtxInit ( uint64_t seed, int algorithm )
 {
-	int i;
-
 	ctx.algorithm = getAlogrithm( algorithm );
 
 	switch( ctx.algorithm ) {
 	case FB_RND_CRT:
-		ctx.rndproc = hRnd_CRT;
-		ctx.rndproc32 = hRnd_CRT32;
-		srand( (unsigned int)seed );
-		rand( );
+		fb_RndCtxInitCRT32( (uint32_t)seed );
+		fb_Rnd32();
 		break;
 
 	case FB_RND_FAST:
-		ctx.rndproc = hRnd_FAST;
-		ctx.rndproc32 = hRnd_FAST32;
-		ctx.iseed32 = (uint32_t)seed;
+		fb_RndCtxInitFAST32( (uint32_t)seed );
 		break;
 
 	case FB_RND_QB:
-		ctx.rndproc = hRnd_QB;
-		ctx.rndproc32 = hRnd_QB32;
 		dtoi.d = seed;
 		uint32_t s = dtoi.i[1];
 		s ^= ( s >> 16 );
 		s = ( ( s & 0xFFFF ) << 8 ) | ( ctx.iseed32 & 0xFF );
-		ctx.iseed32 = s;
+		fb_RndCtxInitQB32( s );
 		break;
 
 #if defined HOST_WIN32 || defined HOST_LINUX
 	case FB_RND_REAL:
-		ctx.rndproc = hRnd_REAL;
-		ctx.rndproc32 = hRnd_REAL32;
-		ctx.state32[0] = (unsigned int)seed;
-		for( i = 1; i < MAX_STATE; i++ )
-			ctx.state32[i] = ( ctx.state32[i - 1] * 1664525 ) + 1013904223;
-		ctx.index32 = ctx.state32 + MAX_STATE;
+		fb_RndCtxInitREAL32( (uint32_t)seed );
 		break;
 #endif
 
 	default:
 	case FB_RND_MTWIST:
-		ctx.rndproc = hRnd_MTWIST;
-		ctx.rndproc32 = hRnd_MTWIST32;
-		ctx.state32[0] = (unsigned int)seed;
-		for( i = 1; i < MAX_STATE; i++ )
-			ctx.state32[i] = ( ctx.state32[i - 1] * 1664525 ) + 1013904223;
-		ctx.index32 = ctx.state32 + MAX_STATE;
+		fb_RndCtxInitMTWIST32( (uint32_t)seed );
 		break;
 	}
 }
 
+/* Public API for the built-in PRNGs */
+
+/* declare sub randomize alias "fb_Randomize" ( byval seed as double = -1.0, byval algorithm as long = FB.FB_RND_AUTO ) */
 FBCALL void fb_Randomize ( double seed, int algorithm )
 {
 	FB_MATH_LOCK();
@@ -325,16 +347,35 @@ FBCALL void fb_Randomize ( double seed, int algorithm )
 		algorithms (with the exception of the QB one) take the integer value
 		of the seed, so make a value that will change more than once a second */
 
-		dtoi.d = fb_Timer( );
+		dtoi.d = fb_Timer();
 		seed = (double)(dtoi.i[0] ^ dtoi.i[1]);
 	}
 
 	fb_RndCtxInit( (uint64_t)seed, algorithm );
 
 	FB_MATH_UNLOCK();
-
 }
 
+/* declare function rnd alias "fb_Rnd" ( byval n as single = 1.0 ) as double */
+FBCALL double fb_Rnd ( float n )
+{
+	FB_MATH_LOCK();
+	last_num = ctx.rndproc( n );
+	FB_MATH_UNLOCK();
+	return last_num;
+}
+
+/* declare function rnd32 alias "fb_Rnd32" ( ) as ulong */
+FBCALL uint32_t fb_Rnd32 ( void )
+{
+	uint32_t result;
+	FB_MATH_LOCK();
+	result = ctx.rndproc32();
+	FB_MATH_UNLOCK();
+	return result;
+}
+
+/* declare function rndGetState alias "fb_RndGetState" ( ) as FB_RNDSTATE ptr */
 FBCALL FB_RNDSTATE *fb_RndGetState( void )
 {
 	return &ctx;

--- a/tests/fbc-int/math-rnd.bas
+++ b/tests/fbc-int/math-rnd.bas
@@ -20,12 +20,12 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 		CU_ASSERT_EQUAL( fbc.rnd32(), 3027450565 )
 		CU_ASSERT_EQUAL( fbc.rnd32(), 217083232 )
 		
-		dim info as FBC.FB_RNDSTATE
-		fbc.rndGetState( @info )
+		dim info as FBC.FB_RNDSTATE ptr
+		info = fbc.rndGetState( )
 
-		CU_ASSERT( info.algorithm = FB.FB_RND_FAST )
-		CU_ASSERT( info.rndproc <> NULL )
-		CU_ASSERT( info.rndproc32 <> NULL )
+		CU_ASSERT( info->algorithm = FB.FB_RND_FAST )
+		CU_ASSERT( info->rndproc <> NULL )
+		CU_ASSERT( info->rndproc32 <> NULL )
 
 	END_TEST
 
@@ -40,8 +40,8 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 		var x = rnd
 		var y = rnd32
 
-		dim info as FB_RNDSTATE
-		rndGetState( @info )
+		dim info as FB_RNDSTATE ptr
+		info = rndGetState( )
 
 		CU_PASS()
 		

--- a/tests/fbc-int/math-rnd.bas
+++ b/tests/fbc-int/math-rnd.bas
@@ -1,4 +1,5 @@
 #include "fbcunit.bi"
+#include "fbmath.bi"
 #include "fbc-int/math.bi"
 
 #ifndef NULL
@@ -11,7 +12,7 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 
 	TEST( direct )
 
-		fbc.randomize 1, FBC.FB_RND_FAST
+		fbc.randomize 1, FB.FB_RND_FAST
 
 		CU_ASSERT_EQUAL( fbc.rnd32(), 1015568748 )
 		CU_ASSERT_EQUAL( fbc.rnd32(), 1586005467 )
@@ -22,7 +23,7 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 		dim info as FBC.FB_RNDINTERNALS
 		fbc.rndGetInternals( @info )
 
-		CU_ASSERT( info.algorithm = FBC.FB_RND_FAST )
+		CU_ASSERT( info.algorithm = FB.FB_RND_FAST )
 		CU_ASSERT( info.rndproc <> NULL )
 		CU_ASSERT( info.rndproc32 <> NULL )
 
@@ -34,7 +35,7 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 		using fbc
 
 		randomize
-		randomize , FB_RND_MTWIST
+		randomize , FB.FB_RND_MTWIST
 
 		var x = rnd
 		var y = rnd32

--- a/tests/fbc-int/math-rnd.bas
+++ b/tests/fbc-int/math-rnd.bas
@@ -20,8 +20,8 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 		CU_ASSERT_EQUAL( fbc.rnd32(), 3027450565 )
 		CU_ASSERT_EQUAL( fbc.rnd32(), 217083232 )
 		
-		dim info as FBC.FB_RNDINTERNALS
-		fbc.rndGetInternals( @info )
+		dim info as FBC.FB_RNDSTATE
+		fbc.rndGetState( @info )
 
 		CU_ASSERT( info.algorithm = FB.FB_RND_FAST )
 		CU_ASSERT( info.rndproc <> NULL )
@@ -40,8 +40,8 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 		var x = rnd
 		var y = rnd32
 
-		dim info as FB_RNDINTERNALS
-		rndGetInternals( @info )
+		dim info as FB_RNDSTATE
+		rndGetState( @info )
 
 		CU_PASS()
 		

--- a/tests/fbc-int/math-rnd.bas
+++ b/tests/fbc-int/math-rnd.bas
@@ -12,13 +12,13 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 
 	TEST( direct )
 
-		fbc.randomize 1, FB.FB_RND_FAST
+		fb.randomize 1, FB.FB_RND_FAST
 
-		CU_ASSERT_EQUAL( fbc.rnd32(), 1015568748 )
-		CU_ASSERT_EQUAL( fbc.rnd32(), 1586005467 )
-		CU_ASSERT_EQUAL( fbc.rnd32(), 2165703038 )
-		CU_ASSERT_EQUAL( fbc.rnd32(), 3027450565 )
-		CU_ASSERT_EQUAL( fbc.rnd32(), 217083232 )
+		CU_ASSERT_EQUAL( fb.rnd32(), 1015568748 )
+		CU_ASSERT_EQUAL( fb.rnd32(), 1586005467 )
+		CU_ASSERT_EQUAL( fb.rnd32(), 2165703038 )
+		CU_ASSERT_EQUAL( fb.rnd32(), 3027450565 )
+		CU_ASSERT_EQUAL( fb.rnd32(), 217083232 )
 		
 		dim info as FBC.FB_RNDSTATE ptr
 		info = fbc.rndGetState( )
@@ -31,8 +31,25 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 
 	TEST( using_fbc )
 	
-		'' essentially, a compile test only
 		using fbc
+
+		fb.randomize
+		fb.randomize , FB.FB_RND_MTWIST
+
+		dim info as FB_RNDSTATE ptr
+		info = rndGetState( )
+
+		CU_ASSERT( info->algorithm = FB.FB_RND_MTWIST )
+		CU_ASSERT( info->length = FB_RND_MAX_STATE )
+		CU_ASSERT( info->rndproc <> NULL )
+		CU_ASSERT( info->rndproc32 <> NULL )
+		
+	END_TEST
+
+	TEST( using_fb )
+		'' essentially, a compile test only
+
+		using fb
 
 		randomize
 		randomize , FB.FB_RND_MTWIST
@@ -40,11 +57,8 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 		var x = rnd
 		var y = rnd32
 
-		dim info as FB_RNDSTATE ptr
-		info = rndGetState( )
-
 		CU_PASS()
-		
+
 	END_TEST
 
 END_SUITE

--- a/tests/fbc-int/math-rnd.bas
+++ b/tests/fbc-int/math-rnd.bas
@@ -12,13 +12,13 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 
 	TEST( direct )
 
-		fb.randomize 1, FB.FB_RND_FAST
+		fbc.randomize 1, FB.FB_RND_FAST
 
-		CU_ASSERT_EQUAL( fb.rnd32(), 1015568748 )
-		CU_ASSERT_EQUAL( fb.rnd32(), 1586005467 )
-		CU_ASSERT_EQUAL( fb.rnd32(), 2165703038 )
-		CU_ASSERT_EQUAL( fb.rnd32(), 3027450565 )
-		CU_ASSERT_EQUAL( fb.rnd32(), 217083232 )
+		CU_ASSERT_EQUAL( fbc.rnd32(), 1015568748 )
+		CU_ASSERT_EQUAL( fbc.rnd32(), 1586005467 )
+		CU_ASSERT_EQUAL( fbc.rnd32(), 2165703038 )
+		CU_ASSERT_EQUAL( fbc.rnd32(), 3027450565 )
+		CU_ASSERT_EQUAL( fbc.rnd32(), 217083232 )
 		
 		dim info as FBC.FB_RNDSTATE ptr
 		info = fbc.rndGetState( )
@@ -33,8 +33,10 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 	
 		using fbc
 
-		fb.randomize
-		fb.randomize , FB.FB_RND_MTWIST
+		randomize
+		randomize , FB.FB_RND_MTWIST
+		var x = rnd
+		var y = rnd32
 
 		dim info as FB_RNDSTATE ptr
 		info = rndGetState( )
@@ -43,21 +45,19 @@ SUITE( fbc_tests.fbc_int.math_rnd )
 		CU_ASSERT( info->length = FB_RND_MAX_STATE )
 		CU_ASSERT( info->rndproc <> NULL )
 		CU_ASSERT( info->rndproc32 <> NULL )
-		
+
 	END_TEST
 
 	TEST( using_fb )
-		'' essentially, a compile test only
 
 		using fb
 
-		randomize
-		randomize , FB.FB_RND_MTWIST
-
-		var x = rnd
-		var y = rnd32
-
-		CU_PASS()
+		CU_ASSERT( FB_RND_AUTO   = 0 )
+		CU_ASSERT( FB_RND_CRT    = 1 )
+		CU_ASSERT( FB_RND_FAST   = 2 )
+		CU_ASSERT( FB_RND_MTWIST = 3 )
+		CU_ASSERT( FB_RND_QB     = 4 )
+		CU_ASSERT( FB_RND_REAL   = 5 )
 
 	END_TEST
 


### PR DESCRIPTION
New pseudo random number generators added as header file `fbmath.bi`
- can create multiple instances for parallel processing
- when created in multiple threads as separate instances, no mutex locking to worry about
- can be optimized by the gcc backend as inline functions
- can be updated patched easier by fbc users

Background:
- fbc has a few built-in PRNGs that can be conveniently accessed through RANDOMIZE & RND
- it's a simple interface and easy to use
- however, the built-in PRNGs share a single global state which does not lend itself well to optimizations or customization

Also in this update:
- code in src/rtlib/math_rnd.c refactored for readability
- fbc-int/math.bi updated do document and expose internals of src/rtlib/math_rnd.c
- fbc.RndGetState() now simply returns a pointer to the entire internal RND state rather than copying key fields
- previous `FB_RNDINTERNALS` now renamed to `FB_RNDSTATE`
