### PR TITLE
Simple Generic Containers

### DIFF
--- a/inc/containers/_concat.bi
+++ b/inc/containers/_concat.bi
@@ -1,0 +1,57 @@
+#pragma once
+
+'' Concats a comma separated list of arguments
+
+#define __MAC_CONCAT_ARG_LIST1(arg1) arg1
+#define __MAC_CONCAT_ARG_LIST2(arg1, arg2) __FB_JOIN__(arg1, arg2)
+#define __MAC_CONCAT_ARG_LIST3(arg1, arg2, arg3) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST2(arg2, arg3))
+#define __MAC_CONCAT_ARG_LIST4(arg1, arg2, arg3, arg4) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST3(arg2, arg3, arg4))
+#define __MAC_CONCAT_ARG_LIST5(arg1, arg2, arg3, arg4, arg5) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST4(arg2, arg3, arg4, arg5))
+#define __MAC_CONCAT_ARG_LIST6(arg1, arg2, arg3, arg4, arg5, arg6) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST5(arg2, arg3, arg4, arg5, arg6))
+#define __MAC_CONCAT_ARG_LIST7(arg1, arg2, arg3, arg4, arg5, arg6, arg7) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST6(arg2, arg3, arg4, arg5, arg6, arg7))
+#define __MAC_CONCAT_ARG_LIST8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST7(arg2, arg3, arg4, arg5, arg6, arg7, arg8))
+#define __MAC_CONCAT_ARG_LIST9(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST8(arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9))
+#define __MAC_CONCAT_ARG_LIST10(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST9(arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10))
+
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST1(arg1)
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST2(arg1, arg2) arg1
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST3(arg1, arg2, arg3) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST_BUT_LAST2(arg2, arg3))
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST4(arg1, arg2, arg3, arg4) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST_BUT_LAST3(arg2, arg3, arg4))
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST5(arg1, arg2, arg3, arg4, arg5) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST_BUT_LAST4(arg2, arg3, arg4, arg5))
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST6(arg1, arg2, arg3, arg4, arg5, arg6) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST_BUT_LAST5(arg2, arg3, arg4, arg5, arg6))
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST7(arg1, arg2, arg3, arg4, arg5, arg6, arg7) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST_BUT_LAST6(arg2, arg3, arg4, arg5, arg6, arg7))
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST_BUT_LAST7(arg2, arg3, arg4, arg5, arg6, arg7, arg8))
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST9(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST_BUT_LAST8(arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9))
+#define __MAC_CONCAT_ARG_LIST_BUT_LAST10(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) __FB_JOIN__(arg1, __MAC_CONCAT_ARG_LIST_BUT_LAST9(arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9. 10))
+
+
+'' Joins a comma separated list which are all contained in a 'args...' parameter
+''
+'' example 
+'' #define FBType() __FB_JOIN__(__MAC_JOIN_ARG_LIST, __NumArgs)(.,args)
+'' will produce 
+'' MyNamespace.MySecondNamespace.MyType
+'' when (MyNamespace, MySecondNamespace, MyType) are passed to a
+'' variadic macro like #macro DefineListOf(args...)
+#define __MAC_JOIN_ARG_LIST1(sep, arg1) arg1
+#define __MAC_JOIN_ARG_LIST2(sep, arg1, arg2) __FB_JOIN__(arg1, __FB_JOIN__(sep, __MAC_JOIN_ARG_LIST1(sep, arg2)))
+#define __MAC_JOIN_ARG_LIST3(sep, arg1, arg2, arg3) __FB_JOIN__(arg1, __FB_JOIN__(sep, __MAC_JOIN_ARG_LIST2(sep, arg2, arg3)))
+#define __MAC_JOIN_ARG_LIST4(sep, arg1, arg2, arg3, arg4) __FB_JOIN__(arg1, __FB_JOIN__(sep, __MAC_JOIN_ARG_LIST3(sep, arg2, arg3, arg4)))
+#define __MAC_JOIN_ARG_LIST5(sep, arg1, arg2, arg3, arg4, arg5) __FB_JOIN__(arg1, __FB_JOIN__(sep, __MAC_JOIN_ARG_LIST4(sep, arg2, arg3, arg4, arg5)))
+#define __MAC_JOIN_ARG_LIST6(sep, arg1, arg2, arg3, arg4, arg5, arg6) __FB_JOIN__(arg1, __FB_JOIN__(sep, __MAC_JOIN_ARG_LIST5(sep, arg2, arg3, arg4, arg5, arg6)))
+#define __MAC_JOIN_ARG_LIST7(sep, arg1, arg2, arg3, arg4, arg5, arg6, arg7) __FB_JOIN__(arg1, __FB_JOIN__(sep, __MAC_JOIN_ARG_LIST6(sep, arg2, arg3, arg4, arg5, arg6, arg7)))
+#define __MAC_JOIN_ARG_LIST8(sep, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) __FB_JOIN__(arg1, __FB_JOIN__(sep, __MAC_JOIN_ARG_LIST7(sep, arg2, arg3, arg4, arg5, arg6, arg7, arg8)))
+#define __MAC_JOIN_ARG_LIST9(sep, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) __FB_JOIN__(arg1, __FB_JOIN__(sep, __MAC_JOIN_ARG_LIST8(sep, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)))
+#define __MAC_JOIN_ARG_LIST10(sep, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) __FB_JOIN__(arg1, __FB_JOIN__(sep, __MAC_JOIN_ARG_LIST9(sep, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)))
+
+'' Returns the last value of a sequence
+#define __MAC_LAST_ARG1(arg1) arg1
+#define __MAC_LAST_ARG2(arg1, arg2) arg2
+#define __MAC_LAST_ARG3(arg1, arg2, arg3) arg3
+#define __MAC_LAST_ARG4(arg1, arg2, arg3, arg4) arg4
+#define __MAC_LAST_ARG5(arg1, arg2, arg3, arg4, arg5) arg5
+#define __MAC_LAST_ARG6(arg1, arg2, arg3, arg4, arg5, arg6) arg6
+#define __MAC_LAST_ARG7(arg1, arg2, arg3, arg4, arg5, arg6, arg7) arg7
+#define __MAC_LAST_ARG8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) arg8
+#define __MAC_LAST_ARG9(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) arg9
+#define __MAC_LAST_ARG10(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) arg10

--- a/inc/containers/_helpers.bi
+++ b/inc/containers/_helpers.bi
@@ -1,0 +1,37 @@
+#include once "../fbc-int/array.bi"
+#pragma once
+
+Namespace __CONT_Internals
+
+	Private Function GetArrayInfo(ByVal pArrData As FBC.FBARRAY Ptr, Byref arrLBound As Long, Byref arrUBound As Long) As Long
+		dim pFirstDim As FBC.FBARRAYDIM Ptr = @pArrData->dimTb(0)
+		arrLBound = pFirstDim->lbound
+		arrUBound = pFirstDim->ubound
+		Return pFirstDim->elements
+
+	End Function
+	
+	Private Function IsValidArray(ByVal pArrData As FBC.FBARRAY Ptr) As Boolean
+
+		Return pArrData->dimTb(0).elements > 0
+
+	End Function
+	
+'' This is a define so that in the unhandled Error case
+'' the line and file name printed when the Error is unhandled 
+'' are the statement in the appropriate container bi & function
+'' rather than just _helpers.bi which wouldn't be particularly helpful
+#ifdef FB_CONTAINER_DEBUG
+#define __CONT_Internals_SetError(errNum) Error (err)
+#else
+#define __CONT_Internals_SetError(errNum) Err = errNum
+#endif
+	
+#ifdef FB_CONTAINER_DEBUG
+	Dim Shared g_stopRecursiveLoggingFlag As Boolean = False
+#endif
+
+End Namespace
+
+#define __CONT_GetArrayInfo(array, lBoundOut, uBoundOut) __CONT_Internals.GetArrayInfo(FBC.ArrayDescriptorPtr(array()), lBoundOut, uBoundOut)
+#define __CONT_IsValidArray(array) __CONT_Internals.IsValidArray(FBC.ArrayDescriptorPtr(array()))

--- a/inc/containers/_typemacros.bi
+++ b/inc/containers/_typemacros.bi
@@ -1,0 +1,86 @@
+#include once "_concat.bi"
+
+#pragma once
+
+#define __FB_Type_Equals(x, comp) (TypeOf(x) = TypeOf(comp))
+
+#define __FB_Is_Integer(type) (__FB_Type_Equals(type, BOOLEAN) OrElse __FB_Type_Equals(type, BYTE) OrElse __FB_Type_Equals(type, UBYTE) OrElse __FB_Type_Equals(type, SHORT) OrElse __FB_Type_Equals(type, USHORT) OrElse __FB_Type_Equals(type, LONG) OrElse __FB_Type_Equals(type, ULONG) OrElse __FB_Type_Equals(type, INTEGER) OrElse __FB_Type_Equals(type, UINTEGER) OrElse __FB_Type_Equals(type, LONGINT) OrElse __FB_Type_Equals(type, ULONGINT))
+#define __FB_Is_Float(type) (__FB_Type_Equals(type, FLOAT) OrElse __FB_Type_Equals(type, DOUBLE))
+#define __FB_Is_String(type) (__FB_Type_Equals(type, STRING) OrElse __FB_Type_Equals(type, ZSTRING))
+
+#define __FB_Is_BuiltIn(type) (__FB_Is_Integer(type) OrElse __FB_Is_Float(type) OrElse __FB_Is_String(type))
+
+#define __FB_Ptr_Base_Type(type) __FB_ARG_LEFTOF__(type, PTR)
+
+#define __FB_Is_Ptr(type) ( _
+    __FB_QUOTE__(__FB_Ptr_Base_Type(type)) <> "" _
+)
+
+'' Smushes all args together into one long string 
+'' So for __FB_MakePPType(MyNamespace, MySecondNamespace, MyType)
+'' Produce MyNamespaceMySecondNamespaceMyType
+#macro __FB_MakePPType_InternalPtr(args...)
+
+'' concat all but the last arg, and do that manually with Ptr
+__FB_JOIN__( _
+    __FB_JOIN__( _
+        __MAC_CONCAT_ARG_LIST_BUT_LAST, _
+        __FB_ARG_COUNT__(args) _
+    )(args), _
+    __FB_JOIN__(__FB_Ptr_Base_Type(__FB_JOIN__(__MAC_LAST_ARG, __FB_ARG_COUNT__(args))(args)), Ptr) _
+)
+
+#endmacro
+
+'' Smushes all args together into one long string 
+'' So for __FB_MakePPType(MyNamespace, MySecondNamespace, MyType)
+'' Produce MyNamespaceMySecondNamespaceMyType
+#macro __FB_MakePPType_InternalBase(args...)
+
+'' No ptrs, just concat everything
+__FB_JOIN__( _
+    __MAC_CONCAT_ARG_LIST, _
+    __FB_ARG_COUNT__(args) _
+) (args)
+
+#endmacro
+
+'' adds PTR to the end of the type name, then extracts what's to the right of Ptr
+'' If the type wasn't a Ptr, then there is nothing to the right of Ptr so Base is returned
+'' If it was a ptr, then to the right of it will be the Ptr we just added
+#define __FB_GetTypePtrOrBase(type) __FB_ARG_RIGHTOF__(__FB_UNQUOTE__(__FB_EVAL__(__FB_QUOTE__(type) " Ptr")), PTR, Base)
+
+'' Smushes all args together into one long string 
+'' So for __FB_MakePPType(MyNamespace, MySecondNamespace, MyType)
+'' Produce MyNamespaceMySecondNamespaceMyType
+'' Works with ptrs too
+#macro __FB_MakePPType(args...)
+
+__FB_JOIN__( _
+    __FB_MakePPType_Internal, _
+    __FB_GetTypePtrOrBase( _
+		__FB_JOIN__( _
+			__MAC_LAST_ARG, _
+			__FB_ARG_COUNT__(args) _
+		)(args) _
+	) _
+)(args)
+
+#endmacro
+
+'' Put the dots in for the proper FB type
+'' So for __FB_MakeFBType(MyNamespace, MySecondNamespace, MyType)
+'' Produce MyNamespace.MySecondNamespace.MyType
+#macro __FB_MakeFBType(args...)
+__FB_JOIN__(__MAC_JOIN_ARG_LIST, __FB_ARG_COUNT__(args))(.,args)
+#endmacro
+
+#macro __FB_DefinePassType(Type, Name)
+#if  __FB_Is_Integer(Type) OrElse __FB_Is_Float(Type) OrElse __FB_Is_Ptr(Type)
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(Name) " ByVal"))
+#else
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(Name) " "))
+#endif
+#endmacro
+
+#define __FB_MakeTypeName(BaseType, UserType) __FB_JOIN__(BaseType, UserType)

--- a/inc/containers/bitcontainer.bi
+++ b/inc/containers/bitcontainer.bi
@@ -1,0 +1,627 @@
+#include once "icontainer.bi"
+#include once "../fbc-int/memory.bi"
+#include once "../fbc-int/array.bi"
+#include once "_helpers.bi"
+
+#pragma once
+
+#ifndef __CONT_BitContainer_DEFINED
+#define __CONT_BitContainer_DEFINED 1
+
+FBCont_DefineIContainerOf(Boolean)
+
+#define _Min(x, y) IIf((x) < (y), (x), (y))
+
+'' Sorry for the dodgy name but:
+'' Bitset is already a function
+'' Bitmap surely will conflict with somebodies graphic type
+'' BitList would imply it's resizable (like the standard List container)
+Type BitContainer extends FB_IContainer(Boolean)
+Private:
+	Dim _bits(Any) As UByte
+	Dim _numBits As Long
+	Const _allBitsOn As UByte = Not 0
+	
+	Declare Function _RoundToNext(ByVal val1 As Long, ByVal num As Long) As Long
+	Declare Sub _CreateFromPointer(ByVal numBits As Long, ByVal pBits As Any Ptr)
+	Declare Sub _CreateFromBooleanPointer(ByVal numBooleans As Long, ByVal pBits As Boolean Ptr)
+	
+Public:
+	Declare Constructor(ByVal numBits As Long)
+	Declare Constructor(ByVal numBits As Long, ByVal value As Boolean)
+	Declare Constructor(values() As Boolean)
+	Declare Constructor(values() As UByte)
+	Declare Constructor(ByVal numBits As Long, ByVal pBits As Any Ptr)
+	Declare Constructor(ByVal numBooleans As Long, ByVal pBits As Boolean Ptr)
+	
+	Declare Sub Clear() override
+	Declare Function Contains(ByVal element As Boolean) As Boolean override
+	Declare Sub CopyTo(elements() As Boolean) override
+	Declare Sub CopyTo(elements() As UByte)
+	Declare Function Flip(ByVal bitIndex As Long) As Boolean
+	Declare Function Get(ByVal bitIndex As Long) As Boolean
+	Declare Sub GetBits(bits() As Boolean)
+	Declare Sub GetBytes(bytes() As UByte)
+	Declare Function GetIterator() As IIteratorBoolean Ptr override
+	Declare Sub Reset(ByVal index As Long)
+	Declare Sub Set(ByVal index As Long, ByVal value As Boolean = True)
+	Declare Sub SetAll()
+	Declare Sub SetSpan(ByVal index As Long, ByVal howMany As Long, ByVal value As Boolean = True)	
+	
+	Declare Property Count() As Long override
+	Declare Operator[](ByVal bitIndex As Long) As Boolean
+	'' Also:
+	'' Operator Len()
+	'' Operator Imp()
+	'' Operator Eqv()
+	'' Operator And()
+	'' Operator Xor()
+	'' Operator Not()
+	'' Operator Or()
+	
+#ifdef FB_CONTAINER_DEBUG
+	Declare Sub PrintContainer() override
+#endif
+End Type
+
+Type BitContainerIterator extends IIteratorBoolean
+Private:
+	Dim _pBitset As UByte Ptr
+	Dim _numBits As Long
+	Dim _curPos As Long
+	Dim _curBit As Boolean
+	
+Public:
+	Declare Constructor(ByVal bitSet As UByte Ptr, ByVal length As Long)
+	Declare Constructor()
+
+	Declare Operator For()
+	Declare Operator Next(ByRef cond As BitContainerIterator) As Integer
+	Declare Operator Step()
+
+	Declare Function Advance() As Boolean override
+	Declare Function Item() ByRef As Boolean override
+	Declare Sub Reset() override
+
+End Type
+
+
+Private Constructor BitContainer(ByVal numBits As Long)
+	Constructor(numBits, False)
+End Constructor
+
+Private Constructor BitContainer(ByVal numBits As Long, ByVal value As Boolean)
+__CONT_DBG_PRINT("with & bits of value &", numBits; value)
+	If numBits <= 0 Then
+		Assert(StrPtr("Empty array isn't allowed to construct BitContainer") = 0)
+		__CONT_Internals_SetError(1)
+		Exit Constructor
+	End If
+	_numBits = numBits
+	Dim numBytes As Long = _RoundToNext(numBits, 8) \ 8
+	Redim _bits(0 To numBytes - 1)
+	If value = True Then
+		SetAll()
+	End If
+End Constructor
+
+Private Constructor BitContainer(userBits() As Boolean)
+	Dim arrLBound As Long
+	Dim arrUBound As Long
+	Dim numElems As Long = __CONT_GetArrayInfo(userBits, arrLBound, arrUBound)
+__CONT_DBG_PRINT("with bool array of & elements", numElems)
+	If numElems = 0 Then
+		Assert(StrPtr("Empty array isn't allowed to construct BitContainer") = 0)
+		__CONT_Internals_SetError(1)
+		Exit Constructor
+	End If
+	_CreateFromBooleanPointer(numElems, @userBits(arrLBound))
+End Constructor
+
+Private Constructor BitContainer(userBytes() As UByte)
+	Dim arrLBound As Long
+	Dim arrUBound As Long
+	Dim numElems As Long = __CONT_GetArrayInfo(userBytes, arrLBound, arrUBound)
+__CONT_DBG_PRINT("with ubyte array of & elements", numElems)
+	If numElems = 0 Then
+		Assert(StrPtr("Empty array isn't allowed to construct BitContainer") = 0)
+		__CONT_Internals_SetError(1)
+		Exit Constructor
+	End If
+	_CreateFromPointer(numElems * 8, @userBytes(arrLBound))
+End Constructor
+
+Private Constructor BitContainer(ByVal numBits As Long, ByVal pUserBits As Any Ptr)
+__CONT_DBG_PRINT("with & bits from data ptr &", numBits; Hex(pUserBits))
+	If (numBits <= 0) OrElse (pUserBits = 0) Then
+		Assert(StrPtr("Empty array isn't allowed to construct BitContainer") = 0)
+		__CONT_Internals_SetError(1)
+		Exit Constructor
+	End If
+	_CreateFromPointer(numBits, pUserBits)
+End Constructor
+
+Private Constructor BitContainer(ByVal numBooleans As Long, ByVal pUserBits As Boolean Ptr)
+__CONT_DBG_PRINT("with & boolean bytes from boolean ptr &", numBooleans; Hex(pUserBits))
+	If (numBooleans <= 0) OrElse (pUserBits = 0) Then
+		Assert(StrPtr("Empty array isn't allowed to construct BitContainer") = 0)
+		__CONT_Internals_SetError(1)
+		Exit Constructor
+	End If	
+	_CreateFromBooleanPointer(numBooleans, pUserBits)
+End Constructor
+
+Private Sub BitContainer.Clear()
+__CONT_DBG_PRINT("setting all bits to 0")
+	FBC.clear(@_bits(0), 0, UBound(_bits) + 1)
+End Sub
+
+Private Sub BitContainer.CopyTo(target() As Boolean)
+__CONT_DBG_PRINT("& bits in container to & element array", Count; UBound(target) - LBound(target))
+	__CONT_Internals.ContainerToArray(@This, target())
+
+End Sub
+
+Private Sub BitContainer.CopyTo(target() As UByte)
+	Dim As Long arrLBound, arrUBound, numElems = __CONT_GetArrayInfo(target, arrLBound, arrUBound)
+	Dim containerBytes As Long = UBound(_bits) + 1
+__CONT_DBG_PRINT("& bytes in container to & element array", containerBytes; numElems)
+	If numElems = 0 Then
+		numElems = containerBytes
+		Redim target(0 To numElems - 1)
+	Else
+		numElems = _Min(numElems, containerBytes)
+	End If
+	FBC.memcopy(@target(arrLBound), @_bits(0), numElems)
+
+End Sub
+
+Private Function BitContainer.Contains(ByVal value As Boolean) As Boolean
+	Dim numBits As Long = Count
+__CONT_DBG_PRINT("looking for & in & bits", Str(value); numBits)
+	Dim lastByteBits As Long = numBits And 7
+	Dim arrLen As Long = (UBound(_bits) + 1) - IIf(lastByteBits = 0, 1, 2)
+	Dim i As Long
+	Dim result As Boolean = False
+	If value Then
+		For i = 0 To arrLen
+			If (_bits(i) <> 0) Then Return True
+		Next
+		If lastByteBits > 0 Then
+			Dim lastByteMask As UByte = _allBitsOn Shr (8 - lastByteBits)
+			result = ((_bits(arrLen + 1) And lastByteMask) <> 0)
+		End If
+	Else
+		For i = 0 To arrLen
+			If (_bits(i) <> &hff) Then Return True
+		Next
+		If lastByteBits > 0 Then
+			Dim lastByteMask As UByte = _allBitsOn Shr (8 - lastByteBits)
+			result = ((_bits(arrLen + 1) And lastByteMask) <> lastByteMask)
+		End If
+	End If
+	Return result
+End Function
+
+Private Function BitContainer.Flip(ByVal bitIndex As Long) As Boolean
+	Dim numBits As Long = Count
+__CONT_DBG_PRINT("at position & of & bits", bitIndex; numBits)
+	If (bitIndex < 0) OrElse (bitIndex >= numBits) Then
+__CONT_DBG_PRINT("flipping bit out of bounds, ignoring and returning false", bitIndex; numBits)
+		__CONT_Internals_SetError(6)
+		Return False
+    End If
+    Dim byteIndex As Long = bitIndex \ 8
+    bitIndex = bitIndex Mod 8
+    Dim mask As UByte = 1 Shl bitIndex
+    Dim pBitByte As UByte Ptr = @_bits(byteIndex)
+    Dim origValue As Boolean = *pBitByte And mask
+    If origValue Then
+		*pBitByte And= Not mask
+    Else
+		*pBitByte Or= mask
+    End If    
+    Return origValue
+End Function
+
+Private Function BitContainer.Get(ByVal bitIndex As Long) As Boolean
+	Dim numBits As Long = Count
+__CONT_DBG_PRINT("position & of & bits", bitIndex; numBits)
+	If (bitIndex < 0) OrElse (bitIndex >= numBits) Then
+__CONT_DBG_PRINT("indexing bit out of bounds, ignoring and returning false", bitIndex; numBits)
+		__CONT_Internals_SetError(6)
+		Return False
+    End If
+    Dim byteIndex As Long = bitIndex \ 8
+    bitIndex = bitIndex Mod 8
+    Return (_bits(byteIndex) And (1 Shl bitIndex)) <> 0
+End Function
+
+Private Sub BitContainer.GetBits(bits() As Boolean)
+	CopyTo(bits())
+End Sub
+
+Private Sub BitContainer.GetBytes(bytes() As UByte)
+	CopyTo(bytes())
+End Sub
+
+Private Function BitContainer.GetIterator() As IIteratorBoolean Ptr
+	Return New BitContainerIterator(@_bits(0), Count)
+End Function
+
+Private Sub BitContainer.Reset(ByVal index As Long)
+	Set(index, False)
+End Sub
+
+Private Sub BitContainer.Set(ByVal index As Long, ByVal value As Boolean)
+	Dim numBits As Long = Count
+__CONT_DBG_PRINT("Indexing at position & of & bits", index; numBits)
+	If (index < 0) OrElse (index >= numBits) Then
+		__CONT_DBG_PRINT("Trying to set bit position & out of bounds of container (0-&), ignoring", index; numBits)
+		__CONT_Internals_SetError(6)
+		Exit Sub
+    End If
+    
+    Dim byteIndex As Long = index \ 8
+    Dim bitIndex As Long = index Mod 8
+    Dim mask As UByte = 1 Shl bitIndex
+    If value Then
+		_bits(byteIndex) Or= mask
+	Else
+		_bits(byteIndex) And= Not mask
+	End If
+End Sub
+
+Private Sub BitContainer.SetAll()
+__CONT_DBG_PRINT("& bits to true", Count)
+	FBC.clear(@_bits(0), &hff, UBound(_bits) + 1)
+End Sub
+
+Private Sub BitContainer.SetSpan(ByVal index As Long, ByVal howMany As Long, ByVal value As Boolean)
+
+	Dim numBits As Long = Count
+__CONT_DBG_PRINT("& bits from & to &", howMany; index; CLng(value))
+	If (index < 0) OrElse (index >= numBits) OrElse (howMany <= 0) Then
+		__CONT_DBG_PRINT("Trying to index position & out of bounds of container (0-&), ignoring ", index; numBits)
+		__CONT_Internals_SetError(6)
+		Exit Sub
+    End If
+    
+    '' make sure we don't go out of bounds at the top end
+    howMany = _Min(howMany, numBits - index)
+    
+    If howMany = 1 Then
+		Set(index, value)
+		Exit Sub
+	ElseIf (index = 0) AndAlso (howMany = numBits) Then
+		If value = True Then
+			SetAll()
+		Else
+			Clear()
+		End If
+		Exit Sub
+    End If
+    
+    Dim pBits as UByte Ptr = @_bits(0)
+    
+    Dim curByteIndex As Long = index \ 8
+    
+    Dim needsAlign As Long = index And 7
+    If needsAlign <> 0 Then
+		Dim mask As UByte
+		Dim toAlign As Long = 8 - needsAlign
+				
+		'' if we're setting less than we need to align, we need to then clear the bits above
+		'' the ones to set, so we don't change those
+		If howMany < toAlign Then
+			Dim difference As UByte = toAlign - howMany 
+			'' If howMany = 2, toAlign = 4, we need to produce a mask of
+			'' &b00110000
+			'' so &H80 = &b10000000
+			'' Shr howMany - 1 (= Shr 1) = &b11000000 '' needs a signed shift to shift in the sign bit
+			'' Shr difference (= Shr 4 - 2 = Shr 2) = &b00110000
+			mask = (CByte(&h80) Shr (howMany - 1)) Shr difference
+			howMany = 0
+		Else
+			'' shift in zeroes to make a mask for the top (8 - toAlign) bits
+			'' If index = 7, we only need to set the top bit, 
+			'' so &hff << 7 = &h80 which is what we want
+			mask = _allBitsOn Shl needsAlign
+			howMany -= toAlign
+		End If
+		
+		If value Then
+			pBits[curByteIndex] Or= mask
+		Else
+			pBits[curByteIndex] And= Not mask
+		End If
+		
+		curByteIndex += 1
+    End If
+    '' now we're aligned to whole bytes, we can just set them without any tricks
+    Dim wholeValue As UByte = IIf(value, _allBitsOn, 0)
+    While (howMany >= 8)
+		pBits[curByteIndex] = wholeValue
+		curByteIndex += 1
+		howMany -= 8
+    Wend
+    '' pick up any that bits that are left
+    If howMany > 0 Then
+		Dim lowMask As UByte = _allBitsOn Shr (8 - howMany)
+		If value Then
+			pBits[curByteIndex] Or= lowMask
+		Else
+			pBits[curByteIndex] And= Not lowMask
+		End If
+    End If
+
+End Sub
+
+Private Operator BitContainer.[](ByVal bitIndex As Long) As Boolean
+    Return Get(bitIndex)
+End Operator
+
+Private Property BitContainer.Count() As Long
+	Return _numBits
+End Property
+
+Private Sub BitContainer._CreateFromPointer(ByVal numBits As Long, ByVal pUserBits As Any Ptr)
+	Dim allocBytes As Long = _RoundToNext(numBits, 8) \ 8
+	Redim _bits(0 To allocBytes - 1)
+__CONT_DBG_PRINT("Creating with & bits requested from &", numBits; Hex(pUserBits))
+	Assert(pUserBits <> 0)
+	Dim pBitsPtr As UByte Ptr = @_bits(0)
+	Dim fullBytes As Long = numBits \ 8
+	Dim stragglerBits As Long = numBits And 7
+	FBC.memcopy(pBitsPtr, pUserBits, fullBytes)
+	If stragglerBits > 0 Then
+		Dim pRemainingByte As UByte Ptr = cast(UByte Ptr, pUserBits) + fullBytes
+		Dim mask As UByte = _allBitsOn Shr (8 - stragglerBits)
+		pBitsPtr[fullBytes] = (*pRemainingByte) And mask
+	End If
+	_numBits = numBits
+End Sub
+
+Private Sub BitContainer._CreateFromBooleanPointer(ByVal numBooleans As Long, ByVal pBooleanBits As Boolean Ptr)
+	Dim stragglerBits As Long = numBooleans And 7
+	Dim numBytes As Long = _RoundToNext(numBooleans, 8) \ 8
+	Dim wholeBytes As Long = numBooleans \ 8
+	Dim byteArray(0 To numBytes - 1) As UByte
+	Dim byteArrayPtr As UByte Ptr = @byteArray(0)
+	Dim userBitsPtr As Boolean Ptr = pBooleanBits
+	Dim i As Long
+	Dim j As Long
+	Dim curByte As UByte
+	Dim userBitsIndex As Long = 0
+	For i = 0 To wholeBytes - 1
+		curByte = 0
+		Dim mask As UByte = 1
+		For j = 0 To 7
+			Dim valueBit As UByte = CUByte(userBitsPtr[userBitsIndex]) And mask
+			curByte Or= valueBit
+			userBitsIndex += 1
+			mask Shl= 1
+		Next
+		byteArrayPtr[i] = curByte
+	Next
+	If stragglerBits > 0 Then
+		curByte = 0
+		Dim mask As UByte = 1
+		For j = 0 To stragglerBits - 1
+			Dim valueBit As UByte = CUByte(userBitsPtr[userBitsIndex]) And mask
+			curByte Or= valueBit
+			userBitsIndex += 1
+			mask Shl= 1
+		Next
+		byteArrayPtr[numBytes - 1] = curByte
+	End If
+	_CreateFromPointer(numBooleans, byteArrayPtr)
+End Sub
+
+Private Function BitContainer._RoundToNext(ByVal val1 As Long, ByVal val2 As Long) As Long
+	Return (val1 + (val2 - 1)) And (Not (val2 - 1))
+End Function
+
+#ifdef FB_CONTAINER_DEBUG
+Private Sub BitContainer.PrintContainer()
+	Print "BitContainer at " & Hex(@This) & " has " & Count & " bits:"
+	Dim As Long i, j, k, byteIndex = 0
+	const bytesPerLine As Long = 4
+	Dim bitNum As Long = 0
+	Dim numBytes As Long = UBound(_bits) + 1
+	Dim singleBytes As Long = numBytes And (bytesPerLine - 1)
+	Dim numQuads As Long = numBytes \ bytesPerLine
+	Dim lineString As String
+	Dim bitString As ZString * 9
+	For i = 0 To numQuads - 1
+		'' print the highest bit number for this line
+		lineString = Str(bitNum + (bytesPerLine * 8) - 1) & " "
+		'' print the bytes backwards so the highest bytes are on the left
+		For j = byteIndex + (bytesPerLine - 1) To byteIndex Step -1
+			bitString = Bin(_bits(j), 8)
+			lineString += (bitString & " ")
+		Next
+		byteIndex += bytesPerLine
+		'' print the lowest bit number for this line
+		lineString += Str(bitNum)
+		Print lineString
+		lineString = ""
+		bitNum += bytesPerLine * 8
+	Next
+	If singleBytes > 0 Then
+		Dim spaces As Long = (4 - singleBytes) * 9
+		lineString = Str(bitNum + (bytesPerLine * 8) - 1) & " " & Space(spaces)
+		For j = ((byteIndex + singleBytes) - 1) To byteIndex Step -1
+			bitString = Bin(_bits(j), 8)
+			lineString += (bitString & " ")
+			byteIndex += 1
+		Next
+		lineString += Str(bitNum)
+		Print lineString
+	End If
+End Sub
+#endif
+
+#macro ImplementBitContainerBinaryOp(first, second, op)
+	Dim firstN As Long = first.Count
+	Dim secondN As Long = second.Count
+	Const integerSize As ULong = Sizeof(UInteger)
+__CONT_DBG_PRINT("with bitsets of & (first) and & (second) elements", firstN; secondN)
+
+	Dim retBits As Long = _Min(firstN, secondN)
+    Dim bytesSize As Long = (retBits + 7) \ 8
+    Dim numCopies As Long = bytesSize \ integerSize
+    
+    Dim newArr(0 To bytesSize - 1) As UByte
+    Dim firstArr(0 To bytesSize - 1) As UByte
+    Dim secondArr(0 To bytesSize - 1) As UByte
+    
+    first.GetBytes(firstArr())
+    second.GetBytes(secondArr())
+    Dim pFirstArr As UByte Ptr = @firstArr(0)
+    Dim pFirstArrBase As UByte Ptr = pFirstArr
+    Dim pSecondArr As UByte Ptr = @secondArr(0)
+    Dim pResArr As UByte Ptr = @newArr(0)
+    Dim pFirstEndArr As UByte Ptr = pFirstArr + (numCopies * integerSize)
+    '' do integer size chunks
+    While pFirstArr < pFirstEndArr
+		*cast(UInteger Ptr, pResArr) = *cast(UInteger Ptr, pFirstArr) op *cast(UInteger Ptr, pSecondArr)
+		pResArr += integerSize
+		pFirstArr += integerSize
+		pSecondArr += integerSize
+    Wend
+    '' then any straggler bytes
+    numCopies = bytesSize And (integerSize - 1)
+    pFirstEndArr = pFirstArrBase + bytesSize
+    While pFirstArr < pFirstEndArr
+		*pResArr = *pFirstArr op *pSecondArr
+		pResArr += 1
+		pFirstArr += 1
+		pSecondArr += 1
+    Wend
+    '' This is apprently ambiguous without the cast
+    '' Dim retCont As BitContainer = Type(retBits, cast(@newArr(0), Any Ptr))
+    Return BitContainer(retBits, cast(Any Ptr, @newArr(0)))
+#endmacro
+
+Private Operator And(ByRef first As BitContainer, ByRef second As BitContainer) As BitContainer
+	ImplementBitContainerBinaryOp(first, second, And)
+End Operator
+
+Private Operator Or(ByRef first As BitContainer, ByRef second As BitContainer) As BitContainer
+	ImplementBitContainerBinaryOp(first, second, Or)
+End Operator
+
+Private Operator Xor(ByRef first As BitContainer, ByRef second As BitContainer) As BitContainer
+	ImplementBitContainerBinaryOp(first, second, Xor)
+End Operator
+
+Private Operator Eqv(ByRef first As BitContainer, ByRef second As BitContainer) As BitContainer
+__CONT_DBG_PRINT("with bitsets of & (first) and & (second) elements", first.Count; second.Count)
+	ImplementBitContainerBinaryOp(first, second, Eqv)
+End Operator
+
+Private Operator Imp(ByRef first As BitContainer, ByRef second As BitContainer) As BitContainer
+__CONT_DBG_PRINT("with bitsets of & (first) and & (second) elements", first.Count; second.Count)
+	ImplementBitContainerBinaryOp(first, second, Imp)
+End Operator
+
+#undef ImplementBitContainerBinaryOp
+
+Private Operator Not(ByRef first As BitContainer) As BitContainer
+	Dim firstN As Long = first.Count
+	Const integerSize As ULong = Sizeof(UInteger)
+__CONT_DBG_PRINT("with bitset of & (first) elements", firstN)
+
+    Dim bytesSize As Long = (firstN + 7) \ 8
+    Dim numCopies As Long = bytesSize \ integerSize
+    
+    Dim newArr(0 To bytesSize - 1) As UByte
+    Dim firstArr(0 To bytesSize - 1) As UByte
+    
+    first.GetBytes(firstArr())
+    
+    Dim pFirstArr As UByte Ptr = @firstArr(0)
+    Dim pFirstArrBase As UByte Ptr = pFirstArr
+    Dim pResArr As UByte Ptr = @newArr(0)
+    Dim pFirstEndArr As UByte Ptr = pFirstArrBase + (numCopies * integerSize)
+    '' do integer size chunks
+    While pFirstArr < pFirstEndArr
+		*cast(UInteger Ptr, pResArr) = Not *cast(UInteger Ptr, pFirstArr)
+		pResArr += integerSize
+		pFirstArr += integerSize
+    Wend
+    '' then any straggler bytes
+    numCopies = bytesSize And (integerSize - 1)
+    pFirstEndArr = pFirstArrBase + bytesSize
+    While pFirstArr < pFirstEndArr
+		*pResArr = Not *pFirstArr
+		pResArr += 1
+		pFirstArr += 1
+    Wend
+    '' This is apprently ambiguous without the cast
+    Return BitContainer(firstN, cast(Any Ptr, @newArr(0)))
+End Operator
+
+Private Operator Len(ByRef cont As BitContainer) As Integer
+	Return cont.Count
+End Operator
+
+#undef _Min
+
+'''
+'' Iterator functions
+''''
+Private Constructor BitContainerIterator(ByVal bitSet As UByte Ptr, ByVal length As Long)
+	_pBitset = bitSet
+	_numBits = length
+	_curPos = -1
+End Constructor
+
+Private Constructor BitContainerIterator()
+	_pBitset = 0
+	_numBits = 0
+	_curPos = -1
+End Constructor
+
+Private Operator BitContainerIterator.For()
+	_curPos = 0
+End Operator
+
+Private Operator BitContainerIterator.Next(ByRef cond As BitContainerIterator) As Integer
+	Return (_curPos < _numBits) AndAlso (_curPos <> cond._curPos)
+End Operator
+
+Private Operator BitContainerIterator.Step()
+	Advance()
+End Operator
+
+Private Function BitContainerIterator.Advance() As Boolean
+	Dim nextPos As Long = _curPos + 1
+	Dim ret As Boolean = nextPos < _numBits
+	If ret Then
+		Dim numByte As Long = nextPos \ 8
+		Dim numBit As Long = nextPos Mod 8
+		_curBit = (_pBitset[numByte] And (1 Shl numBit)) <> 0
+		_curPos = nextPos
+	End If
+	Return ret
+End Function
+
+Private Function BitContainerIterator.Item() ByRef As Boolean
+	Return _curBit
+End Function
+
+Private Sub BitContainerIterator.Reset()
+	_curPos = -1
+End Sub
+
+#endif '' __CONT_BitContainer_DEFINED
+
+'' this isn't necessary, but as the other containers need it
+'' users may try to do it and get errors when it doesn't exist
+#macro FBCont_DefineBitContainerOf(Type...)
+#Print "FBCont_DefineBitContainerOf isn't necessary"
+#endmacro
+
+#define FB_BitContainer(Type...) BitContainer

--- a/inc/containers/icontainer.bi
+++ b/inc/containers/icontainer.bi
@@ -1,0 +1,123 @@
+#include once "_typemacros.bi"
+#include once "iiterator.bi"
+#include once "_helpers.bi"
+
+#pragma once
+
+'' Turn debug on if compiling with -exx
+#if (__FB_ERR__ And 7) = 7
+#define FB_CONTAINER_DEBUG
+#endif
+
+#if defined(FB_CONTAINER_DEBUG) OrElse defined(FB_CONTAINER_LOG_CALLS)
+#macro __CONT_DBG_PRINT(str, params...) 
+If __CONT_Internals.g_stopRecursiveLoggingFlag = False Then
+    __CONT_Internals.g_stopRecursiveLoggingFlag = True
+	Print Using "FBContainerDbg: &, " & str; __FUNCTION__; params
+	__CONT_Internals.g_stopRecursiveLoggingFlag = false
+End If
+#endmacro
+#else
+#define __CONT_DBG_PRINT(str, params...) 
+#endif
+
+#macro __CONT_DefineIContainerOf_(FBType, PPType)
+
+__CONT_DefineIIteratorOf_(FBType, PPType)
+
+#define _ContainerInterfaceType __FB_JOIN__(IContainer, PPType)
+#define _IteratorInterfaceType __FB_JOIN__(IIterator, PPType)
+#define _TypeDefine() __FB_JOIN__(__CONT_, __FB_JOIN__(_ContainerInterfaceType, _DEFINED))
+__FB_DefinePassType(FBType, _PassType)
+
+#if __FB_QUOTE__(_TypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_TypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _ContainerInterfaceType)
+#endif
+
+Type _ContainerInterfaceType extends Object
+
+	Declare abstract Sub Clear()
+    Declare abstract Property Count() As Long
+    Declare abstract Sub CopyTo(newData() As FBType)
+    Declare abstract Function Contains(_PassType element As FBType) As Boolean
+    Declare abstract Function GetIterator() As _IteratorInterfaceType Ptr
+#ifdef FB_CONTAINER_DEBUG
+    Declare abstract Sub PrintContainer()
+#endif
+	Declare virtual Destructor()
+
+End Type
+
+Private Virtual Destructor _ContainerInterfaceType()
+End Destructor
+
+Namespace __CONT_Internals
+
+Private Sub ContainerToArray Overload (ByVal pContainer As _ContainerInterfaceType Ptr, newData() As FBType)
+	If pContainer = 0 OrElse pContainer->Count = 0 Then
+		__CONT_DBG_PRINT("Container (&) was null or empty, not copying", Hex(pContainer))
+		__CONT_Internals_SetError(1)
+		Exit Sub
+	End If
+    Dim pIterator As _IteratorInterfaceType Ptr = pContainer->GetIterator()
+    dim toCopy As Long = pContainer->Count
+    dim arrUBound As Long
+    dim arrLBound As Long
+    dim arrayElems As Long = __CONT_GetArrayInfo(newData, arrLBound, arrUBound)
+    if arrayElems <= 0 Then
+        arrayElems = toCopy
+        Redim newData(0 To arrayElems - 1)
+    End If
+    dim newDataPtr As FBType Ptr = @newData(arrLBound)
+    dim maxToCopy As Long = IIf(toCopy < arrayElems, toCopy, arrayElems)
+    dim i As Long = 0
+    While (pIterator->Advance()) AndAlso (i < maxToCopy)
+        newDataPtr[i] = pIterator->Item()
+        i += 1
+    Wend
+    Delete pIterator
+End Sub
+
+Private Sub ReverseArray Overload(arr() As FBType)
+	Dim As Long arrLBound, arrUBound, numElems = __CONT_GetArrayInfo(arr, arrLBound, arrUBound)
+	If numElems > 0 Then
+		Dim elemPtr As FBType Ptr = @arr(arrLBound)
+		Dim halfWay As Long = numElems \ 2
+		For i As Long = 0 To halfWay - 1
+			Swap elemPtr[arrLBound + i], elemPtr[arrUBound - i]
+		Next
+	End If
+End Sub
+
+End Namespace
+
+#endif '' __FB_QUOTE__(__TypeDefine()) <> "1"
+
+#undef _ContainerInterfaceType
+#undef _IteratorInterfaceType
+#undef _TypeDefine
+#undef _PassType
+
+#endmacro
+
+'' Use this at global scope to generate the code for the container interface type
+'' You shouldn't need to do this manually, a compatible interface type is 
+'' automatically generated for each type of container defined
+''
+'' Otherwise, if you require one seperately then the type arguments should be the
+'' type to be contained
+'' FBCont_DefineIContainerOf(Any Ptr) '' for an any ptr container interface
+'' FBCont_DefineIContainerOf(MyNamespace, MyType) '' for a type in a namespace
+#macro FBCont_DefineIContainerOf(Type...)
+
+__CONT_DefineIContainerOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro '' FBCont_DefineIContainerOf
+
+'' Use this to declare your variable type
+'' Dim myList As FB_IContainer(Any Ptr)
+'' Dim myList As FB_IContainer(MyNamespace, MyType)
+#define FB_IContainer(Type...) __FB_JOIN__(IContainer, __FB_MakePPType(Type))

--- a/inc/containers/iiterator.bi
+++ b/inc/containers/iiterator.bi
@@ -1,0 +1,69 @@
+#include once "_typemacros.bi"
+
+#pragma once
+
+#macro __CONT_DefineIIteratorOf_(FBType, PPType)
+
+#ifndef _IteratorInterfaceType
+#define __CONT_NEEDS_ITER_UNDEF 1
+#define _IteratorInterfaceType	 __FB_JOIN__(IIterator, PPType)
+#endif
+#define _IteratorTypeDefine()	 __FB_JOIN__(__CONT_, __FB_JOIN__(_IteratorInterfaceType, _DEFINED))
+
+#if __FB_QUOTE__(_IteratorTypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_IteratorTypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _IteratorInterfaceType)
+#endif
+
+Type _IteratorInterfaceType extends object
+	
+	'' Types deriving from this base should also
+	'' implement the for loop operators, these cannot be abstract
+	'' so they're not listed here
+	
+	'' Declare Operator For()
+	'' Declare Operator Next(ByRef cond As IteratorInterfaceType) As Integer
+	'' Declare Operator Step()
+	
+	Declare abstract Function Advance() As Boolean
+	Declare abstract Function Item() ByRef As FBType
+	Declare abstract Sub Reset()
+	
+	Declare virtual Destructor()
+
+End Type
+
+Private Destructor _IteratorInterfaceType()
+End Destructor
+
+#endif '' _IteratorTypeDefine <> "1"
+
+#ifdef __CONT_NEEDS_ITER_UNDEF
+#undef _IteratorInterfaceType
+#undef __CONT_NEEDS_ITER_UNDEF
+#endif
+#undef _IteratorTypeDefine
+
+#endmacro '' DefineIIteratorOf_
+
+
+'' Use this at global scope to generate the code for the iterator interface type
+'' You shouldn't need to do this manually, a compatible interface type is 
+'' automatically generated for each type of container defined
+''
+'' Otherwise, if you require one seperately then the type arguments should be the
+'' type to be iterated
+'' FBCont_DefineIIteratorOf(Any Ptr) '' for an any ptr iterator interface
+'' FBCont_DefineIIteratorOf(MyNamespace, MyType) '' for a type in a namespace
+#macro FBCont_DefineIIteratorOf(Type...)
+
+__CONT_DefineIIteratorOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro '' FBCont_DefineIIteratorOf
+
+'' Use this to declare your variable type
+'' Dim myList As FB_IIterator(Any Ptr)
+'' Dim myList As FB_IIterator(MyNamespace, MyType)
+#define FB_IIterator(Type...) __FB_JOIN__(IIterator, __FB_MakePPType(Type))

--- a/inc/containers/ilist.bi
+++ b/inc/containers/ilist.bi
@@ -1,0 +1,64 @@
+#include once "_typemacros.bi"
+#include once "icontainer.bi"
+
+#pragma once
+
+#macro __CONT_DefineIListOf_(FBType, PPType)
+
+__CONT_DefineIContainerOf_(FBType, PPType)
+
+#define _ListInterfaceType		__FB_JOIN__(IList, PPType)
+#define _ContainerInterfaceType __FB_JOIN__(IContainer, PPType)
+#define _IteratorInterfaceType	__FB_JOIN__(IIterator, PPType)
+#define _TypeDefine()			__FB_JOIN__(__CONT_, __FB_JOIN__(_ListInterfaceType, _DEFINED))
+__FB_DefinePassType(FBType, _PassType)
+
+#if __FB_QUOTE__(_TypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_TypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _ListInterfaceType)
+#endif
+
+Type _ListInterfaceType extends _ContainerInterfaceType
+
+    Declare abstract Sub Add(_PassType element As FBType)
+    Declare abstract Function First() ByRef As FBType
+    Declare abstract Function Last() ByRef As FBType
+    Declare abstract Function IndexOf(_PassType element As FBType) As Long
+    Declare abstract Sub Insert(ByVal index As Long, _PassType newData As FBType)
+    Declare abstract Function LastIndexOf(_PassType element As FBType) As Long
+    Declare abstract Sub Remove(_PassType element As FBType)
+    Declare abstract Sub RemoveAt(Byval index As Long)
+    Declare abstract Operator [] (ByVal index AS Long) ByRef As FBType
+
+End Type
+
+#endif '' __FB_QUOTE__(_TypeDefine()) <> "1"
+
+#undef _ListInterfaceType
+#undef _ContainerInterfaceType
+#undef _IteratorInterfaceType
+#undef _TypeDefine
+#undef _PassType
+
+#endmacro '' __CONT_DefineIListOf_
+
+'' Use this at global scope to generate the code for the list interface type
+'' You shouldn't need to do this manually, a compatible interface type is 
+'' automatically generated for each type of container defined
+''
+'' Otherwise, if you require one seperately then the type arguments should be the
+'' type to be contained in the list
+'' FBCont_DefineIListOf(Any Ptr) '' for an any ptr list interface
+'' FBCont_DefineIListOf(MyNamespace, MyType) '' for a type in a namespace
+#macro FBCont_DefineIListOf(args...)
+
+__CONT_DefineIListOf_(__FB_MakeFBType(args), __FB_MakePPType(args))
+
+#endmacro '' FBCont_DefineIListOf
+
+'' Use this to declare your variable type
+'' Dim myList As FB_IList(Any Ptr)
+'' Dim myList As FB_IList(MyNamespace, MyType)
+#define FB_IList(Type...) __FB_JOIN__(IList, __FB_MakePPType(Type))

--- a/inc/containers/linkedlist.bi
+++ b/inc/containers/linkedlist.bi
@@ -1,0 +1,516 @@
+#include once "_typemacros.bi"
+#include once "icontainer.bi"
+#include once "linkedlistiterator.bi"
+#include once "_helpers.bi"
+
+#pragma once
+
+'' Defines a Linked List Node
+#macro __CONT_DefineLinkedListNodeOf_(FBType, PPType)
+
+#define _LinkedListNodeType			__FB_JOIN__(LinkedListNode, PPType)
+#define _LinkedListType				__FB_JOIN__(LinkedList, PPType)
+#define _TypeDefine()				__FB_JOIN__(__CONT_, __FB_JOIN__(_LinkedListNodeType, _DEFINED))
+__FB_DefinePassType(FBType, _PassType)
+
+#if __FB_QUOTE__(_TypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_TypeDefine()) " 1"))
+
+#define NodePtr _LinkedListNodeType Ptr
+
+Type _LinkedListNodeType
+Protected:
+    dim _next As NodePtr
+    dim _prev As NodePtr
+    dim _data As FBType
+
+Public:
+    Declare Property Back() As NodePtr
+    '' Next by itself is an operator so it has to be Forward
+    Declare Property Forward() As NodePtr
+    Declare Property Data() ByRef As FBType
+    Declare Property Data(_PassType newData As FBType)
+
+End Type
+
+Private Property _LinkedListNodeType.Forward() As NodePtr
+    Return _next
+End Property
+
+Private Property _LinkedListNodeType.Back() As NodePtr
+    Return _prev
+End Property
+
+Private Property _LinkedListNodeType.Data() ByRef As FBType
+    Return _data
+End Property
+
+Private Property _LinkedListNodeType.Data(_PassType newData As FBType)
+    _data = newData
+End Property
+
+#undef NodeType
+
+#endif '' __FB_QUOTE__(_TypeDefine())
+
+#undef _LinkedListType
+#undef _LinkedListNodeType
+#undef _TypeDefine
+#undef _PassType
+
+#endmacro '' __CONT_DefineLinkedListNodeOf_
+
+'' Defines a circular doubly linked list
+#macro __CONT_DefineLinkedListOf_(FBType, PPType)
+
+__CONT_DefineIContainerOf_(FBType, PPType)
+__CONT_DefineLinkedListNodeOf_(FBType, PPType)
+
+#define _LinkedListType				__FB_JOIN__(LinkedList, PPType)
+#define _LinkedListNodeType			__FB_JOIN__(LinkedListNode, PPType)
+#define _LinkedListNodeSuperType	__FB_JOIN__(LinkedListSuperNode, PPType)
+#define _LinkedListTypePtr			__FB_JOIN__(LinkedList, __FB_JOIN__(PPType, Ptr))
+#define _LinkedListIteratorType		__FB_JOIN__(LinkedListIterator, PPType)
+#define _ContainerInterfaceType		__FB_JOIN__(IContainer, PPType)
+#define _IteratorInterfaceType		__FB_JOIN__(IIterator, PPType)
+#define _TypeDefine()				__FB_JOIN__(__CONT_, __FB_JOIN__(_LinkedListType, _DEFINED))
+__FB_DefinePassType(FBType, _PassType)
+
+#if __FB_QUOTE__(_TypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_TypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _LinkedListType)
+#endif
+
+__CONT_DefineLinkedListIteratorOf_(FBType, PPType)
+
+'' This Type alias is required for a forward declare. 
+'' The SuperNode needs to know about the list, and the list uses SuperNodes
+'' so one is required to be forwarded
+Type _LinkedListTypePtr As _LinkedListType Ptr
+#define NodePtr _LinkedListNodeType Ptr
+
+'' C++ style friendship isn't available, so to avoid exposing these setters to users
+'' on the base type that could be used to mess up the list, 
+'' we restrict them to a super type that only the list creates/knows about
+Namespace __CONT_Internals
+#define SuperNodePtr __FB_JOIN__(__CONT_Internals., _LinkedListNodeSuperType) Ptr
+
+Type _LinkedListNodeSuperType extends _LinkedListNodeType
+	dim _parent As _LinkedListTypePtr
+
+Declare Constructor(_PassType newData As FBType, ByVal owner As _LinkedListTypePtr, byVal newNext As NodePtr, byVal newPrev As NodePtr)
+Declare Property Parent() As _LinkedListTypePtr
+Declare Property Parent(ByVal owner As _LinkedListTypePtr)
+Declare Property Forward(ByVal newNext As NodePtr)
+Declare Property Back(ByVal newPrev As NodePtr)
+    
+End Type
+
+Private Constructor _LinkedListNodeSuperType(_PassType newData As FBType, ByVal owner As _LinkedListTypePtr, byVal newNext As NodePtr, byVal newPrev As NodePtr)
+    _data = newData
+    _parent = owner
+    _prev = newPrev
+    
+    If newNext <> 0 Then
+		_next = newNext
+		
+		cast(SuperNodePtr, newNext)->Back = @This
+	Else
+		_next = @This
+	End If
+
+	If newPrev <> 0 Then
+		_prev = newPrev
+		
+		cast(SuperNodePtr, newPrev)->Forward = @This
+	Else
+		_prev = @This
+	End If
+End Constructor
+
+Private Property _LinkedListNodeSuperType.Parent() As _LinkedListTypePtr
+    Return _parent
+End Property
+
+Private Property _LinkedListNodeSuperType.Parent(ByVal newParent As _LinkedListTypePtr)
+    _parent = newParent
+End Property
+
+Private Property _LinkedListNodeSuperType.Forward(ByVal newNext As NodePtr)
+    _next = newNext
+End Property
+
+Private Property _LinkedListNodeSuperType.Back(ByVal newPrev As NodePtr)
+    _prev = newPrev
+End Property
+
+End Namespace
+
+Type _LinkedListType extends _ContainerInterfaceType
+Private:
+	dim _head as NodePtr
+	dim _count As Long
+	
+	Declare Function _CheckNodeOwnership(ByVal node As NodePtr, ByVal container As _LinkedListType Ptr) As Boolean
+	Declare Function _Add(_PassType newData As FBType, ByVal prevNode As SuperNodePtr, ByVal nextNode As SuperNodePtr) As NodePtr
+	
+Public:
+	Declare Constructor
+    Declare Constructor(ByVal iterator As _IteratorInterfaceType Ptr)
+    Declare Constructor(ByRef iterator As _IteratorInterfaceType)
+    Declare Constructor(newData() As FBType)
+    Declare Constructor(ByVal objects As _ContainerInterfaceType Ptr)
+    Declare Constructor(ByRef objects As _ContainerInterfaceType)
+    
+    Declare Function AddAfter(_PassType newData As FBType, ByVal afterThis As NodePtr) As NodePtr
+    Declare Function AddBefore(_PassType newData As FBType, ByVal beforeThis As NodePtr) As NodePtr
+    Declare Function AddHead(_PassType newData As FBType) As NodePtr
+    Declare Function AddTail(_PassType newData As FBType) As NodePtr
+	Declare Sub Clear() override
+    Declare Sub CopyTo(newData() As FBType) override
+    Declare Function Contains(_PassType element As FBType) As Boolean override
+    Declare Function Empty() As Boolean
+    Declare Function Find(_PassType data As FBType, ByVal startNode As NodePtr) As NodePtr
+    Declare Function GetIterator() As _IteratorInterfaceType Ptr override
+    Declare Function RemoveNode(ByVal node As NodePtr) As NodePtr
+    
+    Declare Property Count() As Long override
+    Declare Property Head() As NodePtr
+    Declare Property Tail() As NodePtr
+    
+    '' shallow copy isn't good enough for a LinkedList
+    Declare Operator Let(ByRef other As _LinkedListType)
+    Declare Operator +=(_PassType newData As FBType)
+    '' Also Operator Len()
+    
+#ifdef FB_CONTAINER_DEBUG
+    Declare Sub PrintContainer() override
+#endif
+    Declare Destructor()
+
+End Type
+
+Private Constructor _LinkedListType
+__CONT_DBG_PRINT("Default constructor")
+    _head = 0
+    _count = 0
+End Constructor
+
+Private Constructor _LinkedListType(ByVal iterator As _IteratorInterfaceType Ptr)
+	Constructor()
+__CONT_DBG_PRINT("Iterator constructor")
+    
+    While iterator->Advance()
+        AddTail(iterator->Item())
+    Wend
+End Constructor
+
+Private Constructor _LinkedListType(ByRef iterator As _IteratorInterfaceType)
+	Constructor(@iterator)
+End Constructor
+
+Private Constructor _LinkedListType(newData() As FBType)
+	Constructor()
+__CONT_DBG_PRINT("Array constructor")
+    dim arrLBound As Long
+    dim arrUBound As Long
+    
+    If __CONT_GetArrayInfo(newData, arrLBound, arrUBound) > 0 Then
+        dim i As Long
+		For i = arrLBound to arrUBound
+		    AddTail(newData(i))
+		Next
+    End If
+    
+End Constructor
+
+Private Constructor _LinkedListType(ByVal objects As _ContainerInterfaceType Ptr)
+	Constructor()
+__CONT_DBG_PRINT("ContainerPtr constructor - &", Hex(objects))
+    Dim iter As _IteratorInterfaceType Ptr = objects->GetIterator()
+    While iter->Advance()
+		AddTail(iter->Item())
+    Wend
+    Delete iter
+End Constructor
+
+Private Constructor _LinkedListType(ByRef objects As _ContainerInterfaceType)
+	Constructor(@objects)
+	Print "ContainerRef cons"
+End Constructor
+
+Private Destructor _LinkedListType
+    Clear()
+End Destructor
+
+Private Function _LinkedListType._Add(_PassType newData As FBType, ByVal prevNode As SuperNodePtr, ByVal nextNode As SuperNodePtr) As NodePtr
+    Dim newNode As SuperNodePtr = New __CONT_Internals._LinkedListNodeSuperType(newData, @This, nextNode, prevNode)
+    Dim numElems As Long = Count
+    If numElems = 0 Then
+		_head = newNode
+    End If
+    _count = numElems + 1
+    Return newNode
+End Function
+
+Private Function _LinkedListType.AddHead(_PassType newData As FBType) As NodePtr
+    Dim oldHead As NodePtr = Head
+__CONT_DBG_PRINT("before node &", Hex(oldHead))
+    _head = _Add(newData, cast(SuperNodePtr, Tail), cast(SuperNodePtr, oldHead))
+    Return _head
+End Function
+
+Private Function _LinkedListType.AddTail(_PassType newData As FBType) As NodePtr
+    Dim oldTail As NodePtr = Tail
+__CONT_DBG_PRINT("after node &", Hex(oldTail))
+    Return _Add(newData, cast(SuperNodePtr, oldTail), cast(SuperNodePtr, Head))
+End Function
+
+Private Function _LinkedListType.AddBefore(_PassType newData As FBType, ByVal beforeThis As NodePtr) As NodePtr
+__CONT_DBG_PRINT("before node &", Hex(beforeThis))
+    
+    If beforeThis = 0 Then 
+		Return AddTail(newData)
+    End If
+    If _CheckNodeOwnership(beforeThis, @This) = False Then
+		Dim pSuperNode As SuperNodePtr = cast(SuperNodePtr, beforeThis)
+__CONT_DBG_PRINT("Trying to AddBefore node & that belongs to a different list (&), this list (&), ignoring", Hex(beforeThis); Hex(pSuperNode->Parent); Hex(@This))
+		__CONT_Internals_SetError(1)
+		Return 0
+    End If
+    dim newNode As NodePtr =  _Add(newData, cast(SuperNodePtr, beforeThis->Back), cast(SuperNodePtr, beforeThis))
+    If beforeThis = _head Then
+		_head = newNode
+    End If
+    Return newNode
+End Function
+
+Private Function _LinkedListType.AddAfter(_PassType newData As FBType, ByVal afterThis As NodePtr) As NodePtr
+__CONT_DBG_PRINT("after node &", Hex(afterThis))
+    If afterThis = 0 Then
+		Return AddHead(newData)
+    End If
+    If _CheckNodeOwnership(afterThis, @This) = False Then
+		Dim pSuperNode As SuperNodePtr = cast(SuperNodePtr, afterThis)
+__CONT_DBG_PRINT("Trying to AddAfter node & that belongs to a different list (&), this list (&), ignoring", Hex(afterThis); Hex(pSuperNode->Parent); Hex(@This))
+		__CONT_Internals_SetError(1)
+		Return 0
+    End If
+    Return _Add(newData, cast(SuperNodePtr, afterThis), cast(SuperNodePtr, afterThis->Forward))
+End Function
+
+Private Sub _LinkedListType.Clear()
+	Dim n As Long = Count
+__CONT_DBG_PRINT("& elements"; n)
+
+	If n > 0 Then
+		Dim As _LinkedListNodeType Ptr pNext = Head, pCur
+		For i As Long = 0 To n - 1
+			pCur = pNext
+			pNext = pNext->Forward
+			Delete cast(SuperNodePtr, pCur)
+		Next
+		Assert(pNext = _head)
+		_head = 0
+		_count = 0
+    End If
+End Sub
+
+Private Sub _LinkedListType.CopyTo(newData() as FBType)
+__CONT_DBG_PRINT("with & elements"; Count)
+
+    __CONT_Internals.ContainerToArray(@This, newData())
+End Sub
+
+Private Function _LinkedListType.Contains(_PassType element As FBType) As Boolean
+__CONT_DBG_PRINT("")
+    Dim savedHead As NodePtr = Head
+    Dim temp As NodePtr = savedHead
+    Dim found As Boolean = False
+    
+    If savedHead <> 0 Then    
+		Do
+			found = (temp->Data = element)
+			temp = temp->Forward
+		Loop While (found = False) AndAlso (temp <> savedHead)
+    End If
+    
+    Return found
+    
+End Function
+
+Private Function _LinkedListType.Empty() As Boolean
+	Dim n As Long = Count
+__CONT_DBG_PRINT("Returning &", n = 0)
+	Return n = 0
+End Function
+
+Private Function _LinkedListType.Find(_PassType toFind As FBType, ByVal startNode As NodePtr) As NodePtr
+	Dim n As Long = Count
+__CONT_DBG_PRINT("looking through & nodes starting at &", n; Hex(startNode))
+	If (startNode <> 0) AndAlso (_CheckNodeOwnership(startNode, @This) = False) Then
+		Dim pSuperNode As SuperNodePtr = cast(SuperNodePtr, startNode)
+__CONT_DBG_PRINT("Trying to search from node & that belongs to a different list (&), this list (&), ignoring", Hex(startNode); Hex(pSuperNode->Parent); Hex(@This))
+		__CONT_Internals_SetError(1)
+		Return 0
+    End If
+	If n > 0 Then
+		Dim As NodePtr pIter = Iif(startNode = 0, Head, startNode), pEnd = pIter
+		Do
+			If pIter->Data = toFind Then Return pIter
+			pIter = pIter->Forward
+		Loop While pIter <> pEnd
+	End If
+	Return 0
+End Function
+
+Private Function _LinkedListType.GetIterator() As _IteratorInterfaceType Ptr
+__CONT_DBG_PRINT("for & elements"; Count)
+    Return New _LinkedListIteratorType(Head)
+
+End Function
+
+Private Function _LinkedListType.RemoveNode(ByVal node As NodePtr) As NodePtr
+	Dim numNodes As Long = Count
+__CONT_DBG_PRINT("Removing node at & from list with & entries", Hex(node); numNodes)
+    If node = 0 OrElse numNodes = 0 Then Return 0
+    
+    If _CheckNodeOwnership(node, @This) = False Then
+		Dim pSuperNode As SuperNodePtr = cast(SuperNodePtr, node)
+__CONT_DBG_PRINT("Trying to remove node & that belongs to a different list (&), this list (&), ignoring", Hex(node); Hex(pSuperNode->Parent); Hex(@This))
+		__CONT_Internals_SetError(1)
+		Return 0
+	End If
+    
+    Dim next_ As SuperNodePtr = cast(SuperNodePtr, node->Forward)
+    Dim prev As SuperNodePtr = cast(SuperNodePtr, node->Back)
+    
+    '' Circuar list, this should never happen
+    Assert((next_ <> 0) AndAlso (prev <> 0))
+    
+    next_->Back = prev
+    prev->Forward = next_
+    
+    '' If we're removing the head and its the last node, 
+    '' set our list to 0, otherwise set the new head
+    If node = _head Then
+		If numNodes = 1 Then
+			next_ = 0
+		End If
+		_head = next_
+    End If
+    
+    Delete cast(SuperNodePtr, node)
+    _count = numNodes - 1
+    
+    Return next_
+
+End Function
+
+Private Property _LinkedListType.Count() As Long
+__CONT_DBG_PRINT("Count returning &", _count)
+    Return _count
+End Property
+
+Private Property _LinkedListType.Head() As NodePtr
+__CONT_DBG_PRINT("Returning &", Hex(_head))
+    Return _head
+End Property
+
+Private Property _LinkedListType.Tail() As NodePtr
+	Dim ret As NodePtr = IIf(_head = 0, 0, _head->Back)
+__CONT_DBG_PRINT("Returning &", Hex(ret))
+	Return ret
+End Property
+
+Private Operator _LinkedListType.Let(ByRef other As _LinkedListType)
+__CONT_DBG_PRINT("assigning LinkedList & from LinkedList & with & elements"; Hex(@This); Hex(@other); other.Count)
+	'' Self assignation is logically a no-op and it could be quite an expensive 'do-nothing'
+	'' so don't do it
+	If @other = @This Then Exit Operator
+	Clear()
+	Dim As NodePtr pHead = other.Head, pIter = pHead
+	If pHead <> 0 Then
+		Do
+			AddTail(pIter->Data)
+			pIter = pIter->Forward
+		Loop Until pIter = pHead
+	End If
+End Operator
+
+Private Function _LinkedListType._CheckNodeOwnership(ByVal node As NodePtr, ByVal container As _LinkedListType Ptr) As Boolean
+
+    Return cast(SuperNodePtr, node)->Parent = container
+
+End Function
+
+#ifdef FB_CONTAINER_DEBUG
+Private Sub _LinkedListType.PrintContainer()
+	Dim n As Long = Count
+	Print __FB_QUOTE__(_ListType) " at " & Hex(@This) & " has " & n & " elements:"
+	
+	If n > 0 Then
+		Dim i As Long = 1
+		Dim iter As NodePtr = Head
+		Do
+			Print Using "Node &) 0x&"; i; Hex(iter)
+			i += 1
+			iter = iter->Forward
+		Loop Until iter = head
+	End If
+	
+End Sub
+#endif
+
+Private Operator _LinkedListType.+=(_PassType newData As FBType)
+	__CONT_DBG_PRINT("")
+	AddTail(newData)
+End Operator
+
+Private Operator Len(Byref list As _LinkedListType) As Integer
+	Return list.Count
+End Operator
+
+#undef SuperNodePtr
+#undef NodePtr
+
+#endif '' __FB_QUOTE__(_TypeDefine()) <> "1"
+
+#undef _LinkedListType
+#undef _LinkedListNodeType
+#undef _LinkedListNodeSuperType
+#undef _LinkedListTypePtr
+#undef _LinkedListIteratorType
+#undef _ContainerInterfaceType
+#undef _IteratorInterfaceType
+#undef _TypeDefine
+#undef _PassType
+
+#endmacro
+
+'' Use this at global scope to generate the code for the list type
+'' One of these is required for every separate type you want to put in a list
+'' FBCont_DefineLinkedListOf(Any Ptr) '' for an any ptr list
+'' FBCont_DefineLinkedListOf(MyNamespace, MyType) '' for a type in a namespace
+#macro FBCont_DefineLinkedListOf(Type...)
+
+__CONT_DefineLinkedListOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro '' FBCont_DefineLinkedListOf
+
+#macro FBCont_DefineLinkedListNodeOf(Type...)
+
+__CONT_DefineLinkedListNodeOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro
+
+'' Use these to declare your variable types
+'' Dim myList As FB_LinkedList(Any Ptr)
+'' Dim myList As FB_LinkedList(MyNamespace, MyType)
+'' Dim myNode As FB_LinkedListNode(MyNamespace, MyType)
+'' Dim pMyNode As FB_LinkedListNode(MyNamespace, MyType) Ptr
+#define FB_LinkedList(Type...) __FB_JOIN__(LinkedList, __FB_MakePPType(Type))
+#define FB_LinkedListNode(Type...) __FB_JOIN__(LinkedListNode, __FB_MakePPType(Type)) Ptr
+#define FB_LinkedListNodePtr(Type...) FB_LinkedListNode(Type)

--- a/inc/containers/linkedlistiterator.bi
+++ b/inc/containers/linkedlistiterator.bi
@@ -1,0 +1,147 @@
+#include once "_typemacros.bi"
+#include once "iiterator.bi"
+
+#pragma once
+
+'' Defines an iterator that enumerates a LinkedList from Head to Tail
+#macro __CONT_DefineLinkedListIteratorOf_(FBType, PPType)
+
+__CONT_DefineIIteratorOf_(FBType, PPType)
+
+#ifndef _LinkedListIteratorType
+#define __CONT_NEEDS_TYPE_UNDEF
+#define _LinkedListIteratorType	__FB_JOIN__(LinkedListIterator, PPType)
+#endif
+#ifndef _LinkedListNodeType
+#define __CONT_NEEDS_NODE_UNDEF
+#define _LinkedListNodeType		__FB_JOIN__(LinkedListNode, PPType)
+#endif
+#ifndef _IteratorInterfaceType
+#define __CONT_NEEDS_ITER_UNDEF
+#define _IteratorInterfaceType	__FB_JOIN__(IIterator, PPType)
+#endif
+#define _IteratorTypeDefine()	__FB_JOIN__(__CONT_, __FB_JOIN__(_LinkedListIteratorType, _DEFINED))
+#define _NodePtr _LinkedListNodeType Ptr
+
+#if __FB_QUOTE__(_IteratorTypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_IteratorTypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _LinkedListIteratorType)
+#endif
+
+Type _LinkedListIteratorType extends _IteratorInterfaceType
+Private:
+    dim _head As _NodePtr
+    dim _curPos As _NodePtr
+    dim _stop As Boolean
+    
+Public:
+    Declare Constructor(ByVal head As _NodePtr)
+    Declare Constructor()
+    Declare Operator For()
+	Declare Operator Next(ByRef cond As _LinkedListIteratorType) As Integer
+	Declare Operator Step()
+	
+	Declare Function Advance() As Boolean Override
+	Declare Function Item() Byref As FBType Override
+	Declare Sub Reset() Override
+End Type
+
+Private Constructor _LinkedListIteratorType(ByVal head As _NodePtr)
+__CONT_DBG_PRINT("Head constructor with &", Hex(head))
+    _head = head
+    _curPos = 0
+    _stop = False
+End Constructor
+
+Private Constructor _LinkedListIteratorType()
+__CONT_DBG_PRINT("Default constructor (end iterator)")
+    _head = 0
+    _curPos = 0
+    _stop = False
+End Constructor
+
+Private Operator _LinkedListIteratorType.For()
+__CONT_DBG_PRINT("Starting for")
+    _curPos = _head
+    _stop = False
+End Operator
+
+Private Operator _LinkedListIteratorType.Next(ByRef cond As _LinkedListIteratorType) As Integer
+__CONT_DBG_PRINT("")
+    Return (_curPos <> cond._curPos) AndAlso (_curPos <> 0)
+End Operator
+
+Private Operator _LinkedListIteratorType.Step()
+    dim nextPos As NodePtr = _curPos->Forward
+__CONT_DBG_PRINT("Stepping from & to &", Hex(_curPos); Hex(nextPos))
+    _curPos = IIf(nextPos = _head, 0, nextPos)
+End Operator
+
+Private Function _LinkedListIteratorType.Advance() As Boolean
+	If _stop OrElse _head = 0 Then '' we've gone all the way around to the head, stop
+__CONT_DBG_PRINT("Advanced to end")
+		_curPos = 0
+	Else
+		dim As NodePtr newCur
+		If _curPos = 0 Then '' we haven't started yer, set to start
+			newCur = _head
+		Else
+			newCur = _curPos->Forward
+		End If
+		_stop = (newCur->Forward = _head) '' If the one after this is the _head, this is the last element
+__CONT_DBG_PRINT("Advancing from & to &", Hex(_curPos); Hex(newCur))
+		_curPos = newCur
+	End If
+    Return _curPos <> 0
+End Function
+
+Private Function _LinkedListIteratorType.Item() ByRef As FBType
+__CONT_DBG_PRINT("Accessing Item &", Hex(_curPos))
+    Return _curPos->Data
+End Function
+
+Private Sub _LinkedListIteratorType.Reset()
+__CONT_DBG_PRINT("Resetting")
+    _curPos = 0
+    _stop = False
+End Sub
+
+#endif '' __FB_JOIN__(_LinkedListIteratorType, _DEFINED)
+
+#ifdef __CONT_NEEDS_TYPE_UNDEF
+#undef _LinkedListIteratorType
+#undef __CONT_NEEDS_TYPE_UNDEF
+#endif
+#ifdef __CONT_NEEDS_NODE_UNDEF
+#undef _LinkedListNodeType
+#undef __CONT_NEEDS_NODE_UNDEF
+#endif
+#ifdef __CONT_NEEDS_ITER_UNDEF
+#undef _IteratorInterfaceType
+#undef __CONT_NEEDS_ITER_UNDEF
+#endif
+#undef _IteratorTypeDefine
+#undef _NodePtr
+
+#endmacro '' _CONT_DefineListIterator_
+
+'' Use this at global scope to generate the code for the listiterator type
+'' You shouldn't need to do this manually, a compatible list iterator type is 
+'' automatically generated for each type of container defined
+''
+'' Otherwise one of these is required for every separate type of list to iterate
+'' The type should be the type contained in the list being iterated
+'' FBCont_DefineLinkedListIteratorOf(Any Ptr) '' for an any ptr list iterator
+'' FBCont_DefineLinkedListIteratorOf(MyNamespace, MyType) '' for a type in a namespace
+#macro FBCont_DefineLinkedListIteratorOf(Type...)
+
+__CONT_DefineLinkedListIteratorOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro
+
+'' Use this to declare your variable type
+'' Dim myList As FB_LinkedListIterator(Any Ptr)
+'' Dim myList As FB_LinkedListIterator(MyNamespace, MyType)
+#define FB_LinkedListIterator(Type...) __FB_JOIN__(LinkedListIterator, __FB_MakePPType(Type))

--- a/inc/containers/list.bi
+++ b/inc/containers/list.bi
@@ -1,0 +1,636 @@
+#include once "_typemacros.bi"
+#include once "ilist.bi"
+#include once "listiterator.bi"
+#include once "_helpers.bi"
+
+#pragma once
+
+'' Defines a contiguous resizeable array container like a C++ vector
+'' or a C#/Java/Python list
+
+#macro __CONT_DefineListOf_(FBType, PPType)
+
+__CONT_DefineIListOf_(FBType, PPType)
+__CONT_DefineListIteratorOf_(FBType, PPType)
+
+#define _ListType				__FB_JOIN__(List, PPType)
+#define _ListIteratorType		__FB_JOIN__(ListIterator, PPType)
+#define _ListInterfaceType		__FB_JOIN__(IList, PPType)
+#define _ContainerInterfaceType __FB_JOIN__(IContainer, PPType)
+#define _IteratorInterfaceType	__FB_JOIN__(IIterator, PPType)
+#define _TypeDefine()			__FB_JOIN__(__CONT_, __FB_JOIN__(_ListType, _DEFINED))
+__FB_DefinePassType(FBType, _PassType)
+
+#if __FB_QUOTE__(_TypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_TypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _ListType)
+#endif
+
+#define Min(x, y) (IIf(x < y, x, y))
+
+Type _ListType extends _ListInterfaceType
+Private:
+    Dim _objects(Any) As FBType
+    Dim _count As Long
+
+    Declare Sub _AddOrInsert( _
+        newData() As FBType, _
+        ByVal start As Long, _ 
+        ByVal howMany As Long, _ 
+        ByVal where As Long _
+    )
+
+Public:
+    Declare Constructor
+    Declare Constructor(Byref copy As _ListType)
+    Declare Constructor(ByRef iterator As _IteratorInterfaceType)
+    Declare Constructor(ByVal iterator As _IteratorInterfaceType Ptr)
+    Declare Constructor(newData() As FBType)
+    Declare Constructor(ByRef objects As _ContainerInterfaceType)
+    Declare Constructor(ByVal objects As _ContainerInterfaceType Ptr)
+    
+    Declare Sub Add(_PassType newData As FBType) Override
+    Declare Sub Add(newData() As FBType)
+    Declare Sub Add(newData() As FBType, ByVal start As Long, ByVal howMany As Long)
+    Declare Sub Add(ByRef newData As _ContainerInterfaceType)
+    Declare Sub Add(ByRef newData As _IteratorInterfaceType)
+    Declare Sub Add(ByVal newData As _ContainerInterfaceType Ptr)
+    Declare Sub Add(ByVal newData As _IteratorInterfaceType Ptr)
+    Declare Sub Clear() Override
+    Declare Function Contains(_PassType data As FBType) As Boolean Override
+    Declare Sub CopyTo(data() As FBType) Override
+    Declare Sub CopyTo(data() As FBType, ByVal listStart As Long, ByVal listCount As Long, ByVal arrayStart As Long)
+    Declare Function Empty() As Boolean
+    Declare Function First() ByRef As FBType Override
+    Declare Function GetIterator() As _IteratorInterfaceType Ptr Override
+    Declare Function IndexOf(_PassType needle As FBType) As Long Override
+    Declare Sub Insert(ByVal index As Long, _PassType newData As FBType) Override
+    Declare Sub Insert(ByVal index As Long, newData() As FBType)
+    Declare Sub Insert(ByVal index As Long, newData() As FBType, ByVal newDataStart As Long, ByVal howMany As Long)
+    Declare Sub Insert(ByVal index As Long, ByVal newData As _ContainerInterfaceType Ptr)
+    Declare Sub Insert(ByVal index As Long, ByRef newData As _ContainerInterfaceType)
+    Declare Sub Insert(ByVal index As Long, ByVal newData As _IteratorInterfaceType Ptr)
+    Declare Sub Insert(ByVal index As Long, ByRef newData As _IteratorInterfaceType)
+    Declare Function Last() ByRef As FBType Override
+    Declare Function LastIndexOf(_PassType needle As FBType) As Long Override
+    Declare Sub Remove(_PassType item As FBType) Override
+    Declare Sub RemoveAt(ByVal index As Long) Override
+    Declare Sub RemoveSpan(ByVal index As Long, ByVal count As Long)
+    Declare Sub Resize(ByVal newSize As Long)
+    Declare Sub Reserve(ByVal newSize As Long)
+    
+    Declare Property Count() As Long Override
+    Declare Property Capacity() As Long
+    
+    Declare Operator [] (ByVal index AS Long) ByRef As FBType Override
+    Declare Operator +=(_PassType newData AS FBType)
+    '' Also Operator Len()
+    
+#ifdef FB_CONTAINER_DEBUG
+	Declare Sub PrintContainer() Override
+#endif
+
+End Type
+
+Private Constructor _ListType()
+__CONT_DBG_PRINT("Default constructor", 0)
+    Reserve(16)
+    _count = 0
+End Constructor
+
+Private Constructor _ListType(Byref copy As _ListType)
+__CONT_DBG_PRINT("Copy constructor", 0)
+	copy.CopyTo(_objects())
+	Reserve(copy.Capacity)
+	_count = copy.Count
+End Constructor
+
+Private Constructor _ListType(ByVal iterator As _IteratorInterfaceType Ptr)
+	Constructor()
+__CONT_DBG_PRINT("Iterator constructor", 0)
+    
+    Add(iterator)
+    
+End Constructor
+
+Private Constructor _ListType(ByRef iterator As _IteratorInterfaceType)
+	Constructor(@iterator)    
+End Constructor
+
+Private Constructor _ListType(newData() As FBType)
+	Constructor()
+__CONT_DBG_PRINT("Array constructor, LBound = &, UBound = &", LBound(newData); UBound(newData))
+    
+    Add(newData())
+
+End Constructor
+
+Private Constructor _ListType(ByVal newData As _ContainerInterfaceType Ptr)
+	Constructor()
+__CONT_DBG_PRINT("Container interface constructor")
+	
+    Add(newData)
+
+End Constructor
+
+Private Constructor _ListType(ByRef newData As _ContainerInterfaceType)
+	Constructor(@newData)
+End Constructor
+
+Private Sub _ListType.Add(_PassType newData As FBType)
+__CONT_DBG_PRINT("Adding item to position &", Count)
+
+    Dim n As Long = Count
+    If Capacity < (n + 1) Then
+        Reserve(n + 16)
+    End If
+
+    _objects(n) = newData
+    _count += 1
+
+End Sub
+
+Private Sub _ListType.Add(newData() As FBType)
+    Dim arrLBound As Long
+    Dim arrUBound As Long    
+    Dim numElems As Long = __CONT_GetArrayInfo(newData, arrLBound, arrUBound)
+__CONT_DBG_PRINT("Adding & items at position &", numElems; Count)
+    
+    If numElems > 0 Then
+		_AddOrInsert(newData(), arrLBound, numElems, -1)
+	End If
+
+End Sub
+
+Private Sub _ListType.Add(newData() As FBType, ByVal start As Long, ByVal howMany As Long)
+__CONT_DBG_PRINT("Adding & objects at position &, starting from &", howMany; Count; start)
+
+    If __CONT_IsValidArray(newData) Then
+		_AddOrInsert(newData(), start, howMany, -1)
+	End If
+
+End Sub
+
+Private Sub _ListType.Add(ByVal newData As _ContainerInterfaceType Ptr)
+	Assert(newData <> 0)
+	If newData = 0 Then
+		__CONT_Internals_SetError(1)
+		Exit Sub
+	End If
+__CONT_DBG_PRINT("Adding & items from Container &", newData->Count; Hex(newData))
+    Dim iter As _IteratorInterfaceType Ptr = newData->GetIterator()
+    Add(iter)
+    Delete iter
+
+End Sub
+
+Private Sub _ListType.Add(ByVal iterator As _IteratorInterfaceType Ptr)
+	Assert(iterator <> 0)
+	If iterator = 0 Then
+		__CONT_Internals_SetError(1)
+		Exit Sub
+	End If
+__CONT_DBG_PRINT("Adding items via iterator &", Hex(iterator))
+	While iterator->Advance()
+        Add(iterator->Item())
+    Wend
+End Sub
+
+Private Sub _ListType.Add(ByRef newData As _ContainerInterfaceType)
+	Add(@newData)
+End Sub
+
+Private Sub _ListType.Add(ByRef iterator As _IteratorInterfaceType)
+	Add(@iterator)
+End Sub
+
+Private Sub _ListType._AddOrInsert( _
+    newData() As FBType, _
+    ByVal start As Long, _
+    ByVal howMany As Long, _
+    ByVal insertAt As Long _
+)
+__CONT_DBG_PRINT("Adding & objects at position &, starting from &", howMany; insertAt; start)
+	Dim n As Long = Count
+	
+	If (insertAt < -1) OrElse (insertAt > n) Then
+__CONT_DBG_PRINT("Insert index (&) wasn't -1 or inside list bounds (0-&), not adding anything", insertAt; n)
+		__CONT_Internals_SetError(6)
+		Exit Sub
+	ElseIf insertAt = -1 Then
+		insertAt = n
+	End If
+
+    Dim As Long arrUBound, arrLBound
+    Dim numElems As Long = __CONT_GetArrayInfo(newData, arrLBound, arrUBound)
+
+    If (start > arrUBound) OrElse (start < arrLBound) OrElse (numElems <= 0) Then
+__CONT_DBG_PRINT("Start (&) was outside array bounds of &-&, or array was empty, not adding anything", start; arrLBound; arrUBound)
+		__CONT_Internals_SetError(6)
+        Exit Sub
+    End If
+
+	Dim newDataEnd As Long = start + (howMany - 1)
+    If newDataEnd > arrUBound Then
+        newDataEnd = arrUBound
+        howMany = (newDataEnd - start) + 1
+__CONT_DBG_PRINT("Changing howMany to & because start + howMany was beyond array uBound", howMany)
+    End If
+    
+    Dim newCount As Long = n + howMany
+
+    If newCount > Capacity Then
+        Reserve(newCount + 16)
+    End If
+
+    Dim srcPtr As FBType Ptr
+    Dim dstPtr As FBType Ptr
+
+    If insertAt <> n Then
+
+		'' Move all the elements after the insert position up
+		srcPtr = @_objects(n)
+		dstPtr = @_objects(newCount)
+		Dim i As Long
+		Dim toCopy As Long = n - insertAt
+		For i = 1 To toCopy
+			dstPtr -= 1
+			srcPtr -= 1
+			*dstPtr = *srcPtr
+		Next
+		dstPtr = srcPtr
+	Else
+		dstPtr = @_objects(insertAt)
+    End If
+
+    srcPtr = @newData(start)
+
+    Dim i As Long
+    For i = start To newDataEnd
+        *dstPtr = *srcPtr
+        dstPtr += 1
+        srcPtr += 1
+    Next
+
+    _count = newCount
+
+End Sub
+
+Private Sub _ListType.Clear()
+__CONT_DBG_PRINT("Clearing")
+	Erase _objects
+	_count = 0
+	Reserve(16)
+
+End Sub
+
+Private Function _ListType.Contains(_PassType item As FBType) As Boolean
+    Return IndexOf(item) <> -1
+End Function
+
+Private Sub _ListType.CopyTo(items() As FBType)
+__CONT_DBG_PRINT("Copying all list elements to an array (& elements)", Count)
+
+   __CONT_Internals.ContainerToArray(@This, items())
+
+End Sub
+
+'' listCount can be -1 to copy all elements
+'' If arr is undimensioned, arrayStart is ignored and the returned array is dimensioned from 0 to elementsCopied - 1
+'' elementsCopied is the minimum of:
+''    listCount - listStart
+''    Len(list) - listStart
+''    UBound(arr) - arrayStart + 1 (with a valid array)
+'' 
+Private Sub _ListType.CopyTo(arr() As FBType, ByVal listStart As Long, ByVal listCount As Long, ByVal arrayStart As Long)
+__CONT_DBG_PRINT("Copying & list elements starting at list position & to an array, starting at array position &", listCount; listStart; arrayStart)
+
+    Dim n As Long = Count
+    If (listStart < 0) OrElse (listStart >= n) OrElse (n = 0) Then
+        __CONT_DBG_PRINT("listStart (&) is less than 0 and beyond the number of items in the list (&), or the list is empty, ignoring CopyTo", listStart; n)
+        '' Don't set error on empty list
+        If n > 0 Then __CONT_Internals_SetError(1)
+        Exit Sub
+    End If
+    
+    If listCount = -1 Then listCount = n
+    
+    Dim arrUBound As Long
+    Dim arrLBound As Long
+    '' Constrain the number to copy to the number of elements available
+    If (listStart + listCount) > n Then listCount = (n - listStart)
+    
+    If __CONT_GetArrayInfo(arr, arrLBound, arrUBound) > 0 Then '' dimensioned non-zero size array
+    		
+		'' Check the start point of the array is valid
+		If (arrayStart < arrLBound) OrElse (arrayStart > arrUBound) Then
+			__CONT_DBG_PRINT("arrayStart (&) is less than array LBound (&) or larger than the array UBound (&), ignoring CopyTo", arrayStart; arrLBound; arrUBound)
+			__CONT_Internals_SetError(6)
+			Print "Exiting second exit sub"
+			Exit Sub
+		End If
+		'' If the array is dimensioned, we won't resize it so cap to its ubound
+		dim availableArraySlots As Long = (arrUBound - arrayStart) + 1
+        listCount = Min(listCount, availableArraySlots)
+        
+    Else '' non-dimensioned array
+    
+		Redim arr(0 To listCount - 1)
+		arrayStart = 0
+    End If
+    
+    dim srcPtr As FBType Ptr = @_objects(listStart)
+    dim dstPtr As FBType Ptr = @arr(arrayStart)
+   
+    While listCount > 0
+        *dstPtr = *srcPtr
+        listCount -= 1
+        srcPtr += 1
+        dstPtr += 1
+    Wend
+
+End Sub
+
+Private Function _ListType.Empty() As Boolean
+    Return Count = 0
+End Function
+
+Private Function _ListType.First() ByRef As FBType
+__CONT_DBG_PRINT("Getting first value")
+    Return this[0]
+End Function
+
+Private Function _ListType.GetIterator() As _IteratorInterfaceType Ptr
+__CONT_DBG_PRINT("Creating new iterator")
+	Return New _ListIteratorType(@This)
+End Function
+
+Private Function _ListType.IndexOf(_PassType needle As FBType) As Long
+	Dim itemCount As Long = Count
+    Dim i As Long = 0
+    
+    While i < itemCount
+        If _objects(i) = needle Then
+            Return i
+        End If
+        i += 1
+    Wend
+    Return -1
+End Function
+
+Private Sub _ListType.Insert(ByVal insertAt As Long, _PassType newData As FBType)
+__CONT_DBG_PRINT("Inserting value at &", insertAt)
+
+    Dim tempArr(0 To 0) As FBType
+    tempArr(0) = newData
+    _AddOrInsert(tempArr(), 0, 1, insertAt)
+
+End Sub
+
+Private Sub _ListType.Insert(ByVal insertAt As Long, newData() As FBType)
+    Dim arrLBound As Long
+    Dim arrUBound As Long
+    Dim numElems As Long = __CONT_GetArrayInfo(newData, arrLBound, arrUBound)
+__CONT_DBG_PRINT("Inserting array of & elements at &", numElems; insertAt)
+    If numElems > 0 Then
+		_AddOrInsert(newData(), arrLBound, numElems, insertAt)
+	Else
+		__CONT_Internals_SetError(1) '' undimmed or empty array
+	End If
+
+End Sub
+
+'' insertAt can be Count or -1 to insert at the end of the list (equalivalent to Add)
+Private Sub _ListType.Insert(ByVal insertAt As Long, newData() As FBType, ByVal arrStartIndex As Long, ByVal howMany As Long)
+__CONT_DBG_PRINT("Inserting array from &-& at &", arrStartIndex; arrStartIndex + howMany; insertAt)
+
+	If __CONT_IsValidArray(newData) Then
+        _AddOrInsert(newData(), arrStartIndex, howMany, insertAt)
+    Else
+		__CONT_Internals_SetError(1) '' undimmed or empty array
+	End If
+
+End Sub
+
+Private Sub _ListType.Insert(ByVal insertAt As Long, ByVal newData As _ContainerInterfaceType Ptr)
+__CONT_DBG_PRINT("Inserting container & at &", Hex(newData); insertAt)
+	If newData = 0 Then
+	__CONT_DBG_PRINT("Null/0 container ptr not allowed, ignoring insert")
+		__CONT_Internals_SetError(1)
+		Exit Sub
+	End If
+
+    Dim listCount As Long = newData->Count
+    Dim localErr As Long
+    
+    If listCount > 0 Then
+        Dim tempArr(Any) As FBType    
+        newData->CopyTo(tempArr())
+        _AddOrInsert(tempArr(), 0, listCount, insertAt)
+        localErr = Err
+    Else 
+		__CONT_Internals_SetError(1)
+    End If
+    '' Destroying tempArr in the > 0 case resets Err to 0, so we need to re-set any error status
+    If localErr <> 0 Then
+		Err = localErr
+	End If
+
+End Sub
+
+Private Sub _ListType.Insert(ByVal index As Long, ByRef newData As _ContainerInterfaceType)
+	Insert(index, @newData) 
+End Sub
+
+Private Sub _ListType.Insert(ByVal insertAt As Long, ByVal newData As _IteratorInterfaceType Ptr)
+__CONT_DBG_PRINT("Inserting iterator & at &", Hex(newData); insertAt)
+	If newData = 0 Then
+	__CONT_DBG_PRINT("Null/0 iterator ptr not allowed, ignoring insert")
+		__CONT_Internals_SetError(1)
+		Exit Sub
+	End If
+	
+	Dim localErr As Long = 0
+	
+	Scope
+		Dim insertCont As _ListType = newData
+		Insert(insertAt, @insertCont)
+		localErr = Err
+	End Scope
+	'' Destroying the container resets Err to 0, so it needs re-setting before we exit
+    If localErr <> 0 Then
+		Err = localErr
+    End If
+
+End Sub
+
+Private Sub _ListType.Insert(ByVal index As Long, ByRef newData As _IteratorInterfaceType)
+	Insert(index, @newData) 
+End Sub
+
+Private Function _ListType.Last() ByRef As FBType
+    Dim lastIndex As Long = Count - 1
+__CONT_DBG_PRINT("Last index = &", lastIndex)
+    Return This[lastIndex]
+End Function
+
+Private Function _ListType.LastIndexOf(_PassType needle As FBType) As Long
+__CONT_DBG_PRINT("")
+	Dim itemCount As Long = Count - 1
+    Dim i As Long = itemCount
+    
+    While i >= 0
+        If _objects(i) = needle Then
+            Return i
+        End If
+        i -= 1
+    Wend
+    Return -1
+End Function
+
+Private Sub _ListType.Remove(_PassType item As FBType)
+    Dim index As Long = IndexOf(item)
+    If index <> -1 Then
+        RemoveAt(index)
+        
+#if __FB_QUOTE__(_PassType) = "ByRef"
+    Else
+		__CONT_DBG_PRINT("Item not found. If this is a UDT, and you're sure it should be here, is your Operator= correct?")
+#endif
+	End if
+End Sub
+
+Private Sub _ListType.RemoveAt(ByVal index As Long)
+__CONT_DBG_PRINT("Removing index &", index)
+    RemoveSpan(index, 1)
+End Sub
+
+Private Sub _ListType.RemoveSpan(ByVal index As Long, ByVal howMany As Long)
+__CONT_DBG_PRINT("Removing & elements from position &", index; howMany)
+    Dim n As Long = Count
+    If (index < 0) OrElse (index >= n) OrElse (howMany <= 0) Then
+__CONT_DBG_PRINT("Index (&) was out of bounds (0-&) or howMany (&) was 0 or negative, ignoring remove", index; n - 1; howMany)
+		__CONT_Internals_SetError(IIf(howMany <= 0, 1, 6))
+        Exit Sub
+    End If
+    
+    If (index = 0) AndAlso (howMany = n) Then
+		Clear()
+		Exit Sub
+	End If
+    
+    howMany = Min(n - index, howMany)
+    
+    if howMany > 0 Then
+    
+        Dim newCount As Long = n - howMany
+        If index < newCount Then
+            Dim src As Long = index + howMany
+            Dim dst As Long = index
+            Dim toCopy As Long = newCount - index
+            CopyTo(_objects(), src, toCopy, dst)
+        End If
+        '' call any destructors for ones deleted
+        Redim Preserve _objects(0 To newCount)
+        Resize(newCount)
+    
+    End If
+    
+End Sub
+
+Private Sub _ListType.Resize(ByVal newSize As Long)
+__CONT_DBG_PRINT("Resizing from & to &", Capacity; newSize)
+	Assert(newSize >= 0)
+	If newSize < 0 Then
+		__CONT_Internals_SetError(1)
+		Exit Sub
+	End If
+    Reserve(newSize + 16)
+    _count = newSize
+    
+End Sub
+
+Private Sub _ListType.Reserve(ByVal newSize As Long)
+
+	If newSize > Count Then
+__CONT_DBG_PRINT("Changing capacity to &", newSize)
+		Redim Preserve _objects(0 To newSize - 1)
+	End If
+
+End Sub
+
+Private Property _ListType.Count() As Long
+__CONT_DBG_PRINT("returning &", _count)
+    Return _count
+End Property
+
+Private Property _ListType.Capacity() As Long
+__CONT_DBG_PRINT("Returning &", UBound(_objects) + 1)
+	Return UBound(_objects) + 1
+
+End Property
+
+Private Operator _ListType.[] (ByVal index As Long) ByRef As FBType
+__CONT_DBG_PRINT("Indexing at position & of &", index; Count - 1)
+
+    If (index < 0) OrElse (index >= Count) Then
+		Assert(StrPtr("Index location out of bounds") <> 0)
+		__CONT_Internals_SetError(6)
+    End If
+    Return _objects(index)
+End Operator
+
+Private Operator _ListType.+=(_PassType newData As FBType)
+	Add(newData)
+End Operator
+
+Private Operator Len(ByRef list As _ListType) As Integer
+	Return list.Count
+End Operator
+
+#ifdef FB_CONTAINER_DEBUG
+Private Sub _ListType.PrintContainer()
+    Print __FB_QUOTE__(_ListType) " at " & Hex(@This) & " has " & Count & " elements:"
+    '' If these are primitives or pointers, we can print them out, otherwise we can't
+#if ((__FB_Is_BuiltIn(FBType)) OrElse (__FB_Is_Ptr(FBType)))
+    Dim i As Long, n As Long = Count
+    For i = 0 To n - 1
+        Print Using "&) &, "; i; _objects(i);
+    Next
+#endif
+End Sub
+#endif '' FB_CONTAINER_DEBUG
+
+#endif '' __FB_QUOTE__(_TypeDefine()) <> "1"
+
+#undef _ListType
+#undef _ListIteratorType
+#undef _ListInterfaceType
+#undef _ContainerInterfaceType
+#undef _IteratorInterfaceType
+#undef _TypeDefine
+#undef _PassType
+#undef Min
+
+#endmacro '' __CONT_DefineListOf_
+
+
+'' Use this at global scope to generate the code for the list type
+'' One of these is required for every separate type you want to put in a list
+'' FBCont_DefineListOf(Any Ptr) '' for an any ptr list
+'' FBCont_DefineListOf(MyNamespace, MyType) '' for a type in a namespace
+''
+'' If you get a Type Mismatch error on the macro line when defining a list for your UDT type
+'' You need to implement Operator= 
+#macro FBCont_DefineListOf(Type...)
+
+__CONT_DefineListOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro '' FBCont_DefineListOf
+
+'' Use this to declare your variable type
+'' Dim myList As FB_List(Any Ptr)
+'' Dim myList As FB_List(MyNamespace, MyType)
+#define FB_List(Type...) __FB_JOIN__(List, __FB_MakePPType(Type))

--- a/inc/containers/listiterator.bi
+++ b/inc/containers/listiterator.bi
@@ -1,0 +1,115 @@
+#include once "_typemacros.bi"
+#include once "iiterator.bi"
+#include once "ilist.bi"
+
+#pragma once
+
+'' Defines an iterator that enumerates an IList forwards (from list.First() to list.Last())
+#macro __CONT_DefineListIteratorOf_(FBType, PPType)
+
+__CONT_DefineIListOf_(FBType, PPType)
+__CONT_DefineIIteratorOf_(FBType, PPType)
+
+#define _ListIteratorType		__FB_JOIN__(ListIterator, PPType)
+#define _IteratorInterfaceType	__FB_JOIN__(IIterator, PPType)
+#define _ListInterfaceType		__FB_JOIN__(IList, PPType)
+#define _TypeDefine()			__FB_JOIN__(__CONT_, __FB_JOIN__(_ListIteratorType, _DEFINED))
+
+#if __FB_QUOTE__(_TypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_TypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _ListIteratorType)
+#endif
+
+Type _ListIteratorType extends _IteratorInterfaceType
+Private:
+    dim parentList As _ListInterfaceType Ptr
+    dim curPos As Long
+    
+Public:
+    Declare Constructor(ByVal parent As _ListInterfaceType Ptr)
+    Declare Constructor()
+    Declare Operator For()
+	Declare Operator Next(ByRef cond As _ListIteratorType) As Integer
+	Declare Operator Step()
+	
+	Declare Function Advance() As Boolean Override
+	Declare Function Item() Byref As FBType Override
+	Declare Sub Reset() Override
+End Type
+
+Private Constructor _ListIteratorType(ByVal parent As _ListInterfaceType Ptr)
+__CONT_DBG_PRINT("List constructor with list &", Hex(parent))
+    parentList = parent
+    curPos = -1
+End Constructor
+
+Private Constructor _ListIteratorType()
+__CONT_DBG_PRINT("Default constructor (end iterator)")
+    parentList = 0
+    curPos = -1
+End Constructor
+
+Private Operator _ListIteratorType.For()
+__CONT_DBG_PRINT("Starting for")
+    curPos = 0
+End Operator
+
+Private Operator _ListIteratorType.Next(ByRef cond As _ListIteratorType) As Integer
+__CONT_DBG_PRINT("")
+    Return (curPos <> cond.curPos) AndAlso (curPos >= 0)
+End Operator
+
+Private Operator _ListIteratorType.Step()
+    Dim from As Long = curPos
+    curPos += 1
+    If curPos >= parentList->Count Then
+        curPos = -1
+    End If
+__CONT_DBG_PRINT("Stepped from & to &", from; curPos)
+End Operator
+
+Private Function _ListIteratorType.Advance() As Boolean
+__CONT_DBG_PRINT("Advancing from & to &", curPos; curPos + 1)
+    curPos += 1
+    Return curPos < parentList->Count
+End Function
+
+Private Function _ListIteratorType.Item() ByRef As FBType
+__CONT_DBG_PRINT("Accessing Item &", curPos)
+    Return (*parentList)[curPos]
+End Function
+
+Private Sub _ListIteratorType.Reset()
+__CONT_DBG_PRINT("Resetting")
+    curPos = -1
+End Sub
+
+#endif '' __FB_JOIN__(_ListIteratorType, _DEFINED)
+
+#undef _ListIteratorType
+#undef _IteratorInterfaceType
+#undef _ListInterfaceType
+#undef _TypeDefine
+
+#endmacro '' _CONT_DefineListIterator_
+
+'' Use this at global scope to generate the code for the listiterator type
+'' You shouldn't need to do this manually, a compatible list iterator type is 
+'' automatically generated for each type of container defined
+''
+'' Otherwise one of these is required for every separate type of list to iterate
+'' The type should be the type contained in the list being iterated
+'' FBCont_DefineListIteratorOf(Any Ptr) '' for an any ptr list iterator
+'' FBCont_DefineListIteratorOf(MyNamespace, MyType) '' for a type in a namespace
+#macro FBCont_DefineListIteratorOf(Type...)
+
+__CONT_DefineListIteratorOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro
+
+'' Use this to declare your variable type
+'' Dim myList As FB_ListIterator(Any Ptr)
+'' Dim myList As FB_ListIterator(MyNamespace, MyType)
+#define FB_ListIterator(Type...) __FB_JOIN__(ListIterator, __FB_MakePPType(Type))

--- a/inc/containers/queue.bi
+++ b/inc/containers/queue.bi
@@ -1,0 +1,186 @@
+#include once "_typemacros.bi"
+#include once "icontainer.bi"
+#include once "linkedlist.bi"
+#include once "_helpers.bi"
+
+#pragma once
+
+'' Defines a First-in, First-Out queue
+#macro __CONT_DefineQueueOf_(FBType, PPType)
+
+__CONT_DefineLinkedListOf_(FBType, PPType)
+
+#define _QueueType					__FB_JOIN__(Queue, PPType)
+#define _LinkedListType				__FB_JOIN__(LinkedList, PPType)
+#define _LinkedListNodeType			__FB_JOIN__(LinkedListNode, PPType)
+#define _ContainerInterfaceType		__FB_JOIN__(IContainer, PPType)
+#define _IteratorInterfaceType		__FB_JOIN__(IIterator, PPType)
+#define _TypeDefine()				__FB_JOIN__(__CONT_, __FB_JOIN__(_QueueType, _DEFINED))
+__FB_DefinePassType(FBType, _PassType)
+
+#if __FB_QUOTE__(_TypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_TypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _QueueType)
+#endif
+
+Type _QueueType extends _ContainerInterfaceType
+Private:
+	dim _queue As _LinkedListType
+
+Public:
+	Declare Constructor()
+	Declare Constructor(ByVal iter As _IteratorInterfaceType Ptr)
+	Declare Constructor(ByRef iter As _IteratorInterfaceType)
+	Declare Constructor(ByVal cont As _ContainerInterfaceType Ptr)
+	Declare Constructor(ByRef cont As _ContainerInterfaceType)
+	Declare Constructor(items() As FBType)
+	
+	Declare Sub Clear() override
+    Declare Function Contains(_PassType element As FBType) As Boolean override
+    Declare Sub CopyTo(newData() As FBType) override
+    Declare Function Empty() As Boolean
+    Declare Function GetIterator() As _IteratorInterfaceType Ptr override
+    Declare Sub Push(_PassType element As FBType)
+    Declare Function Pop() As FBType
+    
+    Declare Property Count() As Long override
+    Declare Property Front() ByRef As FBType
+    
+    Declare Operator +=(_PassType newData AS FBType)
+    '' Also Operator Len()
+    
+#ifdef FB_CONTAINER_DEBUG
+    Declare Sub PrintContainer() override
+#endif
+
+End Type
+
+Private Constructor _QueueType()
+__CONT_DBG_PRINT("Default constructor")
+End Constructor
+
+Private Constructor _QueueType(ByVal iter As _IteratorInterfaceType Ptr)
+	_queue.Constructor(iter)
+__CONT_DBG_PRINT("iterator constructor")
+End Constructor
+
+Private Constructor _QueueType(ByRef iter As _IteratorInterfaceType)
+	Constructor(@iter)
+End Constructor
+
+Private Constructor _QueueType(ByVal cont As _ContainerInterfaceType Ptr)
+	_queue.Constructor(cont)
+__CONT_DBG_PRINT("container constructor")
+End Constructor
+
+Private Constructor _QueueType(ByRef cont As _ContainerInterfaceType)
+	Constructor(@cont)
+End Constructor
+
+Private Constructor _QueueType(items() As FBType)
+	_queue.Constructor(items())
+__CONT_DBG_PRINT("array constructor")
+End Constructor
+
+Private Sub _QueueType.Clear()
+__CONT_DBG_PRINT("")
+	_queue.Clear()
+End Sub
+
+Private Function _QueueType.Contains(_PassType element As FBType) As Boolean
+__CONT_DBG_PRINT("")
+	Return _queue.Contains(element)
+End Function
+
+Private Sub _QueueType.CopyTo(elements() As FBType)
+__CONT_DBG_PRINT("")
+	_queue.CopyTo(elements())
+End Sub
+
+Private Function _QueueType.Empty() As Boolean
+__CONT_DBG_PRINT("")
+	Return Count = 0
+End Function
+
+Private Function _QueueType.GetIterator() As _IteratorInterfaceType Ptr
+__CONT_DBG_PRINT("for queue of size &", Count)
+	Return _queue.GetIterator()
+End Function
+
+Private Sub _QueueType.Push(_PassType element As FBType)
+__CONT_DBG_PRINT("to queue of size &", Count)
+	_queue.AddTail(element)
+End Sub
+
+Private Function _QueueType.Pop() As FBType
+__CONT_DBG_PRINT("from stack of size &", Count)
+    Dim n As Long = Count
+	Assert(n > 0)
+	If n = 0 Then
+		__CONT_Internals_SetError(6)
+	End If
+	Dim temp As FBType = Front
+	_queue.RemoveNode(_queue.Head)
+	Return temp
+End Function
+
+#ifdef FB_CONTAINER_DEBUG
+Private Sub _QueueType.PrintContainer()
+	Print __FB_QUOTE__(_QueueType) " at " & Hex(@This) & " has " & Count & " elements"
+	Print "Inner List";
+	_queue.PrintContainer()
+End Sub
+#endif
+
+Private Property _QueueType.Front() ByRef As FBType
+    dim elems As Long = Count
+__CONT_DBG_PRINT("of stack of size &", elems)
+	Assert(elems > 0)
+	If elems = 0 Then
+		__CONT_Internals_SetError(6)
+	End If
+	Return _queue.Head->Data
+End Property
+
+Private Property _QueueType.Count() As Long
+	Return _queue.Count
+End Property
+
+Private Operator _QueueType.+=(_PassType newData As FBType)
+	Push(newData)
+End Operator
+
+Private Operator Len(Byref queue As _QueueType) As Integer
+	Return queue.Count
+End Operator
+
+#endif '' __FB_QUOTE__(_TypeDefine()) <> "1"
+
+#undef _QueueType
+#undef _LinkedListType
+#undef _LinkedListNodeType
+#undef _ContainerInterfaceType
+#undef _IteratorInterfaceType
+#undef _TypeDefine
+#undef _PassType
+
+#endmacro
+
+'' Use this at global scope to generate the code for the list type
+'' One of these is required for every separate type you want to put in a list
+'' FBCont_DefineQueueOf(Any Ptr) '' for an any ptr list
+'' FBCont_DefineQueueOf(MyNamespace, MyType) '' for a type in a namespace
+#macro FBCont_DefineQueueOf(Type...)
+
+__CONT_DefineQueueOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro '' FBCont_DefineQueueOf
+#define FBCont_DefineQueueIteratorOf(Type...) FBCont_DefineLinkedListIteratorOf(Type)
+
+'' Use this to declare your variable type
+'' Dim myList As FB_Queue(Any Ptr)
+'' Dim myList As FB_Queue(MyNamespace, MyType)
+#define FB_Queue(Type...) __FB_JOIN__(Queue, __FB_MakePPType(Type))
+#define FB_QueueIterator(Type...) __FB_JOIN__(LinkedList, __FB_MakePPType(Type))

--- a/inc/containers/reverselistiterator.bi
+++ b/inc/containers/reverselistiterator.bi
@@ -1,0 +1,115 @@
+#include once "_typemacros.bi"
+#include once "iiterator.bi"
+#include once "ilist.bi"
+
+#pragma once
+
+'' Defines an iterator that enumerates an IList backwards (from list.Last() to list.First())
+#macro __CONT_DefineReverseListIteratorOf_(FBType, PPType)
+
+__CONT_DefineIListOf_(FBType, PPType)
+__CONT_DefineIIteratorOf_(FBType, PPType)
+
+#define _ReverseListIteratorType		__FB_JOIN__(ReverseListIterator, PPType)
+#define _IteratorInterfaceType			__FB_JOIN__(IIterator, PPType)
+#define _ListInterfaceType				__FB_JOIN__(IList, PPType)
+#define _TypeDefine()					__FB_JOIN__(__CONT_, __FB_JOIN__(_ReverseListIteratorType, _DEFINED))
+
+#if __FB_QUOTE__(_TypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_TypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _ReverseListIteratorType)
+#endif
+
+Type _ReverseListIteratorType extends _IteratorInterfaceType
+Private:
+    dim parentList As _ListInterfaceType Ptr
+    dim curPos As Long
+    
+Public:
+    Declare Constructor(ByVal parent As _ListInterfaceType Ptr)
+    Declare Constructor()
+    Declare Operator For()
+	Declare Operator Next(ByRef cond As _ReverseListIteratorType) As Integer
+	Declare Operator Step()
+	
+	Declare Function Advance() As Boolean Override
+	Declare Function Item() Byref As FBType Override
+	Declare Sub Reset() Override
+End Type
+
+Private Constructor _ReverseListIteratorType(ByVal parent As _ListInterfaceType Ptr)
+__CONT_DBG_PRINT("List constructor with list &", Hex(parent))
+    parentList = parent
+    curPos = parentList->Count
+End Constructor
+
+Private Constructor _ReverseListIteratorType()
+__CONT_DBG_PRINT("Default constructor (end iterator)")
+    parentList = 0
+    curPos = &H7fffffff
+End Constructor
+
+Private Operator _ReverseListIteratorType.For()
+__CONT_DBG_PRINT("Starting for")
+    curPos = parentList->Count - 1
+End Operator
+
+Private Operator _ReverseListIteratorType.Next(ByRef cond As _ReverseListIteratorType) As Integer
+__CONT_DBG_PRINT("")
+    Return (curPos <> cond.curPos) AndAlso (curPos < parentList->Count)
+End Operator
+
+Private Operator _ReverseListIteratorType.Step()
+    Dim from As Long = curPos
+    curPos -= 1
+    If curPos < 0 Then
+        curPos = parentList->Count
+    End If
+__CONT_DBG_PRINT("Stepped from & to &", from; curPos)
+End Operator
+
+Private Function _ReverseListIteratorType.Advance() As Boolean
+__CONT_DBG_PRINT("Advancing from & to &", curPos; curPos - 1)
+    curPos -= 1
+    Return curPos >= 0
+End Function
+
+Private Function _ReverseListIteratorType.Item() ByRef As FBType
+__CONT_DBG_PRINT("Accessing Item &", curPos)
+    Return (*parentList)[curPos]
+End Function
+
+Private Sub _ReverseListIteratorType.Reset()
+__CONT_DBG_PRINT("")
+    curPos = parentList->Count
+End Sub
+
+#endif '' __FB_JOIN__(_ReverseListIteratorType, _DEFINED)
+
+#undef _ReverseListIteratorType
+#undef _IteratorInterfaceType
+#undef _ListInterfaceType
+#undef _TypeDefine
+
+#endmacro '' _CONT_DefineReverseListIterator_
+
+'' Use this at global scope to generate the code for the reverselistiterator type
+'' You shouldn't need to do this manually, a compatible list iterator type is 
+'' automatically generated for each type of container defined
+''
+'' Otherwise one of these is required for every separate type of list to iterate
+'' The type should be the type contained in the list being iterated
+'' FBCont_DefineReverseListIteratorOf(Any Ptr) '' for an any ptr list iterator
+'' FBCont_DefineReverseListIteratorOf(MyNamespace, MyType) '' for a type in a namespace
+#macro FBCont_DefineReverseListIteratorOf(Type...)
+
+__CONT_DefineReverseListIteratorOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro
+
+'' Use this to declare your variable type
+'' Dim myList As FB_ReverseListIterator(Any Ptr)
+'' Dim myList As FB_ReverseListIterator(MyNamespace, MyType)
+#define FB_ReverseListIterator(Type...) __FB_JOIN__(ReverseListIterator, __FB_MakePPType(Type))

--- a/inc/containers/stack.bi
+++ b/inc/containers/stack.bi
@@ -1,0 +1,229 @@
+#include once "_typemacros.bi"
+#include once "icontainer.bi"
+#include once "list.bi"
+#include once "reverselistiterator.bi"
+#include once "_helpers.bi"
+
+#pragma once
+
+'' Defines a Last-in, First-Out stack
+#macro __CONT_DefineStackOf_(FBType, PPType)
+
+__CONT_DefineListOf_(FBType, PPType)
+__CONT_DefineReverseListIteratorOf_(FBType, PPType)
+
+#define _StackType					__FB_JOIN__(Stack, PPType)
+#define _StackTypeIterator			__FB_JOIN__(ReverseListIterator, PPType)
+#define _ListType					__FB_JOIN__(List, PPType)
+#define _ContainerInterfaceType		__FB_JOIN__(IContainer, PPType)
+#define _IteratorInterfaceType		__FB_JOIN__(IIterator, PPType)
+#define _TypeDefine()				__FB_JOIN__(__CONT_, __FB_JOIN__(_StackType, _DEFINED))
+__FB_DefinePassType(FBType, _PassType)
+
+#if __FB_QUOTE__(_TypeDefine()) <> "1"
+__FB_UNQUOTE__(__FB_EVAL__("#define " __FB_QUOTE__(_TypeDefine()) " 1"))
+
+#ifdef FB_CONTAINER_DEBUG
+#Print __FB_JOIN__(Containers: Generating-, _StackType)
+#endif
+
+Type _StackType extends _ContainerInterfaceType
+Private:
+	dim _stack As _ListType
+
+Public:
+	Declare Constructor()
+	Declare Constructor(ByRef otherStack As _StackType)
+	Declare Constructor(ByVal iter As _IteratorInterfaceType Ptr)
+	Declare Constructor(ByRef iter As _IteratorInterfaceType)
+	Declare Constructor(ByVal cont As _ContainerInterfaceType Ptr)
+	Declare Constructor(ByRef cont As _ContainerInterfaceType)
+	Declare Constructor(items() As FBType)
+	
+	Declare Sub Clear() override
+    Declare Function Contains(_PassType element As FBType) As Boolean override
+    Declare Sub CopyTo(newData() As FBType) override
+    Declare Function Empty() As Boolean
+    Declare Function GetIterator() As _IteratorInterfaceType Ptr override
+    Declare Sub Push(_PassType element As FBType)
+    Declare Function Pop() As FBType
+    
+    Declare Property Count() As Long override
+    Declare Property Top() ByRef As FBType
+    
+    Declare Operator +=(_PassType newData AS FBType)
+    '' Also Operator Len()
+    
+#ifdef FB_CONTAINER_DEBUG
+    Declare Sub PrintContainer() override
+#endif
+
+End Type
+
+'' Can't use the general container or iterator constructors to copy construct
+'' as the stack iterator goes from top to bottom, if we push in iterator order
+'' we end up with a reversed copy of the stack
+Private Constructor _StackType(ByRef otherStack As _StackType)
+	_stack.Constructor(otherStack._stack)
+__CONT_DBG_PRINT("Copy constructor with & elements"; otherStack.Count)
+	
+End Constructor
+
+Private Constructor _StackType()
+__CONT_DBG_PRINT("Default constructor")
+End Constructor
+
+Private Constructor _StackType(ByVal iter As _IteratorInterfaceType Ptr)
+	_stack.Constructor(iter)
+__CONT_DBG_PRINT("iterator constructor")
+End Constructor
+
+Private Constructor _StackType(ByRef iter As _IteratorInterfaceType)
+	Constructor(@iter)
+End Constructor
+
+Private Constructor _StackType(ByVal cont As _ContainerInterfaceType Ptr)
+	_stack.Constructor(cont)
+__CONT_DBG_PRINT("container constructor")
+End Constructor
+
+Private Constructor _StackType(ByRef cont As _ContainerInterfaceType)
+	Constructor(@cont)
+End Constructor
+
+Private Constructor _StackType(items() As FBType)
+	_stack.Constructor(items())
+__CONT_DBG_PRINT("array constructor")
+End Constructor
+
+Private Sub _StackType.Clear()
+__CONT_DBG_PRINT("")
+	_stack.Clear()
+End Sub
+
+Private Function _StackType.Contains(_PassType element As FBType) As Boolean
+__CONT_DBG_PRINT("")
+	Return _stack.Contains(element)
+End Function
+
+'' This returns elements in most-recently-pushed-first order
+'' ie from the Top down
+Private Sub _StackType.CopyTo(elements() As FBType)
+__CONT_DBG_PRINT("with & elements", Count)
+	Dim localErr As Long
+	'' If _stack.CopyTo errors, then Err will be reset at the of the scope
+	'' when tempElems is destroyed, so we introduce a scope so we can control
+	'' when that happens so we can reset the error
+	Scope
+		Dim curStackCount As Long = Count
+		Dim tempElems(Any) As FBType
+		Err = 0
+		_stack.CopyTo(tempElems())
+		localErr = Err
+		if localErr = 0 Then
+			__CONT_Internals.ReverseArray(tempElems())
+			Dim As Long arrLBound, arrUBound, numElems = __CONT_GetArrayInfo(elements, arrLBound, arrUBound)
+			If numElems = 0 Then
+				arrUBound = UBound(tempElems)
+				Redim elements(0 To arrUBound)
+				Assert(arrLBound = 0)
+			ElseIf (numElems >= curStackCount) Then
+				arrUBound = arrLBound + curStackCount - 1
+			End If
+			
+			Dim As FBType Ptr pSrc = @tempElems(0), pDest = @elements(arrLBound)
+			For i As Long = arrLBound To arrUBound
+				*pDest = *pSrc
+				pDest += 1
+				pSrc += 1
+			Next
+		End If
+	End Scope
+	Err = localErr
+End Sub
+
+Private Function _StackType.Empty() As Boolean
+__CONT_DBG_PRINT("")
+	Return Count = 0
+End Function
+
+Private Function _StackType.GetIterator() As _IteratorInterfaceType Ptr
+__CONT_DBG_PRINT("for stack of size &", Count)
+	Return New _StackTypeIterator(@_stack)
+End Function
+
+Private Sub _StackType.Push(_PassType element As FBType)
+__CONT_DBG_PRINT("to stack of size &", Count)
+	_stack.Add(element)
+End Sub
+
+Private Function _StackType.Pop() As FBType
+	Dim elems As Long = Count
+__CONT_DBG_PRINT("from stack of size &", elems)
+	Assert(elems > 0)
+	If elems = 0 Then
+		__CONT_Internals_SetError(6)
+	End If
+	Dim temp As FBType = Top
+	_stack.RemoveAt(_stack.Count - 1)
+	Return temp
+End Function
+
+#ifdef FB_CONTAINER_DEBUG
+Private Sub _StackType.PrintContainer()
+	Print __FB_QUOTE__(_StackType) " at " & Hex(@This) & " has " & Count & " elements"
+	Print "Inner List";
+	_stack.PrintContainer()
+End Sub
+#endif
+
+Private Property _StackType.Top() ByRef As FBType
+    dim elems As Long = Count
+__CONT_DBG_PRINT("of stack of size &", elems)
+	Assert(elems > 0)
+	If elems = 0 Then
+		__CONT_Internals_SetError(6)
+	End If
+	Return _stack.Last()
+End Property
+
+Private Property _StackType.Count() As Long
+	Return _stack.Count
+End Property
+
+Private Operator _StackType.+=(_PassType newData As FBType)
+	Push(newData)
+End Operator
+
+Private Operator Len(Byref stack As _StackType) As Integer
+	Return stack.Count
+End Operator
+
+#endif '' __FB_QUOTE__(_TypeDefine()) <> "1"
+
+#undef _StackType
+#undef _StackTypeIterator
+#undef _ListType
+#undef _ContainerInterfaceType
+#undef _IteratorInterfaceType
+#undef _TypeDefine
+#undef _PassType
+
+#endmacro
+
+'' Use this at global scope to generate the code for the list type
+'' One of these is required for every separate type you want to put in a list
+'' FBCont_DefineStackOf(Any Ptr) '' for an any ptr list
+'' FBCont_DefineStackOf(MyNamespace, MyType) '' for a type in a namespace
+#macro FBCont_DefineStackOf(Type...)
+
+__CONT_DefineStackOf_(__FB_MakeFBType(Type), __FB_MakePPType(Type))
+
+#endmacro '' FBCont_DefineStackOf
+#define FBCont_DefineStackIteratorOf(Type...) FBCont_DefineReverseListIteratorOf(Type)
+
+'' Use this to declare your variable type
+'' Dim myList As FB_Stack(Any Ptr)
+'' Dim myList As FB_Stack(MyNamespace, MyType)
+#define FB_Stack(Type...) __FB_JOIN__(Stack, __FB_MakePPType(Type))
+#define FB_StackIterator(Type...) __FB_JOIN__(ReverseListIterator, __FB_MakePPType(Type))

--- a/tests/containers/BitContainerTest.bas
+++ b/tests/containers/BitContainerTest.bas
@@ -1,0 +1,1117 @@
+#define FB_CONTAINER_DEBUG 1
+#include "../../inc/containers/bitcontainer.bi"
+#include "fbcunit.bi"
+
+Private Function RoundToNext(ByVal num As Long, Byval nextWhat As Long) As Long
+	Return (num + (nextWhat - 1)) And Not (nextWhat - 1)
+End Function
+
+SUITE(fbc_tests.containers.bitcontainers)
+	TEST(ConstructorTest)
+		Dim contSize As Long = 9
+		Dim contSizeBits As Long = contSize * 8
+		dim allFalse As BitContainer = (contSizeBits)
+		CU_ASSERT_EQUAL(allFalse.Count, contSizeBits)
+		Dim i As Long
+		For i = 0 To contSizeBits - 1
+			CU_ASSERT_EQUAL(allFalse[i], False)
+		Next
+		
+		dim allFalse2 As BitContainer = (1)
+		CU_ASSERT_EQUAL(allFalse2.Count, 1)
+		CU_ASSERT_EQUAL(allFalse2[0], False)
+		
+		contSize *= 2
+		contSizeBits = contSize * 8
+		dim allTrue As BitContainer = Type(contSizeBits, True)
+		CU_ASSERT_EQUAL(allTrue.Count, contSizeBits)
+
+		For i = 0 To contSizeBits - 1
+			CU_ASSERT_EQUAL(allTrue[i], True)
+		Next
+		
+		dim allFalse3 As BitContainer = Type(5, False)
+		CU_ASSERT_EQUAL(allFalse3.Count, 5)
+		For i = 0 To 4
+			CU_ASSERT_EQUAL(allFalse3[i], False)
+		Next
+		
+		contSize = 90
+		contSizeBits = contSize * 8
+		dim boolArray(0 To contSize - 1) As Boolean
+		For i = 0 To contSize - 1
+			boolArray(i) = CBool(i And 1)
+		Next
+		
+		dim boolArrayCont As BitContainer = boolArray()
+		CU_ASSERT_EQUAL(boolArrayCont.Count, contSize)
+		For i = 0 To contSize - 1
+			CU_ASSERT_EQUAL(boolArrayCont[i], boolArray(i))
+			boolArray(i) = Not boolArray(i)
+		Next
+		
+		dim boolArrayCont2 As BitContainer = boolArray()
+		CU_ASSERT_EQUAL(boolArrayCont2.Count, contSize)
+		For i = 0 To contSize
+			CU_ASSERT_EQUAL(boolArrayCont2[i], boolArray(i))
+		Next
+		
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		contSize = 56
+		contSizeBits = contSize * 8
+		dim alternaLBound As Long = 7
+		dim alternaUBound As Long = alternaLBound + contSize - 1
+		Redim alternaByteArray(alternaLBound To alternaUBound)
+		For i = alternaLBound To alternaUBound
+			alternaByteArray(i) = alternaBitByte
+		Next
+		
+		dim byteArrayCont As BitContainer = alternaByteArray()
+		CU_ASSERT_EQUAL(byteArrayCont.Count, contSizeBits)
+		For i = 0 To contSizeBits - 1
+			dim curByte As Long = alternaLBound + (i \ 8)
+			dim alternaByte As UByte = alternaByteArray(curByte)
+			dim alternaBit As Boolean = alternaByte And (1 Shl (i Mod 8))
+			CU_ASSERT_EQUAL(byteArrayCont[i], alternaBit)
+			CU_ASSERT_EQUAL(byteArrayCont[i], CBool(i And 1))
+		Next
+		For i = 7 To 62
+			alternaByteArray(i) = Not alternaBitByte
+		Next
+		
+		dim pByteArray As UByte Ptr = @alternaByteArray(alternaLBound)
+		dim anyPtrArrayCont As BitContainer = Type(contSizeBits, cast(Any Ptr, pByteArray))
+		CU_ASSERT_EQUAL(anyPtrArrayCont.Count, contSizeBits)
+		For i = 0 To contSizeBits - 1
+			dim curByte As Long = alternaLBound + (i \ 8)
+			dim alternaByte As UByte = alternaByteArray(curByte)
+			dim alternaBit As Boolean = alternaByte And (1 Shl (i Mod 8))
+			CU_ASSERT_EQUAL(anyPtrArrayCont[i], alternaBit)
+			CU_ASSERT_EQUAL(anyPtrArrayCont[i], CBool((i And 1) = 0))
+		Next
+		
+		dim anyPtrArrayCont2 As BitContainer = Type(24, cast(Any Ptr, pByteArray + 8))
+		CU_ASSERT_EQUAL(anyPtrArrayCont2.Count, 24)
+		For i = 0 To 23
+			dim curByte As Long = alternaLBound + 8 + (i \ 8)
+			dim alternaByte As UByte = alternaByteArray(curByte)
+			dim alternaBit As Boolean = alternaByte And (1 Shl (i Mod 8))
+			CU_ASSERT_EQUAL(anyPtrArrayCont2[i], alternaBit)
+			CU_ASSERT_EQUAL(anyPtrArrayCont2[i], CBool((i And 1) = 0))
+		Next
+		
+		Dim allTrueArray(0 To 17) As Boolean
+		For i = 0 To 17
+			allTrueArray(i) = True
+		Next
+		Dim pBooleanArray As Boolean Ptr = @allTrueArray(0)
+		dim fromTruePtrCont As BitContainer = Type(15, pBooleanArray + 1)
+		CU_ASSERT_EQUAL(fromTruePtrCont.Count, 15)
+		
+		'' undimmed/empty array to constructs is an error...
+		Dim undimmedArr(Any) As Boolean
+		On Local Error Goto nextTest
+		dim localErr As Long
+		Err = 0
+		dim udCont As BitContainer = undimmedArr()
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+	nextTest:
+	
+		'' ...no matter which type
+		dim undimmedByteArr(Any) As UByte
+		On Local Error Goto nextTest2
+		localErr = 0
+		Err = 0
+		dim udCont2 As BitContainer = undimmedByteArr()
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+	nextTest2:
+	
+		'' a negative or 0 number of bits is an error too
+		On Local Error Goto nextTest3
+		localErr = 0
+		Err = 0
+		dim udCont3 As BitContainer = Type(-7, cast(Any Ptr, pByteArray))
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+	nextTest3:
+	
+		On Local Error Goto nextTest4
+		localErr = 0
+		Err = 0
+		dim udCont4 As BitContainer = Type(0, pBooleanArray)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+	nextTest4:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(Clear)
+		dim bits As BitContainer = Type(50, True)
+		dim i As Long
+		bits.Clear()
+		For i = 0 To 50
+			CU_ASSERT_EQUAL(bits[i], False)
+		Next
+		
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		Redim alternaByteArray(7 To 62)
+		For i = 7 To 62
+			alternaByteArray(i) = alternaBitByte
+		Next
+		
+		dim bits2 As BitContainer = Type(32, cast(Any Ptr, @alternaByteArray(7)))
+		Dim contBytes(Any) As UByte
+		dim contBytesUBound As Long = UBound(contBytes)
+		bits2.Clear()
+		bits2.GetBytes(contBytes())
+		For i = 0 To contBytesUBound
+			CU_ASSERT_EQUAL(contBytes(i), 0)
+		Next
+		For i = 0 To 32 - 1
+			CU_ASSERT_EQUAL(bits2[i], False)
+		Next
+		
+		bits2.Set(31, True)
+		bits2.Clear()
+		CU_ASSERT_EQUAL(bits2[31], False)
+		
+		bits2.SetSpan(3, 5, True)
+		bits2.Clear()
+		For i = 3 To 7
+			CU_ASSERT_EQUAL(bits2[i], False)
+		Next
+	END_TEST
+	
+	TEST(Contains)
+		dim haystack As BitContainer = Type(46, False)
+		dim needle As Boolean = True
+		dim result As Boolean
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, False)
+		hayStack.Set(7, True)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.SetSpan(30, 9)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		result = haystack.Contains(False)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.Clear()
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.SetAll()
+		result = haystack.Contains(False)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Set(0, False)
+		result = haystack.Contains(False)
+		CU_ASSERT_EQUAL(result, True)
+	END_TEST
+	
+	TEST(CopyTo)
+		dim As BitContainer bits = Type(64, True), bitsAlt = bits
+		dim i As Long
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As Boolean
+		bits.CopyTo(undimmedArr())
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, bits.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr(i), True)
+			If (i And 1) Then bitsAlt.Set(i, False)
+		Next
+		
+		dim undimmedArr2(Any) As Boolean
+		bitsAlt.CopyTo(undimmedArr2())
+		arrUBound = UBound(undimmedArr2)
+		arrLBound = LBound(undimmedArr2)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, bitsAlt.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr2(i), ((i And 1) = 0))
+		Next
+		
+		dim undimmedBytes(Any) As UByte
+		bits.CopyTo(undimmedBytes())
+		arrUBound = UBound(undimmedBytes)
+		arrLBound = LBound(undimmedBytes)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, RoundToNext(bits.Count, 8) \ 8)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedBytes(i), &HFF)
+		Next
+		
+		dim undimmedBytes2(Any) As UByte
+		bitsAlt.CopyTo(undimmedBytes2())
+		arrUBound = UBound(undimmedBytes2)
+		arrLBound = LBound(undimmedBytes2)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, RoundToNext(bits.Count, 8) \ 8)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedBytes2(i), &B01010101)
+		Next
+		
+		'' already sized arrays copy the number of items in the container or the size of the array
+		'' whichever is smaller
+		dim largerThanContBitArr(11 To 81) As Boolean
+		bits.CopyTo(largerThanContBitArr())
+		arrUBound = UBound(largerThanContBitArr)
+		arrLBound = LBound(largerThanContBitArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 71)
+		CU_ASSERT_EQUAL(arrLBound, 11)
+		CU_ASSERT_EQUAL(arrUBound, 81)
+		For i = arrLBound To arrUBound
+			CU_ASSERT_EQUAL(largerThanContBitArr(i), i < 75)
+		Next
+		
+		bitsAlt.CopyTo(largerThanContBitArr())
+		arrUBound = UBound(largerThanContBitArr)
+		arrLBound = LBound(largerThanContBitArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 71)
+		CU_ASSERT_EQUAL(arrLBound, 11)
+		CU_ASSERT_EQUAL(arrUBound, 81)
+		For i = arrLBound To arrUBound
+			CU_ASSERT_EQUAL(largerThanContBitArr(i), (i < (64 + arrLBound)) AndAlso ((i And 1) = 1))
+		Next
+		
+		dim largerThanContByteArr(10 To 18) As UByte
+		For i = 10 To 18
+			largerThanContByteArr(i) = i
+		Next
+		bits.CopyTo(largerThanContByteArr())
+		arrUBound = UBound(largerThanContByteArr)
+		arrLBound = LBound(largerThanContByteArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 9)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 18)
+		For i = 10 To 18
+			CU_ASSERT_EQUAL(largerThanContByteArr(i), IIf(i <= 17, &b11111111, i))
+		Next
+		
+		For i = 10 To 18
+			largerThanContByteArr(i) = i
+		Next
+		bitsAlt.CopyTo(largerThanContByteArr())
+		arrUBound = UBound(largerThanContByteArr)
+		arrLBound = LBound(largerThanContByteArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 9)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 18)
+		For i = 10 To 18
+			CU_ASSERT_EQUAL(largerThanContByteArr(i), IIf(i <= 17, &b01010101, i))
+		Next
+		
+		dim smallerThanContArr(21 To 24) As Boolean
+		bits.CopyTo(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 4)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 24)
+		For i = 21 To 24
+			CU_ASSERT_EQUAL(smallerThanContArr(i), True)
+		Next
+		
+		For i = 21 To 24
+			smallerThanContArr(i) = False
+		Next
+		bitsAlt.CopyTo(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 4)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 24)
+		For i = 21 To 24
+			CU_ASSERT_EQUAL(smallerThanContArr(i), CBool((i And 1) = 1))
+		Next
+		
+		dim smallerThanContByteArr(21 To 23) As UByte
+		bits.CopyTo(smallerThanContByteArr())
+		arrUBound = UBound(smallerThanContByteArr)
+		arrLBound = LBound(smallerThanContByteArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 3)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 23)
+		For i = 21 To 23
+			CU_ASSERT_EQUAL(smallerThanContByteArr(i), &b11111111)
+		Next
+		
+		For i = 21 To 23
+			smallerThanContArr(i) = 0
+		Next
+		bitsAlt.CopyTo(smallerThanContByteArr())
+		arrUBound = UBound(smallerThanContByteArr)
+		arrLBound = LBound(smallerThanContByteArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 3)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 23)
+		For i = 21 To 23
+			CU_ASSERT_EQUAL(smallerThanContByteArr(i), &b01010101)
+		Next
+	END_TEST
+	
+	TEST(Flip)
+		dim As BitContainer bits = Type(64, True), bitsAlt = bits
+		dim i As Long
+		For i = 0 To bits.Count - 1
+			CU_ASSERT_EQUAL(bits.Flip(i), True)
+			If (i And 1) Then bitsAlt.Set(i, False)
+		Next
+		CU_ASSERT_EQUAL(bits.Contains(True), False)
+		CU_ASSERT_EQUAL(bits.Flip(59), False)
+		For i = 0 To bits.Count - 1
+			CU_ASSERT_EQUAL(bits[i], i = 59)
+		Next
+		CU_ASSERT_EQUAL(bitsAlt.Flip(0), True)
+		CU_ASSERT_EQUAL(bitsAlt[0], False)
+		For i = 1 To bitsAlt.Count - 1
+			CU_ASSERT_EQUAL(bitsAlt[i], (i And 1) = 0)
+		Next
+		bitsAlt.Set(0)
+		For i = 0 To bitsAlt.Count - 1
+			CU_ASSERT_EQUAL(bitsAlt.Flip(i), (i And 1) = 0)
+			CU_ASSERT_EQUAL(bitsAlt[i], CBool((i And 1) = 1))
+		Next
+		bits.Clear()
+		'' set only the lowest bits
+		For i = 0 To 7
+			bits.Flip(i * 8)
+		Next
+		'' check only the lowest bits are set
+		dim bytes(Any) As UByte
+		bits.GetBytes(bytes())
+		For i = 0 To UBound(bytes)
+			CU_ASSERT_EQUAL(bytes(i), 1)
+		Next
+		
+		On Local Error Goto nextTest
+		dim localErr As Long = 0
+		Err = 0
+		dim oobBit As Boolean = bits.Flip(866)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(oobBit, False)
+	nextTest:
+		On Local Error Goto nextTest2
+		localErr = 0
+		Err = 0
+		oobBit = bits.Flip(-7)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(oobBit, False)
+	nextTest2:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(GetTest)
+		dim As BitContainer bits = Type(64, True), bitsAlt = bits
+		dim i As Long
+		For i = 0 To bits.Count - 1
+			CU_ASSERT_EQUAL(bits.Get(i), True)
+			If (i And 1) Then bitsAlt.Set(i, False)
+		Next
+		For i = 0 To bits.Count - 1
+			CU_ASSERT_EQUAL(bits[i], True)
+		Next
+		
+		For i = 0 To bitsAlt.Count - 1
+			CU_ASSERT_EQUAL(bitsAlt.Get(i), (i And 1) = 0)
+		Next
+		For i = 0 To bitsAlt.Count - 1
+			CU_ASSERT_EQUAL(bitsAlt[i], (i And 1) = 0)
+		Next
+		bits.Clear()
+		For i = 0 To bits.Count - 1
+			CU_ASSERT_EQUAL(bits.Get(i), False)
+		Next
+		bits.Flip(34)
+		For i = 0 To bits.Count - 1
+			CU_ASSERT_EQUAL(bits.Get(i), i = 34)
+		Next
+		
+		bitsAlt.SetAll()
+		For i = 0 To bitsAlt.Count - 1
+			CU_ASSERT_EQUAL(bitsAlt.Get(i), True)
+		Next
+		bitsAlt.Flip(19)
+		For i = 0 To bitsAlt.Count - 1
+			CU_ASSERT_EQUAL(bitsAlt[i], i <> 19)
+		Next
+		
+		On Local Error Goto nextTest
+		dim localErr As Long = 0
+		Err = 0
+		dim oobBit As Boolean = bits.Get(65)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(oobBit, False)
+	nextTest:
+		On Local Error Goto nextTest2
+		localErr = 0
+		Err = 0
+		oobBit = bitsAlt.Get(-6)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(oobBit, False)
+	nextTest2:
+		On Local Error Goto 0		
+	END_TEST
+	
+	TEST(GetBitsBytes)
+		dim As BitContainer bits = Type(64, True), bitsAlt = bits
+		dim i As Long
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As Boolean
+		bits.GetBits(undimmedArr())
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, bits.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr(i), True)
+			If (i And 1) Then bitsAlt.Set(i, False)
+		Next
+		
+		dim undimmedArr2(Any) As Boolean
+		bitsAlt.GetBits(undimmedArr2())
+		arrUBound = UBound(undimmedArr2)
+		arrLBound = LBound(undimmedArr2)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, bitsAlt.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr2(i), ((i And 1) = 0))
+		Next
+		
+		dim undimmedBytes(Any) As UByte
+		bits.GetBytes(undimmedBytes())
+		arrUBound = UBound(undimmedBytes)
+		arrLBound = LBound(undimmedBytes)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, RoundToNext(bits.Count, 8) \ 8)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedBytes(i), &HFF)
+		Next
+		
+		dim undimmedBytes2(Any) As UByte
+		bitsAlt.GetBytes(undimmedBytes2())
+		arrUBound = UBound(undimmedBytes2)
+		arrLBound = LBound(undimmedBytes2)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, RoundToNext(bitsAlt.Count, 8) \ 8)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedBytes2(i), &B01010101)
+		Next
+		
+		'' already sized arrays copy the number of items in the container or the size of the array
+		'' whichever is smaller
+		dim largerThanContBitArr(11 To 81) As Boolean
+		bits.GetBits(largerThanContBitArr())
+		arrUBound = UBound(largerThanContBitArr)
+		arrLBound = LBound(largerThanContBitArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 71)
+		CU_ASSERT_EQUAL(arrLBound, 11)
+		CU_ASSERT_EQUAL(arrUBound, 81)
+		For i = arrLBound To arrUBound
+			CU_ASSERT_EQUAL(largerThanContBitArr(i), i < 75)
+		Next
+		
+		bitsAlt.GetBits(largerThanContBitArr())
+		arrUBound = UBound(largerThanContBitArr)
+		arrLBound = LBound(largerThanContBitArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 71)
+		CU_ASSERT_EQUAL(arrLBound, 11)
+		CU_ASSERT_EQUAL(arrUBound, 81)
+		For i = arrLBound To arrUBound
+			CU_ASSERT_EQUAL(largerThanContBitArr(i), (i < (64 + arrLBound)) AndAlso ((i And 1) = 1))
+		Next
+		
+		dim largerThanContByteArr(10 To 18) As UByte
+		For i = 10 To 18
+			largerThanContByteArr(i) = i
+		Next
+		bits.GetBytes(largerThanContByteArr())
+		arrUBound = UBound(largerThanContByteArr)
+		arrLBound = LBound(largerThanContByteArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 9)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 18)
+		For i = 10 To 18
+			CU_ASSERT_EQUAL(largerThanContByteArr(i), IIf(i <= 17, &b11111111, i))
+		Next
+		
+		For i = 10 To 18
+			largerThanContByteArr(i) = i
+		Next
+		bitsAlt.GetBytes(largerThanContByteArr())
+		arrUBound = UBound(largerThanContByteArr)
+		arrLBound = LBound(largerThanContByteArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 9)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 18)
+		For i = 10 To 18
+			CU_ASSERT_EQUAL(largerThanContByteArr(i), IIf(i <= 17, &b01010101, i))
+		Next
+		
+		dim smallerThanContArr(21 To 24) As Boolean
+		bits.GetBits(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 4)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 24)
+		For i = 21 To 24
+			CU_ASSERT_EQUAL(smallerThanContArr(i), True)
+		Next
+		
+		For i = 21 To 24
+			smallerThanContArr(i) = False
+		Next
+		bitsAlt.GetBits(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 4)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 24)
+		For i = 21 To 24
+			CU_ASSERT_EQUAL(smallerThanContArr(i), CBool((i And 1) = 1))
+		Next
+		
+		dim smallerThanContByteArr(21 To 23) As UByte
+		bits.GetBytes(smallerThanContByteArr())
+		arrUBound = UBound(smallerThanContByteArr)
+		arrLBound = LBound(smallerThanContByteArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 3)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 23)
+		For i = 21 To 23
+			CU_ASSERT_EQUAL(smallerThanContByteArr(i), &b11111111)
+		Next
+		
+		For i = 21 To 23
+			smallerThanContArr(i) = 0
+		Next
+		bitsAlt.GetBytes(smallerThanContByteArr())
+		arrUBound = UBound(smallerThanContByteArr)
+		arrLBound = LBound(smallerThanContByteArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 3)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 23)
+		For i = 21 To 23
+			CU_ASSERT_EQUAL(smallerThanContByteArr(i), &b01010101)
+		Next
+	END_TEST
+	
+	TEST(GetIterator)
+		dim bits As BitContainer = Type(80, True)
+		dim pBitIter As FB_IIterator(Boolean) Ptr = bits.GetIterator()
+		dim pBitIter2 As FB_IIterator(Boolean) Ptr = bits.GetIterator()
+		dim i As Long
+		CU_ASSERT(pBitIter <> 0)
+		CU_ASSERT(pBitIter2 <> 0)
+		CU_ASSERT(pBitIter <> pBitIter2)
+		CU_ASSERT(pBitIter->Advance() = True)
+		CU_ASSERT_EQUAL(pBitIter->Item(), True)
+		CU_ASSERT(pBitIter2->Advance() = True)
+		CU_ASSERT_EQUAL(pBitIter->Item(), True)
+		CU_ASSERT_EQUAL(pBitIter2->Item(), True)
+		Delete pBitIter
+		Delete pBitIter2
+		pBitIter = 0
+		pBitIter2 = 0
+		dim bitsFalse As BitContainer = Type(80, False)
+		pBitIter = bits.GetIterator()
+		pBitIter2 = bitsFalse.GetIterator()
+		CU_ASSERT(pBitIter <> 0)
+		For i = 0 To 79
+			CU_ASSERT(pBitIter->Advance() = True)
+			CU_ASSERT(pBitIter2->Advance() = True)
+			CU_ASSERT_EQUAL(pBitIter->Item(), True)
+			CU_ASSERT_EQUAL(pBitIter2->Item(), False)
+		Next
+		CU_ASSERT(pBitIter->Advance() = False)
+		CU_ASSERT(pBitIter2->Advance() = False)
+		Delete pBitIter
+		Delete pBitIter2
+	END_TEST
+	
+	TEST(SetTest)
+		dim bits As BitContainer = Type(64, False)
+		dim bitsUBound As Long = bits.Count - 1
+		dim i As Long
+		For i = 0 To bitsUBound
+			bits.Set(i, True)
+		Next
+		
+		CU_ASSERT_EQUAL(bits.Contains(False), False)
+		bits.Set(0, False)
+		CU_ASSERT_EQUAL(bits.Contains(False), True)
+		CU_ASSERT_EQUAL(bits[0], False)
+		For i = 1 To bitsUBound
+			CU_ASSERT_EQUAL(bits[i], True)
+		Next
+		bits.Set(37)
+		CU_ASSERT_EQUAL(bits[37], True)
+		CU_ASSERT_EQUAL(bits[0], False)
+		For i = 1 To bitsUBound
+			CU_ASSERT_EQUAL(bits[i], True)
+		Next
+		bits.Set(37, False)
+		For i = 0 To bitsUBound
+			CU_ASSERT_EQUAL(bits[i], (i > 0) AndAlso (i <> 37))
+		Next
+		For i = 0 To bitsUBound
+			bits.Set(i, False)
+		Next
+		CU_ASSERT_EQUAL(bits.Contains(True), False)
+		
+		On Local Error Goto nextTest
+		Dim localErr As Long = 0
+		Err = 0
+		bits.Set(866, False)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+	
+		On Local Error Goto nextTest2
+		localErr = 0
+		Err = 0
+		bits.Set(-7, True)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest2:
+		On Local Error Goto 0		
+	END_TEST
+	
+	TEST(SetAll)
+		dim bits As BitContainer = Type(50, False)
+		dim i As Long
+		bits.SetAll()
+		For i = 0 To 49
+			CU_ASSERT_EQUAL(bits[i], True)
+		Next
+		
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		Redim alternaByteArray(7 To 62)
+		For i = 7 To 62
+			alternaByteArray(i) = alternaBitByte
+		Next
+		
+		dim bits2 As BitContainer = Type(32, cast(Any Ptr, @alternaByteArray(7)))
+		Dim contBytes(Any) As UByte
+		dim contBytesUBound As Long = UBound(contBytes)
+		bits2.SetAll()
+		bits2.GetBytes(contBytes())
+		For i = 0 To contBytesUBound
+			CU_ASSERT_EQUAL(contBytes(i), &Hff)
+		Next
+		For i = 0 To 32 - 1
+			CU_ASSERT_EQUAL(bits2[i], True)
+		Next
+		
+		bits2.Set(31, False)
+		CU_ASSERT_EQUAL(bits2[31], False)
+		bits2.SetAll()
+		CU_ASSERT_EQUAL(bits2[31], True)
+		
+		bits2.SetSpan(3, 5, False)
+		bits2.SetAll()
+		For i = 0 To 32 - 1
+			CU_ASSERT_EQUAL(bits2[i], True)
+		Next
+	END_TEST
+	
+	TEST(SetSpan)
+		dim bits As BitContainer = Type(50, True)
+		dim i As Long
+		bits.SetSpan(0, 8, False)
+		
+		For i = 0 To 49
+			CU_ASSERT_EQUAL(bits[i], i > 7)
+		Next
+		
+		bits.Clear()
+		bits.SetSpan(4, 12)
+		For i = 0 To 49
+			CU_ASSERT_EQUAL(bits[i], i >= 4 AndAlso i <= 15)
+		Next
+		bits.SetSpan(4, 5, False)
+		For i = 0 To 49
+			CU_ASSERT_EQUAL(bits[i], i >= 9 AndAlso i <= 15)
+		Next
+		
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		Redim alternaByteArray(7 To 62)
+		For i = 7 To 62
+			alternaByteArray(i) = alternaBitByte
+		Next
+		
+		dim bits2 As BitContainer = Type(51, cast(Any Ptr, @alternaByteArray(8)))
+		bits2.SetSpan(35, 10)
+		For i = 0 To 50
+			If i >= 35 AndAlso i <= 44 Then
+				CU_ASSERT_EQUAL(bits2[i], True)
+			Else
+				CU_ASSERT_EQUAL(bits2[i], CBool((i And 1) = 1))
+			End If
+		Next
+		bits2.SetSpan(35, 1, False)
+		For i = 0 To 50
+			If i >= 36 AndAlso i <= 44 Then
+				CU_ASSERT_EQUAL(bits2[i], True)
+			Else
+				CU_ASSERT_EQUAL(bits2[i], CBool((i <> 35) AndAlso (i And 1) = 1))
+			End If
+		Next
+		bits2.SetSpan(20, 100)
+		CU_ASSERT_EQUAL(bits2.Count, 51)
+		For i = 0 To 50
+			If i >= 20 Then
+				CU_ASSERT_EQUAL(bits2[i], True)
+			Else
+				CU_ASSERT_EQUAL(bits2[i], CBool((i And 1) = 1))
+			End If
+		Next
+		bits.SetSpan(0, 500, False)
+		CU_ASSERT_EQUAL(bits.Count, 50)
+		For i = 0 To 49
+			CU_ASSERT_EQUAL(bits[i], False)
+		Next
+		
+		On Local Error Goto nextTest
+		Dim localErr As Long = 0
+		Err = 0
+		bits.SetSpan(-5, 20, False)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+	
+		On Local Error Goto nextTest2
+		localErr = 0
+		Err = 0
+		bits.SetSpan(5, -20, False)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest2:
+	
+		On Local Error Goto nextTest3
+		localErr = 0
+		Err = 0
+		bits2.SetSpan(-9, -23)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest3:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(AndTest)
+		dim i As Long
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		Redim alternaByteArray(7 To 62)
+		For i = 7 To 62
+			alternaByteArray(i) = alternaBitByte
+		Next
+		
+		dim bits As BitContainer = Type(32, cast(Any Ptr, @alternaByteArray(7)))
+		dim bitsRes As BitContainer = bits And bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bitsRes[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(bits[i], bitsRes[i])
+		Next
+		dim allSet As BitContainer = Type(32, True)
+		bitsRes = allSet And bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bitsRes[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(bits[i], bitsRes[i])
+			CU_ASSERT_EQUAL(allSet[i], True)
+		Next
+		dim oneByte As UByte = 0
+		dim oneByteBits As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		dim oneByteAndRes As BitContainer = oneByteBits And allSet
+		CU_ASSERT_EQUAL(oneByteAndRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteAndRes[i], False)
+			CU_ASSERT_EQUAL(allSet[i], True)
+		Next
+		oneByte = 1
+		dim oneByteBits2 As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		oneByteAndRes = oneByteBits2 And bits
+		CU_ASSERT_EQUAL(oneByteAndRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteAndRes[i], False)
+		Next
+		oneByteAndRes = oneByteBits2 And allSet
+		CU_ASSERT_EQUAL(oneByteAndRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteAndRes[i], i = 0)
+		Next
+	END_TEST
+	
+	TEST(OrTest)
+		dim i As Long
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		Redim alternaByteArray(7 To 62)
+		For i = 7 To 62
+			alternaByteArray(i) = alternaBitByte
+		Next
+		
+		dim bits As BitContainer = Type(32, cast(Any Ptr, @alternaByteArray(7)))
+		dim bitsRes As BitContainer = bits Or bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bitsRes[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(bits[i], bitsRes[i])
+		Next
+		dim allSet As BitContainer = Type(32, True)
+		bitsRes = allSet Or bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bitsRes[i], True)
+			CU_ASSERT_EQUAL(bits[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(allSet[i], True)
+		Next
+		dim oneByte As UByte = 0
+		dim oneByteBits As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		dim oneByteOrRes As BitContainer = oneByteBits Or allSet
+		CU_ASSERT_EQUAL(oneByteOrRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteOrRes[i], allSet[i])
+			CU_ASSERT_EQUAL(oneByteOrRes[i], True)
+		Next
+		oneByte = 1
+		dim oneByteBits2 As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		oneByteOrRes = oneByteBits2 Or bits
+		CU_ASSERT_EQUAL(oneByteOrRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteOrRes[i], (CBool((i And 1) = 1) OrElse (i = 0)))
+		Next
+	END_TEST
+	
+	TEST(XorTest)
+		dim i As Long
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		Redim alternaByteArray(7 To 62)
+		For i = 7 To 62
+			alternaByteArray(i) = alternaBitByte
+		Next
+		
+		dim bits As BitContainer = Type(32, cast(Any Ptr, @alternaByteArray(7)))
+		dim bitsRes As BitContainer = bits Xor bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bits[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(bitsRes[i], False)
+		Next
+		dim allSet As BitContainer = Type(32, True)
+		bitsRes = allSet Xor bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bitsRes[i], CBool((i And 1) = 0))
+			CU_ASSERT_EQUAL(bits[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(allSet[i], True)
+		Next
+		dim oneByte As UByte = 0
+		dim oneByteBits As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		dim oneByteXOrRes As BitContainer = oneByteBits Xor allSet
+		CU_ASSERT_EQUAL(oneByteXOrRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteXOrRes.Get(i), True)
+		Next
+		oneByte = 1
+		dim oneByteBits2 As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		oneByteXOrRes = oneByteBits2 Xor bits
+		CU_ASSERT_EQUAL(oneByteXorRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteXOrRes[i], (CBool((i And 1) = 1) OrElse (i = 0)))
+		Next
+	END_TEST
+	
+	TEST(ImpTest)
+		dim i As Long
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		Redim alternaByteArray(7 To 62)
+		For i = 7 To 62
+			alternaByteArray(i) = alternaBitByte
+		Next
+		
+		dim bits As BitContainer = Type(32, cast(Any Ptr, @alternaByteArray(7)))
+		dim bitsRes As BitContainer = bits Imp bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bits[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(bitsRes[i], True)
+		Next
+		
+		dim allSet As BitContainer = Type(32, True)
+		bitsRes = allSet Imp bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bitsRes[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(bits[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(allSet[i], True)
+		Next
+		dim oneByte As UByte = 0
+		dim oneByteBits As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		dim oneByteImpRes As BitContainer = oneByteBits Imp allSet
+		CU_ASSERT_EQUAL(oneByteImpRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteImpRes.Get(i), True)
+		Next
+		oneByteImpRes = allSet Imp oneByteBits
+		CU_ASSERT_EQUAL(oneByteImpRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteImpRes.Get(i), False)
+		Next
+		oneByte = 1
+		dim oneByteBits2 As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		oneByteImpRes = oneByteBits2 Imp bits
+		CU_ASSERT_EQUAL(oneByteImpRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteImpRes[i], i > 0)
+		Next
+		oneByteImpRes = bits Imp oneByteBits2
+		CU_ASSERT_EQUAL(oneByteImpRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteImpRes[i], CBool((i And 1) = 0))
+		Next
+	END_TEST
+	
+	TEST(EqvTest)
+		dim i As Long
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		Redim alternaByteArray(7 To 62)
+		For i = 7 To 62
+			alternaByteArray(i) = alternaBitByte
+		Next
+		
+		dim bits As BitContainer = Type(32, cast(Any Ptr, @alternaByteArray(7)))
+		dim bitsRes As BitContainer = bits Eqv bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bits[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(bitsRes[i], True)
+		Next
+		
+		dim allSet As BitContainer = Type(32, True)
+		bitsRes = allSet Eqv bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bitsRes[i], bits[i])
+			CU_ASSERT_EQUAL(bits[i], CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(allSet[i], True)
+		Next
+		dim oneByte As UByte = 0
+		dim oneByteBits As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		dim oneByteEqvRes As BitContainer = oneByteBits Eqv allSet
+		CU_ASSERT_EQUAL(oneByteEqvRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteEqvRes.Get(i), False)
+		Next
+		oneByte = 1
+		dim oneByteBits2 As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		oneByteEqvRes = oneByteBits2 Eqv bits
+		CU_ASSERT_EQUAL(oneByteEqvRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteEqvRes[i], CBool((i > 0) AndAlso (i And 1) = 0))
+		Next
+		oneByteEqvRes = bits Eqv oneByteBits2
+		CU_ASSERT_EQUAL(oneByteEqvRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteEqvRes[i], CBool((i > 0) AndAlso (i And 1) = 0))
+		Next
+	END_TEST
+	
+	TEST(NotTest)
+		dim i As Long
+		dim alternaBitByte As UByte = &B10101010
+		Dim alternaByteArray(Any) As UByte
+		Redim alternaByteArray(7 To 62)
+		For i = 7 To 62
+			alternaByteArray(i) = alternaBitByte
+		Next		
+
+		dim bits As BitContainer = Type(32, cast(Any Ptr, @alternaByteArray(7)))
+		dim bitsRes As BitContainer = Not bits
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bitsRes[i], CBool((i And 1) = 0))
+			CU_ASSERT_EQUAL(bits[i], CBool((i And 1) = 1))
+		Next
+		dim allSet As BitContainer = Type(32, True)
+		bitsRes = Not allSet
+		For i = 0 To 31
+			CU_ASSERT_EQUAL(bitsRes[i], False)
+			CU_ASSERT_EQUAL(allSet[i], True)
+		Next
+		dim oneByte As UByte = 0
+		dim oneByteBits As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		dim oneByteNotRes As BitContainer = Not oneByteBits
+		CU_ASSERT_EQUAL(oneByteNotRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteNotRes[i], True)
+			CU_ASSERT_EQUAL(oneByteBits[i], False)
+		Next
+		oneByte = 1
+		dim oneByteBits2 As BitContainer = Type(8, cast(Any Ptr, @oneByte))
+		oneByteNotRes = Not oneByteBits2
+		CU_ASSERT_EQUAL(oneByteNotRes.Count, oneByteBits2.Count)
+		CU_ASSERT_EQUAL(oneByteNotRes.Count, 8)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(oneByteNotRes[i], CBool(i > 0))
+		Next
+	END_TEST
+	
+	TEST(LenTest)
+		dim bits As BitContainer = Type(65)
+		dim i As Long
+		CU_ASSERT_EQUAL(Len(bits), 65)
+		For i = 0 To 32
+			dim loopCont As BitContainer = Type(i * 3, CBool((i And 1) = 1))
+			CU_ASSERT_EQUAL(loopCont.Count, i * 3)
+			CU_ASSERT_EQUAL(Len(loopCont), loopCont.Count)
+		Next
+		dim arr(Any) As Boolean
+		Redim arr(0 To 63)
+		Randomize
+		For i = 0 To 50
+			dim numBits As Long = (Rnd * 62) + 1
+			dim arrCont As BitContainer = Type(numBits, cast(Any Ptr, @arr(0)))
+			CU_ASSERT_EQUAL(Len(arrCont), numBits)
+			CU_ASSERT_EQUAL(arrCont.Count, numBits)
+		Next
+	END_TEST
+END_SUITE

--- a/tests/containers/ContainerTestPrereqs.bi
+++ b/tests/containers/ContainerTestPrereqs.bi
@@ -1,0 +1,103 @@
+Namespace One
+    Namespace Two
+        Type IntegerHolder
+        Dim num As Integer
+	Declare Constructor
+	Declare Constructor(ByVal val As Long)
+	Declare Operator Let(ByVal val As Long)
+        End Type
+	Private Constructor IntegerHolder
+		num = 0
+	End Constructor
+	Private Constructor IntegerHolder(ByVal val As Long)
+		num = val
+	End Constructor
+        Private Operator =(ByRef cv1 As IntegerHolder, ByRef cv2 As IntegerHolder) As Boolean
+		'' Equality operator required for most containers
+		Return (cv1.num = cv2.num)
+        End Operator
+	Private Operator IntegerHolder.Let(ByVal val As Long)
+		num = val
+	End Operator
+    End Namespace
+End Namespace
+
+FBCont_DefineIIteratorOf(Long)
+
+Type SequentialLongGenerator extends FB_IIterator(Long)
+	Private:
+		Dim numToGenerate As Long
+		Dim soFar As Long
+		Dim firstVal As Long
+
+	Public:
+		Declare Constructor(ByVal howMany as Long, ByVal startPoint As Long)
+		Declare Function Advance() As Boolean Override
+		Declare Function Item() ByRef As Long Override
+		Declare Sub Reset() Override
+		Declare Sub Skip(byVal howMany As Long)
+End Type
+
+Private Constructor SequentialLongGenerator(ByVal howMany As Long, ByVal startPoint As Long)
+	numToGenerate = howMany
+	firstVal = startPoint
+	Reset()
+End Constructor
+
+Private Function SequentialLongGenerator.Advance() As Boolean
+	soFar += 1
+	Return soFar < (firstVal + numToGenerate)
+End Function
+
+Private Function SequentialLongGenerator.Item() ByRef As Long
+	Return soFar
+End Function
+
+Private Sub SequentialLongGenerator.Reset()
+	soFar = firstVal - 1
+End Sub
+
+Private Sub SequentialLongGenerator.Skip(byVal howMany As Long)
+	soFar += howMany
+End Sub
+
+FBCont_DefineIIteratorOf(One, Two, IntegerHolder)
+
+Type SequentialIntegerHolderGenerator extends FB_IIterator(One, Two, IntegerHolder)
+	Private:
+		Dim numToGenerate As Long
+		Dim soFar As Long
+		Dim firstVal As Integer
+		dim tempObj As One.Two.IntegerHolder
+
+	Public:
+		Declare Constructor(ByVal howMany as Long, ByVal startPoint As Integer)
+		Declare Function Advance() As Boolean Override
+		Declare Function Item() ByRef As One.Two.IntegerHolder Override
+		Declare Sub Reset() Override
+		Declare Sub Skip(byVal howMany As Long)
+End Type
+
+Private Constructor SequentialIntegerHolderGenerator(ByVal howMany As Long, ByVal startPoint As Integer)
+	numToGenerate = howMany
+	firstVal = startPoint
+	Reset()
+End Constructor
+
+Private Function SequentialIntegerHolderGenerator.Advance() As Boolean
+	soFar += 1
+	Return soFar < (firstVal + numToGenerate)
+End Function
+
+Private Function SequentialIntegerHolderGenerator.Item() ByRef As One.Two.IntegerHolder
+	tempObj.num = soFar
+	Return tempObj
+End Function
+
+Private Sub SequentialIntegerHolderGenerator.Reset()
+	soFar = firstVal - 1
+End Sub
+
+Private Sub SequentialIntegerHolderGenerator.Skip(byVal howMany As Long)
+	soFar += howMany
+End Sub

--- a/tests/containers/LinkedListTestPrimitive.bas
+++ b/tests/containers/LinkedListTestPrimitive.bas
@@ -1,0 +1,855 @@
+'' #define FB_CONTAINER_DEBUG 1
+#include "../../inc/containers/linkedlist.bi"
+#include "ContainerTestPrereqs.bi"
+#include "fbcunit.bi"
+
+FBCont_DefineLinkedListOf(Long)
+Type LongLinkedList As FB_LinkedList(Long)
+Type LongLLNode As FB_LinkedListNode(Long)
+
+Private Sub CheckListAgainstArray(Byref list As LongLinkedList, arr() As Long)
+    Dim As LongLLNode pHead = list.Head, pIter = pHead
+    Dim As Long arrLBound, arrUBound, numElems, i
+    arrLBound = LBound(arr)
+    arrUBound = UBound(arr)
+    numElems = (arrUBound - arrLBound) + 1
+    CU_ASSERT_EQUAL(numElems, Len(list))
+    For i = arrLBound To arrUBound
+        CU_ASSERT_EQUAL(arr(i), pIter->Data)
+        pIter = pIter->Forward
+        If i <> arrUBound Then CU_ASSERT(pIter <> pHead)
+    Next
+End Sub
+
+SUITE(fbc_tests.containers.linkedlists.primitive)
+	TEST(ConstructorTest)
+		dim emptyQueue As LongLinkedList
+		CU_ASSERT_EQUAL(emptyQueue.Count, 0)
+		dim emptyIterator As SequentialLongGenerator = Type(0, 1)
+
+		Dim zt1NumToGenerate As Long = 15
+		Dim zt1StartNum As Long = 0
+		Dim i As Long
+		Dim zeroTo14Iterator As SequentialLongGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 7
+		Dim tt2StartNum As Long = 203
+		Dim twoHundred3To210Iterator As SequentialLongGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		'' Iterator constructor
+		Dim zt1List As LongLinkedList = zeroTo14Iterator
+		Dim As LongLLNode zt1ListHead = zt1List.Head, zt1ListIter = zt1ListHead
+		CU_ASSERT_EQUAL(zt1List.Count, zt1NumToGenerate)
+		For i = 0 To (zt1NumToGenerate - 1)
+			CU_ASSERT_EQUAL(zt1ListIter->Data, zt1StartNum + i)
+			If i > 0 Then
+				CU_ASSERT(zt1ListHead <> zt1ListIter)
+			End If
+			zt1ListIter = zt1ListIter->Forward
+		Next
+		
+		Dim tt2List As LongLinkedList = twoHundred3To210Iterator
+		Dim As LongLLNode tt2ListHead = tt2List.Head, tt2ListIter = tt2ListHead
+		CU_ASSERT_EQUAL(tt2List.Count, tt2NumToGenerate)
+		For i = 0 To (tt2NumToGenerate - 1)
+			CU_ASSERT_EQUAL(tt2ListIter->Data, tt2StartNum + i)
+			If i > 0 Then
+				CU_ASSERT(tt2ListHead <> tt2ListIter)
+			End If
+			tt2ListIter = tt2ListIter->Forward
+		Next
+		zeroTo14Iterator.Reset()
+
+		Dim zt1List2 As LongLinkedList = @zeroTo14Iterator
+		Dim As LongLLNode zt1List2Head = zt1List2.Head, zt1List2Iter = zt1List2Head
+		CU_ASSERT_EQUAL(zt1List.Count, zt1List2.Count)
+		For i = 0 To (zt1NumToGenerate - 1)
+			CU_ASSERT_EQUAL(zt1List2Iter->Data, zt1ListIter->Data)
+			If i > 0 Then
+				CU_ASSERT(zt1List2Head <> zt1List2Iter)
+			End If
+			zt1List2Iter = zt1List2Iter->Forward
+			zt1ListIter = zt1ListIter->Forward
+		Next		
+		twoHundred3To210Iterator.Reset()
+
+		Dim tt2List2 As LongLinkedList = @twoHundred3To210Iterator
+		Dim As LongLLNode tt2List2Head = tt2List2.Head, tt2List2Iter = tt2List2Head
+		CU_ASSERT_EQUAL(tt2List2.Count, tt2List.Count)
+		For i = 0 To (tt2NumToGenerate - 1)
+			CU_ASSERT_EQUAL(tt2List2Iter->Data, tt2ListIter->Data)
+			If i > 0 Then
+				CU_ASSERT(tt2List2Head <> tt2List2Iter)
+			End If
+			tt2List2Iter = tt2List2Iter->Forward
+			tt2ListIter = tt2ListIter->Forward
+		Next
+		
+		dim newEmptyList As LongLinkedList = emptyIterator
+		CU_ASSERT_EQUAL(newEmptyList.Count, 0)
+		emptyIterator.Reset()
+		
+		dim numArray(7) As Long
+		dim numArrayLBound As Long = LBound(numArray)
+		dim numArrayUBound As Long = UBound(numArray)
+		For i = numArrayLBound To numArrayUBound
+			numArray(i) = i
+		Next
+		
+		Dim arrayList As LongLinkedList = numArray()
+		CheckListAgainstArray(arrayList, numArray())
+		
+		dim numArrayBased(5 To 9) As Long
+		numArrayLBound = LBound(numArrayBased)
+		numArrayUBound = UBound(numArrayBased)
+		For i = numArrayLBound To numArrayUBound
+			numArrayBased(i) = i
+		Next
+		
+		Dim arrayListBased As LongLinkedList = numArrayBased()
+		CheckListAgainstArray(arrayListBased, numArrayBased())
+		
+		dim undimmedArray(Any) As Long
+		dim anyArrayList As LongLinkedList = undimmedArray()
+		CU_ASSERT_EQUAL(anyArrayList.Count, 0)
+
+		'' Container constructors
+		dim contList As LongLinkedList = @arrayListBased
+		Dim As LongLLNode contListHead = contList.Head, contListIter = contListHead
+		For i = numArrayLBound To numArrayUBound
+			CU_ASSERT_EQUAL(numArrayBased(i), contListIter->Data)
+			contListIter = contListIter->Forward
+		Next
+
+		dim contList2 As LongLinkedList = @arrayList
+		Dim As LongLLNode contList2Head = contList2.Head, contList2Iter = contList2Head
+		For i = LBound(numArray) To UBound(numArray)
+			CU_ASSERT_EQUAL(numArray(i), contList2Iter->Data)
+			contList2Iter = contList2Iter->Forward
+		Next
+
+		Dim fromEmptyContainerList As LongLinkedList = @newEmptyList
+		CU_ASSERT_EQUAL(fromEmptyContainerList.Count, 0)
+	END_TEST
+	
+	TEST(AddHead)
+		dim singleItemList As LongLinkedList
+		dim As LongLLNode pPrevHead = singleItemList.AddHead(78), pNewHead, pFirstNode = pPrevHead
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, 78)
+		CU_ASSERT_EQUAL(pPrevHead, singleItemList.Head)
+		'' circular list with one node points to itself
+		CU_ASSERT_EQUAL(pPrevHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pPrevHead)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		
+		pNewHead = singleItemList.AddHead(-78)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, -78)
+		CU_ASSERT_EQUAL(pNewHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pNewHead->Back, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pNewHead)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		CU_ASSERT_EQUAL(pFirstNode->Forward, pNewHead)
+		pPrevHead = pNewHead
+		
+		pNewHead = singleItemList.AddHead(35)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, 35)
+		CU_ASSERT_EQUAL(pNewHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pNewHead->Back, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pNewHead)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		CU_ASSERT_EQUAL(pFirstNode->Forward, pNewHead)
+		pPrevHead = pNewHead
+		
+		pNewHead = singleItemList.AddHead(-87)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, -87)
+		CU_ASSERT_EQUAL(pNewHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pNewHead->Back, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pNewHead)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		CU_ASSERT_EQUAL(pFirstNode->Forward, pNewHead)
+		CU_ASSERT_EQUAL(singleItemList.Count, 4)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		
+		singleItemList.RemoveNode(pNewHead)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, 35)
+		CU_ASSERT_EQUAL(singleItemList.Head, pPrevHead)		
+		
+		pNewHead = singleItemList.AddHead(123456)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, 123456)
+		CU_ASSERT_EQUAL(pNewHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pNewHead->Back, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pNewHead)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		CU_ASSERT_EQUAL(pFirstNode->Forward, pNewHead)
+		
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, 35)
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, -78)
+		singleItemList.RemoveNode(singleItemList.Head)
+		singleItemList.Clear()
+		
+		singleItemList += 19
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, 19)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		singleItemList += 99
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, 19)
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, 99)
+	END_TEST
+	
+	TEST(AddTail)
+		dim singleItemList As LongLinkedList
+		dim As LongLLNode pPrevTail = singleItemList.AddTail(78), pNewTail, pFirstNode = pPrevTail
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, 78)
+		CU_ASSERT_EQUAL(pPrevTail, singleItemList.Tail)
+		'' circular list with one node points to itself
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pPrevTail)
+		CU_ASSERT_EQUAL(pPrevTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, 78)
+		
+		pNewTail = singleItemList.AddTail(-78)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, -78)
+		CU_ASSERT_EQUAL(pNewTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(pNewTail->Forward, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pNewTail)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		CU_ASSERT_EQUAL(pFirstNode->Back, pNewTail)
+		pPrevTail = pNewTail
+		
+		pNewTail = singleItemList.AddTail(35)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, 35)
+		CU_ASSERT_EQUAL(pNewTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(pNewTail->Forward, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pNewTail)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		CU_ASSERT_EQUAL(pFirstNode->Back, pNewTail)
+		pPrevTail = pNewTail
+		
+		pNewTail = singleItemList.AddTail(-87)
+		CU_ASSERT_EQUAL(pNewTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(pNewTail->Forward, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pNewTail)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		CU_ASSERT_EQUAL(pFirstNode->Back, pNewTail)
+		CU_ASSERT_EQUAL(singleItemList.Count, 4)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, -87)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		
+		singleItemList.RemoveNode(pNewTail)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, 35)
+		CU_ASSERT_EQUAL(singleItemList.Tail, pPrevTail)		
+		
+		pNewTail = singleItemList.AddTail(123456)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, 123456)
+		CU_ASSERT_EQUAL(pNewTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(pNewTail->Forward, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pNewTail)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		CU_ASSERT_EQUAL(pFirstNode->Back, pNewTail)
+		
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, 35)
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, -78)
+		singleItemList.RemoveNode(singleItemList.Tail)
+		singleItemList.Clear()
+		
+		singleItemList += 19
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, 19)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		singleItemList += 99
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, 99)
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, 19)
+	END_TEST
+	
+	TEST(AddAfter)
+		dim singleItemList As LongLinkedList
+		Dim i As Long
+		dim values(7 To 11) As Long
+		dim arrLBound As Long = LBound(values)
+		dim arrUBound As Long = UBound(values)
+		For i = arrLBound To arrUBound
+			values(i) = i * 2
+		Next
+		dim pPrevNode As LongLLNode = 0
+		dim numAdded As Long = 0
+		For i = arrLBound to arrUBound
+			dim pNewNode As LongLLNode = singleItemList.AddAfter(values(i), pPrevNode)
+			numAdded += 1
+			CU_ASSERT_EQUAL(singleItemList.Count, numAdded)
+			If i > arrLBound Then
+				CU_ASSERT_EQUAL(pNewNode->Back, pPrevNode)
+				CU_ASSERT_EQUAL(pNewNode->Forward, singleItemList.Head)
+				CU_ASSERT_EQUAL(pPrevNode->Forward, pNewNode)
+			Else
+				CU_ASSERT_EQUAL(pNewNode->Back, pNewNode)
+				CU_ASSERT_EQUAL(pNewNode->Forward, singleItemList.Head)
+				CU_ASSERT_EQUAL(pNewNode->Forward, pNewNode)
+				CU_ASSERT_EQUAL(pNewNode, singleItemList.Head)
+				CU_ASSERT_EQUAL(pNewNode, singleItemList.Tail)
+			End If
+			dim pRevIter As LongLLNode = pNewNode
+			For j As Long = i To arrLBound Step -1
+				CU_ASSERT_EQUAL(pRevIter->Data, j * 2)
+				pRevIter = pRevIter->Back
+			Next
+			pPrevNode = pNewNode
+		Next
+		'' Trying to add after a node that belongs to a different list is an error
+		'' (since it could then be the head of one list and a node in a different list
+		'' which would eventually be deleted twice)
+		dim tempList As LongLinkedList
+		dim As LongLLNode tempNode = tempList.AddHead(47575), errNode
+		On Local Error Goto nextTest
+		dim localErr As Long
+		Err = 0
+		errNode = singleItemList.AddAfter(87, tempNode)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		CU_ASSERT_EQUAL(errNode, 0)
+	nextTest:
+		On Local Error Goto 0
+		singleItemList.Clear()
+		
+		dim pNode(0 To 3) As LongLLNode
+		dim toInsert(0 To 3) As Long
+		pNode(0) = singleItemList.AddHead(5437)
+		pNode(1) = singleItemList.AddTail(96437)
+		pNode(2) = singleItemList.AddAfter(1, pNode(1))
+		pNode(3) = singleItemList.Tail
+		CU_ASSERT_EQUAL(pNode(2)->Back, pNode(1))
+		CU_ASSERT_EQUAL(pNode(2)->Forward, pNode(0))
+		CU_ASSERT_EQUAL(pNode(1)->Forward, pNode(2))
+		
+		For i = LBound(pNode) to UBound(pNode)
+			toInsert(i) = 9 + i
+		Next
+		dim pInsert As LongLLNode
+		For i = LBound(pNode) to UBound(pNode)
+			pInsert = singleItemList.AddAfter(toInsert(i), pNode(i))
+			CU_ASSERT_EQUAL(pNode(i)->Forward, pInsert)
+			CU_ASSERT_EQUAL(pInsert->Back, pNode(i))
+		Next
+		
+		'' AddAfter Null adds to the Head (ie it's not after anything)
+		pInsert = singleItemList.AddAfter(89, 0)
+		CU_ASSERT_EQUAL(singleItemList.Head, pInsert)
+		CU_ASSERT_EQUAL(singleItemList.Tail, pInsert->Back)
+		CU_ASSERT_EQUAL(pNode(0)->Back, pInsert)
+		CU_ASSERT_EQUAL(pNode(0), pInsert->Forward)
+		
+		dim pIter As LongLLNode = singleItemList.Head
+		dim listSize As Long = singleItemList.Count
+		dim listData(0 to listSize - 1) As Long
+		listData(0) = 89
+		listData(1) = 5437
+		listData(2) = 9
+		listData(3) = 96437
+		listData(4) = 10
+		listData(5) = 1
+		listData(6) = 12
+		listData(7) = 11
+		For i = 0 to listSize - 1
+			CU_ASSERT_EQUAL(pIter->Data, listData(i))
+			pIter = pIter->Forward
+		Next
+	END_TEST
+	
+	TEST(AddBefore)
+		dim singleItemList As LongLinkedList
+		Dim i As Long
+		dim values(7 To 11) As Long
+		dim arrLBound As Long = LBound(values)
+		dim arrUBound As Long = UBound(values)
+		For i = arrLBound To arrUBound
+			values(i) = i * 2
+		Next
+		dim pPrevNode As LongLLNode = 0
+		dim numAdded As Long = 0
+		For i = arrLBound to arrUBound
+			dim pNewNode As LongLLNode = singleItemList.AddBefore(values(i), pPrevNode)
+			numAdded += 1
+			CU_ASSERT_EQUAL(singleItemList.Count, numAdded)
+			If i > arrLBound Then
+				CU_ASSERT_EQUAL(pNewNode->Back, singleItemList.Tail)
+				CU_ASSERT_EQUAL(pNewNode->Forward, pPrevNode)
+				CU_ASSERT_EQUAL(pPrevNode->Back, pNewNode)
+			Else
+				CU_ASSERT_EQUAL(pNewNode->Back, pNewNode)
+				CU_ASSERT_EQUAL(pNewNode->Forward, singleItemList.Head)
+				CU_ASSERT_EQUAL(pNewNode->Forward, pNewNode)
+				CU_ASSERT_EQUAL(pNewNode, singleItemList.Head)
+				CU_ASSERT_EQUAL(pNewNode, singleItemList.Tail)
+			End If
+			dim pRevIter As LongLLNode = pNewNode
+			For j As Long = i To arrLBound Step -1
+				CU_ASSERT_EQUAL(pRevIter->Data, j * 2)
+				pRevIter = pRevIter->Forward
+			Next
+			pPrevNode = pNewNode
+		Next
+		'' Trying to add after a node that belongs to a different list is an error
+		'' (since it could then be the head of one list and a node in a different list
+		'' which would eventually be deleted twice)
+		dim tempList As LongLinkedList
+		dim As LongLLNode tempNode = tempList.AddHead(47575), errNode
+		On Local Error Goto nextTest
+		dim localErr As Long
+		Err = 0
+		errNode = singleItemList.AddBefore(87, tempNode)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		CU_ASSERT_EQUAL(errNode, 0)
+	nextTest:
+		On Local Error Goto 0
+		singleItemList.Clear()
+
+		dim pNode(0 To 3) As LongLLNode
+		dim toInsert(0 To 3) As Long
+		pNode(1) = singleItemList.AddHead(5437)
+		pNode(2) = singleItemList.AddTail(96437)
+		pNode(3) = singleItemList.AddAfter(1, pNode(1))
+		pNode(0) = singleItemList.Head
+		CU_ASSERT_EQUAL(pNode(2)->Back, pNode(3))
+		CU_ASSERT_EQUAL(pNode(2)->Forward, pNode(0))
+		CU_ASSERT_EQUAL(pNode(1)->Forward, pNode(3))
+		
+		For i = LBound(pNode) to UBound(pNode)
+			toInsert(i) = 9 + i
+		Next
+		dim pInsert As LongLLNode
+		For i = LBound(pNode) to UBound(pNode)
+			pInsert = singleItemList.AddBefore(toInsert(i), pNode(i))
+			CU_ASSERT_EQUAL(pNode(i)->Back, pInsert)
+			CU_ASSERT_EQUAL(pInsert->Forward, pNode(i))
+		Next
+
+		'' AddBefore Null adds to the Tail (ie it's not before anything)
+		pInsert = singleItemList.AddBefore(89, 0)
+		CU_ASSERT_EQUAL(singleItemList.Tail, pInsert)
+		CU_ASSERT_EQUAL(singleItemList.Head, pInsert->Forward)
+		CU_ASSERT_EQUAL(pNode(2)->Forward, pInsert)
+		CU_ASSERT_EQUAL(pNode(2), pInsert->Back)
+
+		dim pIter As LongLLNode = singleItemList.Head
+		dim listSize As Long = singleItemList.Count
+		dim listData(0 to listSize - 1) As Long
+		listData(0) = 9
+		listData(1) = 10
+		listData(2) = 5437
+		listData(3) = 12
+		listData(4) = 1
+		listData(5) = 11
+		listData(6) = 96437
+		listData(7) = 89
+		For i = 0 to listSize - 1
+			CU_ASSERT_EQUAL(pIter->Data, listData(i))
+			pIter = pIter->Forward
+		Next
+	END_TEST
+	
+	TEST(Clear)
+		dim singleItemList As LongLinkedList
+		singleItemList.AddHead(78)
+		singleItemList.AddTail(-78)
+		dim listSize As Long = singleItemList.Count
+		singleItemList.Clear()
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		CU_ASSERT(singleItemList.Count <> listSize)
+		listSize = singleItemList.Count
+		singleItemList.Clear()
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		CU_ASSERT_EQUAL(singleItemList.Count, listSize)
+		dim list2 As LongLinkedList	
+		list2.Clear()
+		CU_ASSERT_EQUAL(list2.Count, 0)
+	END_TEST
+	
+	TEST(Contains)
+		dim haystack As LongLinkedList
+		dim needle As Long = 78
+		dim As LongLLNode needleNode, node52
+		dim result As Boolean
+		result = haystack.Contains(0)
+		CU_ASSERT_EQUAL(result, False)
+		needleNode = haystack.AddHead(needle)
+		haystack.AddTail(-needle)
+		node52 = haystack.AddTail(52)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		result = haystack.Contains(52)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.RemoveNode(needleNode)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.RemoveNode(haystack.Head)
+		result = haystack.Contains(52)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.RemoveNode(node52)
+		result = haystack.Contains(52)
+		CU_ASSERT_EQUAL(result, False)
+		Dim generate100 As SequentialLongGenerator = Type(100, 100)
+		dim secondHaystack As LongLinkedList = @generate100
+		result = secondHaystack.Contains(157)
+		CU_ASSERT_EQUAL(result, True)
+	END_TEST
+	
+	TEST(CopyTo)
+		dim singleItemList As LongLinkedList
+		dim i As Long
+		singleItemList.AddTail(78)
+		singleItemList.AddTail(-78)
+		singleItemList.AddTail(8537536)
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As Long
+		singleItemList.CopyTo(undimmedArr())
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, singleItemList.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		Dim pIter As LongLLNode = singleItemList.Head
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr(i), pIter->Data)
+			pIter = pIter->Forward
+		Next
+		
+		'' Except in empty lists, where nothing happens
+		'' If container debug is defined, this calls Error
+		dim emptyQueue As LongLinkedList
+		dim emptyArr(Any) As Long
+		On Local Error Goto nextTest1
+		dim localErr As Long
+		Err = 0
+		emptyQueue.CopyTo(emptyArr())
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+
+	nextTest1:
+		On Local Error Goto 0
+		'' already sized arrays copy the number of items in the queue or the size of the array
+		'' whichever is smaller
+		dim largerThanContArr(10 To 14) As Long
+		For i = 10 To 14
+			largerThanContArr(i) = i
+		Next
+		singleItemList.CopyTo(largerThanContArr())
+		arrUBound = UBound(largerThanContArr)
+		arrLBound = LBound(largerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 5)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 14)
+		pIter = singleItemList.Head
+		For i = 10 To 14
+			dim value As Long = i
+			If i <= 12 Then
+				value = pIter->Data
+				pIter = pIter->Forward
+			End If
+			CU_ASSERT_EQUAL(largerThanContArr(i), value)
+		Next
+		
+		dim smallerThanContArr(21 To 22) As Long
+		For i = 21 To 22
+			smallerThanContArr(i) = i
+		Next
+		singleItemList.AddTail(4)
+		singleItemList.CopyTo(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 2)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 22)
+		pIter = singleItemList.Head
+		For i = 21 To 22
+			CU_ASSERT_EQUAL(smallerThanContArr(i), pIter->Data)
+			pIter = pIter->Forward
+		Next
+	END_TEST
+	
+	TEST(FindTest)
+		dim As LongLinkedList singleItemList, otherList
+		dim As LongLLNode findRet, findRet2
+		dim i As Long
+		singleItemList.AddTail(78)
+		singleItemList.AddTail(-78)
+		singleItemList.AddTail(8537536)
+		findRet = singleItemList.Find(-78, 0)
+		CU_ASSERT(findRet <> 0)
+		CU_ASSERT_EQUAL(findRet->Data, -78)
+		findRet2 = singleItemList.Find(-78, findRet)
+		CU_ASSERT(findRet2 <> 0)
+		CU_ASSERT_EQUAL(findRet2->Data, -78)
+		CU_ASSERT_EQUAL(findRet2, findRet)
+		singleItemList.RemoveNode(findRet)
+		findRet2 = singleItemList.Find(-78, 0)
+		CU_ASSERT_EQUAL(findRet2, 0)
+		
+		findRet = otherList.Find(0, 0)
+		CU_ASSERT_EQUAL(findRet, 0)
+		
+		findRet2 = singleItemList.Head
+		otherList.AddHead(987655)
+		Dim localErr As Long
+		On Local Error Goto nextTest
+		Err = 0
+		'' finding using a foreign list node is an error
+		findRet = otherList.Find(987655, findRet2)
+		localErr = Err
+		CU_ASSERT_EQUAL(findRet, 0)
+		CU_ASSERT_EQUAL(localErr, 1)
+	nextTest:
+		On Local Error Goto 0
+		dim As LongLLNode startNode = singleItemList.Head, iterNode = startNode
+		For i = 0 To singleItemList.Count - 1
+			findRet = singleItemList.Find(iterNode->Data, startNode)
+			CU_ASSERT_EQUAL(findRet, iterNode)
+			CU_ASSERT_EQUAL(findRet->Data, iterNode->Data)
+			iterNode = iterNode->Forward
+		Next
+		startNode = singleItemList.Tail
+		iterNode = singleItemList.Head
+		For i = 0 To singleItemList.Count - 1
+			findRet = singleItemList.Find(iterNode->Data, startNode)
+			CU_ASSERT_EQUAL(findRet, iterNode)
+			CU_ASSERT_EQUAL(findRet->Data, iterNode->Data)
+			iterNode = iterNode->Forward
+		Next
+		
+		findRet = singleItemList.Find(-937537, 0)
+		CU_ASSERT_EQUAL(findRet, 0)
+	END_TEST
+	
+	Private Sub TestContainerIter(ByRef list As LongLinkedList)
+		dim pListIter As FB_IIterator(Long) Ptr = list.GetIterator()
+		dim As LongLLNode pHead = list.Head, pNode = pHead
+		While pListIter->Advance()
+			CU_ASSERT_EQUAL(pNode->Data, pListIter->Item())
+			pNode = pNode->Forward
+		Wend
+		CU_ASSERT_EQUAL(pNode, pHead)
+		Delete pListIter
+	End Sub
+	
+	TEST(GetIterator)
+		dim list As LongLinkedList
+		dim pListIter As FB_IIterator(Long) Ptr = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+		pListIter = 0
+		list.AddTail(7)
+		pListIter = list.GetIterator()
+		dim pListIter2 As FB_IIterator(Long) Ptr = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter2 <> 0)
+		CU_ASSERT(pListIter <> pListIter2)
+		CU_ASSERT(pListIter->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT(pListIter2->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT_EQUAL(pListIter2->Item(), 7)
+		pListIter->Reset()
+		TestContainerIter(pListIter)
+		pListIter2->Reset()
+		TestContainerIter(pListIter2)
+		Delete pListIter
+		Delete pListIter2
+		pListIter = 0
+		pListIter2 = 0
+		list.Clear()
+		Dim i As Long
+		For i = 0 To 6
+			list.AddHead(i)
+		Next
+		pListIter = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		For i = 6 To 0 Step -1
+			CU_ASSERT(pListIter->Advance() = True)
+			CU_ASSERT_EQUAL(pListIter->Item(), i)
+		Next
+		CU_ASSERT(pListIter->Advance() = False)
+		pListIter->Reset()
+		TestContainerIter(pListIter)
+		Delete pListIter
+	END_TEST
+	
+	Private Function DoesNodeExist(Byref list As LongLinkedList, ByVal pNode As LongLLNode) As Boolean
+		dim As LongLLNode pHead = list.Head, pIter = pHead
+		dim found As Boolean
+		If pHead <> 0 Then
+			Do
+				found = (pIter = pNode)
+				pIter = pIter->Forward
+			Loop While (pIter <> pHead) AndAlso (found = False)
+		End If
+		Return found
+	End Function
+	
+	TEST(RemoveNode)
+		dim singleItemList As LongLinkedList
+		dim pNodes(0 To 2) As LongLLNode
+		dim i As Long
+		pNodes(0) = singleItemList.AddTail(78)
+		pNodes(1) = singleItemList.AddTail(-78)
+		pNodes(2) = singleItemList.AddTail(8537536)
+		dim listSize As Long = singleItemList.Count
+		
+		CU_ASSERT_EQUAL(pNodes(2)->Forward, pNodes(0))
+		CU_ASSERT_EQUAL(pNodes(1)->Back, pNodes(0))
+		singleItemList.RemoveNode(pNodes(0))
+		CU_ASSERT_EQUAL(singleItemList.Count, listSize - 1)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(0)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(1)), True)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(2)), True)
+		CU_ASSERT(pNodes(2)->Forward <> pNodes(0))
+		CU_ASSERT(pNodes(1)->Back <> pNodes(0))
+		
+		CU_ASSERT(pNodes(2)->Forward = pNodes(1))
+		CU_ASSERT(pNodes(2)->Back = pNodes(1))
+		singleItemList.RemoveNode(pNodes(1))
+		CU_ASSERT_EQUAL(singleItemList.Count, listSize - 2)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(0)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(1)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(2)), True)
+		CU_ASSERT(pNodes(2)->Forward <> pNodes(1))
+		CU_ASSERT(pNodes(2)->Back <> pNodes(1))
+		
+		CU_ASSERT(pNodes(2)->Forward = pNodes(2))
+		CU_ASSERT(pNodes(2)->Back = pNodes(2))
+		singleItemList.RemoveNode(pNodes(2))
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(0)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(1)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(2)), False)
+		CU_ASSERT(singleItemList.Head = 0)
+		
+		pNodes(0) = singleItemList.AddTail(78)
+		pNodes(1) = singleItemList.AddTail(-78)
+		pNodes(2) = singleItemList.AddTail(8537536)
+		dim otherList As LongLinkedList
+		dim As LongLLNode otherListNode = otherList.AddHead(0), removeRet
+		'' trying to remove a node that belongs to a different list
+		'' is an error
+		On Local Error Goto nextTest
+		dim localErr As Long
+		Err = 0
+		removeRet = singleItemList.RemoveNode(otherListNode)
+		localErr = Err
+		CU_ASSERT_EQUAL(removeRet, 0)
+		CU_ASSERT_EQUAL(localErr, 1)
+	nextTest:
+		On Local Error Goto 0
+	
+		removeRet = singleItemList.RemoveNode(pNodes(0))
+		CU_ASSERT_EQUAL(removeRet, pNodes(1))
+		CU_ASSERT_EQUAL(removeRet, singleItemList.Head)
+		listSize = singleItemList.Count
+		
+		'' RemoveNode 0 does nothing
+		removeRet = singleItemList.RemoveNode(0)
+		CU_ASSERT_EQUAL(removeRet, 0)
+		CU_ASSERT_EQUAL(listSize, singleItemList.Count)
+		
+		removeRet = singleItemList.RemoveNode(pNodes(1))
+		CU_ASSERT_EQUAL(removeRet, pNodes(2))
+		CU_ASSERT_EQUAL(removeRet, singleItemList.Head)
+		CU_ASSERT_EQUAL(listSize - 1, singleItemList.Count)
+		CU_ASSERT_EQUAL(1, singleItemList.Count)
+		
+		removeRet = singleItemList.RemoveNode(pNodes(2))
+		CU_ASSERT_EQUAL(removeRet, 0)
+		CU_ASSERT_EQUAL(removeRet, singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Empty(), True)
+	END_TEST
+	
+	TEST(LenTest)
+		dim singleItemList As LongLinkedList
+		singleItemList.AddHead(78)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.AddTail(-78)
+		singleItemList.AddTail(35)
+		singleItemList.AddHead(-87)
+		CU_ASSERT_EQUAL(singleItemList.Count, 4)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Count, 3)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Tail)
+		singleItemList.Clear()
+		singleItemList += 19
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList += 99
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+	END_TEST
+
+	TEST(Empty)
+		dim singleItemList As LongLinkedList
+		CU_ASSERT_EQUAL(singleItemList.Empty(), True)
+		singleItemList.AddHead(78)
+		CU_ASSERT_EQUAL(singleItemList.Empty(), False)
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Empty(), True)
+		Dim arr(0 To 1) As Long
+		dim otherQueue As LongLinkedList = arr()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), False)
+		dim pHead As LongLLNode = singleItemList.Head
+		singleItemList.AddAfter(30, pHead)
+		CU_ASSERT_EQUAL(otherQueue.Empty(), False)
+		otherQueue.Clear()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), True)
+	END_TEST
+	
+	TEST(LetTest)
+		dim As LongLinkedList list1, list2
+		list1.AddTail(8586)
+		list1.AddTail(2)
+		CU_ASSERT(list1.Count <> list2.Count)
+		list2 = list1
+		CU_ASSERT_EQUAL(list1.Count, list2.Count) 
+		CU_ASSERT_EQUAL(list1.Head->Data, list2.Head->Data)
+		CU_ASSERT_EQUAL(list1.Tail->Data, list2.Tail->Data)
+		list2.Clear()
+		CU_ASSERT(list1.Count <> list2.Count)
+		CU_ASSERT(list1.Head <> 0)
+		CU_ASSERT(list2.Head = 0)
+		list1 = list2
+		CU_ASSERT_EQUAL(list1.Count, list2.Count)
+		CU_ASSERT_EQUAL(list1.Head, 0)
+		CU_ASSERT_EQUAL(list2.Head, 0)
+		list2.AddHead(9485)
+		CU_ASSERT(list1.Count <> list2.Count)
+		CU_ASSERT(list2.Head <> 0)
+		CU_ASSERT(list1.Head = 0)
+		list1 = list2
+		CU_ASSERT_EQUAL(list1.Count, list2.Count)
+		CU_ASSERT(list1.Head <> 0)
+		CU_ASSERT(list2.Head <> 0)
+		CU_ASSERT(list1.Head <> list2.Head)
+		CU_ASSERT_EQUAL(list1.Head->Data, list2.Head->Data)
+	END_TEST
+END_SUITE

--- a/tests/containers/LinkedListTestUDT.bas
+++ b/tests/containers/LinkedListTestUDT.bas
@@ -1,0 +1,871 @@
+''#define FB_CONTAINER_DEBUG 1
+#include "../../inc/containers/linkedlist.bi"
+#include "ContainerTestPrereqs.bi"
+#include "fbcunit.bi"
+
+FBCont_DefineLinkedListOf(One, Two, IntegerHolder)
+Type IntegerHolderLinkedList As FB_LinkedList(One, Two, IntegerHolder)
+Type IntegerHolderLLNode As FB_LinkedListNode(One, Two, IntegerHolder)
+
+Private Sub CheckListAgainstArray(Byref list As IntegerHolderLinkedList, arr() As One.Two.IntegerHolder)
+    Dim As IntegerHolderLLNode pHead = list.Head, pIter = pHead
+    Dim As Long arrLBound, arrUBound, numElems, i
+    arrLBound = LBound(arr)
+    arrUBound = UBound(arr)
+    numElems = (arrUBound - arrLBound) + 1
+    CU_ASSERT_EQUAL(numElems, Len(list))
+    For i = arrLBound To arrUBound
+        CU_ASSERT_EQUAL(arr(i), pIter->Data)
+        pIter = pIter->Forward
+        If i <> arrUBound Then CU_ASSERT(pIter <> pHead)
+    Next
+End Sub
+
+SUITE(fbc_tests.containers.linkedlists.udt)
+	TEST(ConstructorTest)
+		dim emptyQueue As IntegerHolderLinkedList
+		CU_ASSERT_EQUAL(emptyQueue.Count, 0)
+		dim emptyIterator As SequentialIntegerHolderGenerator = Type(0, 1)
+
+		Dim zt1NumToGenerate As Long = 15
+		Dim zt1StartNum As Long = 0
+		Dim i As Long
+		Dim zeroTo14Iterator As SequentialIntegerHolderGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 7
+		Dim tt2StartNum As Long = 203
+		Dim twoHundred3To210Iterator As SequentialIntegerHolderGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		'' Iterator constructor
+		Dim zt1List As IntegerHolderLinkedList = zeroTo14Iterator
+		Dim As IntegerHolderLLNode zt1ListHead = zt1List.Head, zt1ListIter = zt1ListHead
+		CU_ASSERT_EQUAL(zt1List.Count, zt1NumToGenerate)
+		For i = 0 To (zt1NumToGenerate - 1)
+			CU_ASSERT_EQUAL(zt1ListIter->Data.num, zt1StartNum + i)
+			If i > 0 Then
+				CU_ASSERT(zt1ListHead <> zt1ListIter)
+			End If
+			zt1ListIter = zt1ListIter->Forward
+		Next
+		
+		Dim tt2List As IntegerHolderLinkedList = twoHundred3To210Iterator
+		Dim As IntegerHolderLLNode tt2ListHead = tt2List.Head, tt2ListIter = tt2ListHead
+		CU_ASSERT_EQUAL(tt2List.Count, tt2NumToGenerate)
+		For i = 0 To (tt2NumToGenerate - 1)
+			CU_ASSERT_EQUAL(tt2ListIter->Data.num, tt2StartNum + i)
+			If i > 0 Then
+				CU_ASSERT(tt2ListHead <> tt2ListIter)
+			End If
+			tt2ListIter = tt2ListIter->Forward
+		Next
+		zeroTo14Iterator.Reset()
+
+		Dim zt1List2 As IntegerHolderLinkedList = @zeroTo14Iterator
+		Dim As IntegerHolderLLNode zt1List2Head = zt1List2.Head, zt1List2Iter = zt1List2Head
+		CU_ASSERT_EQUAL(zt1List.Count, zt1List2.Count)
+		For i = 0 To (zt1NumToGenerate - 1)
+			CU_ASSERT_EQUAL(zt1List2Iter->Data.num, zt1ListIter->Data)
+			If i > 0 Then
+				CU_ASSERT(zt1List2Head <> zt1List2Iter)
+			End If
+			zt1List2Iter = zt1List2Iter->Forward
+			zt1ListIter = zt1ListIter->Forward
+		Next		
+		twoHundred3To210Iterator.Reset()
+
+		Dim tt2List2 As IntegerHolderLinkedList = @twoHundred3To210Iterator
+		Dim As IntegerHolderLLNode tt2List2Head = tt2List2.Head, tt2List2Iter = tt2List2Head
+		CU_ASSERT_EQUAL(tt2List2.Count, tt2List.Count)
+		For i = 0 To (tt2NumToGenerate - 1)
+			CU_ASSERT_EQUAL(tt2List2Iter->Data, tt2ListIter->Data)
+			If i > 0 Then
+				CU_ASSERT(tt2List2Head <> tt2List2Iter)
+			End If
+			tt2List2Iter = tt2List2Iter->Forward
+			tt2ListIter = tt2ListIter->Forward
+		Next
+		
+		dim newEmptyList As IntegerHolderLinkedList = emptyIterator
+		CU_ASSERT_EQUAL(newEmptyList.Count, 0)
+		emptyIterator.Reset()
+		
+		dim numArray(7) As One.Two.IntegerHolder
+		dim numArrayLBound As Long = LBound(numArray)
+		dim numArrayUBound As Long = UBound(numArray)
+		For i = numArrayLBound To numArrayUBound
+			numArray(i) = i
+		Next
+		
+		Dim arrayList As IntegerHolderLinkedList = numArray()
+		CheckListAgainstArray(arrayList, numArray())
+		
+		dim numArrayBased(5 To 9) As One.Two.IntegerHolder
+		numArrayLBound = LBound(numArrayBased)
+		numArrayUBound = UBound(numArrayBased)
+		For i = numArrayLBound To numArrayUBound
+			numArrayBased(i) = i
+		Next
+		
+		Dim arrayListBased As IntegerHolderLinkedList = numArrayBased()
+		CheckListAgainstArray(arrayListBased, numArrayBased())
+		
+		dim undimmedArray(Any) As One.Two.IntegerHolder
+		dim anyArrayList As IntegerHolderLinkedList = undimmedArray()
+		CU_ASSERT_EQUAL(anyArrayList.Count, 0)
+
+		'' Container constructors
+		dim contList As IntegerHolderLinkedList = @arrayListBased
+		Dim As IntegerHolderLLNode contListHead = contList.Head, contListIter = contListHead
+		For i = numArrayLBound To numArrayUBound
+			CU_ASSERT_EQUAL(numArrayBased(i), contListIter->Data)
+			contListIter = contListIter->Forward
+		Next
+
+		dim contList2 As IntegerHolderLinkedList = @arrayList
+		Dim As IntegerHolderLLNode contList2Head = contList2.Head, contList2Iter = contList2Head
+		For i = LBound(numArray) To UBound(numArray)
+			CU_ASSERT_EQUAL(numArray(i), contList2Iter->Data)
+			contList2Iter = contList2Iter->Forward
+		Next
+
+		Dim fromEmptyContainerList As IntegerHolderLinkedList = @newEmptyList
+		CU_ASSERT_EQUAL(fromEmptyContainerList.Count, 0)
+	END_TEST
+	
+	TEST(AddHead)
+		dim singleItemList As IntegerHolderLinkedList
+		dim temp As One.Two.IntegerHolder = (78)
+		dim As IntegerHolderLLNode pPrevHead = singleItemList.AddHead(temp), pNewHead, pFirstNode = pPrevHead
+		CU_ASSERT_EQUAL(singleItemList.Head->Data.num, 78)
+		CU_ASSERT_EQUAL(pPrevHead, singleItemList.Head)
+		'' circular list with one node points to itself
+		CU_ASSERT_EQUAL(pPrevHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pPrevHead)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		
+		temp.num = -78 : pNewHead = singleItemList.AddHead(temp)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, temp)
+		CU_ASSERT_EQUAL(pNewHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pNewHead->Back, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pNewHead)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		CU_ASSERT_EQUAL(pFirstNode->Forward, pNewHead)
+		pPrevHead = pNewHead
+		
+		temp.num = 35 : pNewHead = singleItemList.AddHead(temp)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data.num, 35)
+		CU_ASSERT_EQUAL(pNewHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pNewHead->Back, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pNewHead)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		CU_ASSERT_EQUAL(pFirstNode->Forward, pNewHead)
+		pPrevHead = pNewHead
+		
+		temp.num = -87 : pNewHead = singleItemList.AddHead(temp)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, temp)
+		CU_ASSERT_EQUAL(pNewHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pNewHead->Back, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pNewHead)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		CU_ASSERT_EQUAL(pFirstNode->Forward, pNewHead)
+		CU_ASSERT_EQUAL(singleItemList.Count, 4)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		
+		singleItemList.RemoveNode(pNewHead)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data.num, 35)
+		CU_ASSERT_EQUAL(singleItemList.Head, pPrevHead)		
+		
+		temp.num = 123456 : pNewHead = singleItemList.AddHead(temp)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data.num, 123456)
+		CU_ASSERT_EQUAL(pNewHead->Forward, pPrevHead)
+		CU_ASSERT_EQUAL(pNewHead->Back, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevHead->Back, pNewHead)
+		CU_ASSERT_EQUAL(pNewHead, singleItemList.Head)
+		CU_ASSERT_EQUAL(pFirstNode->Forward, pNewHead)
+		
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data.num, 35)
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data.num, -78)
+		singleItemList.RemoveNode(singleItemList.Head)
+		singleItemList.Clear()
+		
+		temp.num = 19 : singleItemList += temp
+		CU_ASSERT_EQUAL(singleItemList.Head->Data, temp)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		temp.num = 99 : singleItemList += temp
+		CU_ASSERT_EQUAL(singleItemList.Head->Data.num, 19)
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Head->Data.num, 99)
+	END_TEST
+	
+	TEST(AddTail)
+		dim singleItemList As IntegerHolderLinkedList
+		dim temp As One.Two.IntegerHolder = (78)
+		dim As IntegerHolderLLNode pPrevTail = singleItemList.AddTail(temp), pNewTail, pFirstNode = pPrevTail
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, 78)
+		CU_ASSERT_EQUAL(pPrevTail, singleItemList.Tail)
+		'' circular list with one node points to itself
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pPrevTail)
+		CU_ASSERT_EQUAL(pPrevTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, 78)
+		
+		temp.num = -78 : pNewTail = singleItemList.AddTail(temp)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, temp)
+		CU_ASSERT_EQUAL(pNewTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(pNewTail->Forward, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pNewTail)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		CU_ASSERT_EQUAL(pFirstNode->Back, pNewTail)
+		pPrevTail = pNewTail
+		
+		temp.num = 35 : pNewTail = singleItemList.AddTail(temp)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, 35)
+		CU_ASSERT_EQUAL(pNewTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(pNewTail->Forward, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pNewTail)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		CU_ASSERT_EQUAL(pFirstNode->Back, pNewTail)
+		pPrevTail = pNewTail
+		
+		temp.num = -87 : pNewTail = singleItemList.AddTail(temp)
+		CU_ASSERT_EQUAL(pNewTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(pNewTail->Forward, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pNewTail)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		CU_ASSERT_EQUAL(pFirstNode->Back, pNewTail)
+		CU_ASSERT_EQUAL(singleItemList.Count, 4)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, -87)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		
+		singleItemList.RemoveNode(pNewTail)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, 35)
+		CU_ASSERT_EQUAL(singleItemList.Tail, pPrevTail)		
+		
+		temp.num = 123456 : pNewTail = singleItemList.AddTail(temp)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, 123456)
+		CU_ASSERT_EQUAL(pNewTail->Back, pPrevTail)
+		CU_ASSERT_EQUAL(pNewTail->Forward, pFirstNode)
+		CU_ASSERT_EQUAL(pPrevTail->Forward, pNewTail)
+		CU_ASSERT_EQUAL(pNewTail, singleItemList.Tail)
+		CU_ASSERT_EQUAL(pFirstNode->Back, pNewTail)
+		
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, 35)
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, -78)
+		singleItemList.RemoveNode(singleItemList.Tail)
+		singleItemList.Clear()
+		
+		temp.num = 19 : singleItemList += temp
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, 19)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		temp.num = 99 : singleItemList += temp
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data, temp)
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Tail->Data.num, 19)
+	END_TEST
+	
+	TEST(AddAfter)
+		dim singleItemList As IntegerHolderLinkedList
+		Dim temp As One.Two.IntegerHolder
+		Dim i As Long
+		dim values(7 To 11) As One.Two.IntegerHolder
+		dim arrLBound As Long = LBound(values)
+		dim arrUBound As Long = UBound(values)
+		For i = arrLBound To arrUBound
+			values(i).num = i * 2
+		Next
+		dim pPrevNode As IntegerHolderLLNode = 0
+		dim numAdded As Long = 0
+		For i = arrLBound to arrUBound
+			dim pNewNode As IntegerHolderLLNode = singleItemList.AddAfter(values(i), pPrevNode)
+			numAdded += 1
+			CU_ASSERT_EQUAL(singleItemList.Count, numAdded)
+			If i > arrLBound Then
+				CU_ASSERT_EQUAL(pNewNode->Back, pPrevNode)
+				CU_ASSERT_EQUAL(pNewNode->Forward, singleItemList.Head)
+				CU_ASSERT_EQUAL(pPrevNode->Forward, pNewNode)
+			Else
+				CU_ASSERT_EQUAL(pNewNode->Back, pNewNode)
+				CU_ASSERT_EQUAL(pNewNode->Forward, singleItemList.Head)
+				CU_ASSERT_EQUAL(pNewNode->Forward, pNewNode)
+				CU_ASSERT_EQUAL(pNewNode, singleItemList.Head)
+				CU_ASSERT_EQUAL(pNewNode, singleItemList.Tail)
+			End If
+			dim pRevIter As IntegerHolderLLNode = pNewNode
+			For j As Long = i To arrLBound Step -1
+				CU_ASSERT_EQUAL(pRevIter->Data.num, j * 2)
+				pRevIter = pRevIter->Back
+			Next
+			pPrevNode = pNewNode
+		Next
+		'' Trying to add after a node that belongs to a different list is an error
+		'' (since it could then be the head of one list and a node in a different list
+		'' which would eventually be deleted twice)
+		temp = 47575
+		dim tempList As IntegerHolderLinkedList
+		dim As IntegerHolderLLNode tempNode = tempList.AddHead(temp), errNode
+		On Local Error Goto nextTest
+		dim localErr As Long
+		Err = 0
+		temp = 87 : errNode = singleItemList.AddAfter(temp, tempNode)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		CU_ASSERT_EQUAL(errNode, 0)
+	nextTest:
+		On Local Error Goto 0
+		singleItemList.Clear()
+		
+		dim pNode(0 To 3) As IntegerHolderLLNode
+		dim toInsert(0 To 3) As One.Two.IntegerHolder
+		temp.num = 5437 : pNode(0) = singleItemList.AddHead(temp)
+		temp.num = 96437 : pNode(1) = singleItemList.AddTail(temp)
+		temp.num = 1 : pNode(2) = singleItemList.AddAfter(temp, pNode(1))
+		pNode(3) = singleItemList.Tail
+		CU_ASSERT_EQUAL(pNode(2)->Back, pNode(1))
+		CU_ASSERT_EQUAL(pNode(2)->Forward, pNode(0))
+		CU_ASSERT_EQUAL(pNode(1)->Forward, pNode(2))
+		
+		For i = LBound(pNode) to UBound(pNode)
+			toInsert(i).num = 9 + i
+		Next
+		dim pInsert As IntegerHolderLLNode
+		For i = LBound(pNode) to UBound(pNode)
+			pInsert = singleItemList.AddAfter(toInsert(i), pNode(i))
+			CU_ASSERT_EQUAL(pNode(i)->Forward, pInsert)
+			CU_ASSERT_EQUAL(pInsert->Back, pNode(i))
+		Next
+		
+		'' AddAfter Null adds to the Head (ie it's not after anything)
+		temp.num = 89 : pInsert = singleItemList.AddAfter(temp, 0)
+		CU_ASSERT_EQUAL(singleItemList.Head, pInsert)
+		CU_ASSERT_EQUAL(singleItemList.Tail, pInsert->Back)
+		CU_ASSERT_EQUAL(pNode(0)->Back, pInsert)
+		CU_ASSERT_EQUAL(pNode(0), pInsert->Forward)
+		
+		dim pIter As IntegerHolderLLNode = singleItemList.Head
+		dim listSize As Long = singleItemList.Count
+		dim listData(0 to listSize - 1) As One.Two.IntegerHolder
+		listData(0).num = 89
+		listData(1).num = 5437
+		listData(2).num = 9
+		listData(3).num = 96437
+		listData(4).num = 10
+		listData(5).num = 1
+		listData(6).num = 12
+		listData(7).num = 11
+		For i = 0 to listSize - 1
+			CU_ASSERT_EQUAL(pIter->Data, listData(i))
+			pIter = pIter->Forward
+		Next
+	END_TEST
+	
+	TEST(AddBefore)
+		dim singleItemList As IntegerHolderLinkedList
+		dim temp As One.Two.IntegerHolder
+		Dim i As Long
+		dim values(7 To 11) As One.Two.IntegerHolder
+		dim arrLBound As Long = LBound(values)
+		dim arrUBound As Long = UBound(values)
+		For i = arrLBound To arrUBound
+			values(i).num = i * 2
+		Next
+		dim pPrevNode As IntegerHolderLLNode = 0
+		dim numAdded As Long = 0
+
+		For i = arrLBound to arrUBound
+			dim pNewNode As IntegerHolderLLNode = singleItemList.AddBefore(values(i), pPrevNode)
+			numAdded += 1
+			CU_ASSERT_EQUAL(singleItemList.Count, numAdded)
+			If i > arrLBound Then
+				CU_ASSERT_EQUAL(pNewNode->Back, singleItemList.Tail)
+				CU_ASSERT_EQUAL(pNewNode->Forward, pPrevNode)
+				CU_ASSERT_EQUAL(pPrevNode->Back, pNewNode)
+			Else
+				CU_ASSERT_EQUAL(pNewNode->Back, pNewNode)
+				CU_ASSERT_EQUAL(pNewNode->Forward, singleItemList.Head)
+				CU_ASSERT_EQUAL(pNewNode->Forward, pNewNode)
+				CU_ASSERT_EQUAL(pNewNode, singleItemList.Head)
+				CU_ASSERT_EQUAL(pNewNode, singleItemList.Tail)
+			End If
+			dim pRevIter As IntegerHolderLLNode = pNewNode
+			For j As Long = i To arrLBound Step -1
+				CU_ASSERT_EQUAL(pRevIter->Data.num, j * 2)
+				pRevIter = pRevIter->Forward
+			Next
+			pPrevNode = pNewNode
+		Next
+		'' Trying to add after a node that belongs to a different list is an error
+		'' (since it could then be the head of one list and a node in a different list
+		'' which would eventually be deleted twice)
+		temp = 47575
+		dim tempList As IntegerHolderLinkedList
+		dim As IntegerHolderLLNode tempNode = tempList.AddHead(temp), errNode
+		On Local Error Goto nextTest
+		dim localErr As Long
+		Err = 0
+		temp = 87 : errNode = singleItemList.AddAfter(temp, tempNode)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		CU_ASSERT_EQUAL(errNode, 0)
+	nextTest:
+		On Local Error Goto 0
+		singleItemList.Clear()
+
+		dim pNode(0 To 3) As IntegerHolderLLNode
+		dim toInsert(0 To 3) As One.Two.IntegerHolder
+		temp.num = 5437 : pNode(1) = singleItemList.AddHead(temp)
+		temp.num = 96437 : pNode(2) = singleItemList.AddTail(temp)
+		temp.num = 1 : pNode(3) = singleItemList.AddAfter(temp, pNode(1))
+		pNode(0) = singleItemList.Head
+		CU_ASSERT_EQUAL(pNode(2)->Back, pNode(3))
+		CU_ASSERT_EQUAL(pNode(2)->Forward, pNode(0))
+		CU_ASSERT_EQUAL(pNode(1)->Forward, pNode(3))
+
+		For i = LBound(pNode) to UBound(pNode)
+			toInsert(i).num = 9 + i
+		Next
+		dim pInsert As IntegerHolderLLNode
+		For i = LBound(pNode) to UBound(pNode)
+			pInsert = singleItemList.AddBefore(toInsert(i), pNode(i))
+			CU_ASSERT_EQUAL(pNode(i)->Back, pInsert)
+			CU_ASSERT_EQUAL(pInsert->Forward, pNode(i))
+		Next
+		'' AddBefore Null adds to the Tail (ie it's not before anything)
+		temp.num = 89 : pInsert = singleItemList.AddBefore(temp, 0)
+		CU_ASSERT_EQUAL(singleItemList.Tail, pInsert)
+		CU_ASSERT_EQUAL(singleItemList.Head, pInsert->Forward)
+		CU_ASSERT_EQUAL(pNode(2)->Forward, pInsert)
+		CU_ASSERT_EQUAL(pNode(2), pInsert->Back)
+
+		dim pIter As IntegerHolderLLNode = singleItemList.Head
+		dim listSize As Long = singleItemList.Count
+		dim listData(0 to listSize - 1) As One.Two.IntegerHolder
+		listData(0).num = 9
+		listData(1).num = 10
+		listData(2).num = 5437
+		listData(3).num = 12
+		listData(4).num = 1
+		listData(5).num = 11
+		listData(6).num = 96437
+		listData(7).num = 89
+		For i = 0 to listSize - 1
+			CU_ASSERT_EQUAL(pIter->Data, listData(i))
+			pIter = pIter->Forward
+		Next
+	END_TEST
+	
+	TEST(Clear)
+		dim singleItemList As IntegerHolderLinkedList
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemList.AddHead(temp)
+		temp.num = -78 : singleItemList.AddTail(temp)
+		dim listSize As Long = singleItemList.Count
+		singleItemList.Clear()
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		CU_ASSERT(singleItemList.Count <> listSize)
+		listSize = singleItemList.Count
+		singleItemList.Clear()
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		CU_ASSERT_EQUAL(singleItemList.Count, listSize)
+		dim list2 As IntegerHolderLinkedList	
+		list2.Clear()
+		CU_ASSERT_EQUAL(list2.Count, 0)
+	END_TEST
+	
+	TEST(Contains)
+		dim haystack As IntegerHolderLinkedList
+		dim needle As One.Two.IntegerHolder = (78)
+		dim temp As One.Two.IntegerHolder
+		dim As IntegerHolderLLNode needleNode, node52
+		dim result As Boolean
+		result = haystack.Contains(0)
+		CU_ASSERT_EQUAL(result, False)
+		needleNode = haystack.AddHead(needle)
+		temp.num = -needle.num : haystack.AddTail(temp)
+		temp.num = 52 : node52 = haystack.AddTail(temp)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.RemoveNode(needleNode)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.RemoveNode(haystack.Head)
+		result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.RemoveNode(node52)
+		result = haystack.Contains(52)
+		CU_ASSERT_EQUAL(result, False)
+		Dim generate100 As SequentialIntegerHolderGenerator = Type(100, 100)
+		dim secondHaystack As IntegerHolderLinkedList = @generate100
+		temp.num = 157 : result = secondHaystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+	END_TEST
+	
+	TEST(CopyTo)
+		dim singleItemList As IntegerHolderLinkedList
+		dim temp As One.Two.IntegerHolder
+		dim i As Long
+		temp.num = 78 : singleItemList.AddTail(temp)
+		temp.num = -78 : singleItemList.AddTail(temp)
+		temp.num = 8537536 : singleItemList.AddTail(temp)
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As One.Two.IntegerHolder
+		singleItemList.CopyTo(undimmedArr())
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, singleItemList.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		Dim pIter As IntegerHolderLLNode = singleItemList.Head
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr(i), pIter->Data)
+			pIter = pIter->Forward
+		Next
+		
+		'' Except in empty lists, where nothing happens
+		'' If container debug is defined, this calls Error
+		dim emptyQueue As IntegerHolderLinkedList
+		dim emptyArr(Any) As One.Two.IntegerHolder
+		On Local Error Goto nextTest1
+		dim localErr As Long
+		Err = 0
+		emptyQueue.CopyTo(emptyArr())
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+
+	nextTest1:
+		On Local Error Goto 0	
+		'' already sized arrays copy the number of items in the list or the size of the array
+		'' whichever is smaller
+		dim largerThanContArr(10 To 14) As One.Two.IntegerHolder
+		For i = 10 To 14
+			largerThanContArr(i) = i
+		Next
+		singleItemList.CopyTo(largerThanContArr())
+		arrUBound = UBound(largerThanContArr)
+		arrLBound = LBound(largerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 5)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 14)
+		pIter = singleItemList.Head
+		For i = 10 To 14
+			dim value As One.Two.IntegerHolder = i
+			If i <= 12 Then
+				value = pIter->Data
+				pIter = pIter->Forward
+			End If
+			CU_ASSERT_EQUAL(largerThanContArr(i), value)
+		Next
+		
+		dim smallerThanContArr(21 To 22) As One.Two.IntegerHolder
+		For i = 21 To 22
+			smallerThanContArr(i).num = i
+		Next
+		temp.num = 4 : singleItemList.AddTail(temp)
+		singleItemList.CopyTo(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 2)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 22)
+		pIter = singleItemList.Head
+		For i = 21 To 22
+			CU_ASSERT_EQUAL(smallerThanContArr(i), pIter->Data)
+			pIter = pIter->Forward
+		Next
+	END_TEST
+	
+	TEST(FindTest)
+		dim As IntegerHolderLinkedList singleItemList, otherList
+		dim As IntegerHolderLLNode findRet, findRet2
+		dim i As Long
+		dim temp As One.Two.IntegerHolder
+		temp = 78 : singleItemList.AddTail(temp)
+		temp = -78 : singleItemList.AddTail(temp)
+		temp = 8537536 : singleItemList.AddTail(temp)
+		temp = -78 : findRet = singleItemList.Find(temp, 0)
+		CU_ASSERT(findRet <> 0)
+		CU_ASSERT_EQUAL(findRet->Data.num, -78)
+		findRet2 = singleItemList.Find(temp, findRet)
+		CU_ASSERT(findRet2 <> 0)
+		CU_ASSERT_EQUAL(findRet2->Data.num, -78)
+		CU_ASSERT_EQUAL(findRet2, findRet)
+		singleItemList.RemoveNode(findRet)
+		findRet2 = singleItemList.Find(temp, 0)
+		CU_ASSERT_EQUAL(findRet2, 0)
+		
+		findRet = otherList.Find(0, 0)
+		CU_ASSERT_EQUAL(findRet, 0)
+		
+		findRet2 = singleItemList.Head
+		temp = 987655 : otherList.AddHead(temp)
+		Dim localErr As Long
+		On Local Error Goto nextTest
+		Err = 0
+		'' finding using a foreign list node is an error
+		findRet = otherList.Find(temp, findRet2)
+		localErr = Err
+		CU_ASSERT_EQUAL(findRet, 0)
+		CU_ASSERT_EQUAL(localErr, 1)
+	nextTest:
+		On Local Error Goto 0
+		dim As IntegerHolderLLNode startNode = singleItemList.Head, iterNode = startNode
+		For i = 0 To singleItemList.Count - 1
+			findRet = singleItemList.Find(iterNode->Data, startNode)
+			CU_ASSERT_EQUAL(findRet, iterNode)
+			CU_ASSERT_EQUAL(findRet->Data, iterNode->Data)
+			iterNode = iterNode->Forward
+		Next
+		startNode = singleItemList.Tail
+		iterNode = singleItemList.Head
+		For i = 0 To singleItemList.Count - 1
+			findRet = singleItemList.Find(iterNode->Data, startNode)
+			CU_ASSERT_EQUAL(findRet, iterNode)
+			CU_ASSERT_EQUAL(findRet->Data, iterNode->Data)
+			iterNode = iterNode->Forward
+		Next
+		
+		temp = -937537 : findRet = singleItemList.Find(temp, 0)
+		CU_ASSERT_EQUAL(findRet, 0)
+	END_TEST
+	
+	Private Sub TestContainerIter(ByRef list As IntegerHolderLinkedList)
+		dim pListIter As FB_IIterator(One, Two, IntegerHolder) Ptr = list.GetIterator()
+		dim As IntegerHolderLLNode pHead = list.Head, pNode = pHead
+		While pListIter->Advance()
+			CU_ASSERT_EQUAL(pNode->Data, pListIter->Item())
+			pNode = pNode->Forward
+		Wend
+		CU_ASSERT_EQUAL(pNode, pHead)
+		Delete pListIter
+	End Sub
+	
+	TEST(GetIterator)
+		dim list As IntegerHolderLinkedList
+		dim pListIter As FB_IIterator(One, Two, IntegerHolder) Ptr = list.GetIterator()
+		dim temp As One.Two.IntegerHolder
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+		pListIter = 0
+		temp.num = 7 : list.AddTail(temp)
+		pListIter = list.GetIterator()
+		dim pListIter2 As FB_IIterator(One, Two, IntegerHolder) Ptr = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter2 <> 0)
+		CU_ASSERT(pListIter <> pListIter2)
+		CU_ASSERT(pListIter->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT(pListIter2->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT_EQUAL(pListIter2->Item(), 7)
+		pListIter->Reset()
+		TestContainerIter(pListIter)
+		pListIter2->Reset()
+		TestContainerIter(pListIter2)
+		Delete pListIter
+		Delete pListIter2
+		pListIter = 0
+		pListIter2 = 0
+		list.Clear()
+		Dim i As Long
+		For i = 0 To 6
+			temp.num = i
+			list.AddHead(temp)
+		Next
+		pListIter = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		For i = 6 To 0 Step -1
+			CU_ASSERT(pListIter->Advance() = True)
+			CU_ASSERT_EQUAL(pListIter->Item().num, i)
+		Next
+		CU_ASSERT(pListIter->Advance() = False)
+		pListIter->Reset()
+		TestContainerIter(pListIter)
+		Delete pListIter
+	END_TEST
+	
+	Private Function DoesNodeExist(Byref list As IntegerHolderLinkedList, ByVal pNode As IntegerHolderLLNode) As Boolean
+		dim As IntegerHolderLLNode pHead = list.Head, pIter = pHead
+		dim found As Boolean
+		If pHead <> 0 Then
+			Do
+				found = (pIter = pNode)
+				pIter = pIter->Forward
+			Loop While (pIter <> pHead) AndAlso (found = False)
+		End If
+		Return found
+	End Function
+	
+	TEST(RemoveNode)
+		dim singleItemList As IntegerHolderLinkedList
+		dim pNodes(0 To 2) As IntegerHolderLLNode
+		dim temp As One.Two.IntegerHolder
+		dim i As Long
+		temp = 78 : pNodes(0) = singleItemList.AddTail(temp)
+		temp = -78 : pNodes(1) = singleItemList.AddTail(temp)
+		temp = 8537536 : pNodes(2) = singleItemList.AddTail(temp)
+		dim listSize As Long = singleItemList.Count
+		
+		CU_ASSERT_EQUAL(pNodes(2)->Forward, pNodes(0))
+		CU_ASSERT_EQUAL(pNodes(1)->Back, pNodes(0))
+		singleItemList.RemoveNode(pNodes(0))
+		CU_ASSERT_EQUAL(singleItemList.Count, listSize - 1)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(0)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(1)), True)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(2)), True)
+		CU_ASSERT(pNodes(2)->Forward <> pNodes(0))
+		CU_ASSERT(pNodes(1)->Back <> pNodes(0))
+		
+		CU_ASSERT(pNodes(2)->Forward = pNodes(1))
+		CU_ASSERT(pNodes(2)->Back = pNodes(1))
+		singleItemList.RemoveNode(pNodes(1))
+		CU_ASSERT_EQUAL(singleItemList.Count, listSize - 2)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(0)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(1)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(2)), True)
+		CU_ASSERT(pNodes(2)->Forward <> pNodes(1))
+		CU_ASSERT(pNodes(2)->Back <> pNodes(1))
+		
+		CU_ASSERT(pNodes(2)->Forward = pNodes(2))
+		CU_ASSERT(pNodes(2)->Back = pNodes(2))
+		singleItemList.RemoveNode(pNodes(2))
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(0)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(1)), False)
+		CU_ASSERT_EQUAL(DoesNodeExist(singleItemList, pNodes(2)), False)
+		CU_ASSERT(singleItemList.Head = 0)
+		
+		temp = 78 : pNodes(0) = singleItemList.AddTail(temp)
+		temp = -78 : pNodes(1) = singleItemList.AddTail(temp)
+		temp = 8537536 : pNodes(2) = singleItemList.AddTail(temp)
+		dim otherList As IntegerHolderLinkedList
+		dim As IntegerHolderLLNode otherListNode = otherList.AddHead(0), removeRet
+		'' trying to remove a node that belongs to a different list
+		'' is an error
+		On Local Error Goto nextTest
+		dim localErr As Long
+		Err = 0
+		removeRet = singleItemList.RemoveNode(otherListNode)
+		localErr = Err
+		CU_ASSERT_EQUAL(removeRet, 0)
+		CU_ASSERT_EQUAL(localErr, 1)
+	nextTest:
+		On Local Error Goto 0
+
+		removeRet = singleItemList.RemoveNode(pNodes(0))
+		CU_ASSERT_EQUAL(removeRet, pNodes(1))
+		CU_ASSERT_EQUAL(removeRet, singleItemList.Head)
+		listSize = singleItemList.Count
+		
+		'' RemoveNode 0 does nothing
+		removeRet = singleItemList.RemoveNode(0)
+		CU_ASSERT_EQUAL(removeRet, 0)
+		CU_ASSERT_EQUAL(listSize, singleItemList.Count)
+		
+		removeRet = singleItemList.RemoveNode(pNodes(1))
+		CU_ASSERT_EQUAL(removeRet, pNodes(2))
+		CU_ASSERT_EQUAL(removeRet, singleItemList.Head)
+		CU_ASSERT_EQUAL(listSize - 1, singleItemList.Count)
+		CU_ASSERT_EQUAL(1, singleItemList.Count)
+		
+		removeRet = singleItemList.RemoveNode(pNodes(2))
+		CU_ASSERT_EQUAL(removeRet, 0)
+		CU_ASSERT_EQUAL(removeRet, singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Empty(), True)
+	END_TEST
+	
+	TEST(LenTest)
+		dim singleItemList As IntegerHolderLinkedList
+		dim temp As One.Two.IntegerHolder
+		temp = 78 : singleItemList.AddHead(temp)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		temp = -78 : singleItemList.AddTail(temp)
+		temp = 35 : singleItemList.AddTail(temp)
+		temp = -87 : singleItemList.AddHead(temp)
+		CU_ASSERT_EQUAL(singleItemList.Count, 4)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Count, 3)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Tail)
+		singleItemList.Clear()
+		temp = 19 : singleItemList += temp
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		temp = 99 : singleItemList += temp
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Count, 1)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+		singleItemList.RemoveNode(singleItemList.Tail)
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		CU_ASSERT_EQUAL(singleItemList.Count, Len(singleItemList))
+	END_TEST
+
+	TEST(Empty)
+		dim singleItemList As IntegerHolderLinkedList
+		dim temp As One.Two.IntegerHolder = (78)
+		CU_ASSERT_EQUAL(singleItemList.Empty(), True)
+		singleItemList.AddHead(temp)
+		CU_ASSERT_EQUAL(singleItemList.Empty(), False)
+		singleItemList.RemoveNode(singleItemList.Head)
+		CU_ASSERT_EQUAL(singleItemList.Empty(), True)
+		Dim arr(0 To 1) As One.Two.IntegerHolder
+		dim otherQueue As IntegerHolderLinkedList = arr()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), False)
+		dim pHead As IntegerHolderLLNode = singleItemList.Head
+		temp = 30 : singleItemList.AddAfter(temp, pHead)
+		CU_ASSERT_EQUAL(otherQueue.Empty(), False)
+		otherQueue.Clear()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), True)
+	END_TEST
+	
+	TEST(LetTest)
+		dim As IntegerHolderLinkedList list1, list2
+		dim temp As One.Two.IntegerHolder = (8586)
+		list1.AddTail(temp)
+		temp = 2 : list1.AddTail(temp)
+		CU_ASSERT(list1.Count <> list2.Count)
+		list2 = list1
+		CU_ASSERT_EQUAL(list1.Count, list2.Count)
+		CU_ASSERT_EQUAL(list1.Head->Data, list2.Head->Data)
+		CU_ASSERT_EQUAL(list1.Tail->Data, list2.Tail->Data)
+		list2.Clear()
+		CU_ASSERT(list1.Count <> list2.Count)
+		CU_ASSERT(list1.Head <> 0)
+		CU_ASSERT(list2.Head = 0)
+		list1 = list2
+		CU_ASSERT_EQUAL(list1.Count, list2.Count)
+		CU_ASSERT_EQUAL(list1.Head, 0)
+		CU_ASSERT_EQUAL(list2.Head, 0)
+		temp = 9478 : list2.AddHead(temp)
+		CU_ASSERT(list1.Count <> list2.Count)
+		CU_ASSERT(list2.Head <> 0)
+		CU_ASSERT(list1.Head = 0)
+		list1 = list2
+		CU_ASSERT_EQUAL(list1.Count, list2.Count)
+		CU_ASSERT(list1.Head <> 0)
+		CU_ASSERT(list2.Head <> 0)
+		CU_ASSERT(list1.Head <> list2.Head)
+		CU_ASSERT_EQUAL(list1.Head->Data, list2.Head->Data)
+	END_TEST
+END_SUITE

--- a/tests/containers/ListTestPrimitive.bas
+++ b/tests/containers/ListTestPrimitive.bas
@@ -1,0 +1,1202 @@
+''#define FB_CONTAINER_DEBUG 1
+#include "../../inc/containers/List.bi"
+#include "ContainerTestPrereqs.bi"
+#include "fbcunit.bi"
+
+FBCont_DefineListOf(Long)
+Type LongList As FB_List(Long)
+
+SUITE(fbc_tests.containers.lists.primitive)
+	TEST(ConstructorTest)
+		dim emptyList As LongList
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+		dim emptyIterator As SequentialLongGenerator = Type(0, 1)
+
+		Dim zt1NumToGenerate As Long = 15
+		Dim zt1StartNum As Long = 0
+		Dim i As Long
+		Dim zeroTo14Iterator As SequentialLongGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 7
+		Dim tt2StartNum As Long = 203
+		Dim twoHundred3To210Iterator As SequentialLongGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		'' Iterator constructor
+		Dim zt1List As LongList = zeroTo14Iterator
+		For i = 0 To zt1NumToGenerate - 1
+			CU_ASSERT_EQUAL(zt1List[i], zt1StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(zt1List.Count, zt1NumToGenerate)
+		
+		Dim tt2List As LongList = twoHundred3To210Iterator
+		For i = 0 To tt2NumToGenerate - 1
+			CU_ASSERT_EQUAL(tt2List[i], tt2StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(tt2List.Count, tt2NumToGenerate)
+		
+		zeroTo14Iterator.Reset()
+		Dim zt1List2 As LongList = zeroTo14Iterator
+		For i = 0 To zt1NumToGenerate - 1
+			CU_ASSERT_EQUAL(zt1List2[i], zt1List[i])
+		Next
+		CU_ASSERT_EQUAL(zt1List.Count, zt1List2.Count)
+		
+		twoHundred3To210Iterator.Reset()
+		Dim tt2List2 As LongList = twoHundred3To210Iterator
+		For i = 0 To tt2NumToGenerate - 1
+			CU_ASSERT_EQUAL(tt2List[i], tt2StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(tt2List2.Count, tt2List.Count)
+		
+		dim newEmptyList As LongList = emptyIterator
+		CU_ASSERT_EQUAL(newEmptyList.Count, 0)
+		emptyIterator.Reset()
+		
+		'' Container Constructor
+		Dim zt1ListCopy As LongList = zt1List
+		For i = 0 To zt1List.Count - 1
+			CU_ASSERT_EQUAL(zt1ListCopy[i], zt1List[i])
+		Next
+		CU_ASSERT_EQUAL(zt1ListCopy.Count, zt1List.Count)
+		
+		Dim tt2ListCopy As LongList = tt2List
+		For i = 0 To tt2List.Count - 1
+			CU_ASSERT_EQUAL(tt2ListCopy[i], tt2List[i])
+		Next
+		CU_ASSERT_EQUAL(tt2ListCopy.Count, tt2List.Count)
+		
+		Dim fromEmptyContainerList As LongList = @newEmptyList
+		CU_ASSERT_EQUAL(fromEmptyContainerList.Count, 0)
+		
+		dim numArray(7) As Long
+		dim numArrayLBound As Long = LBound(numArray)
+		dim numArrayUBound As Long = UBound(numArray)
+		dim arraySize As Long = numArrayUBound - numArrayLBound + 1
+		For i = numArrayLBound To numArrayUBound
+			numArray(i) = i
+		Next
+		
+		Dim arrayList As LongList = numArray()
+		For i = 0 To arraySize - 1
+			CU_ASSERT_EQUAL(arrayList[i], numArray(numArrayLBound + i))
+		Next
+		CU_ASSERT_EQUAL(arrayList.Count, arraySize)
+		
+		
+		dim numArrayBased(5 To 9) As Long
+		numArrayLBound = LBound(numArrayBased)
+		numArrayUBound = UBound(numArrayBased)
+		arraySize = numArrayUBound - numArrayLBound + 1
+		For i = numArrayLBound To numArrayUBound
+			numArrayBased(i) = i
+		Next
+		
+		Dim arrayListBased As LongList = numArrayBased()
+		For i = 0 To arraySize - 1
+			CU_ASSERT_EQUAL(arrayListBased[i], numArrayBased(numArrayLBound + i))
+		Next
+		CU_ASSERT_EQUAL(arrayListBased.Count, arraySize)
+		
+		dim undimmedArray(Any) As Long
+		dim anyArrayList As LongList = undimmedArray()
+		CU_ASSERT_EQUAL(anyArrayList.Count, 0)
+		
+	END_TEST
+	
+	TEST(Add)
+	
+		'' single item
+		dim i As Long
+		dim singleItemList As LongList
+		singleItemList.Add(78)
+		singleItemList.Add(-78)
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		CU_ASSERT_EQUAL(singleItemList[0], 78)
+		CU_ASSERT_EQUAL(singleItemList[1], -78)
+		singleItemList.Remove(78)
+		singleItemList.Add(123456)
+		CU_ASSERT_EQUAL(singleItemList[0], -78)
+		CU_ASSERT_EQUAL(singleItemList[1], 123456)
+		
+		'' Whole Array Add
+		dim emptyArray() As Long
+		dim addArray(0 to 9) As Long
+		dim As LongList emptyList, arrayList
+		'' undimmed arrays do nothing
+		emptyList.Add(emptyArray())
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+		For i = 0 To 9
+			addArray(i) = i
+		Next
+		arrayList.Add(addArray())
+		CU_ASSERT_EQUAL(arrayList.Count, 10)
+		For i = 0 To 9
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i))
+		Next
+		arrayList.Add(emptyArray())
+		CU_ASSERT_EQUAL(arrayList.Count, 10)
+		For i = 0 To 9
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i))
+		Next
+		arrayList.Add(addArray())
+		CU_ASSERT_EQUAL(arrayList.Count, 20)
+		For i = 0 To 19
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i Mod 10))
+		Next
+		
+		''Partial Array Add
+		
+		'' again undimmed arrays do nothing
+		arrayList.Add(emptyArray(), 4, 2)
+		CU_ASSERT_EQUAL(arrayList.Count, 20)
+		
+		'' Trying to add things outside the bounds of the array
+		'' are constrained to the array
+		''
+		'' This should add addArray(9) then stop, since there aren't 14 more elements after that
+		arrayList.Add(addArray(), 9, 15)
+		CU_ASSERT_EQUAL(arrayList.Count, 21)
+		For i = 0 To 19
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i Mod 10))
+		Next
+		CU_ASSERT_EQUAL(arrayList[20], addArray(9))
+		
+		'' This shouldn't add anything, since the start point is outside the bounds
+		arrayList.Add(addArray(), 15, 2)
+		CU_ASSERT_EQUAL(arrayList.Count, 21)
+		
+		arrayList.Add(addArray(), 3, 2)
+		CU_ASSERT_EQUAL(arrayList.Count, 23)
+		For i = 0 To 19
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i Mod 10))
+		Next
+		CU_ASSERT_EQUAL(arrayList[20], addArray(9))
+		CU_ASSERT_EQUAL(arrayList[21], addArray(3))
+		CU_ASSERT_EQUAL(arrayList[22], addArray(4))
+		
+		arrayList.Add(addArray(), 0, 8)
+		CU_ASSERT_EQUAL(arrayList.Count, 31)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(arrayList[23 + i], addArray(i))
+		Next
+		
+		'' Negative start points should also do nothing
+		arrayList.Add(addArray(), -2, 6)
+		CU_ASSERT_EQUAL(arrayList.Count, 31)
+		
+		'' Container Add
+		''
+		dim anotherList As LongList
+		dim invalidListPtr As LongList Ptr = 0
+		anotherList.Add(emptyList)
+		CU_ASSERT_EQUAL(anotherList.Count, emptyList.Count)
+		anotherList.Add(@arrayList)
+		For i = 0 to arrayList.Count - 1
+			CU_ASSERT_EQUAL(anotherList[i], arrayList[i])
+		Next
+		dim anotherListCount As Long = anotherList.Count
+		CU_ASSERT_EQUAL(anotherListCount, arrayList.Count)
+		'' null pointers shouldn't do anything, passing 0 directly
+		'' will use the Add(Long) overload
+		'' If we're compiling with -exx though, it will raise an error
+		'' so we need to catch that 
+		On Local Error Goto afterTest1
+		anotherList.Add(invalidListPtr)
+		CU_ASSERT_EQUAL(anotherListCount, anotherList.Count)
+	afterTest1:
+		
+		'' Iterator Add
+		dim emptyIterator As SequentialLongGenerator = Type(0, 1)
+		dim nullIterator As SequentialLongGenerator Ptr = 0
+		emptyList.Add(emptyIterator)
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+		
+		'' If we're compiling with -exx, it will raise an error
+		'' so we need to catch that 
+		On Local Error Goto afterTest2
+		emptyList.Add(nullIterator)
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+	afterTest2:
+		On Local Error Goto 0
+
+		Dim zt1NumToGenerate As Long = 15
+		Dim zt1StartNum As Long = 0
+		Dim zeroTo14Iterator As SequentialLongGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 7
+		Dim tt2StartNum As Long = 203
+		Dim twoHundred3To210Iterator As SequentialLongGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		Dim zt1List As LongList
+		zt1List.Add(zeroTo14Iterator)
+		For i = 0 To zt1NumToGenerate - 1
+			CU_ASSERT_EQUAL(zt1List[i], zt1StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(zt1List.Count, zt1NumToGenerate)
+		
+		Dim tt2List As LongList
+		tt2List.Add(@twoHundred3To210Iterator)
+		For i = 0 To tt2NumToGenerate - 1
+			CU_ASSERT_EQUAL(tt2List[i], tt2StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(tt2List.Count, tt2NumToGenerate)
+		
+		zeroTo14Iterator.Reset()
+		Dim zt1List2 As LongList
+		zt1List2.Add(@zeroTo14Iterator)
+		For i = 0 To zt1NumToGenerate - 1
+			CU_ASSERT_EQUAL(zt1List2[i], zt1List[i])
+		Next
+		CU_ASSERT_EQUAL(zt1List.Count, zt1List2.Count)
+		
+		twoHundred3To210Iterator.Reset()
+		Dim tt2List2 As LongList
+		tt2List2.Add(twoHundred3To210Iterator)
+		For i = 0 To tt2NumToGenerate - 1
+			CU_ASSERT_EQUAL(tt2List[i], tt2StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(tt2List2.Count, tt2List.Count)
+		
+		dim newEmptyList As LongList
+		newEmptyList.Add(emptyIterator)
+		CU_ASSERT_EQUAL(newEmptyList.Count, 0)
+	
+	END_TEST
+	
+	TEST(Clear)
+		dim singleItemList As LongList
+		singleItemList.Add(78)
+		singleItemList.Add(-78)
+		singleItemList.Clear()
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		singleItemList.Clear()
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		dim list2 As LongList	
+		list2.Clear()
+		CU_ASSERT_EQUAL(list2.Count, 0)
+	END_TEST
+	
+	TEST(Contains)
+		dim haystack As LongList
+		dim needle As Long = 78
+		dim result As Boolean
+		result = haystack.Contains(0)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Add(needle)
+		haystack.Add(-needle)
+		haystack.Add(52)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.Remove(needle)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, False)
+		Dim generate100 As SequentialLongGenerator = Type(100, 100)
+		haystack.Add(@generate100)
+		result = haystack.Contains(157)
+		CU_ASSERT_EQUAL(result, True)
+	END_TEST
+	
+	Private Sub CopyToOOBTest(ByRef list As LongList, ByVal startPoint As Long)
+		Dim i As Long
+		Dim arr(30 To 36) As Long
+		For i = 30 To 36
+			arr(i) = i
+		Next
+		
+		'' It should be invalid
+		Assert((startPoint >= list.Count) OrElse (startPoint < 0))
+		
+		Err = 0
+		'' Will call Error if FB_CONTAINER_DEBUG is defined
+		On Local Error Goto nextTest
+		list.CopyTo(arr(), startPoint, list.Count, 0)
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		For i = 30 To 36
+			CU_ASSERT_EQUAL(arr(i), i)
+		Next
+		
+		nextTest:
+		On Local Error Goto 0
+	End Sub
+	
+	Private Sub CopyToArrTest(_
+		ByRef list As LongList, _
+		ByVal listStart As Long, _
+		ByVal listCount As Long, _
+		ByVal arrayStart As Long, _
+		ByVal useDimmedArr As Boolean, _
+		ByVal arrLDim As Long, _
+		ByVal arrUDim As Long _
+	)
+		dim iterArr(Any) As Long
+		dim listSize As Long = list.Count
+		dim hadError As Boolean = False
+		dim i As Long
+		dim calcListCount As Long = IIf(listCount = -1, listSize, listCount)
+		dim maxListToCopy As Long = listSize - listStart
+		maxListToCopy = IIf(maxListToCopy > calcListCount, calcListCount, maxListToCopy)
+		dim arrSize As Long = (arrUDim - arrLDim) + 1
+		dim maxArrToCopy As Long = IIf(useDimmedArr, arrSize - (arrayStart - arrLDim), maxListToCopy)
+		dim maxToCopy As Long = IIf(maxArrToCopy < maxListToCopy, maxArrToCopy, maxListToCopy)
+
+		If useDimmedArr Then
+			Redim iterArr(arrLDim To arrUDim)
+			For i = arrLDim To arrUDim
+				iterArr(i) = i
+			Next
+		End If
+
+		On Local Error Goto setError
+		Err = 0
+		list.CopyTo(iterArr(), listStart, listCount, arrayStart)
+		hadError = Err <> 0
+	testElems:
+		If useDimmedArr = False Then arrayStart = 0
+		dim arrUBound As Long = UBound(iterArr)
+		dim arrLBound As Long = LBound(iterArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+
+		If useDimmedArr Then
+
+			CU_ASSERT_EQUAL(arrUBound, arrUDim)
+			CU_ASSERT_EQUAL(arrLBound, arrLDim)
+			CU_ASSERT_EQUAL(numElems, (arrUDim - arrLDim) + 1)
+		Else
+			If hadError Then
+
+				CU_ASSERT_EQUAL(arrUBound, -1)
+				CU_ASSERT_EQUAL(arrLBound, 0)
+				CU_ASSERT_EQUAL(numElems, 0)
+			Else
+				CU_ASSERT_EQUAL(arrUBound, maxListToCopy - 1)
+				CU_ASSERT_EQUAL(arrLBound, 0)
+				CU_ASSERT_EQUAL(numElems, maxListToCopy)
+			End If
+		End If
+		If hadError AndAlso useDimmedArr Then
+			'' unchanged
+			For i = 0 To numElems - 1
+				CU_ASSERT_EQUAL(iterArr(arrLBound + i), arrLBound + i)
+			Next
+		Else
+			If hadError = False Then
+				'' unchanged contents from arrLBound to arrayStart, 
+				'' list contents from arrayStart to maxToCopy
+				'' unchanged contents above that
+				Dim listIter As Long = listStart
+				Dim arrIndex As Long = arrLBound
+				For i = arrLBound To arrUBound
+					If (i < arrayStart) OrElse (i > (arrayStart + maxToCopy)) Then
+						CU_ASSERT_EQUAL(iterArr(i), arrIndex)
+						arrIndex += 1
+					Else
+						CU_ASSERT_EQUAL(iterArr(i), list[listIter])
+						listIter += 1
+					End If
+				Next
+			Endif '' hadError And useDimmedArr = false is an empty array that's already been tested above
+		End If
+		Exit Sub
+setError:
+		On Local Error Goto 0
+		hadError = True
+		Goto testElems
+	End Sub
+	
+	TEST(CopyTo)
+		dim singleItemList As LongList
+		dim i As Long
+		singleItemList.Add(78)
+		singleItemList.Add(-78)
+		singleItemList.Add(8537536)
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As Long
+		singleItemList.CopyTo(undimmedArr())
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, singleItemList.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To singleItemList.Count - 1
+			CU_ASSERT_EQUAL(undimmedArr(i), singleItemList[i])
+		Next
+		
+		'' Except in empty lists, where nothing happens
+		'' If container debug is defined, this calls Error
+		dim emptyList As LongList
+		dim emptyArr(Any) As Long
+		On Local Error Goto nextTest1
+		Dim localErr As Long
+		Err = 0
+		emptyList.CopyTo(emptyArr())
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+
+	nextTest1:
+		On Local Error Goto 0
+		'' already sized arrays copy the number of items in the list or the size of the array
+		'' whichever is smaller
+		dim largerThanContArr(10 To 14) As Long
+		For i = 10 To 14
+			largerThanContArr(i) = i
+		Next
+		singleItemList.CopyTo(largerThanContArr())
+		arrUBound = UBound(largerThanContArr)
+		arrLBound = LBound(largerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 5)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 14)
+		For i = 10 To 14
+			CU_ASSERT_EQUAL(largerThanContArr(i), IIf(i <= 12, singleItemList[i - 10], i))
+		Next
+		
+		dim smallerThanContArr(21 To 22) As Long
+		For i = 21 To 22
+			smallerThanContArr(i) = i
+		Next
+		singleItemList.Add(4)
+		singleItemList.CopyTo(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 2)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 22)
+		For i = 21 To 22
+			CU_ASSERT_EQUAL(smallerThanContArr(i), singleItemList[i - 21])
+		Next
+		
+		'' Then the partial copyto
+		dim slg As SequentialLongGenerator = Type(100, 15)
+		dim iterList As LongList = slg
+		dim iterArr(Any) As Long
+		'' negative or or out of range start points don't do anything
+		'' and call Error if the FB_CONTAINER_DEBUG is defined
+		CopyToOOBTest(iterList, -6)
+		CopyToOOBTest(iterList, iterList.Count + 5)
+		
+		'' standard normal all good copy
+		''' Again, undimmed arrays are redimmed to hold all required elements
+		''' With undimmed arrays, the array is dimmed from 0 To n, so the last argument is ignored
+		CopyToArrTest(iterList, 5, 5, 0, False, 0, 0)
+		
+		'' 'listCount too big' test, check it constrains to list size
+		CopyToArrTest(iterList, 2, 15, 0, False, 0, 0)
+		
+		'' 'All too big' test. Copying 15 elements from position 9
+		'' should constrain to 6. Which should then be further constrained
+		'' to 3 since we want to start copying to the array at 19 of 21 spaces
+		CopyToArrTest(iterList, 9, 15, 19, True, 15, 21)
+		
+		'' 'Array too small, in bounds' test. Copying 7 elements from position 4
+		'' should copy 7. Excep that the array is only 4 elements big
+		CopyToArrTest(iterList, 4, 7, 32, True, 32, 35)
+		
+		'' '-1 all good' test. Copying all elements from position 4 should copy 11
+		CopyToArrTest(iterList, 4, -1, 0, False, 32, 35)
+	END_TEST
+	
+	TEST(Empty)
+		dim list As LongList
+		CU_ASSERT_EQUAL(list.Empty(), True)
+		list.Add(7)
+		CU_ASSERT_EQUAL(list.Empty(), False)
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.Empty(), True)
+		Dim arr(0 To 1) As Long
+		list.Insert(0, arr())
+		CU_ASSERT_EQUAL(list.Empty(), False)
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.Empty(), False)
+		list.Clear()
+		CU_ASSERT_EQUAL(list.Empty(), True)
+	END_TEST
+	
+	TEST(FirstTest)
+		dim list As LongList
+		'' Out of bounds calls Error with FB_CONTAINER_DEBUG
+		On Local Error Goto afterError
+		dim first As Long = list.First()
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6) '' out of bounds
+	afterError:
+		list.Add(7)
+		CU_ASSERT_EQUAL(list.First(), 7)
+		list.Add(9)
+		CU_ASSERT_EQUAL(list.First(), 7)
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.First(), 9)
+		Dim arr(0 To 1) As Long
+		list.Insert(0, arr())
+		CU_ASSERT_EQUAL(list.First(), 0)
+		list.RemoveAt(1)
+		CU_ASSERT_EQUAL(list.First(), 0)
+		list.Clear()
+		Err = 0
+		On Local Error Goto afterError2
+		first = list.First()
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6) '' out of bounds
+	afterError2:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(GetIterator)
+		dim list As LongList
+		dim pListIter As FB_IIterator(Long) Ptr = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+		pListIter = 0
+		list.Add(7)
+		pListIter = list.GetIterator()
+		dim pListIter2 As FB_IIterator(Long) Ptr = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter2 <> 0)
+		CU_ASSERT(pListIter <> pListIter2)
+		CU_ASSERT(pListIter->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT(pListIter2->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT_EQUAL(pListIter2->Item(), 7)
+		Delete pListIter
+		Delete pListIter2
+		pListIter = 0
+		pListIter2 = 0
+		list.Clear()
+		Dim arr(0 To 6) As Long
+		Dim i As Long
+		For i = 0 To 6
+			arr(i) = i
+		Next
+		list.Add(arr())
+		pListIter = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		For i = 0 To 6
+			CU_ASSERT(pListIter->Advance() = True)
+			CU_ASSERT_EQUAL(pListIter->Item(), i)
+		Next
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+	END_TEST
+	
+	TEST(IndexOf)
+		dim list As LongList
+		dim i As Long
+		CU_ASSERT_EQUAL(list.IndexOf(0), -1)
+		list.Add(65) '' 0
+		list.Add(65) '' 1
+		list.Add(0) '' 2
+		list.Add(85) '' 3
+		list.Add(69) '' 4
+		For i = 0 to list.Count - 1
+			If i <> 1 Then
+				CU_ASSERT_EQUAL(list.IndexOf(list[i]), i)
+			Else
+				CU_ASSERT_EQUAL(list.IndexOf(list[i]), 0)
+			End If
+		Next
+		list.RemoveAt(0)
+		For i = 0 to list.Count - 1
+			CU_ASSERT_EQUAL(list.IndexOf(list[i]), i)
+		Next
+		CU_ASSERT_EQUAL(list.IndexOf(list.First()), 0)
+		CU_ASSERT_EQUAL(list.IndexOf(list.Last()), list.Count - 1)
+		list.Add(65)
+		CU_ASSERT_EQUAL(list.IndexOf(65), 0)
+		CU_ASSERT_EQUAL(list.IndexOf(58), -1)
+	END_TEST
+	
+	Private Sub InsertArrTest(ByRef theList As LongList, byVal where As Long, arr() As Long, ByVal arrStartPoint As Long, ByVal howMany As Long, byVal useSimpler As Boolean)
+		dim i As Long
+		dim originalListCopy As LongList = theList
+		dim origIter As Long = 0
+		dim localErr As Long
+		dim curSize As Long = theList.Count
+		dim arrLBound As Long = LBound(arr)
+		dim arrUBound As Long = UBound(arr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		
+		On Local Error Goto commonError
+		Err = 0
+		If useSimpler Then
+			theList.Insert(where, arr())
+			arrStartPoint = arrLBound
+			howMany = numElems
+		Else
+			theList.Insert(where, arr(), arrStartPoint, howMany)
+			dim maxToInsert As Long = (arrUBound - arrStartPoint) + 1
+			howMany = Iif(howMany < maxToInsert, howMany, maxToInsert)
+		End If
+		localErr = Err
+		If localErr <> 0 Then
+			CU_ASSERT_EQUAL(localErr, IIf(numElems = 0, 1, 6))
+			CU_ASSERT_EQUAL(theList.Count, originalListCopy.Count)
+			goto commonError
+		End If
+	testElements:
+		'' make the calculations easier now these values have been used in the Insert
+		If where = -1 Then where = originalListCopy.Count
+		dim newCount As Long = theList.Count
+		dim arrIter As Long = 0
+		For i = 0 To newCount - 1
+			If (i < where) OrElse (i >= (where + howMany)) Then
+				CU_ASSERT_EQUAL(theList[i], originalListCopy[origIter])
+				origIter += 1
+			Else
+				dim arrIndex As Long = arrStartPoint + arrIter
+				CU_ASSERT_EQUAL(theList[i], arr(arrIndex))
+				arrIter += 1
+			End If
+		Next
+		Exit Sub
+	commonError:
+		On Local Error Goto 0
+		howMany = 0
+		'' ensure we aways go in the first If in the check loop
+		'' as the list isn't modified on error
+		where = theList.Count
+		Goto testElements
+	End Sub
+	
+	Private Sub TestInsertSingle()
+		dim theList As LongList
+		dim count As Long = theList.Count
+		theList.Insert(-1, 50) '' 50
+		CU_ASSERT(theList.Count > count)
+		CU_ASSERT_EQUAL(theList.Count, 1)
+		theList.Insert(0, 51) '' 51, 50
+		CU_ASSERT_EQUAL(theList.Count, 2)
+		CU_ASSERT_EQUAL(theList[0], 51)
+		CU_ASSERT_EQUAL(theList.Last(), 50)
+		theList.Insert(1, 52) '' 51, 52, 50
+		CU_ASSERT_EQUAL(theList.Count, 3)
+		CU_ASSERT_EQUAL(theList[0], 51)
+		CU_ASSERT_EQUAL(theList[2], 50)
+		CU_ASSERT_EQUAL(theList.Last(), 50)
+		On Local Error Goto afterTest1
+		Err = 0
+		'' out of bounds insert position (except for -1 or Count) causes Error() in -exx builds
+		theList.Insert(43, 43)
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(theList.Count, 3)
+		CU_ASSERT_EQUAL(theList[0], 51)
+		CU_ASSERT_EQUAL(theList[2], 50)
+		CU_ASSERT_EQUAL(theList.Last(), 50)
+	afterTest1:
+		On Local Error Goto 0
+		theList.Insert(-1, 53) '' 53, 51, 52, 50
+		theList.Insert(0, 53) '' 53, 51, 52, 50, 53
+		CU_ASSERT_EQUAL(theList.Count, 5)
+		CU_ASSERT_EQUAL(theList.First(), 53)
+		CU_ASSERT_EQUAL(theList[1], 51)
+		CU_ASSERT_EQUAL(theList[2], 52)
+		CU_ASSERT_EQUAL(theList[3], 50)
+		CU_ASSERT_EQUAL(theList.Last(), 53)
+	End Sub
+	
+	Private Sub InsertContainerTest(Byref list As LongList, ByRef secondList As LongList, ByVal insertPos As Long, ByVal byPtr As Boolean)
+		dim origCount As Long = list.Count
+		dim originalListCopy As LongList = list
+		dim secondListCopy As LongList = secondList
+		dim newCount As Long = secondList.Count
+		dim localErr As Long
+		dim i As Long
+		
+		Err = 0
+		On Local Error Goto commonError
+		If byPtr Then
+			list.Insert(insertPos, @secondList)
+		Else
+			list.Insert(insertPos, secondList)
+		End If
+		localErr = Err
+
+		'' check out of bounds causes the proper error
+		'' -1 and .Count out of bounds are allowed to signal append
+		If (insertPos > origCount) OrElse (insertPos < -1) Then
+			CU_ASSERT_EQUAL(localErr, 6)
+			goto commonError
+		End If
+	testElems:
+		if insertPos = -1 Then insertPos = origCount '' fix for calculation below
+		dim newSize As Long = newCount + origCount
+		CU_ASSERT_EQUAL(list.Count, newSize)
+		CU_ASSERT_EQUAL(secondList.Count, secondListCopy.Count)
+		dim origIter As Long = 0
+		dim secondIter As Long = 0
+		For i = 0 to newSize - 1
+			If (i < insertPos) OrElse (i >= (insertPos + newCount)) Then
+				CU_ASSERT_EQUAL(list[i], originalListCopy[origIter])
+				origIter += 1
+			Else
+				CU_ASSERT_EQUAL(list[i], secondListCopy[secondIter])
+				secondIter += 1
+			End If
+		Next
+		'' check inserted list isn't changed
+		For i = 0 To secondListCopy.Count - 1
+			CU_ASSERT_EQUAL(secondList[i], secondListCopy[i])
+		Next
+		'' reset for next test
+		list = originalListCopy
+		secondList = secondListCopy
+		Exit Sub
+	commonError:
+		On Local Error Goto 0
+		newCount = 0 '' didn't add any
+		Goto testElems
+	End Sub
+	
+	Private Sub InsertIteratorTest(Byref list As LongList, ByRef iterator As SequentialLongGenerator, ByVal insertPos As Long, ByVal byPtr As Boolean)
+		dim origCount As Long = list.Count
+		dim originalListCopy As LongList = list
+		dim localErr As Long
+		dim iterCount As Long = 0
+		dim i As Long
+		
+		While(iterator.Advance())
+			iterCount += 1
+		Wend
+		iterator.Reset()
+		
+		Err = 0
+		On Local Error Goto commonError
+		If byPtr Then
+			list.Insert(insertPos, @iterator)
+		Else
+			list.Insert(insertPos, iterator)
+		End If
+		localErr = Err
+		'' check out of bounds causes the proper error
+		If (insertPos > origCount) OrElse (insertPos < -1) Then
+			CU_ASSERT_EQUAL(localErr, 6)
+			goto commonError
+		End If		
+	testElems:
+		if insertPos = -1 Then insertPos = origCount '' fix for calculation below
+		dim newSize As Long = origCount + iterCount
+		CU_ASSERT_EQUAL(list.Count, newSize)
+		CU_ASSERT_EQUAL((newSize - origCount), iterCount)
+		iterator.Reset()
+		iterator.Advance()
+		dim origIter As Long = 0
+		For i = 0 to newSize - 1
+			If (i < insertPos) OrElse (i >= (insertPos + iterCount)) Then
+				CU_ASSERT_EQUAL(list[i], originalListCopy[origIter])
+				origIter += 1
+			Else
+				CU_ASSERT_EQUAL(list[i], iterator.Item())
+				iterator.Advance()
+			End If
+		Next
+		'' reset for next test
+		list = originalListCopy
+		iterator.Reset()
+		Exit Sub
+	commonError:
+		On Local Error Goto 0
+		iterCount = 0 '' didn't add any
+		Goto testElems
+	End Sub
+	
+	TEST(Insert)
+		TestInsertSingle()
+		dim theList As LongList
+		dim emptyArray(Any) As Long
+		dim dynArray(Any) As Long
+		Dim goodArray(50 To 54) As Long
+		Dim i As Long
+		dim localErr As Long
+		For i = 50 To 54
+			goodArray(i) = i
+		Next
+		Redim dynArray(0 To 4)
+		'' insert whole array into empty list
+		InsertArrTest(theList, theList.Count, goodArray(), 0, 0, True)
+		'' insert whole array into non-empty list at position 2
+		InsertArrTest(theList, 2, goodArray(), 0, 0, True)
+		'' insert whole array into non-empty list at position 0
+		InsertArrTest(theList, 0, goodArray(), 0, 0, True)
+		'' insert bad array into non-empty list at position 0 (no-op)
+		InsertArrTest(theList, 0, emptyArray(), 0, 0, True)
+		'' insert zero array into non-empty list at end
+		InsertArrTest(theList, -1, dynArray(), 0, 0, True)
+		'' insert zero array into non-empty list out of bounds (no-op)
+		InsertArrTest(theList, 454, dynArray(), 0, 0, True)
+		InsertArrTest(theList, 454, dynArray(), 0, 0, True)
+		theList.Clear()
+		'' insert good array after clear
+		InsertArrTest(theList, 0, goodArray(), 0, 0, True)
+		theList.Clear()
+		theList.Add(6)
+		theList.Add(60)
+		'' insert one element of an the dyn array at the beginning
+		InsertArrTest(theList, 0, dynArray(), 2, 1, False)
+		'' try insert too many items from the goodArray (will add only as many as available from startPoint to end of array)
+		InsertArrTest(theList, 2, goodArray(), 51, 12, False)
+		'' try insert out of bounds (no-op)
+		InsertArrTest(theList, 13, goodArray(), 52, 2, False)
+		'' try insert undimmed array (no-op)
+		InsertArrTest(theList, -1, emptyArray(), 0, 0, False)
+		'' insert first three elements of array at end
+		InsertArrTest(theList, -1, goodArray(), 50, 3, False)
+		'' insert last element at end
+		InsertArrTest(theList, theList.Count, goodArray(), 54, 1, False)
+		theList.Clear()
+		'' make sure it still works after a clear
+		InsertArrTest(theList, theList.Count, goodArray(), 53, 1, False)
+		theList.Clear()
+		dim secondList As LongList
+		dim thirdList As LongList
+		secondList.Add(goodArray())
+		thirdList.Add(75475)
+		thirdList.Add(924384)
+		'' oob, do nothing
+		InsertContainerTest(secondList, thirdList, 67, True)
+		'' insert at position three
+		InsertContainerTest(secondList, thirdList, 3, True)
+		'' insert empty list (no fail, but does nothing)
+		InsertContainerTest(secondList, theList, 3, True)
+		'' insert good list at end
+		InsertContainerTest(secondList, thirdList, -1, True)
+		'' insert good list at end
+		InsertContainerTest(secondList, thirdList, secondList.Count, True)
+		dim nullCont As LongList Ptr = 0
+		Err = 0
+		On Local Error Goto continueTest1
+		secondList.Insert(0, nullCont)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)		
+	continueTest1:
+		'' byref inserts
+		'' oob, do nothing
+		InsertContainerTest(secondList, thirdList, 67, False)
+		'' insert at position three
+		InsertContainerTest(secondList, thirdList, 3, False)
+		'' insert empty list (no fail, but does nothing)
+		InsertContainerTest(secondList, theList, 3, False)
+		'' insert good list at end
+		InsertContainerTest(secondList, thirdList, -1, False)
+		'' insert good list at end
+		InsertContainerTest(secondList, thirdList, secondList.Count, False)
+		dim slg As SequentialLongGenerator = Type(8, 678)
+		dim emptyGen As SequentialLongGenerator = Type(0, 123)
+		'' oob, do nothing
+		InsertIteratorTest(secondList, slg, 67, True)
+		'' insert at position three
+		InsertIteratorTest(secondList, slg, 3, True)
+		'' insert empty list (no fail, but does nothing)
+		InsertIteratorTest(secondList, emptyGen, 3, True)
+		'' insert good list at end
+		InsertIteratorTest(secondList, slg, -1, True)
+		'' insert good list at end
+		InsertIteratorTest(secondList, slg, secondList.Count, True)
+		dim nullIter As FB_IIterator(Long) Ptr = 0
+		Err = 0
+		localErr = 0
+		On Local Error Goto continueTest2
+		secondList.Insert(0, nullIter)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)		
+	continueTest2:
+		'' byref inserts
+		'' oob, do nothing
+		InsertIteratorTest(secondList, slg, 67, False)
+		'' insert at position three
+		InsertIteratorTest(secondList, slg, 3, False)
+		'' insert empty list (no fail, but does nothing)
+		InsertIteratorTest(secondList, emptyGen, 3, False)
+		'' insert good list at end
+		InsertIteratorTest(secondList, slg, -1, False)
+		'' insert good list at end
+		InsertIteratorTest(secondList, slg, secondList.Count, False)
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(LastTest)
+		dim list As LongList
+		'' Out of bounds calls Error with FB_CONTAINER_DEBUG
+		On Local Error Goto afterError
+		Err = 0
+		dim last As Long = list.Last()
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6) '' out of bounds
+	afterError:
+		list.Add(7)
+		CU_ASSERT_EQUAL(list.Last(), 7)
+		list.Add(9)
+		CU_ASSERT_EQUAL(list.Last(), 9)
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.Last(), 9)
+		Dim arr(0 To 1) As Long
+		list.Insert(-1, arr())
+		CU_ASSERT_EQUAL(list.Last(), 0)
+		list.RemoveAt(list.Count - 1)
+		CU_ASSERT_EQUAL(list.Last(), 0)
+		list.Clear()
+		Err = 0
+		On Local Error Goto afterError2
+		dim first As Long = list.Last()
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6) '' out of bounds
+	afterError2:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(LastIndexOf)
+		dim list As LongList
+		dim i As Long
+		CU_ASSERT_EQUAL(list.LastIndexOf(0), -1)
+		list.Add(65) '' 0
+		list.Add(65) '' 1
+		list.Add(0) '' 2
+		list.Add(85) '' 3
+		list.Add(65) '' 4
+		list.Add(69) '' 5
+		For i = 0 to list.Count - 1
+			If i > 1 Then
+				CU_ASSERT_EQUAL(list.LastIndexOf(list[i]), i)
+			Else
+				CU_ASSERT_EQUAL(list.LastIndexOf(list[i]), 4)
+			End If
+		Next
+		list.RemoveAt(0)
+		For i = 0 to list.Count - 1
+			If i > 0 Then
+				CU_ASSERT_EQUAL(list.LastIndexOf(list[i]), i)
+			Else
+				CU_ASSERT_EQUAL(list.LastIndexOf(list[i]), 3)
+			End If
+		Next
+		CU_ASSERT_EQUAL(list.LastIndexOf(list.Last()), list.Count - 1)
+		CU_ASSERT_EQUAL(list.LastIndexOf(list[1]), 1)
+		list.Add(65)
+		CU_ASSERT_EQUAL(list.LastIndexOf(65), list.Count - 1)
+		CU_ASSERT_EQUAL(list.LastIndexOf(58), -1)
+	END_TEST
+	
+	TEST(Remove)
+		dim list As LongList
+		list.Add(65) '' 0
+		list.Add(0) '' 1
+		list.Add(85) '' 2
+		list.Add(65) '' 3
+		list.Add(69) '' 4
+		
+		'' remove a duplicate
+		list.Remove(65)
+		CU_ASSERT_EQUAL(list.Count, 4)
+		CU_ASSERT(list[0] <> 65)
+		CU_ASSERT_EQUAL(list.Contains(65), True) '' because there were two, and remove only removes the first
+		'' remove a single
+		list.Remove(65)
+		CU_ASSERT_EQUAL(list.Count, 3)
+		CU_ASSERT(list[0] <> 65)
+		CU_ASSERT(list[2] <> 65)
+		CU_ASSERT_EQUAL(list.Contains(65), False) '' because there was one, and now there isn't
+		'' remove a non-existant
+		list.Remove(65) '' this shouldn't do anything
+		CU_ASSERT_EQUAL(list.Count, 3)
+		CU_ASSERT_EQUAL(list.Contains(65), False)
+		
+		dim emptyList As LongList
+		emptyList.Remove(0)
+		CU_ASSERT_EQUAL(emptyList.Empty(), True)
+	END_TEST
+	
+	TEST(RemoveAt)
+		dim list As LongList
+		dim arrItems(10 To 20) As Long
+		dim i As Long
+		dim localErr As Long
+		For i = 10 To 20
+			arrItems(i) = i
+		Next
+		list.Add(arrItems())
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.Count, 10)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i], arrItems(i + 11))
+		Next
+		list.RemoveAt(list.Count - 1)
+		CU_ASSERT_EQUAL(list.Count, 9)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i], arrItems(i + 11))
+		Next
+		
+		On Local Error Goto resumeTests
+		Err = 0
+		list.RemoveAt(19)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(list.Count, 9)
+	resumeTests:
+		On Local Error Goto resumeTests2
+		Err = 0
+		list.RemoveAt(-1)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(list.Count, 9)
+	resumeTests2:
+		list.RemoveAt(5)
+		For i = 0 to 4
+			CU_ASSERT_EQUAL(list[i], arrItems(i + 11))
+		Next
+		For i = 5 to list.Count - 1
+			CU_ASSERT_EQUAL(list[i], arrItems(i + 12))
+		Next
+		CU_ASSERT_EQUAL(list.Count, 8)
+		dim emptyList As LongList
+		On Local Error Goto resumeTests3
+		Err = 0
+		emptyList.RemoveAt(0)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+	resumeTests3:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(RemoveSpan)
+		dim slg As SequentialLongGenerator = Type(100, 55)
+		dim list As LongList = slg
+		dim toRemove As Long = 10
+		dim i As Long
+		dim localErr As Long
+		list.RemoveSpan(0, toRemove)
+		CU_ASSERT_EQUAL(list.Count, 90)
+		slg.Reset()
+		slg.Skip(toRemove)
+		For i = 0 To list.Count - 1
+			slg.Advance()
+			CU_ASSERT_EQUAL(list[i], slg.Item())
+		Next		
+		On Local Error Goto resumeTests
+		Err = 0
+		list.RemoveSpan(-5, 15)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(list.Count, 90)
+	resumeTests:
+		'' added 100, removed 10, this will remove 5 from 85-89
+		list.RemoveSpan(85, 15)
+		CU_ASSERT_EQUAL(list.Count, 85)
+		slg.Reset()
+		slg.Skip(toRemove)
+		For i = 0 To list.Count - 1
+			slg.Advance()
+			CU_ASSERT_EQUAL(list[i], slg.Item())
+		Next
+		list.RemoveSpan(0, list.Count)
+		CU_ASSERT_EQUAL(list.Empty(), True)
+		On Local Error Goto resumeTests2
+		Err = 0
+		list.RemoveSpan(0, 10)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(list.Count, 0)
+	resumeTests2:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(Resize)
+		dim i As Long
+		dim list As LongList
+		dim localErr As Long
+		CU_ASSERT_EQUAL(list.Count, 0)
+		list.Resize(6)
+		CU_ASSERT_EQUAL(list.Count, 6)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i], 0)
+		Next
+		list.Resize(3)
+		CU_ASSERT_EQUAL(list.Count, 3)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i], 0)
+		Next
+		On Local Error Goto resumeTests
+		Err = 0
+		list.Resize(-6)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		CU_ASSERT_EQUAL(list.Count, 3)
+	resumeTests:
+		On Local Error Goto 0
+		list.Resize(10)
+		CU_ASSERT_EQUAL(list.Count, 10)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i], 0)
+			list[i] = i
+		Next
+		list.Resize(20)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i], IIf(i < 10, i, 0))
+		Next		
+	END_TEST
+	
+	TEST(ReserveCapacity)
+		dim list As LongList
+		dim curCapacity As Long
+		dim i As Long
+		CU_ASSERT(list.Capacity > 0)
+		CU_ASSERT_EQUAL(list.Count, 0)
+		list.Reserve(30)
+		CU_ASSERT_EQUAL(list.Capacity, 30)
+		CU_ASSERT_EQUAL(list.Count, 0)
+		'' Clear trims the unused space 
+		list.Clear()
+		CU_ASSERT((list.Capacity < 30) AndAlso (list.Capacity > 0))
+		CU_ASSERT_EQUAL(list.Count, 0)
+		list.Resize(60)
+		curCapacity = list.Capacity
+		CU_ASSERT_EQUAL(list.Count, 60)
+		CU_ASSERT(curCapacity > 60)
+		'' can't reserve down
+		list.Reserve(30)
+		CU_ASSERT_EQUAL(list.Count, 60)
+		CU_ASSERT_EQUAL(list.Capacity, curCapacity)
+		list.Reserve(-6)
+		CU_ASSERT_EQUAL(list.Count, 60)
+		CU_ASSERT_EQUAL(list.Capacity, curCapacity)
+		list.Clear()
+		curCapacity = list.Capacity
+		For i = 0 To curCapacity - 1
+			list.Add(i)
+		Next
+		CU_ASSERT_EQUAL(list.Capacity, list.Count)
+		list.Add(89)
+		CU_ASSERT((list.Capacity - list.Count) > 1)
+	END_TEST
+	
+	TEST(Operators)
+		dim list As LongList
+		dim As Long first = 17525, second = 7854, third = 12
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		list += first
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		CU_ASSERT_EQUAL(Len(list), 1)
+		CU_ASSERT_EQUAL(list[0], first)
+		list += second
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		CU_ASSERT_EQUAL(Len(list), 2)
+		CU_ASSERT_EQUAL(list[0], first)
+		CU_ASSERT_EQUAL(list[1], second)
+		list.Clear()
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		CU_ASSERT_EQUAL(Len(list), 0)
+		list += third
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		CU_ASSERT_EQUAL(Len(list), 1)
+		CU_ASSERT_EQUAL(list[0], third)
+	END_TEST
+	'' Don't forget to test that those added are independent variables
+	'' not 'attached' to any added variables
+
+END_SUITE

--- a/tests/containers/ListTestUDT.bas
+++ b/tests/containers/ListTestUDT.bas
@@ -1,0 +1,1247 @@
+''#define FB_CONTAINER_DEBUG 1
+#include "../../inc/containers/List.bi"
+#include "ContainerTestPrereqs.bi"
+#include "fbcunit.bi"
+
+FBCont_DefineListOf(One, Two, IntegerHolder)
+Type IntegerHolderList As FB_List(One, Two, IntegerHolder)
+
+SUITE(fbc_tests.containers.lists.udt)
+	TEST(ConstructorTest)
+		'' check that these can compare equal, it's important
+		Dim test as One.Two.IntegerHolder = Type(45)
+		CU_ASSERT_EQUAL(test, test)
+		
+		dim i As Long
+		dim emptyList As IntegerHolderList
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+		dim emptyIterator As SequentialIntegerHolderGenerator = Type(0, 1)
+
+		Dim zt1NumToGenerate As Long = 21
+		Dim zt1StartNum As Long = 0
+		Dim zeroTo14Iterator As SequentialIntegerHolderGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 12
+		Dim tt2StartNum As Long = 636369
+		Dim twoHundred3To210Iterator As SequentialIntegerHolderGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		'' Iterator constructor
+		Dim zt1List As IntegerHolderList = zeroTo14Iterator
+		For i = 0 To zt1NumToGenerate - 1
+			CU_ASSERT_EQUAL(zt1List[i].num, zt1StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(zt1List.Count, zt1NumToGenerate)
+		
+		Dim tt2List As IntegerHolderList = twoHundred3To210Iterator
+		For i = 0 To tt2NumToGenerate - 1
+			CU_ASSERT_EQUAL(tt2List[i].num, tt2StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(tt2List.Count, tt2NumToGenerate)
+		
+		zeroTo14Iterator.Reset()
+		Dim zt1List2 As IntegerHolderList = zeroTo14Iterator
+		For i = 0 To zt1NumToGenerate - 1
+			CU_ASSERT_EQUAL(zt1List2[i].num, zt1List[i].num)
+		Next
+		CU_ASSERT_EQUAL(zt1List.Count, zt1List2.Count)
+		
+		twoHundred3To210Iterator.Reset()
+		Dim tt2List2 As IntegerHolderList = twoHundred3To210Iterator
+		For i = 0 To tt2NumToGenerate - 1
+			CU_ASSERT_EQUAL(tt2List[i].num, tt2StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(tt2List2.Count, tt2List.Count)
+		
+		dim newEmptyList As IntegerHolderList = emptyIterator
+		CU_ASSERT_EQUAL(newEmptyList.Count, 0)
+		emptyIterator.Reset()
+		
+		'' Container Constructor
+		Dim zt1ListCopy As IntegerHolderList = zt1List
+		For i = 0 To zt1List.Count - 1
+			CU_ASSERT_EQUAL(zt1ListCopy[i].num, zt1List[i].num)
+		Next
+		CU_ASSERT_EQUAL(zt1ListCopy.Count, zt1List.Count)
+		
+		Dim tt2ListCopy As IntegerHolderList = tt2List
+		For i = 0 To tt2List.Count - 1
+			CU_ASSERT_EQUAL(tt2ListCopy[i].num, tt2List[i].num)
+		Next
+		CU_ASSERT_EQUAL(tt2ListCopy.Count, tt2List.Count)
+		
+		Dim fromEmptyContainerList As IntegerHolderList = @newEmptyList
+		CU_ASSERT_EQUAL(fromEmptyContainerList.Count, 0)
+		
+		
+		
+		dim numArray(7) As One.Two.IntegerHolder
+		dim numArrayLBound As Long = LBound(numArray)
+		dim numArrayUBound As Long = UBound(numArray)
+		dim arraySize As Long = numArrayUBound - numArrayLBound + 1
+		For i = numArrayLBound To numArrayUBound
+			numArray(i).num = i
+		Next
+		
+		Dim arrayList As IntegerHolderList = numArray()
+		For i = 0 To arraySize - 1
+			CU_ASSERT_EQUAL(arrayList[i].num, numArray(numArrayLBound + i).num)
+		Next
+		CU_ASSERT_EQUAL(arrayList.Count, arraySize)
+		
+		
+		dim numArrayBased(5 To 9) As One.Two.IntegerHolder
+		numArrayLBound = LBound(numArrayBased)
+		numArrayUBound = UBound(numArrayBased)
+		arraySize = numArrayUBound - numArrayLBound + 1
+		For i = numArrayLBound To numArrayUBound
+			numArrayBased(i).num = i
+		Next
+		
+		Dim arrayListBased As IntegerHolderList = numArrayBased()
+		For i = 0 To arraySize - 1
+			CU_ASSERT_EQUAL(arrayListBased[i].num, numArrayBased(numArrayLBound + i).num)
+		Next
+		CU_ASSERT_EQUAL(arrayListBased.Count, arraySize)
+		
+		dim undimmedArray(Any) As One.Two.IntegerHolder
+		dim anyArrayList As IntegerHolderList = undimmedArray()
+		CU_ASSERT_EQUAL(anyArrayList.Count, 0)
+
+	END_TEST
+	
+	TEST(Add)
+	
+		'' single item
+		dim i As Long
+		dim singleItemList As IntegerHolderList
+		dim holder1 As One.Two.IntegerHolder = (78)
+		dim holder2 As One.Two.IntegerHolder = (-78)
+		dim holder3 As One.Two.IntegerHolder = (123456)
+		singleItemList.Add(holder1)
+		singleItemList.Add(holder2)
+		CU_ASSERT_EQUAL(singleItemList.Count, 2)
+		CU_ASSERT_EQUAL(singleItemList[0], holder1)
+		CU_ASSERT_EQUAL(singleItemList[1], holder2)
+		singleItemList.Remove(holder1)
+		singleItemList.Add(holder3)
+		CU_ASSERT_EQUAL(singleItemList[0], holder2)
+		CU_ASSERT_EQUAL(singleItemList[1], holder3)
+		
+		'' Whole Array Add
+		dim emptyArray() As One.Two.IntegerHolder
+		dim addArray(0 to 9) As One.Two.IntegerHolder
+		dim As IntegerHolderList emptyList, arrayList
+		'' undimmed arrays do nothing
+		emptyList.Add(emptyArray())
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+		For i = 0 To 9
+			addArray(i).num = i
+		Next
+		arrayList.Add(addArray())
+		CU_ASSERT_EQUAL(arrayList.Count, 10)
+		For i = 0 To 9
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i))
+		Next
+		arrayList.Add(emptyArray())
+		CU_ASSERT_EQUAL(arrayList.Count, 10)
+		For i = 0 To 9
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i))
+		Next
+		arrayList.Add(addArray())
+		CU_ASSERT_EQUAL(arrayList.Count, 20)
+		For i = 0 To 19
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i Mod 10))
+		Next
+		
+		''Partial Array Add
+		
+		'' again undimmed arrays do nothing
+		arrayList.Add(emptyArray(), 4, 2)
+		CU_ASSERT_EQUAL(arrayList.Count, 20)
+		
+		'' Trying to add things outside the bounds of the array
+		'' are constrained to the array
+		''
+		'' This should add addArray(9) then stop, since there aren't 14 more elements after that
+		arrayList.Add(addArray(), 9, 15)
+		CU_ASSERT_EQUAL(arrayList.Count, 21)
+		For i = 0 To 19
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i Mod 10))
+		Next
+		CU_ASSERT_EQUAL(arrayList[20], addArray(9))
+		
+		'' This shouldn't add anything, since the start point is outside the bounds
+		arrayList.Add(addArray(), 15, 2)
+		CU_ASSERT_EQUAL(arrayList.Count, 21)
+		
+		arrayList.Add(addArray(), 3, 2)
+		CU_ASSERT_EQUAL(arrayList.Count, 23)
+		For i = 0 To 19
+			CU_ASSERT_EQUAL(arrayList[i], addArray(i Mod 10))
+		Next
+		CU_ASSERT_EQUAL(arrayList[20], addArray(9))
+		CU_ASSERT_EQUAL(arrayList[21], addArray(3))
+		CU_ASSERT_EQUAL(arrayList[22], addArray(4))
+		
+		arrayList.Add(addArray(), 0, 8)
+		CU_ASSERT_EQUAL(arrayList.Count, 31)
+		For i = 0 To 7
+			CU_ASSERT_EQUAL(arrayList[23 + i], addArray(i))
+		Next
+		
+		'' Negative start points should also do nothing
+		arrayList.Add(addArray(), -2, 6)
+		CU_ASSERT_EQUAL(arrayList.Count, 31)
+		
+		'' Container Add
+		''
+		dim anotherList As IntegerHolderList
+		dim invalidListPtr As IntegerHolderList Ptr = 0
+		anotherList.Add(emptyList)
+		CU_ASSERT_EQUAL(anotherList.Count, emptyList.Count)
+		anotherList.Add(@arrayList)
+		For i = 0 to arrayList.Count - 1
+			CU_ASSERT_EQUAL(anotherList[i], arrayList[i])
+		Next
+		dim anotherListCount As Long = anotherList.Count
+		CU_ASSERT_EQUAL(anotherListCount, arrayList.Count)
+		'' null pointers shouldn't do anything, passing 0 directly
+		'' will use the Add(Long) overload
+		On Local Error Goto afterTest3
+		anotherList.Add(invalidListPtr)
+		CU_ASSERT_EQUAL(anotherListCount, anotherList.Count)
+	afterTest3:
+		
+		'' Iterator Add
+		dim emptyIterator As SequentialIntegerHolderGenerator = Type(0, 1)
+		dim nullIterator As SequentialIntegerHolderGenerator Ptr = 0		
+		emptyList.Add(emptyIterator)
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+		'' If we're compiling with -exx, it will raise an error
+		'' so we need to catch that 
+		On Local Error Goto afterTest4
+		emptyList.Add(nullIterator)
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+	afterTest4:
+		On Local Error Goto 0
+
+		Dim zt1NumToGenerate As Long = 15
+		Dim zt1StartNum As Long = 0
+		Dim zeroTo14Iterator As SequentialIntegerHolderGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 7
+		Dim tt2StartNum As Long = 203
+		Dim twoHundred3To210Iterator As SequentialIntegerHolderGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		Dim zt1List As IntegerHolderList
+		zt1List.Add(zeroTo14Iterator)
+		For i = 0 To zt1NumToGenerate - 1
+			CU_ASSERT_EQUAL(zt1List[i].num, zt1StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(zt1List.Count, zt1NumToGenerate)
+		
+		Dim tt2List As IntegerHolderList
+		tt2List.Add(@twoHundred3To210Iterator)
+		For i = 0 To tt2NumToGenerate - 1
+			CU_ASSERT_EQUAL(tt2List[i].num, tt2StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(tt2List.Count, tt2NumToGenerate)
+		
+		zeroTo14Iterator.Reset()
+		Dim zt1List2 As IntegerHolderList
+		zt1List2.Add(@zeroTo14Iterator)
+		For i = 0 To zt1NumToGenerate - 1
+			CU_ASSERT_EQUAL(zt1List2[i], zt1List[i])
+		Next
+		CU_ASSERT_EQUAL(zt1List.Count, zt1List2.Count)
+		
+		twoHundred3To210Iterator.Reset()
+		Dim tt2List2 As IntegerHolderList
+		tt2List2.Add(twoHundred3To210Iterator)
+		For i = 0 To tt2NumToGenerate - 1
+			CU_ASSERT_EQUAL(tt2List[i].num, tt2StartNum + i)
+		Next
+		CU_ASSERT_EQUAL(tt2List2.Count, tt2List.Count)
+		
+		dim newEmptyList As IntegerHolderList
+		newEmptyList.Add(emptyIterator)
+		CU_ASSERT_EQUAL(newEmptyList.Count, 0)
+	
+	END_TEST
+	
+	TEST(Clear)
+		dim singleItemList As IntegerHolderList
+		dim holder1 As One.Two.IntegerHolder = (78)
+		dim holder2 As One.Two.IntegerHolder = (-78)
+		singleItemList.Add(holder1)
+		singleItemList.Add(holder2)
+		singleItemList.Clear()
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		singleItemList.Clear()
+		CU_ASSERT_EQUAL(singleItemList.Count, 0)
+		dim list2 As IntegerHolderList	
+		list2.Clear()
+		CU_ASSERT_EQUAL(list2.Count, 0)
+	END_TEST
+	
+	TEST(Contains)
+		dim haystack As IntegerHolderList
+		dim temp As One.Two.IntegerHolder
+		dim needle As One.Two.IntegerHolder = (78)
+		dim negativeNeedle As One.Two.IntegerHolder = (-needle.num)
+		dim result As Boolean
+		result = haystack.Contains(Type(0))
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Add(needle)
+		haystack.Add(negativeNeedle)
+		temp.num = 52
+		haystack.Add(temp)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.Remove(needle)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, False)
+		Dim generate100 As SequentialIntegerHolderGenerator = Type(100, 100)
+		haystack.Add(@generate100)
+		temp.num = 157
+		result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+	END_TEST
+	
+	Private Sub CopyToOOBTest(ByRef list As IntegerHolderList, ByVal startPoint As Long)
+		Dim i As Integer
+		Dim arr(30 To 36) As One.Two.IntegerHolder
+		For i = 30 To 36
+			arr(i).num = i
+		Next
+		
+		'' It should be invalid
+		Assert((startPoint >= list.Count) OrElse (startPoint < 0))
+		
+		Err = 0
+		'' Will call Error if FB_CONTAINER_DEBUG is defined
+		On Local Error Goto nextTest
+		list.CopyTo(arr(), startPoint, list.Count, 0)
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		For i = 30 To 36
+			CU_ASSERT_EQUAL(arr(i).num, i)
+		Next
+		
+		nextTest:
+		On Local Error Goto 0
+	End Sub
+	
+	Private Sub CopyToArrTest(_
+		ByRef list As IntegerHolderList, _
+		ByVal listStart As Long, _
+		ByVal listCount As Long, _
+		ByVal arrayStart As Long, _
+		ByVal useDimmedArr As Boolean, _
+		ByVal arrLDim As Long, _
+		ByVal arrUDim As Long _
+	)
+		dim iterArr(Any) As One.Two.IntegerHolder
+		dim listSize As Long = list.Count
+		dim hadError As Boolean = False
+		dim i As Long
+		dim calcListCount As Long = IIf(listCount = -1, listSize, listCount)
+		dim maxListToCopy As Long = listSize - listStart
+		maxListToCopy = IIf(maxListToCopy > calcListCount, calcListCount, maxListToCopy)
+		dim arrSize As Long = (arrUDim - arrLDim) + 1
+		dim maxArrToCopy As Long = IIf(useDimmedArr, arrSize - (arrayStart - arrLDim), maxListToCopy)
+		dim maxToCopy As Long = IIf(maxArrToCopy < maxListToCopy, maxArrToCopy, maxListToCopy)
+
+		If useDimmedArr Then
+			Redim iterArr(arrLDim To arrUDim)
+			For i = arrLDim To arrUDim
+				iterArr(i).num = i
+			Next
+		End If
+
+		On Local Error Goto setError
+		Err = 0
+		list.CopyTo(iterArr(), listStart, listCount, arrayStart)
+		hadError = Err <> 0
+	testElems:
+		If useDimmedArr = False Then arrayStart = 0
+		dim arrUBound As Long = UBound(iterArr)
+		dim arrLBound As Long = LBound(iterArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+
+		If useDimmedArr Then
+
+			CU_ASSERT_EQUAL(arrUBound, arrUDim)
+			CU_ASSERT_EQUAL(arrLBound, arrLDim)
+			CU_ASSERT_EQUAL(numElems, (arrUDim - arrLDim) + 1)
+		Else
+			If hadError Then
+
+				CU_ASSERT_EQUAL(arrUBound, -1)
+				CU_ASSERT_EQUAL(arrLBound, 0)
+				CU_ASSERT_EQUAL(numElems, 0)
+			Else
+				CU_ASSERT_EQUAL(arrUBound, maxListToCopy - 1)
+				CU_ASSERT_EQUAL(arrLBound, 0)
+				CU_ASSERT_EQUAL(numElems, maxListToCopy)
+			End If
+		End If
+		If hadError AndAlso useDimmedArr Then
+			'' unchanged
+			For i = 0 To numElems - 1
+				CU_ASSERT_EQUAL(iterArr(arrLBound + i).num, arrLBound + i)
+			Next
+		Else
+			If hadError = False Then
+				'' unchanged contents from arrLBound to arrayStart, 
+				'' list contents from arrayStart to maxToCopy
+				'' unchanged contents above that
+				Dim listIter As Long = listStart
+				Dim arrIndex As Long = arrLBound
+				For i = arrLBound To arrUBound
+					If (i < arrayStart) OrElse (i > (arrayStart + maxToCopy)) Then
+						CU_ASSERT_EQUAL(iterArr(i).num, arrIndex)
+						arrIndex += 1
+					Else
+						CU_ASSERT_EQUAL(iterArr(i), list[listIter])
+						listIter += 1
+					End If
+				Next
+			Endif '' hadError And useDimmedArr = false is an empty array that's already been tested above
+		End If
+		Exit Sub
+setError:
+		On Local Error Goto 0
+		hadError = True
+		Goto testElems
+	End Sub
+	
+	TEST(CopyTo)
+		dim singleItemList As IntegerHolderList
+		dim i As Long
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemList.Add(temp)
+		temp.num = -78
+		singleItemList.Add(temp)
+		temp.num = 8537536
+		singleItemList.Add(temp)
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As One.Two.IntegerHolder
+		singleItemList.CopyTo(undimmedArr())
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, singleItemList.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		For i = 0 To singleItemList.Count - 1
+			CU_ASSERT_EQUAL(undimmedArr(i), singleItemList[i])
+		Next
+
+		'' Except in empty lists, where nothing happens
+		'' If container debug is defined, this calls Error
+		dim emptyList As IntegerHolderList
+		dim emptyArr(Any) As One.Two.IntegerHolder
+		On Local Error Goto nextTest1
+		Dim localErr As Long
+		Err = 0
+		emptyList.CopyTo(emptyArr())
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+	nextTest1:
+		On Local Error Goto 0
+
+		'' already sized arrays copy the number of items in the list or the size of the array
+		'' whichever is smaller
+		dim largerThanContArr(10 To 14) As One.Two.IntegerHolder
+		For i = 10 To 14
+			largerThanContArr(i).num = i
+		Next
+		singleItemList.CopyTo(largerThanContArr())
+		arrUBound = UBound(largerThanContArr)
+		arrLBound = LBound(largerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+
+		CU_ASSERT_EQUAL(numElems, 5)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 14)
+		For i = 10 To 14
+			CU_ASSERT_EQUAL(largerThanContArr(i).num, IIf(i <= 12, singleItemList[i - 10].num, i))
+		Next
+
+		dim smallerThanContArr(21 To 22) As One.Two.IntegerHolder
+		For i = 21 To 22
+			smallerThanContArr(i).num = i
+		Next
+		temp.num = 4
+		singleItemList.Add(temp)
+		singleItemList.CopyTo(smallerThanContArr())
+
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 2)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 22)
+		For i = 21 To 22
+			CU_ASSERT_EQUAL(smallerThanContArr(i), singleItemList[i - 21])
+		Next
+
+		'' Then the partial copyto
+		dim sihg As SequentialIntegerHolderGenerator = Type(100, 15)
+		dim iterList As IntegerHolderList = sihg
+		dim iterArr(Any) As One.Two.IntegerHolder
+		'' negative or or out of range start points don't do anything
+		'' and call Error if the FB_CONTAINER_DEBUG is defined
+		CopyToOOBTest(iterList, -6)
+		CopyToOOBTest(iterList, iterList.Count + 5)
+		'' standard normal all good copy
+		''' Again, undimmed arrays are redimmed to hold all required elements
+		''' With undimmed arrays, the array is dimmed from 0 To n, so the last argument is ignored
+		CopyToArrTest(iterList, 5, 5, 0, False, 0, 0)
+		'' 'listCount too big' test, check it constrains to list size
+		CopyToArrTest(iterList, 2, 15, 0, False, 0, 0)
+
+		'' 'All too big' test. Copying 15 elements from position 9
+		'' should constrain to 6. Which should then be further constrained
+		'' to 3 since we want to start copying to the array at 19 of 21 spaces
+		CopyToArrTest(iterList, 9, 15, 19, True, 15, 21)
+
+		'' 'Array too small, in bounds' test. Copying 7 elements from position 4
+		'' should copy 7. Excep that the array is only 4 elements big
+		CopyToArrTest(iterList, 4, 7, 32, True, 32, 35)
+
+		'' '-1 all good' test. Copying all elements from position 4 should copy 11
+		CopyToArrTest(iterList, 4, -1, 0, False, 32, 35)
+	END_TEST
+	
+	TEST(Empty)
+		dim list As IntegerHolderList
+		dim temp As One.Two.IntegerHolder = (7)
+		CU_ASSERT_EQUAL(list.Empty(), True)
+		list.Add(temp)
+		CU_ASSERT_EQUAL(list.Empty(), False)
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.Empty(), True)
+		Dim arr(0 To 1) As One.Two.IntegerHolder
+		list.Insert(0, arr())
+		CU_ASSERT_EQUAL(list.Empty(), False)
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.Empty(), False)
+		list.Clear()
+		CU_ASSERT_EQUAL(list.Empty(), True)
+	END_TEST
+	
+	TEST(FirstTest)
+		dim list As IntegerHolderList
+		dim temp As One.Two.IntegerHolder
+		'' Out of bounds calls Error with FB_CONTAINER_DEBUG
+		On Local Error Goto afterError
+		dim first As One.Two.IntegerHolder = list.First()
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6) '' out of bounds
+	afterError:
+		temp.num = 7
+		list.Add(temp)
+		CU_ASSERT_EQUAL(list.First().num, 7)
+		temp.num = 9
+		list.Add(temp)
+		CU_ASSERT_EQUAL(list.First().num, 7)
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.First().num, 9)
+		Dim arr(0 To 1) As One.Two.IntegerHolder
+		list.Insert(0, arr())
+		CU_ASSERT_EQUAL(list.First().num, 0)
+		list.RemoveAt(1)
+		CU_ASSERT_EQUAL(list.First().num, 0)
+		list.Clear()
+		Err = 0
+		On Local Error Goto afterError2
+		first = list.First()
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6) '' out of bounds
+	afterError2:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(GetIterator)
+		dim list As IntegerHolderList
+		dim temp As One.Two.IntegerHolder = (7)
+		dim pListIter As FB_IIterator(One, Two, IntegerHolder) Ptr = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+		pListIter = 0
+		list.Add(temp)
+		pListIter = list.GetIterator()
+		dim pListIter2 As FB_IIterator(One, Two, IntegerHolder) Ptr = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter2 <> 0)
+		CU_ASSERT(pListIter <> pListIter2)
+		CU_ASSERT(pListIter->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item().num, 7)
+		CU_ASSERT(pListIter2->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item().num, 7)
+		CU_ASSERT_EQUAL(pListIter2->Item().num, 7)
+		Delete pListIter
+		Delete pListIter2
+		pListIter = 0
+		pListIter2 = 0
+		list.Clear()
+		Dim arr(0 To 6) As One.Two.IntegerHolder
+		Dim i As Long
+		For i = 0 To 6
+			arr(i).num = i
+		Next
+		list.Add(arr())
+		pListIter = list.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		For i = 0 To 6
+			CU_ASSERT(pListIter->Advance() = True)
+			CU_ASSERT_EQUAL(pListIter->Item().num, i)
+		Next
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+	END_TEST
+	
+	TEST(IndexOf)
+		dim list As IntegerHolderList
+		dim temp As One.Two.IntegerHolder = (65)
+		dim i As Long
+		CU_ASSERT_EQUAL(list.IndexOf(Type(0)), -1)
+		list.Add(temp) '' 0
+		temp.num = 65 : list.Add(temp) '' 1
+		temp.num = 0 : list.Add(temp) '' 2
+		temp.num = 85 : list.Add(temp) '' 3
+		temp.num = 69 : list.Add(temp) '' 4
+		For i = 0 to list.Count - 1
+			If i <> 1 Then
+				CU_ASSERT_EQUAL(list.IndexOf(list[i]), i)
+			Else
+				CU_ASSERT_EQUAL(list.IndexOf(list[i]), 0)
+			End If
+		Next
+		list.RemoveAt(0)
+		For i = 0 to list.Count - 1
+			CU_ASSERT_EQUAL(list.IndexOf(list[i]), i)
+		Next
+		CU_ASSERT_EQUAL(list.IndexOf(list.First()), 0)
+		CU_ASSERT_EQUAL(list.IndexOf(list.Last()), list.Count - 1)
+		temp.num = 65 : list.Add(temp)
+		CU_ASSERT_EQUAL(list.IndexOf(Type(65)), 0)
+		CU_ASSERT_EQUAL(list.IndexOf(Type(58)), -1)
+	END_TEST
+	
+	Private Sub InsertArrTest(ByRef theList As IntegerHolderList, byVal where As Long, arr() As One.Two.IntegerHolder, ByVal arrStartPoint As Long, ByVal howMany As Long, byVal useSimpler As Boolean)
+		dim i As Long
+		dim originalListCopy As IntegerHolderList = theList
+		dim origIter As Long = 0
+		dim localErr As Long
+		dim curSize As Long = theList.Count
+		dim arrLBound As Long = LBound(arr)
+		dim arrUBound As Long = UBound(arr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		'' InsertArrTest(theList, theList.Count, goodArray(), 53, 1, False)
+		On Local Error Goto commonError
+		Err = 0
+		If useSimpler Then
+			theList.Insert(where, arr())
+			arrStartPoint = arrLBound
+			howMany = numElems
+		Else
+			theList.Insert(where, arr(), arrStartPoint, howMany)
+			dim maxToInsert As Long = (arrUBound - arrStartPoint) + 1
+			howMany = Iif(howMany < maxToInsert, howMany, maxToInsert)
+		End If
+		localErr = Err
+		If localErr <> 0 Then
+			CU_ASSERT_EQUAL(localErr, Iif(numElems = 0, 1, 6))
+			CU_ASSERT_EQUAL(theList.Count, originalListCopy.Count)
+			goto commonError
+		End If
+	testElements:
+		'' make the calculations easier now these values have been used in the Insert
+		If where = -1 Then where = originalListCopy.Count
+		dim newCount As Long = theList.Count
+		dim arrIter As Long = 0
+		For i = 0 To newCount - 1
+			If (i < where) OrElse (i >= (where + howMany)) Then
+				CU_ASSERT_EQUAL(theList[i], originalListCopy[origIter])
+				origIter += 1
+			Else
+				dim arrIndex As Long = arrStartPoint + arrIter
+				CU_ASSERT_EQUAL(theList[i], arr(arrIndex))
+				arrIter += 1
+			End If
+		Next
+		Exit Sub
+	commonError:
+		On Local Error Goto 0
+		howMany = 0
+		'' ensure we aways go in the first If in the check loop
+		'' as the list isn't modified on error
+		where = theList.Count
+		Goto testElements
+	End Sub
+	
+	Private Sub TestInsertSingle()
+		dim theList As IntegerHolderList
+		dim temp As One.Two.IntegerHolder = (50)
+		dim count As Long = theList.Count
+		theList.Insert(-1, temp) '' 50
+		CU_ASSERT(theList.Count > count)
+		CU_ASSERT_EQUAL(theList.Count, 1)
+		temp.num = 51 : theList.Insert(0, temp) '' 51, 50
+		CU_ASSERT_EQUAL(theList.Count, 2)
+		CU_ASSERT_EQUAL(theList[0].num, 51)
+		CU_ASSERT_EQUAL(theList.Last().num, 50)
+		temp.num = 52 : theList.Insert(1, temp) '' 51, 52, 50
+		CU_ASSERT_EQUAL(theList.Count, 3)
+		CU_ASSERT_EQUAL(theList[1], temp)
+		temp.num = 50
+		CU_ASSERT_EQUAL(theList[2], temp)
+		CU_ASSERT_EQUAL(theList.Last().num, 50)
+		On Local Error Goto afterTest1
+		Err = 0
+		'' out of bounds insert position (except for -1 or Count) causes Error() in -exx builds
+		temp.num = 43 : theList.Insert(43, temp)
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(theList.Count, 3)
+		CU_ASSERT_EQUAL(theList[0].num, 51)
+		CU_ASSERT_EQUAL(theList[2].num, 50)
+		CU_ASSERT_EQUAL(theList.Last().num, 50)
+	afterTest1:
+		On Local Error Goto 0
+		temp.num = 53 : theList.Insert(-1, temp) '' 51, 52, 50, 53
+		theList.Insert(0, temp) '' 53, 51, 52, 50, 53
+		CU_ASSERT_EQUAL(theList.Count, 5)
+		CU_ASSERT_EQUAL(theList.First(), temp)
+		CU_ASSERT_EQUAL(theList[1].num, 51)
+		CU_ASSERT_EQUAL(theList[2].num, 52)
+		CU_ASSERT_EQUAL(theList[3].num, 50)
+		CU_ASSERT_EQUAL(theList.Last(), temp)
+	End Sub
+	
+	Private Sub InsertContainerTest(Byref list As IntegerHolderList, ByRef secondList As IntegerHolderList, ByVal insertPos As Long, ByVal byPtr As Boolean)
+		dim origCount As Long = list.Count
+		dim originalListCopy As IntegerHolderList = list
+		dim secondListCopy As IntegerHolderList = secondList
+		dim newCount As Long = secondList.Count
+		dim localErr As Long
+		dim i As Long
+
+		Err = 0
+		On Local Error Goto commonError
+		If byPtr Then
+			list.Insert(insertPos, @secondList)
+		Else
+			list.Insert(insertPos, secondList)
+		End If
+		localErr = Err
+
+		'' check out of bounds causes the proper error
+		'' -1 and .Count out of bounds are allowed to signal append
+		If (insertPos > origCount) OrElse (insertPos < -1) Then
+			CU_ASSERT_EQUAL(localErr, 6)
+			goto commonError
+		End If
+	testElems:
+		if insertPos = -1 Then insertPos = origCount '' fix for calculation below
+		dim newSize As Long = newCount + origCount
+		CU_ASSERT_EQUAL(list.Count, newSize)
+		CU_ASSERT_EQUAL(secondList.Count, secondListCopy.Count)
+		dim origIter As Long = 0
+		dim secondIter As Long = 0
+		For i = 0 to newSize - 1
+			If (i < insertPos) OrElse (i >= (insertPos + newCount)) Then
+				CU_ASSERT_EQUAL(list[i], originalListCopy[origIter])
+				origIter += 1
+			Else
+				CU_ASSERT_EQUAL(list[i], secondListCopy[secondIter])
+				secondIter += 1
+			End If
+		Next
+		'' check inserted list isn't changed
+		For i = 0 To secondListCopy.Count - 1
+			CU_ASSERT_EQUAL(secondList[i], secondListCopy[i])
+		Next
+		'' reset for next test
+		list = originalListCopy
+		secondList = secondListCopy
+		Exit Sub
+	commonError:
+		On Local Error Goto 0
+		newCount = 0 '' didn't add any
+		Goto testElems
+	End Sub
+	
+	Private Sub InsertIteratorTest(Byref list As IntegerHolderList, ByRef iterator As SequentialIntegerHolderGenerator, ByVal insertPos As Long, ByVal byPtr As Boolean)
+		dim origCount As Long = list.Count
+		dim originalListCopy As IntegerHolderList = list
+		dim localErr As Long
+		dim iterCount As Long = 0
+		dim i As Long
+		
+		While(iterator.Advance())
+			iterCount += 1
+		Wend
+		iterator.Reset()
+		
+		Err = 0
+		On Local Error Goto commonError
+		If byPtr Then
+			list.Insert(insertPos, @iterator)
+		Else
+			list.Insert(insertPos, iterator)
+		End If
+		localErr = Err
+		'' check out of bounds causes the proper error
+		If (insertPos > origCount) OrElse (insertPos < -1) Then
+			CU_ASSERT_EQUAL(localErr, 6)
+			goto commonError '' didn't insert any
+		End If
+	testElems:
+		if insertPos = -1 Then insertPos = origCount '' fix for calculation below
+		dim newSize As Long = origCount + iterCount
+		CU_ASSERT_EQUAL(list.Count, newSize)
+		CU_ASSERT_EQUAL((newSize - origCount), iterCount)
+		iterator.Reset()
+		iterator.Advance()
+		dim origIter As Long = 0
+		For i = 0 to newSize - 1
+			If (i < insertPos) OrElse (i >= (insertPos + iterCount)) Then
+				CU_ASSERT_EQUAL(list[i], originalListCopy[origIter])
+				origIter += 1
+			Else
+				CU_ASSERT_EQUAL(list[i], iterator.Item())
+				iterator.Advance()
+			End If
+		Next
+		'' reset for next test
+		list = originalListCopy
+		iterator.Reset()
+		Exit Sub
+	commonError:
+		On Local Error Goto 0
+		iterCount = 0 '' didn't add any
+		Goto testElems
+	End Sub
+	
+	TEST(Insert)
+		TestInsertSingle()
+		dim theList As IntegerHolderList
+		dim emptyArray(Any) As One.Two.IntegerHolder
+		dim dynArray(Any) As One.Two.IntegerHolder
+		Dim goodArray(50 To 54) As One.Two.IntegerHolder
+		Dim i As Long
+		For i = 50 To 54
+			goodArray(i).num = i
+		Next
+		Redim dynArray(0 To 4)
+		'' insert whole array into empty list
+		InsertArrTest(theList, theList.Count, goodArray(), 0, 0, True)
+		'' insert whole array into non-empty list at position 2
+		InsertArrTest(theList, 2, goodArray(), 0, 0, True)
+		'' insert whole array into non-empty list at position 0
+		InsertArrTest(theList, 0, goodArray(), 0, 0, True)
+		'' insert bad array into non-empty list at position 0 (no-op)
+		InsertArrTest(theList, 0, emptyArray(), 0, 0, True)
+		'' insert zero array into non-empty list at end
+		InsertArrTest(theList, -1, dynArray(), 0, 0, True)
+		'' insert zero array into non-empty list out of bounds (no-op)
+		InsertArrTest(theList, 454, dynArray(), 0, 0, True)
+		theList.Clear()
+		'' insert good array after clear
+		InsertArrTest(theList, 0, goodArray(), 0, 0, True)
+		theList.Clear()
+		dim temp As One.Two.IntegerHolder = (6)
+		theList.Add(temp)
+		temp.num = 60 : theList.Add(temp)
+		'' insert one element of an the dyn array at the beginning
+		InsertArrTest(theList, 0, dynArray(), 2, 1, False)
+		'' try insert too many items from the goodArray (will add only as many as available from startPoint to end of array)
+		InsertArrTest(theList, 2, goodArray(), 51, 12, False)
+		'' try insert out of bounds (no-op)
+		InsertArrTest(theList, 13, goodArray(), 52, 2, False)
+		'' try insert undimmed array (no-op)
+		InsertArrTest(theList, -1, emptyArray(), 0, 0, False)
+		'' insert first three elements of array at end
+		InsertArrTest(theList, -1, goodArray(), 50, 3, False)
+		'' insert last element at end
+		InsertArrTest(theList, theList.Count, goodArray(), 54, 1, False)
+		theList.Clear()
+		'' make sure it still works after a clear
+		InsertArrTest(theList, theList.Count, goodArray(), 53, 1, False)
+		theList.Clear()
+		dim secondList As IntegerHolderList
+		dim thirdList As IntegerHolderList
+		secondList.Add(goodArray())
+		temp.num = 75475 : thirdList.Add(temp)
+		temp.num = 924384 : thirdList.Add(temp)
+		'' oob, do nothing
+		InsertContainerTest(secondList, thirdList, 67, True)
+		'' insert at position three
+		InsertContainerTest(secondList, thirdList, 3, True)
+		'' insert empty list (no fail, but does nothing)
+		InsertContainerTest(secondList, theList, 3, True)
+		'' insert good list at end
+		InsertContainerTest(secondList, thirdList, -1, True)
+		'' insert good list at end
+		InsertContainerTest(secondList, thirdList, secondList.Count, True)
+		dim nullCont As IntegerHolderList Ptr = 0
+		Err = 0
+		On Local Error Goto continueTest1
+		secondList.Insert(0, nullCont)
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 1)		
+	continueTest1:
+		'' byref inserts
+		'' oob, do nothing
+		InsertContainerTest(secondList, thirdList, 67, False)
+		'' insert at position three
+		InsertContainerTest(secondList, thirdList, 3, False)
+		'' insert empty list (no fail, but does nothing)
+		InsertContainerTest(secondList, theList, 3, False)
+		'' insert good list at end
+		InsertContainerTest(secondList, thirdList, -1, False)
+		'' insert good list at end
+		InsertContainerTest(secondList, thirdList, secondList.Count, False)
+		dim slg As SequentialIntegerHolderGenerator = Type(8, 678)
+		dim emptyGen As SequentialIntegerHolderGenerator = Type(0, 123)
+		'' oob, do nothing
+		InsertIteratorTest(secondList, slg, 67, True)
+		'' insert at position three
+		InsertIteratorTest(secondList, slg, 3, True)
+		'' insert empty list (no fail, but does nothing)
+		InsertIteratorTest(secondList, emptyGen, 3, True)
+		'' insert good list at end
+		InsertIteratorTest(secondList, slg, -1, True)
+		'' insert good list at end
+		InsertIteratorTest(secondList, slg, secondList.Count, True)
+		dim nullIter As FB_IIterator(One, Two, IntegerHolder) Ptr = 0
+		Err = 0
+		localErr = 0
+		On Local Error Goto continueTest2
+		secondList.Insert(0, nullIter)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)		
+	continueTest2:
+		'' byref inserts
+		'' oob, do nothing
+		InsertIteratorTest(secondList, slg, 67, False)
+		'' insert at position three
+		InsertIteratorTest(secondList, slg, 3, False)
+		'' insert empty list (no fail, but does nothing)
+		InsertIteratorTest(secondList, emptyGen, 3, False)
+		'' insert good list at end
+		InsertIteratorTest(secondList, slg, -1, False)
+		'' insert good list at end
+		InsertIteratorTest(secondList, slg, secondList.Count, False)
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(LastTest)
+		dim list As IntegerHolderList
+		dim temp As One.Two.IntegerHolder
+		'' Out of bounds calls Error with FB_CONTAINER_DEBUG
+		On Local Error Goto afterError
+		Err = 0
+		dim last As One.Two.IntegerHolder = list.Last()
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6) '' out of bounds
+	afterError:
+		temp.num = 7 : list.Add(temp)
+		CU_ASSERT_EQUAL(list.Last().num, 7)
+		temp.num = 9 : list.Add(temp)
+		CU_ASSERT_EQUAL(list.Last().num, 9)
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.Last().num, 9)
+		Dim arr(0 To 1) As One.Two.IntegerHolder
+		list.Insert(-1, arr())
+		CU_ASSERT_EQUAL(list.Last().num, 0)
+		list.RemoveAt(list.Count - 1)
+		CU_ASSERT_EQUAL(list.Last().num, 0)
+		list.Clear()
+		Err = 0
+		On Local Error Goto afterError2
+		dim first As One.Two.IntegerHolder = list.Last()
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6) '' out of bounds
+	afterError2:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(LastIndexOf)
+		dim list As IntegerHolderList
+		dim i As Long
+		dim temp As One.Two.IntegerHolder = (0)
+		CU_ASSERT_EQUAL(list.LastIndexOf(temp), -1)
+		temp.num = 65 : list.Add(temp) '' 0
+		list.Add(temp) '' 1
+		temp.num = 0 : list.Add(temp) '' 2
+		temp.num = 85 : list.Add(temp) '' 3
+		temp.num = 65 : list.Add(temp) '' 4
+		temp.num = 69 : list.Add(temp) '' 5
+		For i = 0 to list.Count - 1
+			If i > 1 Then
+				CU_ASSERT_EQUAL(list.LastIndexOf(list[i]), i)
+			Else
+				CU_ASSERT_EQUAL(list.LastIndexOf(list[i]), 4)
+			End If
+		Next
+		list.RemoveAt(0)
+		For i = 0 to list.Count - 1
+			If i > 0 Then
+				CU_ASSERT_EQUAL(list.LastIndexOf(list[i]), i)
+			Else
+				CU_ASSERT_EQUAL(list.LastIndexOf(list[i]), 3)
+			End If
+		Next
+		CU_ASSERT_EQUAL(list.LastIndexOf(list.Last()), list.Count - 1)
+		CU_ASSERT_EQUAL(list.LastIndexOf(list[1]), 1)
+		temp.num = 65 : list.Add(temp)
+		CU_ASSERT_EQUAL(list.LastIndexOf(temp), list.Count - 1)
+		temp.num = 58 : CU_ASSERT_EQUAL(list.LastIndexOf(temp), -1)
+	END_TEST
+	
+	TEST(Remove)
+		dim list As IntegerHolderList
+		dim sixtyFive As One.Two.IntegerHolder = (65)
+		dim temp As One.Two.IntegerHolder
+		list.Add(sixtyFive) '' 0
+		temp.num = 0 : list.Add(temp) '' 1
+		temp.num = 85 : list.Add(temp) '' 2
+		list.Add(sixtyFive) '' 3
+		temp.num = 69 : list.Add(temp) '' 4
+		
+		'' remove a duplicate
+		temp.num = 65 : list.Remove(temp)
+		CU_ASSERT_EQUAL(list.Count, 4)
+		CU_ASSERT(list[0].num <> 65)
+		CU_ASSERT_EQUAL(list.Contains(sixtyFive), True) '' because there were two, and remove only removes the first
+		'' remove a single
+		list.Remove(sixtyFive)
+		CU_ASSERT_EQUAL(list.Count, 3)
+		CU_ASSERT(list[0].num <> 65)
+		CU_ASSERT(list[2].num <> 65)
+		CU_ASSERT_EQUAL(list.Contains(sixtyFive), False) '' because there was one, and now there isn't
+		'' remove a non-existant
+		list.Remove(sixtyFive) '' this shouldn't do anything
+		CU_ASSERT_EQUAL(list.Count, 3)
+		CU_ASSERT_EQUAL(list.Contains(sixtyFive), False)
+		
+		dim emptyList As IntegerHolderList
+		temp.num = 0 : emptyList.Remove(temp)
+		CU_ASSERT_EQUAL(emptyList.Empty(), True)
+	END_TEST
+	
+	TEST(RemoveAt)
+		dim list As IntegerHolderList
+		dim arrItems(10 To 20) As One.Two.IntegerHolder
+		dim i As Long
+		dim localErr As Long
+		For i = 10 To 20
+			arrItems(i).num = i
+		Next
+		list.Add(arrItems())
+		list.RemoveAt(0)
+		CU_ASSERT_EQUAL(list.Count, 10)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i], arrItems(i + 11))
+		Next
+		list.RemoveAt(list.Count - 1)
+		CU_ASSERT_EQUAL(list.Count, 9)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i], arrItems(i + 11))
+		Next
+		
+		On Local Error Goto resumeTests
+		Err = 0
+		list.RemoveAt(19)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(list.Count, 9)
+	resumeTests:
+		On Local Error Goto resumeTests2
+		Err = 0
+		list.RemoveAt(-1)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(list.Count, 9)
+	resumeTests2:
+		list.RemoveAt(5)
+		For i = 0 to 4
+			CU_ASSERT_EQUAL(list[i], arrItems(i + 11))
+		Next
+		For i = 5 to list.Count - 1
+			CU_ASSERT_EQUAL(list[i], arrItems(i + 12))
+		Next
+		CU_ASSERT_EQUAL(list.Count, 8)
+		dim emptyList As IntegerHolderList
+		On Local Error Goto resumeTests3
+		Err = 0
+		emptyList.RemoveAt(0)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(emptyList.Count, 0)
+	resumeTests3:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(RemoveSpan)
+		dim slg As SequentialIntegerHolderGenerator = Type(100, 55)
+		dim list As IntegerHolderList = slg
+		dim toRemove As Long = 10
+		dim i As Long
+		dim localErr As Long
+		list.RemoveSpan(0, toRemove)
+		CU_ASSERT_EQUAL(list.Count, 90)
+		slg.Reset()
+		slg.Skip(toRemove)
+		For i = 0 To list.Count - 1
+			slg.Advance()
+			CU_ASSERT_EQUAL(list[i], slg.Item())
+		Next		
+		On Local Error Goto resumeTests
+		Err = 0
+		list.RemoveSpan(-5, 15)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(list.Count, 90)
+	resumeTests:
+		'' added 100, removed 10, this will remove 5 from 85-89
+		list.RemoveSpan(85, 15)
+		CU_ASSERT_EQUAL(list.Count, 85)
+		slg.Reset()
+		slg.Skip(toRemove)
+		For i = 0 To list.Count - 1
+			slg.Advance()
+			CU_ASSERT_EQUAL(list[i], slg.Item())
+		Next
+		list.RemoveSpan(0, list.Count)
+		CU_ASSERT_EQUAL(list.Empty(), True)
+		On Local Error Goto resumeTests2
+		Err = 0
+		list.RemoveSpan(0, 10)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+		CU_ASSERT_EQUAL(list.Count, 0)
+	resumeTests2:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(Resize)
+		dim i As Long
+		dim list As IntegerHolderList
+		dim localErr As Long
+		CU_ASSERT_EQUAL(list.Count, 0)
+		list.Resize(6)
+		CU_ASSERT_EQUAL(list.Count, 6)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i].num, 0)
+		Next
+		list.Resize(3)
+		CU_ASSERT_EQUAL(list.Count, 3)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i].num, 0)
+		Next
+		On Local Error Goto resumeTests
+		Err = 0
+		list.Resize(-6)
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+		CU_ASSERT_EQUAL(list.Count, 3)
+	resumeTests:
+		On Local Error Goto 0
+		list.Resize(10)
+		CU_ASSERT_EQUAL(list.Count, 10)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i].num, 0)
+			list[i].num = i
+		Next
+		list.Resize(20)
+		For i = 0 To list.Count - 1
+			CU_ASSERT_EQUAL(list[i].num, IIf(i < 10, i, 0))
+		Next		
+	END_TEST
+	
+	TEST(ReserveCapacity)
+		dim list As IntegerHolderList
+		dim temp As One.Two.IntegerHolder
+		dim curCapacity As Long
+		dim i As Long
+		CU_ASSERT(list.Capacity > 0)
+		CU_ASSERT_EQUAL(list.Count, 0)
+		list.Reserve(30)
+		CU_ASSERT_EQUAL(list.Capacity, 30)
+		CU_ASSERT_EQUAL(list.Count, 0)
+		'' Clear trims the unused space 
+		list.Clear()
+		CU_ASSERT((list.Capacity < 30) AndAlso (list.Capacity > 0))
+		CU_ASSERT_EQUAL(list.Count, 0)
+		list.Resize(60)
+		curCapacity = list.Capacity
+		CU_ASSERT_EQUAL(list.Count, 60)
+		CU_ASSERT(curCapacity > 60)
+		'' can't reserve down
+		list.Reserve(30)
+		CU_ASSERT_EQUAL(list.Count, 60)
+		CU_ASSERT_EQUAL(list.Capacity, curCapacity)
+		list.Reserve(-6)
+		CU_ASSERT_EQUAL(list.Count, 60)
+		CU_ASSERT_EQUAL(list.Capacity, curCapacity)
+		list.Clear()
+		curCapacity = list.Capacity
+		For i = 0 To curCapacity - 1
+			temp.num = i
+			list.Add(temp)
+		Next
+		CU_ASSERT_EQUAL(list.Capacity, list.Count)
+		temp.num = 89 : list.Add(temp)
+		CU_ASSERT((list.Capacity - list.Count) > 1)
+	END_TEST
+	
+	TEST(Operators)
+		dim list As IntegerHolderList
+		dim As One.Two.IntegerHolder first = (17525), second = (7854), third = (12)
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		list += first
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		CU_ASSERT_EQUAL(Len(list), 1)
+		CU_ASSERT_EQUAL(list[0], first)
+		list += second
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		CU_ASSERT_EQUAL(Len(list), 2)
+		CU_ASSERT_EQUAL(list[0], first)
+		CU_ASSERT_EQUAL(list[1], second)
+		list.Clear()
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		CU_ASSERT_EQUAL(Len(list), 0)
+		list += third
+		CU_ASSERT_EQUAL(Len(list), list.Count)
+		CU_ASSERT_EQUAL(Len(list), 1)
+		CU_ASSERT_EQUAL(list[0], third)
+	END_TEST
+	
+	'' This asserts that the items in the list are copies
+	'' and not linked to the added variable
+	TEST(Independence)
+		dim list As IntegerHolderList
+		dim As One.Two.IntegerHolder first = (17525), second = (7854), third = (12)
+		list.Add(first)
+		CU_ASSERT_EQUAL(list[0], first)
+		first.num = 1
+		CU_ASSERT(list[0].num <> first.num)
+		list[0].num = 98
+		CU_ASSERT(first.num <> 98)
+		list.Add(second)
+		dim oldSecond As One.Two.IntegerHolder = second
+		CU_ASSERT_EQUAL(list[1], second)
+		list.Clear()
+		CU_ASSERT_EQUAL(second, oldSecond)
+	END_TEST
+
+END_SUITE

--- a/tests/containers/QueueTestPrimitive.bas
+++ b/tests/containers/QueueTestPrimitive.bas
@@ -1,0 +1,426 @@
+'' #define FB_CONTAINER_DEBUG 1
+#include "../../inc/containers/queue.bi"
+#include "ContainerTestPrereqs.bi"
+#include "fbcunit.bi"
+
+FBCont_DefineQueueOf(Long)
+Type LongQueue As FB_Queue(Long)
+
+Private Sub CheckQueueAgainstArray(Byref queue As LongQueue, arr() As Long)
+    Dim queueCopy As LongQueue = queue
+    Dim As Long arrLBound, arrUBound, numElems, i
+    arrLBound = LBound(arr)
+    arrUBound = UBound(arr)
+    numElems = (arrUBound - arrLBound) + 1
+    CU_ASSERT_EQUAL(numElems, Len(queue))
+    For i = arrLBound To arrUBound
+        CU_ASSERT_EQUAL(arr(i), queueCopy.Pop())
+    Next
+End Sub
+
+SUITE(fbc_tests.containers.queues.primitive)
+	TEST(ConstructorTest)
+		dim emptyQueue As LongQueue
+		CU_ASSERT_EQUAL(emptyQueue.Count, 0)
+		dim emptyIterator As SequentialLongGenerator = Type(0, 1)
+
+		Dim zt1NumToGenerate As Long = 15
+		Dim zt1StartNum As Long = 0
+		Dim i As Long
+		Dim zeroTo14Iterator As SequentialLongGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 7
+		Dim tt2StartNum As Long = 203
+		Dim twoHundred3To210Iterator As SequentialLongGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		'' Iterator constructor
+		Dim zt1Queue As LongQueue = zeroTo14Iterator
+		Dim zt1QueueCopy As LongQueue = zt1Queue
+		CU_ASSERT_EQUAL(zt1Queue.Count, zt1NumToGenerate)
+		For i = 0 To (zt1NumToGenerate - 1)
+			CU_ASSERT_EQUAL(zt1Queue.Pop(), zt1StartNum + i)
+		Next
+		zt1Queue = zt1QueueCopy
+		
+		Dim tt2Queue As LongQueue = twoHundred3To210Iterator
+		Dim tt2QueueCopy As LongQueue = tt2Queue
+		CU_ASSERT_EQUAL(tt2Queue.Count, tt2NumToGenerate)
+		For i = 0 To (tt2NumToGenerate - 1)
+			CU_ASSERT_EQUAL(tt2Queue.Pop(), tt2StartNum + i)
+		Next
+		tt2Queue = tt2QueueCopy
+		zeroTo14Iterator.Reset()
+
+		Dim zt1Queue2 As LongQueue = @zeroTo14Iterator
+		Dim zt1Queue2Copy As LongQueue = zt1Queue2
+		CU_ASSERT_EQUAL(zt1Queue.Count, zt1Queue2.Count)
+		For i = 0 To (zt1NumToGenerate - 1)
+			CU_ASSERT_EQUAL(zt1Queue2.Pop(), zt1Queue.Pop())
+		Next		
+		zt1Queue2 = zt1Queue2Copy
+		twoHundred3To210Iterator.Reset()
+
+		Dim tt2Queue2 As LongQueue = @twoHundred3To210Iterator
+		Dim tt2QueueCopy2 As LongQueue = tt2Queue2
+		CU_ASSERT_EQUAL(tt2Queue2.Count, tt2Queue.Count)
+		For i = 0 To (tt2NumToGenerate - 1)
+			CU_ASSERT_EQUAL(tt2Queue.Pop(), tt2StartNum + i)
+		Next
+		tt2Queue2 = tt2QueueCopy2
+		
+		dim newEmptyQueue As LongQueue = emptyIterator
+		CU_ASSERT_EQUAL(newEmptyQueue.Count, 0)
+		emptyIterator.Reset()
+
+		'' Copy Constructors
+		Dim zt1Temp As LongQueue = zt1Queue
+		CU_ASSERT_EQUAL(zt1Temp.Count, zt1Queue.Count)
+		For i = 0 To zt1Queue.Count - 1
+			CU_ASSERT_EQUAL(zt1Temp.Pop(), zt1Queue.Pop())
+		Next
+
+		Dim tt2Temp As LongQueue = tt2Queue
+		CU_ASSERT_EQUAL(tt2Temp.Count, tt2Queue.Count)
+		For i = 0 To tt2Queue.Count - 1
+			CU_ASSERT_EQUAL(tt2Temp.Pop(), tt2Queue.Pop())
+		Next
+		
+		dim numArray(7) As Long
+		dim numArrayLBound As Long = LBound(numArray)
+		dim numArrayUBound As Long = UBound(numArray)
+		For i = numArrayLBound To numArrayUBound
+			numArray(i) = i
+		Next
+		
+		Dim arrayQueue As LongQueue = numArray()
+		CheckQueueAgainstArray(arrayQueue, numArray())
+		
+		dim numArrayBased(5 To 9) As Long
+		numArrayLBound = LBound(numArrayBased)
+		numArrayUBound = UBound(numArrayBased)
+		For i = numArrayLBound To numArrayUBound
+			numArrayBased(i) = i
+		Next
+		
+		Dim arrayQueueBased As LongQueue = numArrayBased()
+		CheckQueueAgainstArray(arrayQueueBased, numArrayBased())
+		
+		dim undimmedArray(Any) As Long
+		dim anyArrayQueue As LongQueue = undimmedArray()
+		CU_ASSERT_EQUAL(anyArrayQueue.Count, 0)
+
+		'' Container constructors
+		dim contQueue As LongQueue = @arrayQueueBased
+		For i = numArrayLBound To numArrayUBound
+			CU_ASSERT_EQUAL(numArrayBased(i), contQueue.Pop())
+		Next
+
+		dim contQueue2 As LongQueue = @arrayQueue
+		For i = LBound(numArray) To UBound(numArray)
+			CU_ASSERT_EQUAL(numArray(i), contQueue2.Pop())
+		Next
+
+		Dim fromEmptyContainerQueue As LongQueue = @newEmptyQueue
+		CU_ASSERT_EQUAL(fromEmptyContainerQueue.Count, 0)
+	END_TEST
+	
+	TEST(Push)
+		dim singleItemQueue As LongQueue
+		singleItemQueue.Push(78)
+		CU_ASSERT_EQUAL(singleItemQueue.Front, 78)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		singleItemQueue.Push(-78)
+		singleItemQueue.Push(35)
+		singleItemQueue.Push(-87)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 4)
+		CU_ASSERT_EQUAL(singleItemQueue.Front, 78)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Front, -78)
+		singleItemQueue.Push(123456)
+		CU_ASSERT_EQUAL(singleItemQueue.Front, -78)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop(), -78)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop(), 35)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop(), -87)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop(), 123456)
+		singleItemQueue.Clear()
+		singleItemQueue += 19
+		CU_ASSERT_EQUAL(singleItemQueue.Front, 19)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		singleItemQueue += 99
+		CU_ASSERT_EQUAL(singleItemQueue.Front, 19)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 2)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop(), 19)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop(), 99)
+	END_TEST
+	
+	TEST(Pop)
+		dim singleItemQueue As LongQueue
+		singleItemQueue.Push(78)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop(), 78)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+		
+		singleItemQueue.Push(-78)
+		singleItemQueue.Push(35)
+		singleItemQueue.Push(-87)
+		Dim poppedVal As Long = singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(poppedVal, -78)
+		CU_ASSERT(singleItemQueue.Front <> -78)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 2)
+		poppedVal = singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(poppedVal, 35)
+		CU_ASSERT(singleItemQueue.Front <> 35)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		poppedVal = singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(poppedVal, -87)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+#ifdef FB_CONTAINER_DEBUG
+		'' Pop on an empty Queue will crash since the underlying queue is empty
+		'' so this is guarded otherwise it'll always crash the tests
+		Err = 0
+		On Local Error Goto nextTest
+		poppedVal = singleItemQueue.Pop() '' Pop with no elements is an error
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+		On Local Error Goto 0
+#endif
+	END_TEST
+	
+	TEST(Front)
+		dim singleItemQueue As LongQueue
+		singleItemQueue.Push(78)
+		CU_ASSERT_EQUAL(singleItemQueue.Front, 78)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		
+		singleItemQueue.Push(-78)
+		CU_ASSERT(singleItemQueue.Front <> -78)
+		singleItemQueue.Push(35)
+		CU_ASSERT_EQUAL(singleItemQueue.Front, 78)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Front, -78)
+		singleItemQueue.Push(-87)
+		CU_ASSERT(singleItemQueue.Front <> -87)
+		CU_ASSERT_EQUAL(singleItemQueue.Front, -78)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Front, 35)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Front, -87)
+		singleItemQueue.Pop()
+		singleItemQueue.Push(123456)
+		CU_ASSERT_EQUAL(singleItemQueue.Front, 123456)
+
+#ifdef FB_CONTAINER_DEBUG
+		'' See comment in above test
+		singleItemQueue.Pop()
+		Err = 0
+		On Local Error Goto nextTest
+		dim poppedVal As Long = singleItemQueue.Front '' Front with no elements is an error
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+		On Local Error Goto 0
+#endif
+	END_TEST
+	
+	TEST(Clear)
+		dim singleItemQueue As LongQueue
+		singleItemQueue.Push(78)
+		singleItemQueue.Push(-78)
+		dim queueSize As Long = singleItemQueue.Count
+		singleItemQueue.Clear()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+		CU_ASSERT(singleItemQueue.Count <> queueSize)
+		queueSize = singleItemQueue.Count
+		singleItemQueue.Clear()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, queueSize)
+		dim queue2 As LongQueue	
+		queue2.Clear()
+		CU_ASSERT_EQUAL(queue2.Count, 0)
+	END_TEST
+	
+	TEST(Contains)
+		dim haystack As LongQueue
+		dim needle As Long = 78
+		dim result As Boolean
+		result = haystack.Contains(0)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Push(needle)
+		haystack.Push(-needle)
+		haystack.Push(52)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		result = haystack.Contains(52)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.Pop()
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Pop()
+		result = haystack.Contains(52)
+		CU_ASSERT_EQUAL(result, True)
+		result = haystack.Contains(-needle)
+		CU_ASSERT_EQUAL(result, False)
+		Dim generate100 As SequentialLongGenerator = Type(100, 100)
+		dim secondHaystack As LongQueue = @generate100
+		result = secondHaystack.Contains(157)
+		CU_ASSERT_EQUAL(result, True)
+	END_TEST
+	
+	TEST(CopyTo)
+		dim singleItemQueue As LongQueue
+		dim i As Long
+		singleItemQueue.Push(78)
+		singleItemQueue.Push(-78)
+		singleItemQueue.Push(8537536)
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As Long
+		singleItemQueue.CopyTo(undimmedArr())
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, singleItemQueue.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		Dim itemQueueCopy As LongQueue = singleItemQueue
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr(i), itemQueueCopy.Pop())
+		Next
+		
+		'' Except in empty lists, where nothing happens
+		'' If container debug is defined, this calls Error
+		dim emptyQueue As LongQueue
+		dim emptyArr(Any) As Long
+		On Local Error Goto nextTest1
+		dim localErr As Long
+		Err = 0
+		emptyQueue.CopyTo(emptyArr())
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+
+	nextTest1:
+		On Local Error Goto 0
+		'' already sized arrays copy the number of items in the queue or the size of the array
+		'' whichever is smaller
+		dim largerThanContArr(10 To 14) As Long
+		For i = 10 To 14
+			largerThanContArr(i) = i
+		Next
+		singleItemQueue.CopyTo(largerThanContArr())
+		arrUBound = UBound(largerThanContArr)
+		arrLBound = LBound(largerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 5)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 14)
+		itemQueueCopy = singleItemQueue
+		For i = 10 To 14
+			CU_ASSERT_EQUAL(largerThanContArr(i), IIf(i <= 12, itemQueueCopy.Pop(), i))
+		Next
+		
+		dim smallerThanContArr(21 To 22) As Long
+		For i = 21 To 22
+			smallerThanContArr(i) = i
+		Next
+		singleItemQueue.Push(4)
+		singleItemQueue.CopyTo(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 2)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 22)
+		For i = 21 To 22
+			CU_ASSERT_EQUAL(smallerThanContArr(i), singleItemQueue.Pop())
+		Next
+	END_TEST
+	
+	TEST(GetIterator)
+		dim queue As LongQueue
+		dim pListIter As FB_IIterator(Long) Ptr = queue.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+		pListIter = 0
+		queue.Push(7)
+		pListIter = queue.GetIterator()
+		dim pListIter2 As FB_IIterator(Long) Ptr = queue.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter2 <> 0)
+		CU_ASSERT(pListIter <> pListIter2)
+		CU_ASSERT(pListIter->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT(pListIter2->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT_EQUAL(pListIter2->Item(), 7)
+		Delete pListIter
+		Delete pListIter2
+		pListIter = 0
+		pListIter2 = 0
+		queue.Clear()
+		Dim i As Long
+		For i = 0 To 6
+			queue.Push(i)
+		Next
+		pListIter = queue.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		For i = 0 To 6
+			CU_ASSERT(pListIter->Advance() = True)
+			CU_ASSERT_EQUAL(pListIter->Item(), i)
+		Next
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+	END_TEST
+	
+	TEST(LenTest)
+		dim singleItemQueue As LongQueue
+		singleItemQueue.Push(78)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Push(-78)
+		singleItemQueue.Push(35)
+		singleItemQueue.Push(-87)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 4)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 3)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 2)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		singleItemQueue.Clear()
+		singleItemQueue += 19
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue += 99
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 2)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+	END_TEST
+
+	TEST(Empty)
+		dim singleItemQueue As LongQueue
+		CU_ASSERT_EQUAL(singleItemQueue.Empty(), True)
+		singleItemQueue.Push(78)
+		CU_ASSERT_EQUAL(singleItemQueue.Empty(), False)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Empty(), True)
+		Dim arr(0 To 1) As Long
+		dim otherQueue As LongQueue = arr()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), False)
+		otherQueue.Pop()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), False)
+		otherQueue.Clear()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), True)
+	END_TEST
+END_SUITE

--- a/tests/containers/QueueTestUDT.bas
+++ b/tests/containers/QueueTestUDT.bas
@@ -1,0 +1,446 @@
+''#define FB_CONTAINER_DEBUG 1
+#include "../../inc/containers/queue.bi"
+#include "ContainerTestPrereqs.bi"
+#include "fbcunit.bi"
+
+FBCont_DefineQueueOf(One, Two, IntegerHolder)
+Type IntegerHolderQueue As FB_Queue(One, Two, IntegerHolder)
+
+Private Sub CheckQueueAgainstArray(Byref queue As IntegerHolderQueue, arr() As One.Two.IntegerHolder)
+    Dim queueCopy As IntegerHolderQueue = queue
+    Dim As Long arrLBound, arrUBound, numElems, i
+    arrLBound = LBound(arr)
+    arrUBound = UBound(arr)
+    numElems = (arrUBound - arrLBound) + 1
+    CU_ASSERT_EQUAL(numElems, Len(queue))
+    For i = arrLBound To arrUBound
+        CU_ASSERT_EQUAL(arr(i), queueCopy.Pop())
+    Next
+End Sub
+
+SUITE(fbc_tests.containers.queues.udt)
+	TEST(ConstructorTest)
+		dim emptyQueue As IntegerHolderQueue
+		CU_ASSERT_EQUAL(emptyQueue.Count, 0)
+		dim emptyIterator As SequentialIntegerHolderGenerator = Type(0, 1)
+
+		Dim zt1NumToGenerate As Long = 15
+		Dim zt1StartNum As Long = 0
+		Dim i As Long
+		Dim zeroTo14Iterator As SequentialIntegerHolderGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 7
+		Dim tt2StartNum As Long = 203
+		Dim twoHundred3To210Iterator As SequentialIntegerHolderGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		'' Iterator constructor
+		Dim zt1Queue As IntegerHolderQueue = zeroTo14Iterator
+		Dim zt1QueueCopy As IntegerHolderQueue = zt1Queue
+		CU_ASSERT_EQUAL(zt1Queue.Count, zt1NumToGenerate)
+		For i = 0 To (zt1NumToGenerate - 1)
+			CU_ASSERT_EQUAL(zt1Queue.Pop().num, zt1StartNum + i)
+		Next
+		zt1Queue = zt1QueueCopy
+		
+		Dim tt2Queue As IntegerHolderQueue = twoHundred3To210Iterator
+		Dim tt2QueueCopy As IntegerHolderQueue = tt2Queue
+		CU_ASSERT_EQUAL(tt2Queue.Count, tt2NumToGenerate)
+		For i = 0 To (tt2NumToGenerate - 1)
+			CU_ASSERT_EQUAL(tt2Queue.Pop().num, tt2StartNum + i)
+		Next
+		tt2Queue = tt2QueueCopy
+		zeroTo14Iterator.Reset()
+
+		Dim zt1Queue2 As IntegerHolderQueue = @zeroTo14Iterator
+		Dim zt1Queue2Copy As IntegerHolderQueue = zt1Queue2
+		CU_ASSERT_EQUAL(zt1Queue.Count, zt1Queue2.Count)
+		For i = 0 To (zt1NumToGenerate - 1)
+			CU_ASSERT_EQUAL(zt1Queue2.Pop(), zt1Queue.Pop())
+		Next		
+		zt1Queue2 = zt1Queue2Copy
+		twoHundred3To210Iterator.Reset()
+
+		Dim tt2Queue2 As IntegerHolderQueue = @twoHundred3To210Iterator
+		Dim tt2QueueCopy2 As IntegerHolderQueue = tt2Queue2
+		CU_ASSERT_EQUAL(tt2Queue2.Count, tt2Queue.Count)
+		For i = 0 To (tt2NumToGenerate - 1)
+			CU_ASSERT_EQUAL(tt2Queue.Pop().num, tt2StartNum + i)
+		Next
+		tt2Queue2 = tt2QueueCopy2
+		
+		dim newEmptyQueue As IntegerHolderQueue = emptyIterator
+		CU_ASSERT_EQUAL(newEmptyQueue.Count, 0)
+		emptyIterator.Reset()
+
+		'' Copy Constructors
+		Dim zt1Temp As IntegerHolderQueue = zt1Queue
+		CU_ASSERT_EQUAL(zt1Temp.Count, zt1Queue.Count)
+		For i = 0 To zt1Queue.Count - 1
+			CU_ASSERT_EQUAL(zt1Temp.Pop(), zt1Queue.Pop())
+		Next
+
+		Dim tt2Temp As IntegerHolderQueue = tt2Queue
+		CU_ASSERT_EQUAL(tt2Temp.Count, tt2Queue.Count)
+		For i = 0 To tt2Queue.Count - 1
+			CU_ASSERT_EQUAL(tt2Temp.Pop(), tt2Queue.Pop())
+		Next
+		
+		dim numArray(7) As One.Two.IntegerHolder
+		dim numArrayLBound As Long = LBound(numArray)
+		dim numArrayUBound As Long = UBound(numArray)
+		For i = numArrayLBound To numArrayUBound
+			numArray(i).num = i
+		Next
+		
+		Dim arrayQueue As IntegerHolderQueue = numArray()
+		CheckQueueAgainstArray(arrayQueue, numArray())
+		
+		dim numArrayBased(5 To 9) As One.Two.IntegerHolder
+		numArrayLBound = LBound(numArrayBased)
+		numArrayUBound = UBound(numArrayBased)
+		For i = numArrayLBound To numArrayUBound
+			numArrayBased(i).num = i
+		Next
+		
+		Dim arrayQueueBased As IntegerHolderQueue = numArrayBased()
+		CheckQueueAgainstArray(arrayQueueBased, numArrayBased())
+		
+		dim undimmedArray(Any) As One.Two.IntegerHolder
+		dim anyArrayQueue As IntegerHolderQueue = undimmedArray()
+		CU_ASSERT_EQUAL(anyArrayQueue.Count, 0)
+
+		'' Container constructors
+		dim contQueue As IntegerHolderQueue = @arrayQueueBased
+		For i = numArrayLBound To numArrayUBound
+			CU_ASSERT_EQUAL(numArrayBased(i), contQueue.Pop())
+		Next
+
+		dim contQueue2 As IntegerHolderQueue = @arrayQueue
+		For i = LBound(numArray) To UBound(numArray)
+			CU_ASSERT_EQUAL(numArray(i), contQueue2.Pop())
+		Next
+
+		Dim fromEmptyContainerQueue As IntegerHolderQueue = @newEmptyQueue
+		CU_ASSERT_EQUAL(fromEmptyContainerQueue.Count, 0)
+
+	END_TEST
+	
+	TEST(Push)
+		dim singleItemQueue As IntegerHolderQueue
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Front, temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		temp.num = -78 : singleItemQueue.Push(temp)
+		temp.num = 35 : singleItemQueue.Push(temp)
+		temp.num = -87 : singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 4)
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, 78)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, -78)
+		temp.num = 123456 : singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, -78)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop().num, -78)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop().num, 35)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop().num, -87)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop().num, 123456)
+		singleItemQueue.Clear()
+		temp.num = 19 : singleItemQueue += temp
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, 19)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		temp.num = 99 : singleItemQueue += temp
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, 19)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 2)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop().num, 19)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop().num, 99)
+	END_TEST
+	
+	TEST(Pop)
+		dim singleItemQueue As IntegerHolderQueue
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Pop(), temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+		
+		temp.num = -78 : singleItemQueue.Push(temp)
+		temp.num = 35 : singleItemQueue.Push(temp)
+		temp.num = -87 : singleItemQueue.Push(temp)
+		Dim poppedVal As One.Two.IntegerHolder = singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(poppedVal.num, -78)
+		CU_ASSERT(singleItemQueue.Front.num <> -78)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 2)
+		poppedVal = singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(poppedVal.num, 35)
+		CU_ASSERT(singleItemQueue.Front.num <> 35)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		poppedVal = singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(poppedVal.num, -87)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+#ifdef FB_CONTAINER_DEBUG
+		'' Pop on an empty Queue will crash since the underlying queue is empty
+		'' so this is guarded otherwise it'll always crash the tests
+		Err = 0
+		On Local Error Goto nextTest
+		poppedVal = singleItemQueue.Pop() '' Pop with no elements is an error
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+		On Local Error Goto 0
+#endif
+	END_TEST
+	
+	TEST(Front)
+		dim singleItemQueue As IntegerHolderQueue
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Front, temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		
+		temp.num = -78 : singleItemQueue.Push(temp)
+		CU_ASSERT(singleItemQueue.Front.num <> -78)
+		temp.num = 35 : singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, 78)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, -78)
+		temp.num = -87 : singleItemQueue.Push(temp)
+		CU_ASSERT(singleItemQueue.Front.num <> -87)
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, -78)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, 35)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, -87)
+		singleItemQueue.Pop()
+		temp.num = 123456 : singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Front.num, 123456)
+
+#ifdef FB_CONTAINER_DEBUG
+		'' See comment in above test
+		singleItemQueue.Pop()
+		Err = 0
+		On Local Error Goto nextTest
+		dim poppedVal As One.Two.IntegerHolder = singleItemQueue.Front '' Front with no elements is an error
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+		On Local Error Goto 0
+#endif
+	END_TEST
+	
+	TEST(Clear)
+		dim singleItemQueue As IntegerHolderQueue
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemQueue.Push(temp)
+		temp.num = -78 : singleItemQueue.Push(temp)
+		dim queueSize As Long = singleItemQueue.Count
+		singleItemQueue.Clear()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+		CU_ASSERT(singleItemQueue.Count <> queueSize)
+		queueSize = singleItemQueue.Count
+		singleItemQueue.Clear()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, queueSize)
+		dim queue2 As IntegerHolderQueue	
+		queue2.Clear()
+		CU_ASSERT_EQUAL(queue2.Count, 0)
+	END_TEST
+	
+	TEST(Contains)
+		dim haystack As IntegerHolderQueue
+		dim needle As One.Two.IntegerHolder = (78)
+		dim temp As One.Two.IntegerHolder = (0)
+		dim result As Boolean
+		result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Push(needle)
+		temp.num = -needle.num : haystack.Push(temp)
+		temp.num = 52 : haystack.Push(temp)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.Pop()
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Pop()
+		result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+		temp.num = -needle.num : result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, False)
+		temp.num = 52 : result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+		Dim generate100 As SequentialIntegerHolderGenerator = Type(100, 100)
+		dim secondHaystack As IntegerHolderQueue = @generate100
+		temp.num = 157 : result = secondHaystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+	END_TEST
+	
+	TEST(CopyTo)
+		dim singleItemQueue As IntegerHolderQueue
+		dim i As Long
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemQueue.Push(temp)
+		temp.num = -78 : singleItemQueue.Push(temp)
+		temp.num = 8537536 : singleItemQueue.Push(temp)
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As One.Two.IntegerHolder
+		singleItemQueue.CopyTo(undimmedArr())
+
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, singleItemQueue.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		Dim itemQueueCopy As IntegerHolderQueue = singleItemQueue
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr(i), itemQueueCopy.Pop())
+		Next
+
+		'' Except in empty lists, where nothing happens
+		'' If container debug is defined, this calls Error
+		dim emptyQueue As IntegerHolderQueue
+		dim emptyArr(Any) As One.Two.IntegerHolder
+		On Local Error Goto nextTest1
+		dim localErr As Long
+		Err = 0
+		emptyQueue.CopyTo(emptyArr())
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+
+	nextTest1:
+		On Local Error Goto 0
+		'' already sized arrays copy the number of items in the queue or the size of the array
+		'' whichever is smaller
+		dim largerThanContArr(10 To 14) As One.Two.IntegerHolder
+		For i = 10 To 14
+			largerThanContArr(i).num = i
+		Next
+
+		singleItemQueue.CopyTo(largerThanContArr())
+		arrUBound = UBound(largerThanContArr)
+		arrLBound = LBound(largerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 5)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 14)
+		itemQueueCopy = singleItemQueue
+		For i = 10 To 14
+			temp.num = i
+			CU_ASSERT_EQUAL(largerThanContArr(i), IIf(i <= 12, itemQueueCopy.Pop(), temp))
+		Next
+		dim smallerThanContArr(21 To 22) As One.Two.IntegerHolder
+		For i = 21 To 22
+			smallerThanContArr(i).num = i
+		Next
+		temp.num = 4 : singleItemQueue.Push(temp)
+		singleItemQueue.CopyTo(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 2)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 22)
+		For i = 21 To 22
+			CU_ASSERT_EQUAL(smallerThanContArr(i), singleItemQueue.Pop())
+		Next
+	END_TEST
+	
+	TEST(GetIterator)
+		dim queue As IntegerHolderQueue
+		dim pListIter As FB_IIterator(One, Two, IntegerHolder) Ptr = queue.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+		pListIter = 0
+
+		Dim temp As One.Two.IntegerHolder = (7)
+		queue.Push(temp)
+		pListIter = queue.GetIterator()
+		dim pListIter2 As FB_IIterator(One, Two, IntegerHolder) Ptr = queue.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter2 <> 0)
+		CU_ASSERT(pListIter <> pListIter2)
+		CU_ASSERT(pListIter->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), temp)
+		CU_ASSERT(pListIter2->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), temp)
+		CU_ASSERT_EQUAL(pListIter2->Item(), temp)
+		Delete pListIter
+		Delete pListIter2
+		pListIter = 0
+		pListIter2 = 0
+		queue.Clear()
+
+		Dim i As Long
+		For i = 0 To 6
+			temp.num = i
+			queue.Push(temp)
+		Next
+		pListIter = queue.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		For i = 0 To 6
+			temp.num = i
+			CU_ASSERT(pListIter->Advance() = True)
+			CU_ASSERT_EQUAL(pListIter->Item(), temp)
+		Next
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+	END_TEST
+	
+	TEST(LenTest)
+		dim singleItemQueue As IntegerHolderQueue
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		temp.num = -78 : singleItemQueue.Push(temp)
+		temp.num = 35 : singleItemQueue.Push(temp)
+		temp.num = -87 : singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 4)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 3)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 2)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		singleItemQueue.Clear()
+
+		temp.num = 19
+		singleItemQueue += temp
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		temp.num = 99 : singleItemQueue += temp
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 2)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 1)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Count, 0)
+		CU_ASSERT_EQUAL(singleItemQueue.Count, Len(singleItemQueue))
+	END_TEST
+
+	TEST(Empty)
+		dim singleItemQueue As IntegerHolderQueue
+		dim temp As One.Two.IntegerHolder = (78)
+		CU_ASSERT_EQUAL(singleItemQueue.Empty(), True)
+		singleItemQueue.Push(temp)
+		CU_ASSERT_EQUAL(singleItemQueue.Empty(), False)
+		singleItemQueue.Pop()
+		CU_ASSERT_EQUAL(singleItemQueue.Empty(), True)
+		Dim arr(0 To 1) As One.Two.IntegerHolder
+		dim otherQueue As IntegerHolderQueue = arr()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), False)
+		otherQueue.Pop()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), False)
+		otherQueue.Clear()
+		CU_ASSERT_EQUAL(otherQueue.Empty(), True)
+	END_TEST
+END_SUITE

--- a/tests/containers/StackTestPrimitive.bas
+++ b/tests/containers/StackTestPrimitive.bas
@@ -1,0 +1,420 @@
+''#define FB_CONTAINER_DEBUG 1
+#include "../../inc/containers/stack.bi"
+#include "ContainerTestPrereqs.bi"
+#include "fbcunit.bi"
+
+FBCont_DefineStackOf(Long)
+Type LongStack As FB_Stack(Long)
+
+Private Sub CheckStackAgainstArray(Byref stack As LongStack, arr() As Long)
+    Dim stackCopy As LongStack = stack
+    Dim As Long arrLBound, arrUBound, numElems, i
+    arrLBound = LBound(arr)
+    arrUBound = UBound(arr)
+    numElems = (arrUBound - arrLBound) + 1
+    CU_ASSERT_EQUAL(numElems, Len(stack))
+    For i = arrUBound To arrLBound Step -1
+        CU_ASSERT_EQUAL(arr(i), stackCopy.Pop())
+    Next
+End Sub
+
+SUITE(fbc_tests.containers.stacks.primitive)
+	TEST(ConstructorTest)
+		dim emptyStack As LongStack
+		CU_ASSERT_EQUAL(emptyStack.Count, 0)
+		dim emptyIterator As SequentialLongGenerator = Type(0, 1)
+
+		Dim zt1NumToGenerate As Long = 15
+		Dim zt1StartNum As Long = 0
+		Dim i As Long
+		Dim zeroTo14Iterator As SequentialLongGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 7
+		Dim tt2StartNum As Long = 203
+		Dim twoHundred3To210Iterator As SequentialLongGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		'' Iterator constructor
+		Dim zt1Stack As LongStack = zeroTo14Iterator
+		Dim zt1StackCopy As LongStack = zt1Stack
+		CU_ASSERT_EQUAL(zt1Stack.Count, zt1NumToGenerate)
+		For i = (zt1NumToGenerate - 1) To 0 Step -1
+			CU_ASSERT_EQUAL(zt1Stack.Pop(), zt1StartNum + i)
+		Next
+		zt1Stack = zt1StackCopy
+		
+		Dim tt2Stack As LongStack = twoHundred3To210Iterator
+		Dim tt2StackCopy As LongStack = tt2Stack
+		CU_ASSERT_EQUAL(tt2Stack.Count, tt2NumToGenerate)
+		For i = (tt2NumToGenerate - 1) To 0 Step -1
+			CU_ASSERT_EQUAL(tt2Stack.Pop(), tt2StartNum + i)
+		Next
+		tt2Stack = tt2StackCopy
+		zeroTo14Iterator.Reset()
+
+		Dim zt1Stack2 As LongStack = @zeroTo14Iterator
+		Dim zt1Stack2Copy As LongStack = zt1Stack2
+		CU_ASSERT_EQUAL(zt1Stack.Count, zt1Stack2.Count)
+		For i = (zt1NumToGenerate - 1) To 0 Step -1
+			CU_ASSERT_EQUAL(zt1Stack2.Pop(), zt1Stack.Pop())
+		Next		
+		zt1Stack2 = zt1Stack2Copy
+		twoHundred3To210Iterator.Reset()
+
+		Dim tt2Stack2 As LongStack = @twoHundred3To210Iterator
+		Dim tt2StackCopy2 As LongStack = tt2Stack2
+		CU_ASSERT_EQUAL(tt2Stack2.Count, tt2Stack.Count)
+		For i = (tt2NumToGenerate - 1) To 0 Step -1
+			CU_ASSERT_EQUAL(tt2Stack.Pop(), tt2StartNum + i)
+		Next
+		tt2Stack2 = tt2StackCopy2
+		
+		dim newEmptyStack As LongStack = emptyIterator
+		CU_ASSERT_EQUAL(newEmptyStack.Count, 0)
+		emptyIterator.Reset()
+
+		'' Copy Constructors
+		Dim zt1Temp As LongStack = zt1Stack
+		CU_ASSERT_EQUAL(zt1Temp.Count, zt1Stack.Count)
+		For i = 0 To zt1Stack.Count - 1
+			CU_ASSERT_EQUAL(zt1Temp.Pop(), zt1Stack.Pop())
+		Next
+
+		Dim tt2Temp As LongStack = tt2Stack
+		CU_ASSERT_EQUAL(tt2Temp.Count, tt2Stack.Count)
+		For i = 0 To tt2Stack.Count - 1
+			CU_ASSERT_EQUAL(tt2Temp.Pop(), tt2Stack.Pop())
+		Next
+		
+		dim numArray(7) As Long
+		dim numArrayLBound As Long = LBound(numArray)
+		dim numArrayUBound As Long = UBound(numArray)
+		For i = numArrayLBound To numArrayUBound
+			numArray(i) = i
+		Next
+		
+		Dim arrayStack As LongStack = numArray()
+		CheckStackAgainstArray(arrayStack, numArray())
+		
+		dim numArrayBased(5 To 9) As Long
+		numArrayLBound = LBound(numArrayBased)
+		numArrayUBound = UBound(numArrayBased)
+		For i = numArrayLBound To numArrayUBound
+			numArrayBased(i) = i
+		Next
+		
+		Dim arrayStackBased As LongStack = numArrayBased()
+		CheckStackAgainstArray(arrayStackBased, numArrayBased())
+		
+		dim undimmedArray(Any) As Long
+		dim anyArrayStack As LongStack = undimmedArray()
+		CU_ASSERT_EQUAL(anyArrayStack.Count, 0)
+
+		'' Container constructors
+		'' The stack iterator goes from top to bottom so the contents
+		'' of a stack created from that will be in reverse order
+		dim contStack As LongStack = @arrayStackBased
+		For i = numArrayLBound To numArrayUBound
+			CU_ASSERT_EQUAL(numArrayBased(i), contStack.Pop())
+		Next
+
+		dim contStack2 As LongStack = @arrayStack
+		For i = LBound(numArray) To UBound(numArray)
+			CU_ASSERT_EQUAL(numArray(i), contStack2.Pop())
+		Next
+
+		Dim fromEmptyContainerStack As LongStack = @newEmptyStack
+		CU_ASSERT_EQUAL(fromEmptyContainerStack.Count, 0)
+	END_TEST
+	
+	TEST(Push)
+		dim singleItemStack As LongStack
+		singleItemStack.Push(78)
+		CU_ASSERT_EQUAL(singleItemStack.Top, 78)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		singleItemStack.Push(-78)
+		singleItemStack.Push(35)
+		singleItemStack.Push(-87)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 4)
+		CU_ASSERT_EQUAL(singleItemStack.Top, -87)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Top, 35)
+		singleItemStack.Push(123456)
+		CU_ASSERT_EQUAL(singleItemStack.Top, 123456)
+		CU_ASSERT_EQUAL(singleItemStack.Pop(), 123456)
+		CU_ASSERT_EQUAL(singleItemStack.Pop(), 35)
+		CU_ASSERT_EQUAL(singleItemStack.Pop(), -78)
+		CU_ASSERT_EQUAL(singleItemStack.Pop(), 78)
+		singleItemStack.Clear()
+		singleItemStack += 19
+		CU_ASSERT_EQUAL(singleItemStack.Top, 19)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		singleItemStack += 99
+		CU_ASSERT_EQUAL(singleItemStack.Top, 99)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 2)
+		CU_ASSERT_EQUAL(singleItemStack.Pop(), 99)
+		CU_ASSERT_EQUAL(singleItemStack.Pop(), 19)
+	END_TEST
+	
+	TEST(Pop)
+		dim singleItemStack As LongStack
+		singleItemStack.Push(78)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Pop(), 78)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		
+		singleItemStack.Push(-78)
+		singleItemStack.Push(35)
+		singleItemStack.Push(-87)
+		Dim poppedVal As Long = singleItemStack.Pop()
+		CU_ASSERT_EQUAL(poppedVal, -87)
+		CU_ASSERT(singleItemStack.Top <> -87)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 2)
+		poppedVal = singleItemStack.Pop()
+		CU_ASSERT_EQUAL(poppedVal, 35)
+		CU_ASSERT(singleItemStack.Top <> 35)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		poppedVal = singleItemStack.Pop()
+		CU_ASSERT_EQUAL(poppedVal, -78)
+		CU_ASSERT(singleItemStack.Top <> -78)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		Err = 0
+		On Local Error Goto nextTest
+		poppedVal = singleItemStack.Pop() '' Pop with no elements is an error
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(Top)
+		dim singleItemStack As LongStack
+		singleItemStack.Push(78)
+		CU_ASSERT_EQUAL(singleItemStack.Top, 78)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		
+		singleItemStack.Push(-78)
+		CU_ASSERT_EQUAL(singleItemStack.Top, -78)
+		singleItemStack.Push(35)
+		CU_ASSERT_EQUAL(singleItemStack.Top, 35)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Top, -78)
+		singleItemStack.Push(-87)
+		CU_ASSERT_EQUAL(singleItemStack.Top, -87)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Top, -78)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Top, 78)
+		singleItemStack.Pop()
+		singleItemStack.Push(123456)
+		CU_ASSERT_EQUAL(singleItemStack.Top, 123456)
+		singleItemStack.Pop()
+		Err = 0
+		On Local Error Goto nextTest
+		dim poppedVal As Long = singleItemStack.Top '' Top with no elements is an error
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(Clear)
+		dim singleItemStack As LongStack
+		singleItemStack.Push(78)
+		singleItemStack.Push(-78)
+		dim stackSize As Long = singleItemStack.Count
+		singleItemStack.Clear()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		CU_ASSERT(singleItemStack.Count <> stackSize)
+		stackSize = singleItemStack.Count
+		singleItemStack.Clear()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		CU_ASSERT_EQUAL(singleItemStack.Count, stackSize)
+		dim stack2 As LongStack	
+		stack2.Clear()
+		CU_ASSERT_EQUAL(stack2.Count, 0)
+	END_TEST
+	
+	TEST(Contains)
+		dim haystack As LongStack
+		dim needle As Long = 78
+		dim result As Boolean
+		result = haystack.Contains(0)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Push(needle)
+		haystack.Push(-needle)
+		haystack.Push(52)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		result = haystack.Contains(52)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.Pop()
+		result = haystack.Contains(52)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Pop()
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		result = haystack.Contains(-needle)
+		CU_ASSERT_EQUAL(result, False)
+		Dim generate100 As SequentialLongGenerator = Type(100, 100)
+		dim secondHaystack As LongStack = @generate100
+		result = secondHaystack.Contains(157)
+		CU_ASSERT_EQUAL(result, True)
+	END_TEST
+	
+	TEST(CopyTo)
+		dim singleItemStack As LongStack
+		dim i As Long
+		singleItemStack.Push(78)
+		singleItemStack.Push(-78)
+		singleItemStack.Push(8537536)
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As Long
+		singleItemStack.CopyTo(undimmedArr())
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, singleItemStack.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		Dim itemStackCopy As LongStack = singleItemStack
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr(i), itemStackCopy.Pop())
+		Next
+		
+		'' Except in empty lists, where nothing happens
+		'' If container debug is defined, this calls Error
+		dim emptyStack As LongStack
+		dim emptyArr(Any) As Long
+		On Local Error Goto nextTest1
+		dim localErr As Long
+		Err = 0
+		emptyStack.CopyTo(emptyArr())
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+
+	nextTest1:
+		On Local Error Goto 0
+		'' already sized arrays copy the number of items in the stack or the size of the array
+		'' whichever is smaller
+		dim largerThanContArr(10 To 14) As Long
+		For i = 10 To 14
+			largerThanContArr(i) = i
+		Next
+		singleItemStack.CopyTo(largerThanContArr())
+		arrUBound = UBound(largerThanContArr)
+		arrLBound = LBound(largerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 5)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 14)
+		itemStackCopy = singleItemStack
+		For i = 10 To 14
+			CU_ASSERT_EQUAL(largerThanContArr(i), IIf(i <= 12, itemStackCopy.Pop(), i))
+		Next
+		
+		dim smallerThanContArr(21 To 22) As Long
+		For i = 21 To 22
+			smallerThanContArr(i) = i
+		Next
+		singleItemStack.Push(4)
+		singleItemStack.CopyTo(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 2)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 22)
+		For i = 21 To 22
+			CU_ASSERT_EQUAL(smallerThanContArr(i), singleItemStack.Pop())
+		Next
+	END_TEST
+	
+	TEST(GetIterator)
+		dim stack As LongStack
+		dim pListIter As FB_IIterator(Long) Ptr = stack.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+		pListIter = 0
+		stack.Push(7)
+		pListIter = stack.GetIterator()
+		dim pListIter2 As FB_IIterator(Long) Ptr = stack.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter2 <> 0)
+		CU_ASSERT(pListIter <> pListIter2)
+		CU_ASSERT(pListIter->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT(pListIter2->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), 7)
+		CU_ASSERT_EQUAL(pListIter2->Item(), 7)
+		Delete pListIter
+		Delete pListIter2
+		pListIter = 0
+		pListIter2 = 0
+		stack.Clear()
+		Dim i As Long
+		For i = 0 To 6
+			stack.Push(i)
+		Next
+		pListIter = stack.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		For i = 6 To 0 Step -1
+			CU_ASSERT(pListIter->Advance() = True)
+			CU_ASSERT_EQUAL(pListIter->Item(), i)
+		Next
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+	END_TEST
+	
+	TEST(LenTest)
+		dim singleItemStack As LongStack
+		singleItemStack.Push(78)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Push(-78)
+		singleItemStack.Push(35)
+		singleItemStack.Push(-87)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 4)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 3)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 2)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		singleItemStack.Clear()
+		singleItemStack += 19
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack += 99
+		CU_ASSERT_EQUAL(singleItemStack.Count, 2)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+	END_TEST
+
+	TEST(Empty)
+		dim singleItemStack As LongStack
+		CU_ASSERT_EQUAL(singleItemStack.Empty(), True)
+		singleItemStack.Push(78)
+		CU_ASSERT_EQUAL(singleItemStack.Empty(), False)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Empty(), True)
+		Dim arr(0 To 1) As Long
+		dim otherStack As LongStack = arr()
+		CU_ASSERT_EQUAL(otherStack.Empty(), False)
+		otherStack.Pop()
+		CU_ASSERT_EQUAL(otherStack.Empty(), False)
+		otherStack.Clear()
+		CU_ASSERT_EQUAL(otherStack.Empty(), True)
+	END_TEST
+END_SUITE

--- a/tests/containers/StackTestUDT.bas
+++ b/tests/containers/StackTestUDT.bas
@@ -1,0 +1,437 @@
+''#define FB_CONTAINER_DEBUG 1
+#include "../../inc/containers/stack.bi"
+#include "ContainerTestPrereqs.bi"
+#include "fbcunit.bi"
+
+FBCont_DefineStackOf(One, Two, IntegerHolder)
+Type IntegerHolderStack As FB_Stack(One, Two, IntegerHolder)
+
+Private Sub CheckStackAgainstArray(Byref stack As IntegerHolderStack, arr() As One.Two.IntegerHolder)
+    Dim stackCopy As IntegerHolderStack = stack
+    Dim As Long arrLBound, arrUBound, numElems, i
+    arrLBound = LBound(arr)
+    arrUBound = UBound(arr)
+    numElems = (arrUBound - arrLBound) + 1
+    CU_ASSERT_EQUAL(numElems, Len(stack))
+    For i = arrUBound To arrLBound Step -1
+        CU_ASSERT_EQUAL(arr(i), stackCopy.Pop())
+    Next
+End Sub
+
+SUITE(fbc_tests.containers.stacks.udt)
+	TEST(ConstructorTest)
+		dim emptyStack As IntegerHolderStack
+		CU_ASSERT_EQUAL(emptyStack.Count, 0)
+		dim emptyIterator As SequentialIntegerHolderGenerator = Type(0, 1)
+
+		Dim zt1NumToGenerate As Long = 15
+		Dim zt1StartNum As Long = 0
+		Dim i As Long
+		Dim zeroTo14Iterator As SequentialIntegerHolderGenerator = Type(zt1NumToGenerate, zt1StartNum)
+		Dim tt2NumToGenerate As Long = 7
+		Dim tt2StartNum As Long = 203
+		Dim twoHundred3To210Iterator As SequentialIntegerHolderGenerator = Type(tt2NumToGenerate, tt2StartNum)
+
+		'' Iterator constructor
+		Dim zt1Stack As IntegerHolderStack = zeroTo14Iterator
+		Dim zt1StackCopy As IntegerHolderStack = zt1Stack
+		CU_ASSERT_EQUAL(zt1Stack.Count, zt1NumToGenerate)
+		For i = (zt1NumToGenerate - 1) To 0 Step -1
+			CU_ASSERT_EQUAL(zt1Stack.Pop().num, zt1StartNum + i)
+		Next
+		zt1Stack = zt1StackCopy
+		
+		Dim tt2Stack As IntegerHolderStack = twoHundred3To210Iterator
+		Dim tt2StackCopy As IntegerHolderStack = tt2Stack
+		CU_ASSERT_EQUAL(tt2Stack.Count, tt2NumToGenerate)
+		For i = (tt2NumToGenerate - 1) To 0 Step -1
+			CU_ASSERT_EQUAL(tt2Stack.Pop().num, tt2StartNum + i)
+		Next
+		tt2Stack = tt2StackCopy
+		zeroTo14Iterator.Reset()
+
+		Dim zt1Stack2 As IntegerHolderStack = @zeroTo14Iterator
+		Dim zt1Stack2Copy As IntegerHolderStack = zt1Stack2
+		CU_ASSERT_EQUAL(zt1Stack.Count, zt1Stack2.Count)
+		For i = (zt1NumToGenerate - 1) To 0 Step -1
+			CU_ASSERT_EQUAL(zt1Stack2.Pop(), zt1Stack.Pop())
+		Next		
+		zt1Stack2 = zt1Stack2Copy
+		twoHundred3To210Iterator.Reset()
+
+		Dim tt2Stack2 As IntegerHolderStack = @twoHundred3To210Iterator
+		Dim tt2StackCopy2 As IntegerHolderStack = tt2Stack2
+		CU_ASSERT_EQUAL(tt2Stack2.Count, tt2Stack.Count)
+		For i = (tt2NumToGenerate - 1) To 0 Step -1
+			CU_ASSERT_EQUAL(tt2Stack.Pop().num, tt2StartNum + i)
+		Next
+		tt2Stack2 = tt2StackCopy2
+		
+		dim newEmptyStack As IntegerHolderStack = emptyIterator
+		CU_ASSERT_EQUAL(newEmptyStack.Count, 0)
+		emptyIterator.Reset()
+
+		'' Copy Constructors
+		Dim zt1Temp As IntegerHolderStack = zt1Stack
+		CU_ASSERT_EQUAL(zt1Temp.Count, zt1Stack.Count)
+		For i = 0 To zt1Stack.Count - 1
+			CU_ASSERT_EQUAL(zt1Temp.Pop(), zt1Stack.Pop())
+		Next
+
+		Dim tt2Temp As IntegerHolderStack = tt2Stack
+		CU_ASSERT_EQUAL(tt2Temp.Count, tt2Stack.Count)
+		For i = 0 To tt2Stack.Count - 1
+			CU_ASSERT_EQUAL(tt2Temp.Pop(), tt2Stack.Pop())
+		Next
+		
+		dim numArray(7) As One.Two.IntegerHolder
+		dim numArrayLBound As Long = LBound(numArray)
+		dim numArrayUBound As Long = UBound(numArray)
+		For i = numArrayLBound To numArrayUBound
+			numArray(i).num = i
+		Next
+		
+		Dim arrayStack As IntegerHolderStack = numArray()
+		CheckStackAgainstArray(arrayStack, numArray())
+		
+		dim numArrayBased(5 To 9) As One.Two.IntegerHolder
+		numArrayLBound = LBound(numArrayBased)
+		numArrayUBound = UBound(numArrayBased)
+		For i = numArrayLBound To numArrayUBound
+			numArrayBased(i).num = i
+		Next
+		
+		Dim arrayStackBased As IntegerHolderStack = numArrayBased()
+		CheckStackAgainstArray(arrayStackBased, numArrayBased())
+		
+		dim undimmedArray(Any) As One.Two.IntegerHolder
+		dim anyArrayStack As IntegerHolderStack = undimmedArray()
+		CU_ASSERT_EQUAL(anyArrayStack.Count, 0)
+
+		'' Container constructors
+		'' The stack iterator goes from top to bottom so the contents
+		'' of a stack created from that will be in reverse order
+		dim contStack As IntegerHolderStack = @arrayStackBased
+		For i = numArrayLBound To numArrayUBound
+			CU_ASSERT_EQUAL(numArrayBased(i), contStack.Pop())
+		Next
+
+		dim contStack2 As IntegerHolderStack = @arrayStack
+		For i = LBound(numArray) To UBound(numArray)
+			CU_ASSERT_EQUAL(numArray(i), contStack2.Pop())
+		Next
+
+		Dim fromEmptyContainerStack As IntegerHolderStack = @newEmptyStack
+		CU_ASSERT_EQUAL(fromEmptyContainerStack.Count, 0)
+
+	END_TEST
+	
+	TEST(Push)
+		dim singleItemStack As IntegerHolderStack
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top, temp)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		temp.num = -78 : singleItemStack.Push(temp)
+		temp.num = 35 : singleItemStack.Push(temp)
+		temp.num = -87 : singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 4)
+		CU_ASSERT_EQUAL(singleItemStack.Top, temp)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Top.num, 35)
+		temp.num = 123456 : singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top.num, 123456)
+		CU_ASSERT_EQUAL(singleItemStack.Pop().num, 123456)
+		CU_ASSERT_EQUAL(singleItemStack.Pop().num, 35)
+		CU_ASSERT_EQUAL(singleItemStack.Pop().num, -78)
+		CU_ASSERT_EQUAL(singleItemStack.Pop().num, 78)
+		singleItemStack.Clear()
+		temp.num = 19
+		singleItemStack += temp
+		CU_ASSERT_EQUAL(singleItemStack.Top, temp)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		temp.num = 99 : singleItemStack += temp
+		CU_ASSERT_EQUAL(singleItemStack.Top, temp)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 2)
+		CU_ASSERT_EQUAL(singleItemStack.Pop(), temp)
+		CU_ASSERT_EQUAL(singleItemStack.Pop().num, 19)
+	END_TEST
+	
+	TEST(Pop)
+		dim singleItemStack As IntegerHolderStack
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Pop(), temp)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		
+		temp.num = -78 : singleItemStack.Push(temp)
+		temp.num = 35 : singleItemStack.Push(temp)
+		temp.num = -87 : singleItemStack.Push(temp)
+		Dim poppedVal As One.Two.IntegerHolder = singleItemStack.Pop()
+		CU_ASSERT_EQUAL(poppedVal, temp)
+		CU_ASSERT(singleItemStack.Top.num <> -87)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 2)
+		poppedVal = singleItemStack.Pop()
+		CU_ASSERT_EQUAL(poppedVal.num, 35)
+		CU_ASSERT(singleItemStack.Top.num <> 35)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		poppedVal = singleItemStack.Pop()
+		CU_ASSERT_EQUAL(poppedVal.num, -78)
+		CU_ASSERT(singleItemStack.Top.num <> -78)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		Err = 0
+		On Local Error Goto nextTest
+		poppedVal = singleItemStack.Pop() '' Pop with no elements is an error
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(Top)
+		dim singleItemStack As IntegerHolderStack
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top, temp)
+		
+		temp.num = -78 : singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top, temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top.num, -78)
+		temp.num = 35 : singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top, temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top.num, 35)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Top.num, -78)
+		temp.num = -87 : singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top, temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top.num, -87)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Top.num, -78)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Top.num, 78)
+		singleItemStack.Pop()
+		temp.num = 123456 : singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Top, temp)
+		singleItemStack.Pop()
+		Err = 0
+		On Local Error Goto nextTest
+		temp = singleItemStack.Top '' Top with no elements is an error
+		dim localErr As Long = Err
+		CU_ASSERT_EQUAL(localErr, 6)
+	nextTest:
+		On Local Error Goto 0
+	END_TEST
+	
+	TEST(Clear)
+		dim singleItemStack As IntegerHolderStack
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemStack.Push(temp)
+		temp.num = -78 : singleItemStack.Push(temp)
+		dim stackSize As Long = singleItemStack.Count
+		singleItemStack.Clear()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		CU_ASSERT(singleItemStack.Count <> stackSize)
+		stackSize = singleItemStack.Count
+		singleItemStack.Clear()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		CU_ASSERT_EQUAL(singleItemStack.Count, stackSize)
+		dim stack2 As IntegerHolderStack	
+		stack2.Clear()
+		CU_ASSERT_EQUAL(stack2.Count, 0)
+	END_TEST
+	
+	TEST(Contains)
+		dim haystack As IntegerHolderStack
+		dim needle As One.Two.IntegerHolder = (78)
+		dim temp As One.Two.IntegerHolder = (0)
+		dim result As Boolean
+		result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Push(needle)
+		temp.num = -needle.num : haystack.Push(temp)
+		temp.num = 52 : haystack.Push(temp)
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+		haystack.Pop()
+		result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, False)
+		haystack.Pop()
+		result = haystack.Contains(needle)
+		CU_ASSERT_EQUAL(result, True)
+		temp.num = -needle.num : result = haystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, False)
+		Dim generate100 As SequentialIntegerHolderGenerator = Type(100, 100)
+		dim secondHaystack As IntegerHolderStack = @generate100
+		temp.num = 157 : result = secondHaystack.Contains(temp)
+		CU_ASSERT_EQUAL(result, True)
+	END_TEST
+	
+	TEST(CopyTo)
+		dim singleItemStack As IntegerHolderStack
+		dim i As Long
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemStack.Push(temp)
+		temp.num = -78 : singleItemStack.Push(temp)
+		temp.num = 8537536 : singleItemStack.Push(temp)
+		'' Undimmed arrays are redimmed to be the size of the container, from 0 To n-1
+		dim undimmedArr(Any) As One.Two.IntegerHolder
+		singleItemStack.CopyTo(undimmedArr())
+		dim arrUBound As Long = UBound(undimmedArr)
+		dim arrLBound As Long = LBound(undimmedArr)
+		dim numElems As Long = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, singleItemStack.Count)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 0)
+		Dim itemStackCopy As IntegerHolderStack = singleItemStack
+		For i = 0 To arrUBound
+			CU_ASSERT_EQUAL(undimmedArr(i), itemStackCopy.Pop())
+		Next
+		
+		'' Except in empty lists, where nothing happens
+		'' If container debug is defined, this calls Error
+		dim emptyStack As IntegerHolderStack
+		dim emptyArr(Any) As One.Two.IntegerHolder
+		On Local Error Goto nextTest1
+		dim localErr As Long
+		Err = 0
+		emptyStack.CopyTo(emptyArr())
+		localErr = Err
+		CU_ASSERT_EQUAL(localErr, 1)
+
+	nextTest1:
+		On Local Error Goto 0
+		'' already sized arrays copy the number of items in the stack or the size of the array
+		'' whichever is smaller
+		dim largerThanContArr(10 To 14) As One.Two.IntegerHolder
+		For i = 10 To 14
+			largerThanContArr(i).num = i
+		Next
+		singleItemStack.CopyTo(largerThanContArr())
+		arrUBound = UBound(largerThanContArr)
+		arrLBound = LBound(largerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 5)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 10)
+		CU_ASSERT_EQUAL(arrUBound, 14)
+		itemStackCopy = singleItemStack
+		For i = 10 To 14
+			temp.num = i
+			CU_ASSERT_EQUAL(largerThanContArr(i), IIf(i <= 12, itemStackCopy.Pop(), temp))
+		Next
+		
+		dim smallerThanContArr(21 To 22) As One.Two.IntegerHolder
+		For i = 21 To 22
+			smallerThanContArr(i).num = i
+		Next
+		temp.num = 4 : singleItemStack.Push(temp)
+		singleItemStack.CopyTo(smallerThanContArr())
+		arrUBound = UBound(smallerThanContArr)
+		arrLBound = LBound(smallerThanContArr)
+		numElems = (arrUBound - arrLBound) + 1
+		CU_ASSERT_EQUAL(numElems, 2)
+		CU_ASSERT(arrUBound > arrLBound)
+		CU_ASSERT_EQUAL(arrLBound, 21)
+		CU_ASSERT_EQUAL(arrUBound, 22)
+		For i = 21 To 22
+			CU_ASSERT_EQUAL(smallerThanContArr(i), singleItemStack.Pop())
+		Next
+	END_TEST
+	
+	TEST(GetIterator)
+		dim stack As IntegerHolderStack
+		dim pListIter As FB_IIterator(One, Two, IntegerHolder) Ptr = stack.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+		pListIter = 0
+		Dim temp As One.Two.IntegerHolder = (7)
+		stack.Push(temp)
+		pListIter = stack.GetIterator()
+		dim pListIter2 As FB_IIterator(One, Two, IntegerHolder) Ptr = stack.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		CU_ASSERT(pListIter2 <> 0)
+		CU_ASSERT(pListIter <> pListIter2)
+		CU_ASSERT(pListIter->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), temp)
+		CU_ASSERT(pListIter2->Advance() = True)
+		CU_ASSERT_EQUAL(pListIter->Item(), temp)
+		CU_ASSERT_EQUAL(pListIter2->Item(), temp)
+		Delete pListIter
+		Delete pListIter2
+		pListIter = 0
+		pListIter2 = 0
+		stack.Clear()
+		Dim i As Long
+		For i = 0 To 6
+			temp.num = i
+			stack.Push(temp)
+		Next
+		pListIter = stack.GetIterator()
+		CU_ASSERT(pListIter <> 0)
+		For i = 6 To 0 Step -1
+			temp.num = i
+			CU_ASSERT(pListIter->Advance() = True)
+			CU_ASSERT_EQUAL(pListIter->Item(), temp)
+		Next
+		CU_ASSERT(pListIter->Advance() = False)
+		Delete pListIter
+	END_TEST
+	
+	TEST(LenTest)
+		dim singleItemStack As IntegerHolderStack
+		dim temp As One.Two.IntegerHolder = (78)
+		singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		temp.num = -78 : singleItemStack.Push(temp)
+		temp.num = 35 : singleItemStack.Push(temp)
+		temp.num = -87 : singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Count, 4)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 3)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 2)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		singleItemStack.Clear()
+		temp.num = 19
+		singleItemStack += temp
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		temp.num = 99 : singleItemStack += temp
+		CU_ASSERT_EQUAL(singleItemStack.Count, 2)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 1)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Count, 0)
+		CU_ASSERT_EQUAL(singleItemStack.Count, Len(singleItemStack))
+	END_TEST
+
+	TEST(Empty)
+		dim singleItemStack As IntegerHolderStack
+		dim temp As One.Two.IntegerHolder = (78)
+		CU_ASSERT_EQUAL(singleItemStack.Empty(), True)
+		singleItemStack.Push(temp)
+		CU_ASSERT_EQUAL(singleItemStack.Empty(), False)
+		singleItemStack.Pop()
+		CU_ASSERT_EQUAL(singleItemStack.Empty(), True)
+		Dim arr(0 To 1) As One.Two.IntegerHolder
+		dim otherStack As IntegerHolderStack = arr()
+		CU_ASSERT_EQUAL(otherStack.Empty(), False)
+		otherStack.Pop()
+		CU_ASSERT_EQUAL(otherStack.Empty(), False)
+		otherStack.Clear()
+		CU_ASSERT_EQUAL(otherStack.Empty(), True)
+	END_TEST
+END_SUITE

--- a/tests/containers/compiletest.bas
+++ b/tests/containers/compiletest.bas
@@ -1,0 +1,70 @@
+'' TEST_MODE: COMPILE_ONLY_OK
+''
+'' Include every container header and define every container multiple times
+'' to ensure none of it conflicts with each other
+
+#include "../../inc/containers/linkedlist.bi"
+#include "../../inc/containers/linkedlist.bi"
+#include "../../inc/containers/list.bi"
+#include "../../inc/containers/list.bi"
+#include "../../inc/containers/queue.bi"
+#include "../../inc/containers/queue.bi"
+#include "../../inc/containers/stack.bi"
+#include "../../inc/containers/stack.bi"
+#include "../../inc/containers/listiterator.bi"
+#include "../../inc/containers/listiterator.bi"
+#include "../../inc/containers/reverselistiterator.bi"
+#include "../../inc/containers/reverselistiterator.bi"
+#include "../../inc/containers/linkedlistiterator.bi"
+#include "../../inc/containers/linkedlistiterator.bi"
+#include "../../inc/containers/bitcontainer.bi"
+#include "../../inc/containers/bitcontainer.bi"
+
+FBCont_DefineIIteratorOf(Long)
+FBCont_DefineIIteratorOf(Long)
+FBCont_DefineIIteratorOf(Integer)
+FBCont_DefineIIteratorOf(Integer)
+FBCont_DefineIContainerOf(Long)
+FBCont_DefineIContainerOf(Long)
+FBCont_DefineIContainerOf(Integer)
+FBCont_DefineIContainerOf(Integer)
+FBCont_DefineIListOf(Long)
+FBCont_DefineIListOf(Long)
+FBCont_DefineIListOf(Integer)
+FBCont_DefineIListOf(Integer)
+FBCont_DefineLinkedListOf(Long)
+FBCont_DefineLinkedListOf(Long)
+FBCont_DefineLinkedListOf(Integer)
+FBCont_DefineLinkedListOf(Integer)
+FBCont_DefineLinkedListNodeOf(Long)
+FBCont_DefineLinkedListNodeOf(Long)
+FBCont_DefineLinkedListNodeOf(Integer)
+FBCont_DefineLinkedListNodeOf(Integer)
+FBCont_DefineListOf(Long)
+FBCont_DefineListOf(Long)
+FBCont_DefineListOf(Integer)
+FBCont_DefineListOf(Integer)
+FBCont_DefineStackOf(Long)
+FBCont_DefineStackOf(Long)
+FBCont_DefineStackOf(Integer)
+FBCont_DefineStackOf(Integer)
+FBCont_DefineQueueOf(Long)
+FBCont_DefineQueueOf(Long)
+FBCont_DefineQueueOf(Integer)
+FBCont_DefineQueueOf(Integer)
+FBCont_DefineLinkedListIteratorOf(Long)
+FBCont_DefineLinkedListIteratorOf(Long)
+FBCont_DefineLinkedListIteratorOf(Integer)
+FBCont_DefineLinkedListIteratorOf(Integer)
+FBCont_DefineListIteratorOf(Long)
+FBCont_DefineListIteratorOf(Long)
+FBCont_DefineListIteratorOf(Integer)
+FBCont_DefineListIteratorOf(Integer)
+FBCont_DefineStackIteratorOf(Long)
+FBCont_DefineStackIteratorOf(Long)
+FBCont_DefineStackIteratorOf(Integer)
+FBCont_DefineStackIteratorOf(Integer)
+FBCont_DefineQueueIteratorOf(Long)
+FBCont_DefineQueueIteratorOf(Long)
+FBCont_DefineQueueIteratorOf(Integer)
+FBCont_DefineQueueIteratorOf(Integer)

--- a/tests/dirlist.mk
+++ b/tests/dirlist.mk
@@ -9,6 +9,7 @@ pretest \
 boolean \
 comments \
 compound \
+containers \
 console \
 const \
 cpp \


### PR DESCRIPTION
I don't have time to write any examples and I won't for a long while but as they all have a bunch of tests written for them, here's a generic List (C++ Vector/C# List), LinkedList, Queue, Stack and a non-generic BitSet that should be OK to start being battle tested.

Compiling with -exx will turn on a debug mode that'll log all container elements built during compile and at runtime spit out prints of parameters to functions and when bad things happen (like popping from an empty queue or inserting at/ indexing a negative index). It'll also call Error instead of setting Err.

Due to this and the On Error not working as intended/as I expected, the tests will crash if compiled with -exx since they obviously also test the Error conditions which corrupts/don't restore the stack when they're caught

A quick usage example

    #include "containers/List.bi"
    FBCont_DefineListOf(Long)  '' needto define each data type

    '' Then you can use it like this
    dim myList As FB_List(Long)
    '' Or probably aliasing it is better
    Type LongIterator As FB_Iterator(Long)

    '' This will work with any contains that contains Longs!
    Sub PrintContainer(ByVal iter As LongIterator)

        While iter->Advance()
            Print iter->Item()
        Wend

    End Sub

    myList.Add(789)
    myList.Insert(0, 123)
    dim pListIter As LongIterator = myList.GetIterator()
    PrintContainer(pListIter)
    Delete pListIter

(This code has been written in the message and not tested, it prob won't compile as is)

I'm not mad about the FBCont_ / FB_ define names, but that's a simple change