### PR TITLE
LLVM backend: on Windows use clang instead of llc

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -108,6 +108,7 @@ Version 1.08.0
 - sf.net #928: Wrong sign / type when printing BYTE values on arm/aarch64
 - various HANDLE_WM_*, FORWARD_WM_* macros in win/windowsx.bi were broken
 - gcc backend was trying to pass single types to double typed built-ins
+- llvm backend on Windows invokes clang.exe instead of llc.exe (which usually doesn't exist)
 
 
 Version 1.07.0


### PR DESCRIPTION
llc.exe is not included with the LLVM official Windows binaries. clang can
compile .ll files too but requires different args.

This behaviour is gated by __FB_WIN32__ because there doesn't seem to be an
existing way to check whether a tool exists. It would be better to fallback to
clang only if llc doesn't exist (for example I see it is missing from at least
some Android NDK toolchains too).

Tested on Linux, not Windows.

C.f. https://www.freebasic.net/forum/viewtopic.php?p=278824#p278824