### PR TITLE
gas64 - fix for future issue when using ld version 2.36

### DIFF
--- a/src/compiler/ir-gas64.bas
+++ b/src/compiler/ir-gas64.bas
@@ -5905,7 +5905,7 @@ private sub _emitjmptb _
 	byval span as ulongint _
 	)
 	dim as string lname,op1=Str(v1->ofs)+"[rbp]",op2
-	dim as long idx
+	dim as long idx,regtempo
 	asm_info("jmptb " + vregPretty( v1 ) )
 	asm_info("v1="+vregdumpfull(v1))
 	asm_info("labelcount="+Str(labelcount)+" bias="+Str(bias)+" span="+Str(span))
@@ -5931,7 +5931,11 @@ private sub _emitjmptb _
 
 		asm_code("cmp rax, "+Str(span))''check limits inf/sup
 		asm_code("ja "+*symbGetMangledName(deflabel))
-		asm_code("jmp QWORD PTR ["+lname+"+rax*8]")
+		'asm_code("jmp QWORD PTR ["+lname+"+rax*8]")  ''issue with ld 2.36 so replaced by the 3 lines below
+		regtempo=reg_findfree(999997)
+		reghandle(regtempo)=KREGFREE ''can be reset here as limited use
+		asm_code("lea "+*regstrq(regtempo)+", "+lname+"[rip]")
+		asm_code("jmp QWORD PTR [rax*8+"+*regstrq(regtempo)+"]")
 		asm_section(".data")
 		asm_code(".align 8")
 		asm_code(lname+":")

--- a/src/compiler/ir-gas64.bas
+++ b/src/compiler/ir-gas64.bas
@@ -3698,7 +3698,7 @@ private sub _emituop(byval op as integer,byval v1 as IRVREG ptr,byval vr as IRVR
 		end if
 	end if
 
-	tempodtype=v1->dtype
+	tempodtype=typeGetDtAndPtrOnly( v1->dtype )
 	if typeisptr(tempodtype) then tempodtype=FB_DATATYPE_INTEGER
 	select case tempodtype
 		case FB_DATATYPE_INTEGER,FB_DATATYPE_UINT,FB_DATATYPE_LONGINT,FB_DATATYPE_ULONGINT,FB_DATATYPE_DOUBLE,FB_DATATYPE_ENUM
@@ -3710,7 +3710,7 @@ private sub _emituop(byval op as integer,byval v1 as IRVREG ptr,byval vr as IRVR
 		case FB_DATATYPE_BYTE,FB_DATATYPE_UBYTE,FB_DATATYPE_BOOLEAN,FB_DATATYPE_CHAR
 			prefix="BYTE PTR "
 		case else
-			asm_error("BOP datatype not handled 01 ="+typedumpToStr(v1->dtype,0))
+			asm_error("UOP datatype not handled 01 ="+typedumpToStr(v1->dtype,0))
 	end select
 
 	select case v1->typ
@@ -3765,7 +3765,7 @@ private sub _emituop(byval op as integer,byval v1 as IRVREG ptr,byval vr as IRVR
 					asm_code("mov "+*regstrb(vrreg)+", "+op1)
 					op1=*regstrb(vrreg)
 				case else
-					asm_error("BOP datatype not handled 011 ="+typedumpToStr(v1->dtype,0))
+					asm_error("UOP datatype not handled 011 ="+typedumpToStr(v1->dtype,0))
 			end select
 			'===
 		end if


### PR DESCRIPTION
srvaldez got an error when using binutils 2.36. This fix doesn't change alot it avoids a 32bit address inside a such instruction  QWORD PTR ["+lname+"+rax*8]"

BTW there is also a warning : fbextra.x contains output sections; did you forget -T?