### PR TITLE
gfxlib2: Allow long data types with SCREENINFO, IMAGEINFO, SCREENCONTROL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -47,6 +47,15 @@ Version 1.08.0
 - optimize byref 'm += s' string concatenations to fb_StrConcatByref() which will check for same string descriptor at run-time which can't be determined at compile time for byref parameters.
 - github #298: allow command line options passed to as, gcc, ld  to be longer than 128 characters by using string types internally
 - sf.net #923: implicitly emit the deleting destructor for extern "c++" mangling for better g++ ABI compatibility
+- Add new gfxlib2 API's fb_GfxScreenInfo32() and fb_GfxScreenInfo64()
+- Change overload to SCREENINFO( byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as string = "" )
+- Add overload for SCREENINFO( byref as longint, byref as longint, byref as longint = 0, byref as longint = 0, byref as longint = 0, byref as longint = 0, byref as string = "" )
+- Add new gflib2 API's fb_GfxImageInfo32() and fb_GfxImageInfo64()
+- Change overload to IMAGEINFO( byval as const any ptr, byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as any ptr = 0, byref as longint = 0 ) as long
+- Add overload for IMAGEINFO( byval as const any ptr, byref as longint, byref as longint, byref as longint = 0, byref as longint = 0, byref as any ptr = 0, byref as longint = 0 ) as long
+- Add new gfxlib2 API's fb_GfxControl_i32() and fb_GfxControl_i64()
+- Change overload for SCREENCONTROL( byval as const long, byref as long = -2147483648, byref as long = -2147483648, byref as long = -2147483648, byref as long = -2147483648 )
+- Add overload for SCREENCONTROL( byval as const long, byref as longint, byref as longint = -2147483648, byref as longint = -2147483648, byref as longint = -2147483648 )
 
 [added]
 - extern "rtlib": respects the parent namespace, uses default fb calling convention and C style name mangling

--- a/src/compiler/rtl-gfx.bas
+++ b/src/compiler/rtl-gfx.bas
@@ -830,28 +830,53 @@ declare function hPorts_cb _
 				( typeSetIsConst( FB_DATATYPE_LONG ), FB_PARAMMODE_BYVAL, FALSE ) _
 			} _
 		), _
-		/' sub screeninfo _
+		/' sub screeninfo overload _
 			( _
-				byref width as integer = 0, _
-				byref height as integer = 0, _
-				byref depth as integer = 0, _
-				byref bpp as integer = 0, _
-				byref pitch as integer = 0, _
-				byref refresh_rate as integer = 0, _
+				byref width as long = 0, _
+				byref height as long = 0, _
+				byref depth as long = 0, _
+				byref bpp as long = 0, _
+				byref pitch as long = 0, _
+				byref refresh_rate as long = 0, _
 				byref driver as string = byval NULL _
 			) '/ _
 		( _
-			@"screeninfo", @"fb_GfxScreenInfo", _
+			@"screeninfo", @"fb_GfxScreenInfo32", _
 			FB_DATATYPE_VOID, FB_FUNCMODE_FBCALL, _
-			@hGfxlib_cb, FB_RTL_OPT_NOQB, _
+			@hGfxlib_cb, FB_RTL_OPT_OVER or FB_RTL_OPT_NOQB, _
 			7, _
 			{ _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_STRING, FB_PARAMMODE_BYREF, TRUE, NULL ) _
+			} _
+		), _
+		/' sub screeninfo overload _
+			( _
+				byref width as longint, _
+				byref height as longint, _
+				byref depth as longint = 0, _
+				byref bpp as longint = 0, _
+				byref pitch as longint = 0, _
+				byref refresh_rate as longint = 0, _
+				byref driver as string = byval NULL _
+			) '/ _
+		( _
+			@"screeninfo", @"fb_GfxScreenInfo64", _
+			FB_DATATYPE_VOID, FB_FUNCMODE_FBCALL, _
+			@hGfxlib_cb, FB_RTL_OPT_OVER or FB_RTL_OPT_NOQB, _
+			7, _
+			{ _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, FALSE ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, FALSE ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, 0 ), _
 				( FB_DATATYPE_STRING, FB_PARAMMODE_BYREF, TRUE, NULL ) _
 			} _
 		), _
@@ -917,29 +942,54 @@ declare function hPorts_cb _
 				( typeAddrOf( typeSetIsConst( FB_DATATYPE_VOID ) ), FB_PARAMMODE_BYVAL, FALSE ) _
 			} _
 		), _
-		/' function imageinfo _
+		/' function imageinfo overload _
 			( _
 				byval img	  as const any ptr, _
-				byref width   as integer = 0, _
-				byref height  as integer = 0, _
-				byref bpp	  as integer = 0, _
-				byref pitch   as integer = 0, _
+				byref width   as long = 0, _
+				byref height  as long = 0, _
+				byref bpp	  as long = 0, _
+				byref pitch   as long = 0, _
 				byref imgdata as any ptr = 0, _
-				byref size	  as integer = 0 _
+				byref size	  as long = 0 _
 			) as long '/ _
 		( _
-			@"imageinfo", @"fb_GfxImageInfo", _
+			@"imageinfo", @"fb_GfxImageInfo32", _
 			FB_DATATYPE_LONG, FB_FUNCMODE_FBCALL, _
-			@hGfxlib_cb, FB_RTL_OPT_NOQB, _
+			@hGfxlib_cb, FB_RTL_OPT_OVER or FB_RTL_OPT_NOQB, _
 			7, _
 			{ _
 				( typeAddrOf( typeSetIsConst( FB_DATATYPE_VOID ) ), FB_PARAMMODE_BYVAL, FALSE ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ), _
 				( typeAddrOf( FB_DATATYPE_VOID ), FB_PARAMMODE_BYREF, TRUE, 0 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, 0 ) _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, 0 ) _
+			} _
+		), _
+		/' function imageinfo overload _
+			( _
+				byval img	  as const any ptr, _
+				byref width   as longint, _
+				byref height  as longint, _
+				byref bpp	  as longint = 0, _
+				byref pitch   as longint = 0, _
+				byref imgdata as any ptr = 0, _
+				byref size	  as longint = 0 _
+			) as long '/ _
+		( _
+			@"imageinfo", @"fb_GfxImageInfo64", _
+			FB_DATATYPE_LONG, FB_FUNCMODE_FBCALL, _
+			@hGfxlib_cb, FB_RTL_OPT_OVER or FB_RTL_OPT_NOQB, _
+			7, _
+			{ _
+				( typeAddrOf( typeSetIsConst( FB_DATATYPE_VOID ) ), FB_PARAMMODE_BYVAL, FALSE ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, FALSE ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, FALSE ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( typeAddrOf( FB_DATATYPE_VOID ), FB_PARAMMODE_BYREF, TRUE, 0 ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, 0 ) _
 			} _
 		), _
 		/' sub imageconvertrow _
@@ -993,22 +1043,43 @@ declare function hPorts_cb _
 		/' sub screencontrol overload _
 			( _
 				byval what as const long, _
-				byref param1 as integer = &h80000000, _
-				byref param2 as integer = &h80000000, _
-				byref param3 as integer = &h80000000, _
-				byref param4 as integer = &h80000000 _
+				byref param1 as long = &h80000000, _
+				byref param2 as long = &h80000000, _
+				byref param3 as long = &h80000000, _
+				byref param4 as long = &h80000000 _
 			) '/ _
 		( _
-			@"screencontrol", @"fb_GfxControl_i", _
+			@"screencontrol", @"fb_GfxControl_i32", _
 			FB_DATATYPE_VOID, FB_FUNCMODE_FBCALL, _
 			@hGfxlib_cb, FB_RTL_OPT_OVER or FB_RTL_OPT_NOQB, _
 			5, _
 			{ _
 				( typeSetIsConst( FB_DATATYPE_LONG ), FB_PARAMMODE_BYVAL, FALSE ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, &h80000000 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, &h80000000 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, &h80000000 ), _
-				( FB_DATATYPE_INTEGER, FB_PARAMMODE_BYREF, TRUE, &h80000000 ) _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, &h80000000 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, &h80000000 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, &h80000000 ), _
+				( FB_DATATYPE_LONG, FB_PARAMMODE_BYREF, TRUE, &h80000000 ) _
+			} _
+		), _
+		/' sub screencontrol overload _
+			( _
+				byval what as const long, _
+				byref param1 as longint, _
+				byref param2 as longint = &h80000000, _
+				byref param3 as longint = &h80000000, _
+				byref param4 as longint = &h80000000 _
+			) '/ _
+		( _
+			@"screencontrol", @"fb_GfxControl_i64", _
+			FB_DATATYPE_VOID, FB_FUNCMODE_FBCALL, _
+			@hGfxlib_cb, FB_RTL_OPT_OVER or FB_RTL_OPT_NOQB, _
+			5, _
+			{ _
+				( typeSetIsConst( FB_DATATYPE_LONG ), FB_PARAMMODE_BYVAL, FALSE ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, FALSE ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, &h80000000 ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, &h80000000 ), _
+				( FB_DATATYPE_LONGINT, FB_PARAMMODE_BYREF, TRUE, &h80000000 ) _
 			} _
 		), _
 		/' function screenglproc( byval proc as const zstring ptr ) as any ptr '/ _

--- a/src/gfxlib2/fb_gfx.h
+++ b/src/gfxlib2/fb_gfx.h
@@ -434,11 +434,15 @@ extern FBCALL int fb_GfxScreen(int mode, int depth, int num_pages, int flags, in
 extern FBCALL int fb_GfxScreenQB(int mode, int visible, int active);
 extern FBCALL int fb_GfxScreenRes(int width, int height, int depth, int num_pages, int flags, int refresh_rate);
 extern FBCALL void fb_GfxScreenInfo(ssize_t *width, ssize_t *height, ssize_t *depth, ssize_t *bpp, ssize_t *pitch, ssize_t *refresh_rate, FBSTRING *driver);
+extern FBCALL void fb_GfxScreenInfo32(int *width, int *height, int *depth, int *bpp, int *pitch, int *refresh_rate, FBSTRING *driver);
+extern FBCALL void fb_GfxScreenInfo64(long long *width, long long  *height, long long  *depth, long long  *bpp, long long  *pitch, long long  *refresh_rate, FBSTRING *driver);
 extern FBCALL int fb_GfxScreenList(int depth);
 extern FBCALL void *fb_GfxImageCreate(int width, int height, unsigned int color, int depth, int flags);
 extern FBCALL void *fb_GfxImageCreateQB(int width, int height, unsigned int color, int depth, int flags);
 extern FBCALL void fb_GfxImageDestroy(void *image);
 extern FBCALL int fb_GfxImageInfo(void *img, ssize_t *width, ssize_t *height, ssize_t *bpp, ssize_t *pitch, void **imgdata, ssize_t *size);
+extern FBCALL int fb_GfxImageInfo32(void *img, int *width, int *height, int *bpp, int *pitch, void **imgdata, int *size);
+extern FBCALL int fb_GfxImageInfo64(void *img, long long *width, long long *height, long long *bpp, long long *pitch, void **imgdata, long long *size);
 extern FBCALL void fb_GfxPalette(int index, int r, int g, int b);
 extern FBCALL void fb_GfxPaletteUsing(int *data);
 extern FBCALL void fb_GfxPaletteUsing64(long long *data);
@@ -470,6 +474,8 @@ extern FBCALL int fb_GfxGetJoystick(int id, ssize_t *buttons, float *a1, float *
 extern FBCALL int fb_GfxEvent(EVENT *event);
 extern FBCALL void fb_GfxControl_s(int what, FBSTRING *param);
 extern FBCALL void fb_GfxControl_i(int what, ssize_t *param1, ssize_t *param2, ssize_t *param3, ssize_t *param4);
+extern FBCALL void fb_GfxControl_i32(int what, int *param1, int *param2, int *param3, int *param4);
+extern FBCALL void fb_GfxControl_i64(int what, long long *param1, long long *param2, long long *param3, long long *param4);
 extern FBCALL int fb_GfxBload(FBSTRING *filename, void *dest, void *pal);
 extern FBCALL int fb_GfxBloadQB(FBSTRING *filename, void *dest, void *pal);
 extern FBCALL int fb_GfxBsave(FBSTRING *filename, void *src, unsigned int size, void *pal);

--- a/src/gfxlib2/gfx_control.c
+++ b/src/gfxlib2/gfx_control.c
@@ -267,3 +267,23 @@ FBCALL void fb_GfxControl_i( int what, ssize_t *param1, ssize_t *param2, ssize_t
 		*param4 = res4;
 	}
 }
+
+FBCALL void fb_GfxControl_i32( int what, int *param1, int *param2, int *param3, int *param4 )
+{
+	ssize_t p1, p2, p3, p4;
+	fb_GfxControl_i( what, &p1, &p2, &p3, &p4 );
+	*param1 = (int)p1;
+	*param2 = (int)p2;
+	*param3 = (int)p3;
+	*param4 = (int)p4;
+}
+
+FBCALL void fb_GfxControl_i64( int what, long long *param1, long long *param2, long long *param3, long long *param4 )
+{
+	ssize_t p1, p2, p3, p4;
+	fb_GfxControl_i( what, &p1, &p2, &p3, &p4 );
+	*param1 = (long long)p1;
+	*param2 = (long long)p2;
+	*param3 = (long long)p3;
+	*param4 = (long long)p4;
+}

--- a/src/gfxlib2/gfx_image_info.c
+++ b/src/gfxlib2/gfx_image_info.c
@@ -48,3 +48,45 @@ FBCALL int fb_GfxImageInfo
 
 	return fb_ErrorSetNum( FB_RTERROR_OK );
 }
+
+FBCALL int fb_GfxImageInfo32
+	(
+		void *img,
+		int *width,
+		int *height,
+		int *bpp,
+		int *pitch,
+		void **imgdata,
+		int *size
+	)
+{
+	ssize_t w, h, b, p, s;
+	int ret = fb_GfxImageInfo( img, &w, &h, &b, &p, imgdata, &s );
+	*width = (int)w;
+	*height = (int)h;
+	*bpp = (int)b;
+	*pitch = (int)p;
+	*size = (int)s;
+	return ret;
+}
+
+FBCALL int fb_GfxImageInfo64
+	(
+		void *img,
+		long long *width,
+		long long *height,
+		long long *bpp,
+		long long *pitch,
+		void **imgdata,
+		long long *size
+	)
+{
+	ssize_t w, h, b, p, s;
+	int ret = fb_GfxImageInfo( img, &w, &h, &b, &p, imgdata, &s );
+	*width = (long long)w;
+	*height = (long long)h;
+	*bpp = (long long)b;
+	*pitch = (long long)p;
+	*size = (long long)s;
+	return ret;
+}

--- a/src/gfxlib2/gfx_screeninfo.c
+++ b/src/gfxlib2/gfx_screeninfo.c
@@ -38,3 +38,45 @@ FBCALL void fb_GfxScreenInfo
 
 	FB_GRAPHICS_UNLOCK( );
 }
+
+FBCALL void fb_GfxScreenInfo32
+	(
+		int *width,
+		int *height,
+		int *depth,
+		int *bpp,
+		int *pitch,
+		int *refresh,
+		FBSTRING *driver
+	)
+{
+	ssize_t w, h, d, b, p, r;
+	fb_GfxScreenInfo( &w, &h, &d, &b, &p, &r, driver );
+	*width = (int)w;
+	*height = (int)h;
+	*depth = (int)d;
+	*bpp = (int)b;
+	*pitch = (int)p;
+	*refresh = (int)r;
+}
+
+FBCALL void fb_GfxScreenInfo64
+	(
+		long long *width,
+		long long *height,
+		long long *depth,
+		long long *bpp,
+		long long *pitch,
+		long long *refresh,
+		FBSTRING *driver
+	)
+{
+	ssize_t w, h, d, b, p, r;
+	fb_GfxScreenInfo( &w, &h, &d, &b, &p, &r, driver );
+	*width = (long long)w;
+	*height = (long long)h;
+	*depth = (long long)d;
+	*bpp = (long long)b;
+	*pitch = (long long)p;
+	*refresh = (long long)r;
+}

--- a/tests/gfx/imageinfo-params.bas
+++ b/tests/gfx/imageinfo-params.bas
@@ -7,15 +7,55 @@ imageinfo img, , , , , pixels
 
 scope
 	dim as integer w, h, bypp, pitch, size
+
+#ifndef __FB_64BIT__
+	'' w & h optional only valid for INTEGER<32>
+	imageinfo img, w
+	imageinfo img,  , h
+	imageinfo img,  ,  , bypp
+	imageinfo img,  ,  ,     , pitch
+	imageinfo img,  ,  ,     ,      ,       , size
+#endif
+
+	'' specifying w & h is valid for INTEGER<32|64>
+	imageinfo img, w, h
+	imageinfo img, w, h, bypp
+	imageinfo img, w, h,     , pitch
+	imageinfo img, w, h,     ,      , pixels
+	imageinfo img, w, h,     ,      ,       , size
 	imageinfo img, w, h, bypp, pitch, pixels, size
+
+
 end scope
 
 scope
-	#ifdef __FB_64BIT__
-		dim as longint w, h, bypp, pitch, size
-		imageinfo img, w, h, bypp, pitch, pixels, size
-	#else
-		dim as long w, h, bypp, pitch, size
-		imageinfo img, w, h, bypp, pitch, pixels, size
-	#endif
+	dim as longint w, h, bypp, pitch, size
+
+	'' specifying w & h required for LONGINT
+	imageinfo img, w, h
+	imageinfo img, w, h, bypp
+	imageinfo img, w, h,     , pitch
+	imageinfo img, w, h,     ,      , pixels
+	imageinfo img, w, h,     ,      ,       , size
+	imageinfo img, w, h, bypp, pitch, pixels, size
+
+end scope
+
+
+scope
+	dim as long w, h, bypp, pitch, size
+
+	'' any combination possible with LONG
+	imageinfo img, w
+	imageinfo img,  , h
+	imageinfo img,  ,  , bypp
+	imageinfo img,  ,  ,     , pitch
+	imageinfo img,  ,  ,     ,      , pixels
+	imageinfo img,  ,  ,     ,      ,       , size
+	imageinfo img, w, h
+	imageinfo img, w, h, bypp
+	imageinfo img, w, h,     , pitch
+	imageinfo img, w, h,     ,      , pixels
+	imageinfo img, w, h,     ,      ,       , size
+	imageinfo img, w, h, bypp, pitch, pixels, size
 end scope

--- a/tests/gfx/screeninfo-params.bas
+++ b/tests/gfx/screeninfo-params.bas
@@ -6,17 +6,65 @@ screeninfo , , , , , , driver
 
 scope
 	dim as integer w, h, bpp, bypp, pitch, refresh_rate
+
+#ifndef __FB_64BIT__
+	'' w & h optional only valid for INTEGER<32>
+	screeninfo w
+	screeninfo  , h
+	screeninfo  ,  , bpp
+	screeninfo  ,  ,    , bypp
+	screeninfo  ,  ,    ,     , pitch
+	screeninfo  ,  ,    ,     ,      , refresh_rate
+	screeninfo  ,  ,    ,     ,      ,             , driver
+
+#endif
+	'' if at least w & h specified, other combninations valid for INTEGER<32|64>
+
+	screeninfo w, h
+	screeninfo w, h, bpp
+	screeninfo w, h,    , bypp
+	screeninfo w, h,    ,     , pitch
+	screeninfo w, h,    ,     ,      , refresh_rate
+	screeninfo w, h,    ,     ,      ,             , driver
 	screeninfo w, h, bpp, bypp, pitch
 	screeninfo w, h, bpp, bypp, pitch, refresh_rate
 	screeninfo w, h, bpp, bypp, pitch, refresh_rate, driver
 end scope
 
 scope
-	#ifdef __FB_64BIT__
-		dim as longint w, h, bpp, bypp, pitch, refresh_rate
-	#else
-		dim as long w, h, bpp, bypp, pitch, refresh_rate
-	#endif
+	dim as longint w, h, bpp, bypp, pitch, size, refresh_rate
+
+	'' specifying w & h required for LONGINT
+	screeninfo w, h
+	screeninfo w, h, bpp
+	screeninfo w, h,    , bypp
+	screeninfo w, h,    ,     , pitch
+	screeninfo w, h,    ,     ,      , refresh_rate
+	screeninfo w, h,    ,     ,      ,             , driver
+	screeninfo w, h, bpp, bypp, pitch
+	screeninfo w, h, bpp, bypp, pitch, refresh_rate
+	screeninfo w, h, bpp, bypp, pitch, refresh_rate, driver
+
+end scope
+
+
+scope
+	dim as long w, h, bpp, bypp, pitch, size, refresh_rate
+
+	'' any combination possible with LONG
+	screeninfo w
+	screeninfo  , h
+	screeninfo  ,  , bpp
+	screeninfo  ,  ,    , bypp
+	screeninfo  ,  ,    ,     , pitch
+	screeninfo  ,  ,    ,     ,      , refresh_rate
+	screeninfo  ,  ,    ,     ,      ,             , driver
+	screeninfo w, h
+	screeninfo w, h, bpp
+	screeninfo w, h,    , bypp
+	screeninfo w, h,    ,     , pitch
+	screeninfo w, h,    ,     ,      , refresh_rate
+	screeninfo w, h,    ,     ,      ,             , driver
 	screeninfo w, h, bpp, bypp, pitch
 	screeninfo w, h, bpp, bypp, pitch, refresh_rate
 	screeninfo w, h, bpp, bypp, pitch, refresh_rate, driver

--- a/tests/warnings/r/dos/rtl-prototypes.txt
+++ b/tests/warnings/r/dos/rtl-prototypes.txt
@@ -178,16 +178,20 @@ function getmouse alias "fb_GetMouse"
 function getmouse alias "fb_GetMouse64"
 function setmouse alias "fb_SetMouse"
 function getjoystick alias "fb_GfxGetJoystick"
-sub screeninfo alias "fb_GfxScreenInfo"
+sub screeninfo alias "fb_GfxScreenInfo32"
+sub screeninfo alias "fb_GfxScreenInfo64"
 function screenlist alias "fb_GfxScreenList"
 function fb_GfxImageCreate
 function fb_GfxImageCreateQB
 sub imagedestroy alias "fb_GfxImageDestroy"
-function imageinfo alias "fb_GfxImageInfo"
+function imageinfo alias "fb_GfxImageInfo32"
+	Suspicious pointer assignment
+function imageinfo alias "fb_GfxImageInfo64"
 sub imageconvertrow alias "fb_GfxImageConvertRow"
 function screenevent alias "fb_GfxEvent"
 sub screencontrol alias "fb_GfxControl_s"
-sub screencontrol alias "fb_GfxControl_i"
+sub screencontrol alias "fb_GfxControl_i32"
+sub screencontrol alias "fb_GfxControl_i64"
 function screenglproc alias "fb_GfxGetGLProcAddress"
 sub fb_hPutTrans
 sub fb_hPutPSet

--- a/tests/warnings/r/linux-x86/rtl-prototypes.txt
+++ b/tests/warnings/r/linux-x86/rtl-prototypes.txt
@@ -178,16 +178,20 @@ function getmouse alias "fb_GetMouse"
 function getmouse alias "fb_GetMouse64"
 function setmouse alias "fb_SetMouse"
 function getjoystick alias "fb_GfxGetJoystick"
-sub screeninfo alias "fb_GfxScreenInfo"
+sub screeninfo alias "fb_GfxScreenInfo32"
+sub screeninfo alias "fb_GfxScreenInfo64"
 function screenlist alias "fb_GfxScreenList"
 function fb_GfxImageCreate
 function fb_GfxImageCreateQB
 sub imagedestroy alias "fb_GfxImageDestroy"
-function imageinfo alias "fb_GfxImageInfo"
+function imageinfo alias "fb_GfxImageInfo32"
+	Suspicious pointer assignment
+function imageinfo alias "fb_GfxImageInfo64"
 sub imageconvertrow alias "fb_GfxImageConvertRow"
 function screenevent alias "fb_GfxEvent"
 sub screencontrol alias "fb_GfxControl_s"
-sub screencontrol alias "fb_GfxControl_i"
+sub screencontrol alias "fb_GfxControl_i32"
+sub screencontrol alias "fb_GfxControl_i64"
 function screenglproc alias "fb_GfxGetGLProcAddress"
 sub fb_hPutTrans
 sub fb_hPutPSet

--- a/tests/warnings/r/linux-x86_64/rtl-prototypes.txt
+++ b/tests/warnings/r/linux-x86_64/rtl-prototypes.txt
@@ -178,16 +178,20 @@ function getmouse alias "fb_GetMouse"
 function getmouse alias "fb_GetMouse64"
 function setmouse alias "fb_SetMouse"
 function getjoystick alias "fb_GfxGetJoystick"
-sub screeninfo alias "fb_GfxScreenInfo"
+sub screeninfo alias "fb_GfxScreenInfo32"
+sub screeninfo alias "fb_GfxScreenInfo64"
 function screenlist alias "fb_GfxScreenList"
 function fb_GfxImageCreate
 function fb_GfxImageCreateQB
 sub imagedestroy alias "fb_GfxImageDestroy"
-function imageinfo alias "fb_GfxImageInfo"
+function imageinfo alias "fb_GfxImageInfo32"
+	Suspicious pointer assignment
+function imageinfo alias "fb_GfxImageInfo64"
 sub imageconvertrow alias "fb_GfxImageConvertRow"
 function screenevent alias "fb_GfxEvent"
 sub screencontrol alias "fb_GfxControl_s"
-sub screencontrol alias "fb_GfxControl_i"
+sub screencontrol alias "fb_GfxControl_i32"
+sub screencontrol alias "fb_GfxControl_i64"
 function screenglproc alias "fb_GfxGetGLProcAddress"
 sub fb_hPutTrans
 sub fb_hPutPSet

--- a/tests/warnings/r/win32/rtl-prototypes.txt
+++ b/tests/warnings/r/win32/rtl-prototypes.txt
@@ -178,16 +178,20 @@ function getmouse alias "fb_GetMouse"
 function getmouse alias "fb_GetMouse64"
 function setmouse alias "fb_SetMouse"
 function getjoystick alias "fb_GfxGetJoystick"
-sub screeninfo alias "fb_GfxScreenInfo"
+sub screeninfo alias "fb_GfxScreenInfo32"
+sub screeninfo alias "fb_GfxScreenInfo64"
 function screenlist alias "fb_GfxScreenList"
 function fb_GfxImageCreate
 function fb_GfxImageCreateQB
 sub imagedestroy alias "fb_GfxImageDestroy"
-function imageinfo alias "fb_GfxImageInfo"
+function imageinfo alias "fb_GfxImageInfo32"
+	Suspicious pointer assignment
+function imageinfo alias "fb_GfxImageInfo64"
 sub imageconvertrow alias "fb_GfxImageConvertRow"
 function screenevent alias "fb_GfxEvent"
 sub screencontrol alias "fb_GfxControl_s"
-sub screencontrol alias "fb_GfxControl_i"
+sub screencontrol alias "fb_GfxControl_i32"
+sub screencontrol alias "fb_GfxControl_i64"
 function screenglproc alias "fb_GfxGetGLProcAddress"
 sub fb_hPutTrans
 sub fb_hPutPSet

--- a/tests/warnings/r/win64/rtl-prototypes.txt
+++ b/tests/warnings/r/win64/rtl-prototypes.txt
@@ -178,16 +178,20 @@ function getmouse alias "fb_GetMouse"
 function getmouse alias "fb_GetMouse64"
 function setmouse alias "fb_SetMouse"
 function getjoystick alias "fb_GfxGetJoystick"
-sub screeninfo alias "fb_GfxScreenInfo"
+sub screeninfo alias "fb_GfxScreenInfo32"
+sub screeninfo alias "fb_GfxScreenInfo64"
 function screenlist alias "fb_GfxScreenList"
 function fb_GfxImageCreate
 function fb_GfxImageCreateQB
 sub imagedestroy alias "fb_GfxImageDestroy"
-function imageinfo alias "fb_GfxImageInfo"
+function imageinfo alias "fb_GfxImageInfo32"
+	Suspicious pointer assignment
+function imageinfo alias "fb_GfxImageInfo64"
 sub imageconvertrow alias "fb_GfxImageConvertRow"
 function screenevent alias "fb_GfxEvent"
 sub screencontrol alias "fb_GfxControl_s"
-sub screencontrol alias "fb_GfxControl_i"
+sub screencontrol alias "fb_GfxControl_i32"
+sub screencontrol alias "fb_GfxControl_i64"
 function screenglproc alias "fb_GfxGetGLProcAddress"
 sub fb_hPutTrans
 sub fb_hPutPSet

--- a/tests/warnings/rtl-prototypes.bas
+++ b/tests/warnings/rtl-prototypes.bas
@@ -1103,9 +1103,15 @@
 	end scope
 #endif
 
-	ID( sub screeninfo alias "fb_GfxScreenInfo" )
+	ID( sub screeninfo alias "fb_GfxScreenInfo32" )
 	scope
-		dim chk as sub fbcall ( byref as integer = 0, byref as integer = 0, byref as integer = 0, byref as integer = 0, byref as integer = 0, byref as integer = 0, byref as string = "" )
+		dim chk as sub fbcall ( byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as string = "" )
+		chk = procptr( screeninfo )
+	end scope
+
+	ID( sub screeninfo alias "fb_GfxScreenInfo64" )
+	scope
+		dim chk as sub fbcall ( byref as longint, byref as longint, byref as longint = 0, byref as longint = 0, byref as longint = 0, byref as longint = 0, byref as string = "" )
 		chk = procptr( screeninfo )
 	end scope
 
@@ -1133,9 +1139,15 @@
 		chk = procptr( imagedestroy )
 	end scope
 
-	ID( function imageinfo alias "fb_GfxImageInfo" )
+	ID( function imageinfo alias "fb_GfxImageInfo32" )
 	scope
-		dim chk as function fbcall ( byval as const any ptr, byref as integer = 0, byref as integer = 0, byref as integer = 0, byref as integer = 0, byref as any ptr = 0, byref as integer = 0 ) as long
+		dim chk as function fbcall ( byval as const any ptr, byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as any ptr = 0, byref as longint = 0 ) as long
+		chk = procptr( imageinfo )
+	end scope
+
+	ID( function imageinfo alias "fb_GfxImageInfo64" )
+	scope
+		dim chk as function fbcall ( byval as const any ptr, byref as longint, byref as longint, byref as longint = 0, byref as longint = 0, byref as any ptr = 0, byref as longint = 0 ) as long
 		chk = procptr( imageinfo )
 	end scope
 
@@ -1157,9 +1169,15 @@
 		chk = procptr( screencontrol )
 	end scope
 
-	ID( sub screencontrol alias "fb_GfxControl_i" )
+	ID( sub screencontrol alias "fb_GfxControl_i32" )
 	scope
-		dim chk as sub fbcall ( byval as const long, byref as integer = -2147483648, byref as integer = -2147483648, byref as integer = -2147483648, byref as integer = -2147483648 )
+		dim chk as sub fbcall ( byval as const long, byref as long = -2147483648, byref as long = -2147483648, byref as long = -2147483648, byref as long = -2147483648 )
+		chk = procptr( screencontrol )
+	end scope
+
+	ID( sub screencontrol alias "fb_GfxControl_i64" )
+	scope
+		dim chk as sub fbcall ( byval as const long, byref as longint, byref as longint = -2147483648, byref as longint = -2147483648, byref as longint = -2147483648 )
 		chk = procptr( screencontrol )
 	end scope
 


### PR DESCRIPTION
This change revisits 2 previous bug reports and proposes solving the overload ambiguity by requiring that certain LONGINT parameters must be given:
- [sf.net #704 ScreenInfo ,,,,,,Driver" induces: "Ambiguous call to overloaded function](https://sourceforge.net/p/fbc/bugs/704/)
- [sf.net #737 Ambiguous overload when certain parameters are omitted in the ImageInfo() call ](https://sourceforge.net/p/fbc/bugs/737/)

Most of the underlying data types for image and screen data are of the fb LONG type (32 bits).  And over time since the fbc upgrades to 64-bit support the tendency for image size & colour information has tended towards using the LONG types.

However, because the datatypes are passed BYREF, passing 32-bit and 64-bit data types is not interchangeable and requires an overloaded function if both are to be permitted.

This change proposes the following:
For 64-bit data types
- SCREENINFO must specify first 2 LONGINT parameters
- IMAGEINFO must specify first 2 LONGINT parameters
- SCREENCONTROL must specify first LONGINT parameter
For 32-bit data types:
- SCREENINFO, SCREENCONTROL, IMAGEINFO parameters are optional as per current documentation and will unambiguously resolve LONG/INTEGER on 32-bit and LONG on 64-bit 

LONG and LONGINT types can not be mixed as there is only 2 versions of the overloads.

In the case where SCREENCONTROL returns a pointer, a pointer sized data type will unambiguously resolve to the 32-bit or 64-bit API's.

Details of the API change:
- Add new gfxlib2 API's fb_GfxScreenInfo32() and fb_GfxScreenInfo64()
- Change overload to SCREENINFO( byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as string = "" )
- Add overload for SCREENINFO( byref as longint, byref as longint, byref as longint = 0, byref as longint = 0, byref as longint = 0, byref as longint = 0, byref as string = "" )
- Add new gflib2 API's fb_GfxImageInfo32() and fb_GfxImageInfo64()
- Change overload to IMAGEINFO( byval as const any ptr, byref as long = 0, byref as long = 0, byref as long = 0, byref as long = 0, byref as any ptr = 0, byref as longint = 0 ) as long
- Add overload for IMAGEINFO( byval as const any ptr, byref as longint, byref as longint, byref as longint = 0, byref as longint = 0, byref as any ptr = 0, byref as longint = 0 ) as long
- Add new gfxlib2 API's fb_GfxControl_i32() and fb_GfxControl_i64()
- Change overload for SCREENCONTROL( byval as const long, byref as long = -2147483648, byref as long = -2147483648, byref as long = -2147483648, byref as long = -2147483648 )
- Add overload for SCREENCONTROL( byval as const long, byref as longint, byref as longint = -2147483648, byref as longint = -2147483648, byref as longint = -2147483648 )