### PR TITLE
Implement a ThreadSelf function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -50,6 +50,7 @@ Version 1.08.0
 - github #256: gfxlib2: add vga16_blitter for linux-arm targets to pack 2 pixels per byte and write to linear frame buffer
 - ./inc/fbc-int/math.bi - fbc API for rnd, rnd32, randomize, expose some random number generator internals
 - ./inc/fbmath.bi - add random number generators fb.rndfast32, fb.rndmsws32, fb.rndsquares32, fb.rndpcg32, fb.rndxoroshiro128
+- add THREADSELF in ./inc/fbthread.bi to return the thread id of the current thread (adeyblue)
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Version 1.08.0
 - gfxlib2: X11 driver - set the window title for both the frame window and the client window
 - rtlib: RANDOMIZE RND_REAL for real random number generator now fills a buffer (624 ulongs) and RND iterates the buffer
 - rtlib: refactor math_rnd.c internals for readability
+- fbcunit: update to version 1.0
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling

--- a/inc/fbthread.bi
+++ b/inc/fbthread.bi
@@ -1,3 +1,4 @@
 #pragma once
 
 declare sub ThreadDetach alias "fb_ThreadDetach"( byval thread as any ptr )
+declare function ThreadSelf alias "fb_ThreadSelf"( ) as any ptr

--- a/src/rtlib/dos/symb_reg.txt
+++ b/src/rtlib/dos/symb_reg.txt
@@ -405,6 +405,7 @@ extern_asm(_fb_LPrintLongint);
 extern_asm(_fb_ConsoleViewEx);
 extern_asm(_fb_hSetFileBufSize);
 extern_asm(_fb_ThreadCall);
+extern_asm(_fb_ThreadSelf);
 extern_asm(___fb_utf8_offsetsTb);
 extern_asm(_fb_StrFill2);
 extern_asm(_fb_WstrOct_l);
@@ -1245,6 +1246,7 @@ DXE_EXPORT_TABLE (libfb_symbol_table)
     DXE_EXPORT_ASM (_fb_ConsoleViewEx)
     DXE_EXPORT_ASM (_fb_hSetFileBufSize)
     DXE_EXPORT_ASM (_fb_ThreadCall)
+    DXE_EXPORT_ASM (_fb_ThreadSelf)
     DXE_EXPORT_ASM (___fb_utf8_offsetsTb)
     DXE_EXPORT_ASM (_fb_StrFill2)
     DXE_EXPORT_ASM (_fb_WstrOct_l)

--- a/src/rtlib/dos/thread_core.c
+++ b/src/rtlib/dos/thread_core.c
@@ -8,10 +8,13 @@
 static void *threadproc( void *param )
 {
 	FBTHREADINFO *info = param;
+	FBTHREAD *thread = info->thread;
+
+	FB_TLSGETCTX( FBTHREAD )->self = thread;
 
 	/* call the user thread */
 	info->proc( info->param );
-	free( info);
+	free( info );
 
 	/* free mem */
 	fb_TlsFreeCtxTb( );
@@ -42,6 +45,8 @@ FBCALL FBTHREAD *fb_ThreadCreate( FB_THREADPROC proc, void *param, ssize_t stack
 
 	info->proc = proc;
 	info->param = param;
+	info->thread = thread;
+	thread->flags = 0;
 
 	if( pthread_attr_init( &tattr ) ) {
 		free( thread );
@@ -63,6 +68,7 @@ FBCALL FBTHREAD *fb_ThreadCreate( FB_THREADPROC proc, void *param, ssize_t stack
 	}
 
 	pthread_attr_destroy( &tattr );
+
 	return thread;
 
 #else
@@ -73,14 +79,18 @@ FBCALL FBTHREAD *fb_ThreadCreate( FB_THREADPROC proc, void *param, ssize_t stack
 
 FBCALL void fb_ThreadWait( FBTHREAD *thread )
 {
-
 #if defined ENABLE_MT
-	if( thread == NULL )
+	/* A wait for the main thread or ourselves will never end */
+	if(
+		( thread == NULL ) ||
+		( ( thread->flags & FBTHREAD_MAIN ) != 0 ) ||
+		( thread == FB_TLSGETCTX( FBTHREAD )->self )
+	) {
 		return;
+	}
 
 	pthread_join( thread->id, NULL );
 
 	free( thread );
 #endif
-        
 }

--- a/src/rtlib/fb_thread.h
+++ b/src/rtlib/fb_thread.h
@@ -10,6 +10,7 @@ struct _FBCOND;
 typedef struct _FBCOND FBCOND;
 
 FBCALL FBTHREAD         *fb_ThreadCreate( FB_THREADPROC proc, void *param, ssize_t stack_size );
+FBCALL FBTHREAD		*fb_ThreadSelf  ( void );
 FBCALL void              fb_ThreadWait  ( FBTHREAD *thread );
 FBCALL void              fb_ThreadDetach( FBTHREAD *thread );
 
@@ -36,6 +37,7 @@ enum {
 	FB_TLSKEY_INPUT,
 	FB_TLSKEY_PRINTUSG,
 	FB_TLSKEY_GFX,
+	FB_TLSKEY_FBTHREAD,
 	FB_TLSKEYS
 };
 
@@ -47,12 +49,12 @@ typedef struct _FB_TLS_CTX_HEADER {
 
 } FB_TLS_CTX_HEADER;
 
-FBCALL void             *fb_TlsGetCtx   ( int index, size_t len, FB_TLS_DESTRUCTOR destructor );
-FBCALL void              fb_TlsDelCtx   ( int index );
-FBCALL void              fb_TlsFreeCtxTb( void );
+FBCALL void             *fb_TlsGetCtx        ( int index, size_t len, FB_TLS_DESTRUCTOR destructor );
+FBCALL void              fb_TlsDelCtx        ( int index );
+FBCALL void              fb_TlsFreeCtxTb     ( void );
 #ifdef ENABLE_MT
-       void              fb_TlsInit     ( void );
-       void              fb_TlsExit     ( void );
+       void              fb_TlsInit          ( void );
+       void              fb_TlsExit          ( void );
 #endif
 
 #define FB_TLSGETCTX(id) ((FB_##id##CTX *)fb_TlsGetCtx( FB_TLSKEY_##id, sizeof( FB_##id##CTX ), fb_##id##CTX_Destructor ))

--- a/src/rtlib/init.c
+++ b/src/rtlib/init.c
@@ -2,6 +2,7 @@
 
 #include "fb.h"
 #include <locale.h>
+#include "fb_private_thread.h"
 
 FB_RTLIB_CTX __fb_ctx /* not initialized */;
 static int __fb_is_inicnt = 0;
@@ -23,6 +24,7 @@ void fb_hRtInit( void )
 #ifdef ENABLE_MT
 	fb_TlsInit( );
 #endif
+	fb_AllocateMainFBThread();
 
 	/**
 	 * With the default "C" locale (which is just plain 7-bit ASCII),

--- a/src/rtlib/thread_ctx.c
+++ b/src/rtlib/thread_ctx.c
@@ -2,8 +2,6 @@
 
 #include "fb.h"
 #include "fb_private_thread.h"
-#include "fb_gfx_private.h"
-#include <assert.h>
 
 #if defined ENABLE_MT && defined HOST_UNIX
 	#define FB_TLSENTRY           pthread_key_t
@@ -55,7 +53,7 @@ FBCALL void *fb_TlsGetCtx( int index, size_t len, FB_TLS_DESTRUCTOR destructorFn
 	else {
 		FB_TLS_CTX_HEADER *ctxHeader = FB_TLS_DATA_TO_HEADER( ctx );
 		/* The && is intentional here so if the assert fires, the message is displayed too */
-		assert( (ctxHeader->destructor == destructorFn) && "fb_TlsGetCtx trying to set different destructor for existing data" );
+		DBG_ASSERT( (ctxHeader->destructor == destructorFn) && "fb_TlsGetCtx trying to set different destructor for existing data" );
 	}
 #endif
 
@@ -102,5 +100,6 @@ void fb_TlsExit( void )
 	for( i = 0; i < FB_TLSKEYS; i++ ) {
 		FB_TLSFREE( __fb_tls_ctxtb[i] );
 	}
+	fb_CloseAtomicFBThreadFlagMutex( );
 }
 #endif

--- a/src/rtlib/thread_self.c
+++ b/src/rtlib/thread_self.c
@@ -1,0 +1,88 @@
+#include "fb.h"
+#include "fb_private_thread.h"
+
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+/* A mutex is massively overkill for atomic int updates, 
+   but we have to support both ancient platforms and build tools
+   so those can use the super slow mutex and everything not 20 years old
+   can use the fast stuff
+
+   GCC 4.1 is the first to implement the atomic builtins, 
+   and InterlockedOr is a macro in the Windows headers for
+   atomic or operations
+
+   NeedsMutex = (EnableMT && (GCC <= 4.0 || !(Windows && InterlockedOr)))
+ */
+#if ( ( defined( ENABLE_MT ) ) && \
+	( ( GCC_VERSION < 40100 ) || \
+	  ( !( defined( HOST_WIN32 ) && defined( InterlockedOr ) ) ) \
+	) \
+)
+#define NEEDS_MUTEX 1
+static FBMUTEX *g_threadFlagMutex = NULL;
+#endif
+
+
+FBCALL FBTHREAD *fb_ThreadSelf( void )
+{
+	return FB_TLSGETCTX( FBTHREAD )->self;
+}
+
+void fb_AllocateMainFBThread( void )
+{
+	/* As TlsGetCtx will allocate a TLS structure and 
+	   space to hold the context, and as the main thread doesn't have
+           its own FBTHREAD* - to avoid making two allocations, 
+           we tell it the context is big enough to cover both
+           and make our own FBTHREAD
+	*/
+	FB_FBTHREADCTX* ctx = fb_TlsGetCtx(
+		FB_TLSKEY_FBTHREAD, 
+		sizeof( *ctx ) + sizeof( *( ctx->self ) ),
+		fb_FBTHREADCTX_Destructor
+	);
+	ctx->self = ( FBTHREAD * )( ctx + 1 );
+	memset( ctx->self, 0, sizeof( *( ctx->self ) ) );
+	ctx->self->flags = FBTHREAD_MAIN;
+
+#ifdef NEEDS_MUTEX
+	g_threadFlagMutex = fb_MutexCreate( );
+#endif
+}
+
+#ifdef ENABLE_MT
+void fb_CloseAtomicFBThreadFlagMutex( void )
+{
+#ifdef NEEDS_MUTEX
+	fb_MutexDestroy( g_threadFlagMutex );
+#endif
+}
+
+FBTHREADFLAGS fb_AtomicSetThreadFlags( volatile FBTHREADFLAGS *threadFlags, FBTHREADFLAGS newFlag )
+{
+
+#ifdef NEEDS_MUTEX
+
+	FBTHREADFLAGS before;
+	fb_MutexLock( g_threadFlagMutex );
+	before = *threadFlags;
+	*threadFlags |= newFlag;
+	fb_MutexUnlock( g_threadFlagMutex );
+	return before;
+
+#else
+
+#if GCC_VERSION >= 40100
+	return __sync_fetch_and_or( threadFlags, newFlag );
+#elif defined ( InterlockedOr )
+	return InterlockedOr( (volatile LONG *) threadFlags, newFlag );
+#endif /* GCC_VERSION */
+
+#endif /* NEEDS_MUTEX */
+
+}
+
+#endif /* ENABLE_MT */

--- a/src/rtlib/unix/thread_detach.c
+++ b/src/rtlib/unix/thread_detach.c
@@ -3,10 +3,15 @@
 
 FBCALL void fb_ThreadDetach( FBTHREAD *thread )
 {
-	if( thread == NULL )
+	FBTHREADFLAGS flags;
+
+	if( thread == NULL || ( thread->flags & FBTHREAD_MAIN ) )
 		return;
 
+	flags = fb_AtomicSetThreadFlags( &thread->flags, FBTHREAD_DETACHED );
 	pthread_detach( thread->id );
-
-	free( thread );
+	/* This thread has already exited, so clean up */
+	if( flags & FBTHREAD_EXITED ) {
+		free( thread );
+	}
 }

--- a/src/rtlib/win32/thread_detach.c
+++ b/src/rtlib/win32/thread_detach.c
@@ -3,10 +3,15 @@
 
 FBCALL void fb_ThreadDetach( FBTHREAD *thread )
 {
-	if( thread == NULL )
+	FBTHREADFLAGS flags;
+
+	if( thread == NULL || ( thread->flags & FBTHREAD_MAIN ) )
 		return;
 
+	flags = fb_AtomicSetThreadFlags( &thread->flags, FBTHREAD_DETACHED );
 	CloseHandle( thread->id );
 
-	free( thread );
+	if( flags & FBTHREAD_EXITED ) {
+		free( thread );
+	}
 }

--- a/src/rtlib/xbox/thread_detach.c
+++ b/src/rtlib/xbox/thread_detach.c
@@ -3,10 +3,15 @@
 
 FBCALL void fb_ThreadDetach( FBTHREAD *thread )
 {
-	if( thread == NULL )
+	FBTHREADFLAGS flags;
+
+	if( thread == NULL || ( thread->flags & FBTHREAD_MAIN ) )
 		return;
 
+	flags = fb_AtomicSetThreadFlags( &thread->flags, FBTHREAD_DETACHED );
 	NtClose( thread->id );
 
-	free( thread );
+	if( flags & FBTHREAD_EXITED ) {
+		free( thread );
+	}
 }

--- a/tests/fbc-tests.bas
+++ b/tests/fbc-tests.bas
@@ -4,13 +4,14 @@
 	test suite main entry point 
 '/
 
-#include once "fbcunit.bi" 
+#include once "fbcunit.bi"
 
 dim opt_help as boolean = false
 dim opt_verbose as boolean = false
 dim opt_show_summary as boolean = true
 dim opt_brief_summary as boolean = false
 dim opt_hide_cases as boolean = false
+dim opt_show_console as boolean = false
 dim opt_xml_report as boolean = false
 dim opt_xml_filename as string = ""
 dim opt_no_error as boolean = false
@@ -48,6 +49,9 @@ while command(i) > ""
 	case "--hide-cases"
 		opt_hide_cases = true
 
+	case "--show-console"
+		opt_show_console = true
+
 	case else
 		print "Unrecognized option '" & command(i) & "'"
 		end 1
@@ -69,6 +73,7 @@ if( opt_help ) then
 	print "   --no-error           don't exit with error code even if tests failed"
 	print "   --brief-summary      only show failures in the summary"
 	print "   --hide-cases         don't show the failed cases"
+	print "   --show-console       show console output"
 	print
 
 	'' exit with an error code
@@ -90,6 +95,7 @@ end if
 '' set extra options
 fbcu.setBriefSummary( opt_brief_summary )
 fbcu.setHideCases( opt_hide_cases )
+fbcu.setShowConsole( opt_show_console )
 
 '' run the tests
 passed = fbcu.run_tests( opt_show_summary, opt_verbose )
@@ -106,7 +112,7 @@ end if
 
 
 '' only return exit code = 0 if all tests passed and no other errors
-'' or if the '-no-error' option was given, suspress the error code
+'' or if the '--no-error' option was given, suspress the error code
 if( passed or opt_no_error ) then
 	end 0
 end if

--- a/tests/fbcunit/changelog.txt
+++ b/tests/fbcunit/changelog.txt
@@ -1,9 +1,18 @@
+Version 1.0
+
+[added]
+- fbcu.setShowConsole( true|false ) method to show console logging (true), or not (false, default)
+- fbcu.getShowConsole() as boolean to return current setting for "showConsole" option
+- fbcu.outputConsoleString( byref s as const string = "" ) output to console depending on showConsole setting
+
+
 Version 0.9
 
 [added]
 - fbcu.setBriefSummary( true|false ) method to choose brief summary (true), otherwise full summary (false, default)
 - fbcu.setHideCases( true|false ) method to prevent cases (failed asserts) from printing (true), otherwise show all (false, default)
 - fbcu.getHideCases() as boolean to return current setting for "hide-cases" option
+- tests/tests.bas will accept --brief-summary and --hide-cases command line options
 
 [fixed]
 - added missing fbcunit_qb.bas:fbcu_check_internal_state() stub

--- a/tests/fbcunit/examples/ex10.bas
+++ b/tests/fbcunit/examples/ex10.bas
@@ -1,0 +1,28 @@
+/'
+	fbcunit example
+
+		- show or hide failed cases
+'/
+
+#include once "fbcunit.bi"
+
+'' console output functions
+
+SUITE( ex10 )
+
+	TEST( cases )
+
+		CU_FAIL( "by default show failed cases" )
+
+		fbcu.setHideCases( true )
+		CU_FAIL( "this will be hidden" )
+
+		fbcu.setHideCases( false )
+		CU_FAIL( "enable showing failed cases" )
+
+	END_TEST
+
+END_SUITE
+
+fbcu.run_tests
+

--- a/tests/fbcunit/examples/ex11.bas
+++ b/tests/fbcunit/examples/ex11.bas
@@ -1,0 +1,33 @@
+/'
+	fbcunit example
+
+		- enable or disable console output
+'/
+
+#include once "fbcunit.bi"
+
+'' console output functions
+
+SUITE( ex11 )
+
+	TEST( console )
+
+		CU_PRINT( "by default console output is disabled" )
+		CU_PASS()
+
+		fbcu.setShowConsole( true )
+		CU_PRINT( "this will be output to console" )
+		CU_PASS()
+
+		fbcu.outputConsoleString( "this will be output to console also" )
+		CU_PASS()
+
+		fbcu.setShowConsole( false )
+		CU_PRINT( "disable output to console again" )
+		CU_PASS()
+
+	END_TEST
+
+END_SUITE
+
+fbcu.run_tests

--- a/tests/fbcunit/inc/fbcunit.bi
+++ b/tests/fbcunit/inc/fbcunit.bi
@@ -12,8 +12,8 @@
 | fbcunit - FreeBASIC Compiler Unit testing module        |
 ---------------------------------------------------------'/
 
-#define FBCU_VER_MAJOR 0
-#define FBCU_VER_MINOR 9
+#define FBCU_VER_MAJOR 1
+#define FBCU_VER_MINOR 0
 
 #inclib "fbcunit"
 
@@ -172,6 +172,7 @@
 #define CU_ASSERT_SINGLE_EQUAL( a, e, g )  fbcu.CU_ASSERT_( (abs(csng(a)-csng(e)) <= abs(csng(g))), __FILE__, __LINE__, __FUNCTION__, "CU_ASSERT_SINGLE_EQUAL(" #a "," #e "," #g ")" )
 #define CU_ASSERT_SINGLE_APPROX( a, e, u ) fbcu.CU_ASSERT_( fbcu.sngApprox(csng(a), csng(e), clng(u)), __FILE__, __LINE__, __FUNCTION__, "CU_ASSERT_SINGLE_APPROX(" #a "," #e "," #u ")" )
 
+#define CU_PRINT( s ) fbcu.outputConsoleString( s )
 
 /'-----------------------------
 | fbcunit code emitter macros |
@@ -548,7 +549,21 @@
 	declare function fbcu.getHideCases alias "fbcu_getHideCases_qb" _
 		( _
 		) as __boolean
-	
+
+	declare sub fbcu.setShowConsole alias "fbcu_setShowConsole_qb" _
+		( _
+			byval showConsole as __boolean _
+		)
+
+	declare function fbcu.getShowConsole alias "fbcu_getShowConsole_qb" _
+		( _
+		) as __boolean
+
+	declare sub fbcu.outputConsoleString alias "fbcu_outputConsoleString_qb" _
+		( _
+			byref s as const string = "" _
+		)
+
 	declare function fbcu.run_tests alias "fbcu_run_tests_qb" _
 		( _
 			byval show_summary as __boolean = __true, _
@@ -690,6 +705,20 @@ namespace fbcu
 	declare function getHideCases _
 		( _
 		) as boolean
+
+	declare sub setShowConsole _
+		( _
+			byval showConsole as boolean _
+		)
+
+	declare function getShowConsole _
+		( _
+		) as boolean
+
+	declare sub outputConsoleString _
+		( _
+			byref s as const string = "" _
+		)
 
 	declare function run_tests _
 		( _

--- a/tests/fbcunit/makefile
+++ b/tests/fbcunit/makefile
@@ -23,6 +23,8 @@ TEST_SRCS += tests/fbcu_float.bas
 TEST_SRCS += tests/fbcu_namespace.bas
 TEST_SRCS += tests/fbcu_default.bas
 TEST_SRCS += tests/fbcu_order.bas
+TEST_SRCS += tests/fbcu_cases.bas
+TEST_SRCS += tests/fbcu_console.bas
 
 TEST_OBJS := $(patsubst %.bas,%.o,$(TEST_SRCS))
 
@@ -37,6 +39,8 @@ EXAMPLES += examples/ex06.exe
 EXAMPLES += examples/ex07.exe
 EXAMPLES += examples/ex08.exe
 EXAMPLES += examples/ex09.exe
+EXAMPLES += examples/ex10.exe
+EXAMPLES += examples/ex11.exe
 
 ifneq ($(ARCH),)
 	FBCFLAGS += -arch $(ARCH)

--- a/tests/fbcunit/readme.txt
+++ b/tests/fbcunit/readme.txt
@@ -1,7 +1,7 @@
 	fbcunit - FreeBASIC Compiler Unit Testing Component
 	Copyright (C) 2017-2020 Jeffery R. Marshall (coder[at]execulink[dot]com)
 
-fbcunit version 0.9
+fbcunit version 1.0
 -------------------
 	Unit testing component for fbc compiler.  Provides macros 
 	and common code for unit testing fbc compiled sources. 

--- a/tests/fbcunit/src/fbcunit.bas
+++ b/tests/fbcunit/src/fbcunit.bas
@@ -65,6 +65,7 @@ dim shared fbcu_suite_index as integer = INVALID_INDEX
 dim shared fbcu_test_index as integer = INVALID_INDEX
 
 dim shared fbcu_hide_cases as boolean = false
+dim shared fbcu_show_console as boolean = false
 dim shared fbcu_brief_summary as boolean = false
 
 '' --------------------
@@ -552,6 +553,31 @@ namespace fbcu
 		) as boolean
 		function = fbcu_hide_cases
 	end function
+
+	''
+	sub setShowConsole _
+		( _
+			byval showConsole as boolean _
+		)
+		fbcu_show_console = showConsole
+	end sub
+
+	''
+	function getShowConsole _
+		( _
+		) as boolean
+		function = fbcu_show_console
+	end function
+
+	''
+	sub outputConsoleString _
+		( _
+			byref s as const string = "" _
+		)
+		if( fbcu_show_console ) then
+			print_output( s )
+		end if
+	end sub
 
 	''
 	function run_tests _

--- a/tests/fbcunit/src/fbcunit_qb.bas
+++ b/tests/fbcunit/src/fbcunit_qb.bas
@@ -104,6 +104,35 @@ function fbcu_getHideCases alias "fbcu_getHideCases_qb" _
 end function
 
 ''
+sub fbcu_setShowConsole alias "fbcu_setShowConsole_qb" _
+	( _
+		byval showConsole as boolean _
+	)
+
+	fbcu.setShowConsole( showConsole )
+
+end sub
+
+''
+function fbcu_getShowConsole alias "fbcu_getShowConsole_qb" _
+	( _
+	) as boolean
+
+	function = fbcu.getShowConsole()
+
+end function
+
+''
+sub fbcu_outoutConsoleString alias "fbcu_outputConsoleString_qb" _
+	( _
+		byref s as const string = "" _
+	)
+
+	fbcu.outputConsoleString( s )
+
+end sub
+
+''
 function fbcu_run_tests_qb alias "fbcu_run_tests_qb" _
 	( _
 		byval show_summary as boolean = true, _

--- a/tests/fbcunit/tests/fbcu_cases.bas
+++ b/tests/fbcunit/tests/fbcu_cases.bas
@@ -1,0 +1,24 @@
+#include once "fbcunit.bi"
+
+'' console output functions
+
+SUITE( cases )
+
+	TEST( get_set )
+
+		'' get current setting
+		var flag = fbcu.getHideCases()
+		CU_PRINT( "current setting of hideCases is " & flag )
+
+		fbcu.setHideCases( true )
+		CU_ASSERT( fbcu.getHideCases() = true )
+
+		fbcu.setHideCases( false )
+		CU_ASSERT( fbcu.getHideCases() = false )
+
+		fbcu.setHideCases( flag )
+		CU_ASSERT( fbcu.getHideCases() = flag )
+
+	END_TEST
+
+END_SUITE

--- a/tests/fbcunit/tests/fbcu_console.bas
+++ b/tests/fbcunit/tests/fbcu_console.bas
@@ -1,0 +1,24 @@
+#include once "fbcunit.bi"
+
+'' console output functions
+
+SUITE( console )
+
+	TEST( get_set )
+
+		'' get current setting
+		var flag = fbcu.getShowConsole()
+		CU_PRINT( "current setting of showConsole is " & flag )
+
+		fbcu.setShowConsole( true )
+		CU_ASSERT( fbcu.getShowConsole() = true )
+
+		fbcu.setShowConsole( false )
+		CU_ASSERT( fbcu.getShowConsole() = false )
+
+		fbcu.setShowConsole( flag )
+		CU_ASSERT( fbcu.getShowConsole() = flag )
+
+	END_TEST
+
+END_SUITE

--- a/tests/fbcunit/tests/tests.bas
+++ b/tests/fbcunit/tests/tests.bas
@@ -21,6 +21,7 @@ dim opt_verbose as boolean = false
 dim opt_show_summary as boolean = true
 dim opt_brief_summary as boolean = false
 dim opt_hide_cases as boolean = false
+dim opt_show_console as boolean = false
 dim opt_xml_report as boolean = false
 dim opt_xml_filename as string = ""
 dim opt_no_error as boolean = false
@@ -58,6 +59,9 @@ while command(i) > ""
 	case "--hide-cases"
 		opt_hide_cases = true
 
+	case "--show-console"
+		opt_show_console = true
+
 	case else
 		print "Unrecognized option '" & command(i) & "'"
 		end 1
@@ -77,8 +81,9 @@ if( opt_help ) then
 	print "   --xml filename       write test results to xml format for filename"
 	print "   --no-summary         don't show the summary (default is to show it)"
 	print "   --no-error           don't exit with error code even if tests failed"
-	print "   --short-summary      only show failures in the summary"
+	print "   --brief-summary      only show failures in the summary"
 	print "   --hide-cases         don't show the failed cases"
+	print "   --show-console       show console output"
 	print
 
 	'' exit with an error code
@@ -100,6 +105,7 @@ end if
 '' set extra options
 fbcu.setBriefSummary( opt_brief_summary )
 fbcu.setHideCases( opt_hide_cases )
+fbcu.setShowConsole( opt_show_console )
 
 '' run the tests
 passed = fbcu.run_tests( opt_show_summary, opt_verbose )
@@ -116,7 +122,7 @@ end if
 
 
 '' only return exit code = 0 if all tests passed and no other errors
-'' or if the '-no-error' option was given, suspress the error code
+'' or if the '--no-error' option was given, suspress the error code
 if( passed or opt_no_error ) then
 	end 0
 end if

--- a/tests/threads/racecondition.bas
+++ b/tests/threads/racecondition.bas
@@ -11,7 +11,7 @@ SUITE( fbc_tests.threads.racecondition )
 
 		declare sub cb( byval i as any ptr )
 
-		sub test_proc
+		TEST( test_proc )
 			dim htb(0 to NUM_THREADS-1) as any ptr
 			dim i as integer
 
@@ -20,32 +20,24 @@ SUITE( fbc_tests.threads.racecondition )
 			for i = 0 to NUM_THREADS-1
 				htb(i) = threadcreate( @cb, cast(any ptr, i) )
 				if( htb(i) = 0 ) then
-					print "error:" & i
+					CU_FAIL_FATAL( "error:" & i )
 					end
 				end if
 			next i
 
 			for i = 0 to NUM_THREADS-1
-				print "waiting:" & i
+				CU_PRINT( "waiting:" & i )
 				threadwait( htb(i) )
 			next
 
-			print "Exiting.."
+			CU_PRINT( "Exiting.." )
 			sleep 1000
-		end sub
+		END_TEST
 
 		sub cb( byval i as any ptr )
 			sleep rnd * 100
-			print "ending:" & i
+			CU_PRINT( "ending:" & i )
 		end sub
-
-		'// !!! TODO !!! fbcunit should handle this internally ...
-		'// need to add capability to fbcunit
-		#if ENABLE_CONSOLE_OUTPUT
-		TEST( default )
-			test_proc
-		END_TEST
-		#endif
 
 	END_TEST_GROUP
 
@@ -60,8 +52,7 @@ SUITE( fbc_tests.threads.racecondition )
 			#macro check( N )
 				case N
 					if( (i mod 100) <> N ) then
-						CU_FAIL( )
-						''print "bad, i = " + str( i ) + ", i mod 100 = " + str( i mod 100 )
+						CU_FAIL( "bad, i = " + str( i ) + ", i mod 100 = " + str( i mod 100 ) )
 					end if
 			#endmacro
 

--- a/tests/threads/self.bas
+++ b/tests/threads/self.bas
@@ -18,7 +18,7 @@ SUITE( fbc_tests.threads.self )
 			for i = 0 to NUM_THREADS-1
 				htb(i) = threadcreate( @cb, @selfThreadIds(i) )
 				if( htb(i) = 0 ) then
-					print "ThreadSelf test error launching thread:" & i
+					CU_FAIL_FATAL( "ThreadSelf test error launching thread:" & i )
 					end
 				end if
 			next i
@@ -71,7 +71,7 @@ SUITE( fbc_tests.threads.self )
 			for i = 0 to NUM_THREADS-1
 				htb(i) = threadcreate( @cb, @selfThreadIds(i) )
 				if( htb(i) = 0 ) then
-					print "ThreadSelf test error launching thread:" & i
+					CU_FAIL_FATAL( "ThreadSelf test error launching thread:" & i )
 					end
 				end if
 				ThreadDetach(htb(i))
@@ -118,9 +118,9 @@ SUITE( fbc_tests.threads.self )
 
 		TEST(mainThreadWait)
 			Dim tid as Any Ptr = ThreadSelf()
-			Print "ThreadSelf test waiting for main thread, if success message isn't printed below, this test failed"
+			CU_PRINT( "ThreadSelf test waiting for main thread, if success message isn't printed below, this test failed" )
 			ThreadWait(tid)
-			Print "ThreadSelf test success"
+			CU_PRINT( "ThreadSelf test success" )
 			Dim tid2 As Any Ptr = ThreadSelf()
 			CU_ASSERT_EQUAL(tid, tid2)
 		END_TEST
@@ -165,7 +165,7 @@ SUITE( fbc_tests.threads.self )
 			for i = 0 to NUM_THREADS-1
 				htb(i) = threadcreate( @cb )
 				if( htb(i) = 0 ) then
-					print "ThreadSelf test error launching thread:" & i
+					CU_FAIL_FATAL( "ThreadSelf test error launching thread:" & i )
 					While i >= 0
 						ThreadWait(htb(i))
 						i -= 1

--- a/tests/threads/self.bas
+++ b/tests/threads/self.bas
@@ -1,0 +1,209 @@
+#include "fbcunit.bi"
+#include "..\..\inc\fbthread.bi"
+
+SUITE( fbc_tests.threads.self )
+
+	'' Tests whether ThreadSelf in a created thread is equal to the 
+	'' return of ThreadCreate, which it should
+	TEST_GROUP( idBasic )
+		const NUM_THREADS = 100
+
+		declare sub cb( byval ta as any ptr )
+
+		sub test_proc
+			dim htb(0 to NUM_THREADS-1) as any ptr
+			dim selfThreadIds(0 to NUM_THREADS-1) as any ptr
+			dim i as integer
+
+			for i = 0 to NUM_THREADS-1
+				htb(i) = threadcreate( @cb, @selfThreadIds(i) )
+				if( htb(i) = 0 ) then
+					print "ThreadSelf test error launching thread:" & i
+					end
+				end if
+			next i
+
+			for i = 0 to NUM_THREADS-1
+				threadwait( htb(i) )
+				CU_ASSERT_EQUAL(htb(i), selfThreadIds(i))
+			next
+		end sub
+
+		sub cb( byval ta as any ptr )
+			Dim selfIdPtr As Any Ptr Ptr = ta
+			*selfIdPtr = ThreadSelf()
+		end sub
+
+		TEST( idsMatch )
+			test_proc
+		END_TEST
+
+		TEST( mainHasId )
+			CU_ASSERT_NOT_EQUAL(threadself(), 0)
+		END_TEST
+
+	END_TEST_GROUP
+
+'' Dos doesn't have detach
+#ifndef __FB_DOS__
+	'' Test that detached threads still have a self that
+	'' is valid
+	TEST_GROUP( idsDetach )
+		const NUM_THREADS = 100
+		dim shared g_incrementMutex As Any Ptr
+		dim shared g_threadsFinished As Integer
+		dim shared g_waitForDetachMutex As Any Ptr
+
+		declare sub cb( byval ta as any ptr )
+
+		sub test_proc2
+			dim htb(0 to NUM_THREADS-1) as any ptr
+			dim selfThreadIds(0 to NUM_THREADS-1) as any ptr
+			dim i as integer
+			dim finished as integer = 0
+
+			g_incrementMutex = MutexCreate()
+			g_waitForDetachMutex = MutexCreate()
+			g_threadsFinished = 0
+
+			MutexLock(g_waitForDetachMutex)
+
+			for i = 0 to NUM_THREADS-1
+				htb(i) = threadcreate( @cb, @selfThreadIds(i) )
+				if( htb(i) = 0 ) then
+					print "ThreadSelf test error launching thread:" & i
+					end
+				end if
+				ThreadDetach(htb(i))
+			next i
+
+			MutexUnlock(g_waitForDetachMutex)
+			
+			while (finished < NUM_THREADS)
+				Sleep 1000
+				MutexLock(g_incrementMutex)
+				finished = g_threadsFinished
+				MutexUnlock(g_incrementMutex)
+			Wend
+
+			for i = 0 to NUM_THREADS-1
+				CU_ASSERT_EQUAL(htb(i), selfThreadIds(i))
+			next
+
+			MutexDestroy(g_waitForDetachMutex)
+			MutexDestroy(g_incrementMutex)
+		end sub
+
+		sub cb( byval ta as any ptr )
+			Dim selfIdPtr As Any Ptr Ptr = ta
+			MutexLock(g_waitForDetachMutex)
+			MutexUnlock(g_waitForDetachMutex)
+			*selfIdPtr = ThreadSelf()
+			MutexLock(g_incrementMutex)
+			g_threadsFinished += 1
+			MutexUnlock(g_incrementMutex)
+		end sub
+
+		TEST(detachThreads)
+			test_proc2
+		END_TEST
+
+		'' Waiting/detaching the main thread shouldn't do anything
+		TEST(mainThreadDetach)
+			Dim tid as Any Ptr = ThreadSelf()
+			ThreadDetach(tid)
+			Dim tid2 As Any Ptr = ThreadSelf()
+			CU_ASSERT_EQUAL(tid, tid2)
+		END_TEST
+
+		TEST(mainThreadWait)
+			Dim tid as Any Ptr = ThreadSelf()
+			Print "ThreadSelf test waiting for main thread, if success message isn't printed below, this test failed"
+			ThreadWait(tid)
+			Print "ThreadSelf test success"
+			Dim tid2 As Any Ptr = ThreadSelf()
+			CU_ASSERT_EQUAL(tid, tid2)
+		END_TEST
+
+		'' Make sure nothing weird happens with doing them both whichever way round
+		TEST(mainThreadDetachWait)
+			Dim tid as Any Ptr = ThreadSelf()
+			ThreadDetach(tid)
+			ThreadWait(tid)
+			Dim tid2 As Any Ptr = ThreadSelf()
+			CU_ASSERT_EQUAL(tid, tid2)
+		END_TEST
+
+		TEST(mainThreadWaitDetach)
+			Dim tid as Any Ptr = ThreadSelf()
+			ThreadWait(tid)
+			ThreadDetach(tid)
+			Dim tid2 As Any Ptr = ThreadSelf()
+			CU_ASSERT_EQUAL(tid, tid2)
+		END_TEST
+	END_TEST_GROUP
+#endif '' FB_DOS
+
+	'' These test that ThreadDetach/Wait still work after the
+	'' threads have actually exited
+	TEST_GROUP( DetachWaitAfterExit )
+		const NUM_THREADS = 100
+		dim shared g_incrementMutex As Any Ptr
+		dim shared g_threadsFinished As Integer
+		dim shared g_waitForDetachMutex As Any Ptr
+
+		declare sub cb( byval ta as any ptr )
+
+		sub test_proc3 ( ByVal threadEnder As Sub (ByVal tid As Any Ptr) )
+			dim htb(0 to NUM_THREADS-1) as any ptr
+			dim i as integer
+			dim finished as integer = 0
+
+			g_incrementMutex = MutexCreate()
+			g_threadsFinished = 0
+
+			for i = 0 to NUM_THREADS-1
+				htb(i) = threadcreate( @cb )
+				if( htb(i) = 0 ) then
+					print "ThreadSelf test error launching thread:" & i
+					While i >= 0
+						ThreadWait(htb(i))
+						i -= 1
+					Wend
+					end
+				end if
+			next i
+			
+			while (finished < NUM_THREADS)
+				Sleep 1000
+				MutexLock(g_incrementMutex)
+				finished = g_threadsFinished
+				MutexUnlock(g_incrementMutex)
+			Wend
+
+			MutexDestroy(g_incrementMutex)
+
+			Sleep 1000 '' simple attempt to try and ensure the threads have truly exited
+
+			for i = 0 to NUM_THREADS-1
+				threadEnder(htb(i))
+			next
+		end sub
+
+		sub cb( byval ta as any ptr )
+			MutexLock(g_incrementMutex)
+			g_threadsFinished += 1
+			MutexUnlock(g_incrementMutex)
+		end sub
+
+#ifndef __FB_DOS__
+		TEST(detachThreads)
+			test_proc3(@ThreadDetach)
+		END_TEST
+#endif
+
+		TEST(WaitThreads)
+			test_proc3(@ThreadWait)
+		END_TEST
+	END_TEST_GROUP
+END_SUITE


### PR DESCRIPTION
Partly due to seeing the second code section here (https://www.freebasic.net/forum/viewtopic.php?f=3&t=28896#p277042) and it needing mutexes and pointers to get the thread id to the actual thread it identifies, I made a ThreadSelf function. It's a little bit embarassing for something that simple.

There's a little of bit of plumbing due to needing the id to remain unique/allocated until the created thread has exited or it has being ThreadDetached/ThreadWaited on, whichever is longer. Plus having to fake a FBTHREAD id for the main thread