### PR TITLE
fbc: github # 203: allow casts of addresses on static initializers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ Version 1.08.0
 - sf.net #927: PUT custom method expects function(ulong,ulong,any pr) as ulong callback function
 - fbc: double the minimum and default stacksize on 64-bit to 64Kb and 2048Kb respectively.
 - fbc: internal changes to optimize away unused call results
+- github #203: allow casts of addresses on static initializers 
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling

--- a/tests/dim/static-const-init.bas
+++ b/tests/dim/static-const-init.bas
@@ -1,0 +1,47 @@
+# include "fbcunit.bi"
+
+SUITE( fbc_tests.dim_.static_const_init )
+
+	sub s() 
+	end sub
+
+	function f1() as any ptr
+		static f as any ptr = @s
+		return f
+	end function
+
+	function f2() as any ptr
+		static f as any ptr = procptr( s )
+		return f
+	end function
+
+	function f3() as any ptr
+		static f as any ptr = cptr( any ptr, @s )
+		return f
+	end function
+
+	function f4() as any ptr
+		static f as any ptr = cptr( sub() ptr, @s )
+		return f
+	end function
+
+	function f5() as uinteger
+		'' must be same size as sizeof(any ptr)
+		static f as uinteger = cptr( uinteger, @s )
+		return f
+	end function
+
+	TEST( PROCPTR_ )
+		var f = @s
+
+		'' CUNSG() returns a uinteger and will preserve size of pointers
+
+		CU_ASSERT( cunsg( f ) = cunsg( f1() ) )
+		CU_ASSERT( cunsg( f ) = cunsg( f2() ) )
+		CU_ASSERT( cunsg( f ) = cunsg( f3() ) )
+		CU_ASSERT( cunsg( f ) = cunsg( f4() ) )
+		CU_ASSERT( cunsg( f ) = cunsg( f5() ) )
+
+	END_TEST
+
+END_SUITE


### PR DESCRIPTION
To address #203 where it's not possible to convert / cast static initializers even though should be considered safe to do so.

```
sub s() 
end sub

static shared as any ptr s1 = @s
static shared as any ptr s2 = procptr( s )
static shared as any ptr s3 = cptr( any ptr, @s )
static shared as any ptr s4 = cptr( sub() ptr, @s )

'' u|integer is ok on 32-bit & 64-bit
static shared as uinteger s5 = cptr( uinteger, @s )

#ifdef __FB_64BIT__
'' u|longint only allowed on 64-bit targets
static shared as uinteger s6 = cptr( ulongint, @s )
#else
'' u|long only allowed on 32-bit targets
static shared as ulong s6 = cptr( ulong, @s )
#endif
```

Explicit casting of static initializers should be allowed if the sizes match.

Under the hood in fbc the conversion of an address cannot be constant folded since the symbol name needs to be emitted to the assembler, therefore evaluation of the conversion / cast is delayed until the initializer is flushed to the initializing assignment.

---
Take care casting away a procedures type though, 
see [sf.net # 889 Complex/compact syntax unsupported by gcc ](https://sourceforge.net/p/fbc/bugs/889/)