### PR TITLE
gas64 : Fixed the signature returned in the debug information is not the signature of the currently compiled FBC source code version. 

### DIFF
--- a/src/compiler/ir-gas64.bas
+++ b/src/compiler/ir-gas64.bas
@@ -887,7 +887,7 @@ sub edbgemitheader_asm64( byval filename as zstring ptr )
 	dbg_addstab ("DUMMY",0)
 
 	''placeholder for information like compiler version, etc
-	dbg_addstab (__FB_SIGNATURE__,255)
+	dbg_addstab (FB_SIGN,255)
 
 	'' directory
 	if( pathIsAbsolute( filename ) = FALSE ) then


### PR DESCRIPTION
gas64 : Fixed the signature returned in the debug information is not the signature of the currently compiled FBC source code version. For example, if you use a compiler with a compiler signature of "freebasic 1.08.1" to compile the FBC source code with a signature of "freebasic 1.07.3", the signature returned in the debugging information of the compiled FBC source code is "freebasic 1.08.1".