### PR TITLE
We need libgpm-dev to be able to build fbc on Debian

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@
         Debian/Ubuntu:
           gcc libncurses5-dev libffi-dev libgl1-mesa-dev
           libx11-dev libxext-dev libxrender-dev libxrandr-dev libxpm-dev
-          libtinfo5
+          libtinfo5 libgpm-dev
         Fedora:
           gcc ncurses-devel ncurses-compat-libs libffi-devel mesa-libGL-devel
           libX11-devel libXext-devel libXrender-devel libXrandr-devel


### PR DESCRIPTION
I tried to build fbc on Debian and found I need this library even though it's not listed on readme.txt.