### PR TITLE
DragonFly still uses VM_METER instead of VM_TOTAL in sys_fmem.c

### DIFF
--- a/src/rtlib/dragonfly/sys_fmem.c
+++ b/src/rtlib/dragonfly/sys_fmem.c
@@ -7,7 +7,7 @@
 
 FBCALL size_t fb_GetMemAvail( int mode )
 {
-	int mib[2] = { CTL_VM, VM_TOTAL };
+	int mib[2] = { CTL_VM, VM_METER };
 	struct vmtotal vmt;
 	size_t size = sizeof(struct vmtotal);
 


### PR DESCRIPTION
After this fix, fbc could produce a working binary on DragonFlyBSD.