### PR TITLE
In the macro definition (#define/#macro), "##_" is used to indicate the dynamic addition of a line continuation character ("_"), Causes the compiler to delay parsing the line continuation.This allows multiple lines of code in the input file to be combined into a single statement.

### DIFF
--- a/src/compiler/pp-define.bas
+++ b/src/compiler/pp-define.bas
@@ -957,7 +957,7 @@ private function hReadMacroText _
 			'' '##'?
 			case CHAR_SHARP
 				lexSkipToken( LEX_FLAGS )
-				lexSkipToken( LEX_FLAGS )
+				lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
 				continue do
 
 			'' '#' macro?

--- a/src/compiler/pp.bas
+++ b/src/compiler/pp.bas
@@ -546,6 +546,14 @@ function ppReadLiteral _
     	case CHAR_SHARP
     		select case lexGetLookAhead( 1, (LEX_FLAGS or LEXCHECK_KWDNAMESPC) and _
     								 		(not LEXCHECK_NOWHITESPC) )
+    		'' '##'?
+    		case CHAR_SHARP
+    			lexSkipToken( LEX_FLAGS )
+    			lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
+    			if *lexGetText( ) <> "_" then     '' Is only '##_'?
+    				DZstrConcatAssign( text, "##" )
+    			end if
+
     		'' '#' macro?
     		case FB_TK_PP_MACRO
     			if( ismultiline ) then
@@ -689,6 +697,14 @@ function ppReadLiteralW _
     	case CHAR_SHARP
     		select case lexGetLookAhead( 1, (LEX_FLAGS or LEXCHECK_KWDNAMESPC) and _
     								 		(not LEXCHECK_NOWHITESPC) )
+    		'' '##'?
+    		case CHAR_SHARP
+    			lexSkipToken( LEX_FLAGS )
+    			lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
+    			if *lexGetText( ) <> "_" then     '' Is only '##_'?
+    				DWstrConcatAssignA( text, "##" )
+    			end if
+
     		'' '#' macro?
     		case FB_TK_PP_MACRO
     			if( ismultiline ) then


### PR DESCRIPTION
> In the macro definition (#define/#macro), "##_" is used to indicate the dynamic addition of a line continuation character ("_"), Causes the compiler to delay parsing the line continuation.This allows multiple lines of code in the input file to be combined into a single statement.For example:
<div><PRE>
Type _MAP_ENTRY
	id As integer
	pA As integer
End Type
#macro BEGIN_ENTRIESMAP()
Function _GetMapEntries() As _MAP_ENTRY Ptr
		Static As _MAP_ENTRY _entries(0 To ...) = { ##_
#endmacro
#macro END_ENTRIESMAP()
		(0, 0)}
		Return @_entries(0)
	End Function
#endmacro
#define _INTERFACE_ENTRY(x, y) (x, y), ##_

BEGIN_ENTRIESMAP()
	_INTERFACE_ENTRY(1, 2)
	_INTERFACE_ENTRY(3, 4)
	_INTERFACE_ENTRY(5, 6)
END_ENTRIESMAP()

/' Compiler parsing results:
	Function _GetMapEntries() As _MAP_ENTRY Ptr
		Static As _MAP_ENTRY _entries(0 To ...) = { _
		(1, 2), _
		(3, 4), _
		(5, 6), _
		(0, 0)}
		Return @_entries(0)
	End Function
'/
</PRE></div>