### PR TITLE
fbc: fix token pasting operator '##' to allow pasting of single '_' characters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -138,6 +138,7 @@ Version 1.08.0
 - sf.net #917: optimize 'm += s' string concatenations to fix the long compile times in the gcc backend (which makes heavy use of string building).
 - github #217: C backend, fix gcc array out of bounds warning when compiled with -O2 or higher optimizations and accessing non-zero lower bound fixed length string arrays
 - C backend: inline asm - don't add rsp/esp to the clobber list, it's deprecated in newer gcc versions and silently ignored in older versions 
+- github #309: token pasting operator '##' allows pasting of single '_' characters
 
 
 Version 1.07.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -86,6 +86,7 @@ Version 1.08.0
 - added warning 'FOR counter variable is unable to exceed limit value' on constant end value for loops to help avoid infinite loops, e.g. for i as ubyte = 0 to 255
 - internal rtlib function fb_LEFTSELF( string, n ) to reduce the size of a string without reallocating the buffer
 - added GFX_SCREEN_EXIT = &h80000000l constant to fbgfx.bi - used with Screen 0 (closing any graphics window and preserving the console window content)
+- github #309: In macro/define's use '##_' to escape line continuation character '_' to allow multiple lines of macro expanded code to be combined into a single statement.(Skyfish)
 
 [fixed]
 - makefile: under MSYS2 (and friends), TARGET_ARCH is now identified from shell's default target architecture instead of shell's host architecture

--- a/src/compiler/lex.bas
+++ b/src/compiler/lex.bas
@@ -72,8 +72,8 @@ sub lexInit _
 		byval is_fb_eval as integer _
 	)
 
-    dim as integer i
-    dim as FBTOKEN ptr n
+	dim as integer i
+	dim as FBTOKEN ptr n
 
 	if( (env.includerec = 0) and (is_fb_eval = FALSE) ) then
 		lex.ctx = @lex.ctxTB(0)
@@ -232,7 +232,7 @@ private function hReadChar _
 					lexReadUTF8( )
 
 				case FBFILE_FORMAT_UTF16LE
-				    lexReadUTF16LE( )
+					lexReadUTF16LE( )
 
 				case FBFILE_FORMAT_UTF16BE
 					lexReadUTF16BE( )
@@ -329,19 +329,19 @@ function lexCurrentChar _
 		byval skipwhitespc as integer = FALSE _
 	) as uinteger
 
-    if( lex.ctx->currchar = UINVALID ) then
-    	lex.ctx->currchar = hReadChar( )
-    end if
+	if( lex.ctx->currchar = UINVALID ) then
+		lex.ctx->currchar = hReadChar( )
+	end if
 
-    if( skipwhitespc ) then
-    	do while( (lex.ctx->currchar = CHAR_TAB) or (lex.ctx->currchar = CHAR_SPACE) )
+	if( skipwhitespc ) then
+		do while( (lex.ctx->currchar = CHAR_TAB) or (lex.ctx->currchar = CHAR_SPACE) )
 			lex.ctx->after_space = TRUE
-    		lexEatChar( )
-    		lex.ctx->currchar = hReadChar( )
-    	loop
-    end if
+			lexEatChar( )
+			lex.ctx->currchar = hReadChar( )
+		loop
+	end if
 
-    function = lex.ctx->currchar
+	function = lex.ctx->currchar
 
 end function
 
@@ -356,13 +356,13 @@ function lexGetLookAheadChar _
 		lex.ctx->lahdchar = hReadChar( )
 	end if
 
-    if( skipwhitespc ) then
-    	do while( (lex.ctx->lahdchar = CHAR_TAB) or (lex.ctx->lahdchar = CHAR_SPACE) )
+	if( skipwhitespc ) then
+		do while( (lex.ctx->lahdchar = CHAR_TAB) or (lex.ctx->lahdchar = CHAR_SPACE) )
 			lex.ctx->after_space = TRUE
-    		hSkipChar( )
-    		lex.ctx->lahdchar = hReadChar( )
-    	loop
-    end if
+			hSkipChar( )
+			lex.ctx->lahdchar = hReadChar( )
+		loop
+	end if
 
 	function = lex.ctx->lahdchar
 
@@ -503,7 +503,7 @@ private sub hReadIdentifier _
 			suffixchar = FB_TK_STRTYPECHAR
 			lexEatChar( )
 		end select
-    end if
+	end if
 
 end sub
 
@@ -542,8 +542,8 @@ private function hReadNonDecNumber _
 		tlen += 2
 		lexEatChar( )
 
-	    '' skip trailing zeroes if not inside a comment or parsing an $include
-	    if( (flags and (LEXCHECK_NOLINECONT or LEXCHECK_NOSUFFIX)) = 0 ) then
+		'' skip trailing zeroes if not inside a comment or parsing an $include
+		if( (flags and (LEXCHECK_NOLINECONT or LEXCHECK_NOSUFFIX)) = 0 ) then
 			while( lexCurrentChar( ) = CHAR_0 )
 				*pnum = CHAR_0
 				pnum += 1
@@ -558,38 +558,38 @@ private function hReadNonDecNumber _
 			case CHAR_ALOW to CHAR_FLOW, CHAR_AUPP to CHAR_FUPP, CHAR_0 to CHAR_9
 				lexEatChar( )
 				if( skipchar = FALSE ) then
-                	*pnum = c
-                	pnum += 1
-                	tlen += 1
+					*pnum = c
+					pnum += 1
+					tlen += 1
 
-                	c -= CHAR_0
-                	if( c > 9 ) then
+					c -= CHAR_0
+					if( c > 9 ) then
 						c -= (CHAR_AUPP - CHAR_9 - 1)
-                	end if
-                	if( c > 16 ) then
-                  		c -= (CHAR_ALOW - CHAR_AUPP)
-                	end if
+					end if
+					if( c > 16 ) then
+						c -= (CHAR_ALOW - CHAR_AUPP)
+					end if
 
 					lgt += 1
 					if( lgt > 8 ) then
 						if( lgt = 9 ) then
 							dtype = FB_DATATYPE_LONGINT
-				    		value64 = (culngint( value ) * 16) + c
-				    	elseif( lgt = 17 ) then
-				    		if( (flags and LEXCHECK_NOLINECONT) = 0 ) then
-				    			errReportWarn( FB_WARNINGMSG_NUMBERTOOBIG )
-				    		end if
+							value64 = (culngint( value ) * 16) + c
+						elseif( lgt = 17 ) then
+							if( (flags and LEXCHECK_NOLINECONT) = 0 ) then
+								errReportWarn( FB_WARNINGMSG_NUMBERTOOBIG )
+							end if
 							skipchar = TRUE
 						else
-				    		value64 = (value64 * 16) + c
-				    	end if
+							value64 = (value64 * 16) + c
+						end if
 					else
 						if( lgt = 5 ) then
 							dtype = FB_DATATYPE_LONG
 						end if
-                		value = (value * 16) + c
-                	end if
-                end if
+						value = (value * 16) + c
+					end if
+				end if
 
 			case else
 				exit do
@@ -622,11 +622,11 @@ private function hReadNonDecNumber _
 				lexEatChar( )
 
 				if( skipchar = FALSE ) then
-                	*pnum = c
-                	pnum += 1
-                	tlen += 1
+					*pnum = c
+					pnum += 1
+					tlen += 1
 
-                	c -= CHAR_0
+					c -= CHAR_0
 
 					lgt += 1
 					if( lgt > 10 ) then
@@ -707,27 +707,27 @@ private function hReadNonDecNumber _
 			case CHAR_0, CHAR_1
 				lexEatChar( )
 				if( skipchar = FALSE ) then
-                	*pnum = c
-                	pnum += 1
-                	tlen += 1
+					*pnum = c
+					pnum += 1
+					tlen += 1
 
-                	c -= CHAR_0
+					c -= CHAR_0
 
 					lgt += 1
 					if( lgt > 32 ) then
 						if( lgt = 33 ) then
 							dtype = FB_DATATYPE_LONGINT
-				    		value64 = (culngint( value ) * 2) + c
+							value64 = (culngint( value ) * 2) + c
 
-				    	elseif( lgt = 65 ) then
-				    		if( (flags and LEXCHECK_NOLINECONT) = 0 ) then
-				    			errReportWarn( FB_WARNINGMSG_NUMBERTOOBIG )
-				    		end if
-				    		skipchar = TRUE
+						elseif( lgt = 65 ) then
+							if( (flags and LEXCHECK_NOLINECONT) = 0 ) then
+								errReportWarn( FB_WARNINGMSG_NUMBERTOOBIG )
+							end if
+							skipchar = TRUE
 
-				    	else
-				    		value64 = (value64 * 2) + c
-				    	end if
+						else
+							value64 = (value64 * 2) + c
+						end if
 
 					else
 						if( lgt = 17 ) then
@@ -903,7 +903,7 @@ private sub hReadFloatNumber _
 		if( (flags and LEXCHECK_NOSUFFIX) = 0 ) then
 			lexEatChar( )
 		end if
-        
+
 	end select
 
 	if( flags = LEXCHECK_EVERYTHING ) then
@@ -1479,36 +1479,36 @@ private sub hCheckPeriods _
 
 		'' is the next char a period?
 		if( lexCurrentChar( ) = CHAR_DOT ) then
-    		'' not a qualified name (namespace or UDT var)?
-    		if( symbGetClass( chain_->sym ) <> FB_SYMBCLASS_NAMESPACE ) then
-    			readfullid = TRUE
+			'' not a qualified name (namespace or UDT var)?
+			if( symbGetClass( chain_->sym ) <> FB_SYMBCLASS_NAMESPACE ) then
+				readfullid = TRUE
 
-    			'' search UDT variables
-    			do while( chain_ <> NULL )
-       				dim as FBSYMBOL ptr sym = chain_->sym
-       				do
-       					if( symbIsVar( sym ) ) then
-	    					if( symbGetType( sym ) = FB_DATATYPE_STRUCT ) then
-       							exit sub
-       						end if
+				'' search UDT variables
+				do while( chain_ <> NULL )
+					dim as FBSYMBOL ptr sym = chain_->sym
+					do
+						if( symbIsVar( sym ) ) then
+							if( symbGetType( sym ) = FB_DATATYPE_STRUCT ) then
+								exit sub
+							end if
 						end if
 
 						sym = sym->hash.next
 					loop while( sym <> NULL )
 
-       				chain_ = symbChainGetNext( chain_ )
-       			loop
-       		end if
-       	end if
+					chain_ = symbChainGetNext( chain_ )
+				loop
+			end if
+		end if
 
 	'' no symbol..
-    else
-    	'' only read if next char is a '.'
-    	readfullid = (lexCurrentChar( ) = CHAR_DOT)
-    end if
+	else
+		'' only read if next char is a '.'
+		readfullid = (lexCurrentChar( ) = CHAR_DOT)
+	end if
 
-    '' read the remaining? (including the '.'s)
-    if( readfullid ) then
+	'' read the remaining? (including the '.'s)
+	if( readfullid ) then
 		t->prdpos = t->len
 		hReadIdentifier( @t->text[t->len], _
 					 	 t->len, _
@@ -1517,7 +1517,7 @@ private sub hCheckPeriods _
 					 	 flags or LEXCHECK_EATPERIOD )
 
 		t->sym_chain = symbLookup( @t->text, t->id, t->class )
-    end if
+	end if
 
 end sub
 
@@ -1720,7 +1720,7 @@ re_read:
 			t->id = CHAR_AMP
 			t->dtype = t->id
 			t->len = 1
-			t->text[0] = CHAR_AMP                   	'' t.text = chr( char )
+			t->text[0] = CHAR_AMP                   '' t.text = chr( char )
 			t->text[1] = 0                          '' /
 			lexEatChar( )
 		end select
@@ -1749,10 +1749,10 @@ re_read:
 
 	'' '!' | '$'?
 	case CHAR_EXCL, CHAR_DOLAR
-        '' '"' following?
-        if( lexGetLookAheadChar( ) <> CHAR_QUOTE ) then
-        	goto read_char
-        end if
+		'' '"' following?
+		if( lexGetLookAheadChar( ) <> CHAR_QUOTE ) then
+			goto read_char
+		end if
 
 		lexEatChar( )
 
@@ -2000,12 +2000,12 @@ function lexGetToken _
 		byval flags as LEXCHECK _
 	) as integer static
 
-    if( lex.ctx->head->id = INVALID ) then
-    	lexNextToken( lex.ctx->head, flags )
-    	ppCheck( )
-    end if
+	if( lex.ctx->head->id = INVALID ) then
+		lexNextToken( lex.ctx->head, flags )
+		ppCheck( )
+	end if
 
-    function = lex.ctx->head->id
+	function = lex.ctx->head->id
 
 end function
 
@@ -2015,12 +2015,12 @@ function lexGetClass _
 		byval flags as LEXCHECK _
 	) as integer static
 
-    if( lex.ctx->head->id = INVALID ) then
-    	lexNextToken( lex.ctx->head, flags )
-    	ppCheck( )
-    end if
+	if( lex.ctx->head->id = INVALID ) then
+		lexNextToken( lex.ctx->head, flags )
+		ppCheck( )
+	end if
 
-    function = lex.ctx->head->class
+	function = lex.ctx->head->class
 
 end function
 
@@ -2031,17 +2031,17 @@ function lexGetLookAhead _
 		byval flags as LEXCHECK _
 	) as integer static
 
-    if( k > FB_LEX_MAXK ) then
-    	exit function
-    end if
+	if( k > FB_LEX_MAXK ) then
+		exit function
+	end if
 
 	if( k > lex.ctx->k ) then
 		lex.ctx->k = k
 		lex.ctx->tail = lex.ctx->tail->next
 	end if
 
-    if( lex.ctx->tail->id = INVALID ) then
-	    lexNextToken( lex.ctx->tail, flags )
+	if( lex.ctx->tail->id = INVALID ) then
+		lexNextToken( lex.ctx->tail, flags )
 	end if
 
 	function = lex.ctx->tail->id
@@ -2055,30 +2055,30 @@ function lexGetLookAheadClass _
 		byval flags as LEXCHECK _
 	) as integer static
 
-    if( k > FB_LEX_MAXK ) then
-    	exit function
-    end if
+	if( k > FB_LEX_MAXK ) then
+		exit function
+	end if
 
 	if( k > lex.ctx->k ) then
 		lex.ctx->k = k
 		lex.ctx->tail = lex.ctx->tail->next
 	end if
 
-    if( lex.ctx->tail->id = INVALID ) then
-    	lexNextToken( lex.ctx->tail, flags )
-    end if
+	if( lex.ctx->tail->id = INVALID ) then
+		lexNextToken( lex.ctx->tail, flags )
+	end if
 
-    function = lex.ctx->tail->class
+	function = lex.ctx->tail->class
 
 end function
 
 '':::::
 private sub hMoveKDown( ) static
 
-    lex.ctx->head->id = INVALID
+	lex.ctx->head->id = INVALID
 
-    lex.ctx->k -= 1
-    lex.ctx->head = lex.ctx->head->next
+	lex.ctx->k -= 1
+	lex.ctx->head = lex.ctx->head->next
 
 end sub
 
@@ -2197,23 +2197,23 @@ sub lexSkipToken( byval flags as LEXCHECK )
 		end if
 	end if
 
-    '' update stats
-    select case lex.ctx->head->id
-    case FB_TK_EOL
-    	UPDATE_LINENUM( )
+	'' update stats
+	select case lex.ctx->head->id
+	case FB_TK_EOL
+		UPDATE_LINENUM( )
 
-    end select
+	end select
 
-    lex.ctx->lasttk_id = lex.ctx->head->id
+	lex.ctx->lasttk_id = lex.ctx->head->id
 
-    ''
-    if( lex.ctx->k = 0 ) then
-    	lexNextToken( lex.ctx->head, flags )
-    else
-    	hMoveKDown( )
-    end if
+	''
+	if( lex.ctx->k = 0 ) then
+		lexNextToken( lex.ctx->head, flags )
+	else
+		hMoveKDown( )
+	end if
 
-    ppCheck( )
+	ppCheck( )
 end sub
 
 '':::::
@@ -2223,14 +2223,14 @@ sub lexEatToken _
 		byval flags as LEXCHECK _
 	) static
 
-    ''
-  	if( lex.ctx->head->dtype <> FB_DATATYPE_WCHAR ) then
-    	*token = lex.ctx->head->text
-    else
-    	*token = str( lex.ctx->head->textw )
-    end if
+	''
+	if( lex.ctx->head->dtype <> FB_DATATYPE_WCHAR ) then
+		*token = lex.ctx->head->text
+	else
+		*token = str( lex.ctx->head->textw )
+	end if
 
-    lexSkipToken( flags )
+	lexSkipToken( flags )
 
 end sub
 
@@ -2239,14 +2239,14 @@ function lexGetText _
 	( _
 	) as zstring ptr static
 
-    static as zstring * FB_MAXLITLEN+1 tmpstr
+	static as zstring * FB_MAXLITLEN+1 tmpstr
 
-  	if( lex.ctx->head->dtype <> FB_DATATYPE_WCHAR ) then
-    	function = @lex.ctx->head->text
-    else
-    	tmpstr = str( lex.ctx->head->textw )
-    	function = @tmpstr
-    end if
+	if( lex.ctx->head->dtype <> FB_DATATYPE_WCHAR ) then
+		function = @lex.ctx->head->text
+	else
+		tmpstr = str( lex.ctx->head->textw )
+		function = @tmpstr
+	end if
 
 end function
 
@@ -2258,37 +2258,37 @@ sub lexReadLine _
 		byval skipline as integer = FALSE _
 	) static
 
-    dim as uinteger char
+	dim as uinteger char
 
 	if( skipline = FALSE ) then
 		*dst = ""
 	end if
 
-    '' check look ahead tokens if any
-    do while( lex.ctx->k > 0 )
-    	select case lex.ctx->head->id
-    	case FB_TK_EOF, FB_TK_EOL, endchar
-    		exit sub
-    	case else
-    		if( skipline = FALSE ) then
-   				*dst += lex.ctx->head->text
-    		end if
-    	end select
+	'' check look ahead tokens if any
+	do while( lex.ctx->k > 0 )
+		select case lex.ctx->head->id
+		case FB_TK_EOF, FB_TK_EOL, endchar
+			exit sub
+		case else
+			if( skipline = FALSE ) then
+				*dst += lex.ctx->head->text
+			end if
+		end select
 
-    	hMoveKDown( )
-    loop
+		hMoveKDown( )
+	loop
 
-   	'' check current token
-    select case lex.ctx->head->id
-    case FB_TK_EOF, FB_TK_EOL, endchar
-   		exit sub
-   	case else
-   		if( skipline = FALSE ) then
-    		*dst += lex.ctx->head->text
-   		end if
-   	end select
+	'' check current token
+	select case lex.ctx->head->id
+	case FB_TK_EOF, FB_TK_EOL, endchar
+		exit sub
+	case else
+		if( skipline = FALSE ) then
+			*dst += lex.ctx->head->text
+		end if
+	end select
 
-    ''
+	''
 	do
 		char = lexCurrentChar( )
 

--- a/src/compiler/lex.bi
+++ b/src/compiler/lex.bi
@@ -84,7 +84,8 @@ type LEX_TKCTX
 	tail			as FBTOKEN ptr
 
 	currchar		as uinteger					'' current char
-	lahdchar		as uinteger					'' look ahead char
+	lahdchar1		as uinteger					'' look ahead first char
+	lahdchar2		as uinteger					'' look ahead second char
 
 	linenum 		as integer
 	lasttk_id 		as integer
@@ -232,6 +233,10 @@ declare function lexCurrentChar _
 declare function lexGetLookAheadChar _
 	( _
 		byval skipwhitespc as integer = FALSE _
+	) as uinteger
+
+declare function lexGetLookAheadChar2 _
+	( _
 	) as uinteger
 
 declare sub lexEatChar( )

--- a/src/compiler/pp-define.bas
+++ b/src/compiler/pp-define.bas
@@ -957,7 +957,7 @@ private function hReadMacroText _
 			'' '##'?
 			case CHAR_SHARP
 				lexSkipToken( LEX_FLAGS )
-				lexSkipToken( LEX_FLAGS )
+				lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
 				continue do
 
 			'' '#' macro?

--- a/src/compiler/pp.bas
+++ b/src/compiler/pp.bas
@@ -550,7 +550,11 @@ function ppReadLiteral _
 			case CHAR_SHARP
 				lexSkipToken( LEX_FLAGS )
 				lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
-				if *lexGetText( ) <> "_" then     '' Is only '##_'?
+
+				'' we can't check lexGetToken( ) here because a single '_' will
+				'' return as FB_TK_ID, so we need to do a lexGetText( ) check
+				'' Is only '##_'?
+				if *lexGetText( ) <> "_" then
 					DZstrConcatAssign( text, "##" )
 				end if
 
@@ -701,7 +705,11 @@ function ppReadLiteralW _
 			case CHAR_SHARP
 				lexSkipToken( LEX_FLAGS )
 				lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
-				if *lexGetText( ) <> "_" then     '' Is only '##_'?
+
+				'' we can't check lexGetToken( ) here because a single '_' will
+				'' return as FB_TK_ID, so we need to do a lexGetText( ) check
+				'' Is only '##_'?
+				if *lexGetText( ) <> "_" then
 					DWstrConcatAssignA( text, "##" )
 				end if
 

--- a/src/compiler/pp.bas
+++ b/src/compiler/pp.bas
@@ -65,30 +65,30 @@ const SYMB_MAXKEYWORDS = 24
 
 ''::::
 sub ppInit( )
-    dim as integer i
+	dim as integer i
 
 	'' create a fake namespace
-    pp.kwdns.class = FB_SYMBCLASS_NAMESPACE
-    pp.kwdns.scope = FB_MAINSCOPE
+	pp.kwdns.class = FB_SYMBCLASS_NAMESPACE
+	pp.kwdns.scope = FB_MAINSCOPE
 
 	symbSymbTbInit( pp.kwdns.nspc.ns.symtb, @pp.kwdns )
 	symbHashTbInit( pp.kwdns.nspc.ns.hashtb, @pp.kwdns, SYMB_MAXKEYWORDS )
-    pp.kwdns.nspc.ns.ext = symbCompAllocExt(  )
+	pp.kwdns.nspc.ns.ext = symbCompAllocExt(  )
 
 	''
 	for i = 0 to SYMB_MAXKEYWORDS-1
-    	if( kwdTb(i).name = NULL ) then
-    		exit for
-    	end if
+		if( kwdTb(i).name = NULL ) then
+			exit for
+		end if
 
-    	kwdTb(i).sym = symbAddKeyword( kwdTb(i).name, _
-    								   kwdTb(i).id, _
-    								   FB_TKCLASS_KEYWORD, _
-    								   @pp.kwdns.nspc.ns.hashtb )
-    	if( kwdTb(i).sym = NULL ) then
-    		exit sub
-    	end if
-    next
+		kwdTb(i).sym = symbAddKeyword( kwdTb(i).name, _
+									   kwdTb(i).id, _
+									   FB_TKCLASS_KEYWORD, _
+									   @pp.kwdns.nspc.ns.hashtb )
+		if( kwdTb(i).sym = NULL ) then
+			exit sub
+		end if
+	next
 
 	''
 	pp.skipping = FALSE
@@ -103,7 +103,7 @@ end sub
 
 ''::::
 sub ppEnd( )
-    dim as integer i
+	dim as integer i
 
 	ppPragmaEnd( )
 
@@ -113,13 +113,13 @@ sub ppEnd( )
 
 	''
 	for i = 0 to SYMB_MAXKEYWORDS-1
-    	if( kwdTb(i).sym = NULL ) then
-    		exit for
-    	end if
+		if( kwdTb(i).sym = NULL ) then
+			exit for
+		end if
 
 		symbFreeSymbol( kwdTb(i).sym )
-    	kwdTb(i).sym = NULL
-    next
+		kwdTb(i).sym = NULL
+	next
 
 	symbCompFreeExt( pp.kwdns.nspc.ns.ext )
 	hashEnd( @pp.kwdns.nspc.ns.hashtb.tb )
@@ -149,14 +149,14 @@ sub ppCheck( )
 
 	lex.ctx->reclevel += 1
 
-    '' !!!FIXME!!! if LEXCHECK_KWDNAMESPC is used in future, it
-    '' must be restored
-    lex.ctx->kwdns = @pp.kwdns
+	'' !!!FIXME!!! if LEXCHECK_KWDNAMESPC is used in future, it
+	'' must be restored
+	lex.ctx->kwdns = @pp.kwdns
 
-    lexSkipToken( LEXCHECK_KWDNAMESPC )
+	lexSkipToken( LEXCHECK_KWDNAMESPC )
 
-    '' let the parser do the rest..
-    ppParse( )
+	'' let the parser do the rest..
+	ppParse( )
 	lex.ctx->reclevel -= 1
 
 end sub
@@ -167,15 +167,15 @@ end sub
 ''               |   '#'IFDEF ID
 ''               |   '#'IFNDEF ID
 ''               |   '#'IF Expression
-''				 |	 '#'ELSE
-''				 |   '#'ELSEIF Expression
+''               |   '#'ELSE
+''               |   '#'ELSEIF Expression
 ''               |   '#'ENDIF
-''				 |	 '#'ASSERT Expression
+''               |   '#'ASSERT Expression
 ''               |   '#'PRINT LITERAL*
-''				 |   '#'INCLUDE ONCE? LIT_STR
-''				 |   '#'INCLIB LIT_STR
-''				 |	 '#'LIBPATH LIT_STR
-''				 |	 '#'ERROR LIT_STR .
+''               |   '#'INCLUDE ONCE? LIT_STR
+''               |   '#'INCLIB LIT_STR
+''               |   '#'LIBPATH LIT_STR
+''               |   '#'ERROR LIT_STR .
 ''
 sub ppParse( )
 	'' note: when adding any new PP symbol, update ppSkip() too
@@ -320,8 +320,8 @@ end sub
 '' ppInclude		=   '#'INCLUDE ONCE? LIT_STR
 ''
 private sub ppInclude()
-    static as zstring * FB_MAXPATHLEN+1 incfile
-    dim as integer isonce = any
+	static as zstring * FB_MAXPATHLEN+1 incfile
+	dim as integer isonce = any
 
 	'' ONCE?
 	isonce = hMatchIdOrKw( "ONCE", LEXCHECK_POST_SUFFIX )
@@ -473,20 +473,20 @@ private sub hRtrimMacroText _
 	end if
 
 	p = text->data + (text->len - 1)
-    do while( p > text->data )
+	do while( p > text->data )
 
 		select case as const (*p)[0]
 		'' space or nl?
-    	case CHAR_SPACE, CHAR_TAB, CHAR_LF
-    		text->len -= 1
-    		*p = 0
+		case CHAR_SPACE, CHAR_TAB, CHAR_LF
+			text->len -= 1
+			*p = 0
 
 		case else
-        	exit do
+			exit do
 		end select
 
 		p -= 1
-    loop
+	loop
 
 end sub
 
@@ -499,10 +499,10 @@ function ppReadLiteral _
 	static as DZSTRING text
 	dim as integer nestedcnt = 0
 
-    DZstrReset( text )
+	DZstrReset( text )
 
-    do
-    	select case as const lexGetToken( LEX_FLAGS )
+	do
+		select case as const lexGetToken( LEX_FLAGS )
 		case FB_TK_EOF
 			if( ismultiline ) then
 				errReport( FB_ERRMSG_EXPECTEDMACRO )
@@ -516,15 +516,15 @@ function ppReadLiteral _
 				exit do
 			end if
 
-    		'' multi-line, only add if it's not at the beginning
-    		if( text.len > 0 ) then
-    			'' just lf
-    			DZstrConcatAssign( text, LFCHAR )
-    		end if
+			'' multi-line, only add if it's not at the beginning
+			if( text.len > 0 ) then
+				'' just lf
+				DZstrConcatAssign( text, LFCHAR )
+			end if
 
-    		lexSkipToken( LEX_FLAGS )
+			lexSkipToken( LEX_FLAGS )
 
-    		continue do
+			continue do
 
 		case FB_TK_COMMENT, FB_TK_REM
 			if( ismultiline = FALSE ) then
@@ -542,72 +542,72 @@ function ppReadLiteral _
 
 			continue do
 
-    	'' '#'?
-    	case CHAR_SHARP
-    		select case lexGetLookAhead( 1, (LEX_FLAGS or LEXCHECK_KWDNAMESPC) and _
-    								 		(not LEXCHECK_NOWHITESPC) )
-    		'' '##'?
-    		case CHAR_SHARP
-    			lexSkipToken( LEX_FLAGS )
-    			lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
-    			if *lexGetText( ) <> "_" then     '' Is only '##_'?
-    				DZstrConcatAssign( text, "##" )
-    			end if
+		'' '#'?
+		case CHAR_SHARP
+			select case lexGetLookAhead( 1, (LEX_FLAGS or LEXCHECK_KWDNAMESPC) and _
+									 		(not LEXCHECK_NOWHITESPC) )
+			'' '##'?
+			case CHAR_SHARP
+				lexSkipToken( LEX_FLAGS )
+				lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
+				if *lexGetText( ) <> "_" then     '' Is only '##_'?
+					DZstrConcatAssign( text, "##" )
+				end if
 
-    		'' '#' macro?
-    		case FB_TK_PP_MACRO
-    			if( ismultiline ) then
-    				nestedcnt += 1
-    			end if
+			'' '#' macro?
+			case FB_TK_PP_MACRO
+				if( ismultiline ) then
+					nestedcnt += 1
+				end if
 
-    		'' '#' endmacro?
-    		case FB_TK_PP_ENDMACRO
-    			if( ismultiline ) then
-    				'' not nested?
-    				if( nestedcnt = 0 ) then
-    					lexSkipToken( LEX_FLAGS )
-    					'' no LEX_FLAGS, white-spaces must be skipped
-    					lexSkipToken( )
+			'' '#' endmacro?
+			case FB_TK_PP_ENDMACRO
+				if( ismultiline ) then
+					'' not nested?
+					if( nestedcnt = 0 ) then
+						lexSkipToken( LEX_FLAGS )
+						'' no LEX_FLAGS, white-spaces must be skipped
+						lexSkipToken( )
 
 						hRtrimMacroText( @text )
 
-    					exit do
-    				end if
+						exit do
+					end if
 
-    				nestedcnt -= 1
-    			end if
+					nestedcnt -= 1
+				end if
 
-   			end select
+			end select
 
-   		'' white space?
-   		case CHAR_SPACE, CHAR_TAB
+		'' white space?
+		case CHAR_SPACE, CHAR_TAB
 
-    		'' only add if it's not at the beginning
-    		if( text.len > 0 ) then
-    			'' condensed to a single white-space
-    			DZstrConcatAssign( text, " " )
-    		end if
+			'' only add if it's not at the beginning
+			if( text.len > 0 ) then
+				'' condensed to a single white-space
+				DZstrConcatAssign( text, " " )
+			end if
 
-    		lexSkipToken( LEX_FLAGS )
+			lexSkipToken( LEX_FLAGS )
 
-    		continue do
+			continue do
 
 	  	case FB_TK_TYPEOF
 			DZstrConcatAssign( text, ppTypeOf( ) )
 			exit do
 
-    	end select
+		end select
 
-    	'' anything else..
-    	if( lexGetType() <> FB_DATATYPE_WCHAR ) then
-    		DZstrConcatAssign( text, lexGetText( ) )
-    	else
-    	    DZstrConcatAssignW( text, lexGetTextW( ) )
-    	end if
+		'' anything else..
+		if( lexGetType() <> FB_DATATYPE_WCHAR ) then
+			DZstrConcatAssign( text, lexGetText( ) )
+		else
+			DZstrConcatAssignW( text, lexGetTextW( ) )
+		end if
 
-    	lexSkipToken( LEX_FLAGS )
+		lexSkipToken( LEX_FLAGS )
 
-    loop
+	loop
 
 	function = text.data
 
@@ -624,20 +624,20 @@ private sub hRtrimMacroTextW _
 	'' remove the white-spaces (including nl)
 
 	p = text->data + (text->len - 1)
-    do while( p > text->data )
+	do while( p > text->data )
 
 		select case as const (*p)[0]
 		'' space or nl?
-    	case CHAR_SPACE, CHAR_TAB, CHAR_LF
-    		text->len -= 1
-    		*p = 0
+		case CHAR_SPACE, CHAR_TAB, CHAR_LF
+			text->len -= 1
+			*p = 0
 
 		case else
-        	exit do
+			exit do
 		end select
 
 		p -= 1
-    loop
+	loop
 
 end sub
 
@@ -650,10 +650,10 @@ function ppReadLiteralW _
 	static as DWSTRING text
 	dim as integer nestedcnt = 0
 
-    DWstrAllocate( text, 0 )
+	DWstrAllocate( text, 0 )
 
-    do
-    	select case as const lexGetToken( LEX_FLAGS )
+	do
+		select case as const lexGetToken( LEX_FLAGS )
 		case FB_TK_EOF
 			if( ismultiline ) then
 				errReport( FB_ERRMSG_EXPECTEDMACRO )
@@ -667,15 +667,15 @@ function ppReadLiteralW _
 				exit do
 			end if
 
-    		'' multi-line, only add if it's not at the beginning
-    		if( text.len > 0 ) then
-    			'' just lf
-    			DWstrConcatAssign( text, wstr( LFCHAR ) )
-    		end if
+			'' multi-line, only add if it's not at the beginning
+			if( text.len > 0 ) then
+				'' just lf
+				DWstrConcatAssign( text, wstr( LFCHAR ) )
+			end if
 
-    		lexSkipToken( LEX_FLAGS )
+			lexSkipToken( LEX_FLAGS )
 
-    		continue do
+			continue do
 
 		case FB_TK_COMMENT, FB_TK_REM
 			if( ismultiline = FALSE ) then
@@ -693,72 +693,72 @@ function ppReadLiteralW _
 
 			continue do
 
-    	'' '#'?
-    	case CHAR_SHARP
-    		select case lexGetLookAhead( 1, (LEX_FLAGS or LEXCHECK_KWDNAMESPC) and _
-    								 		(not LEXCHECK_NOWHITESPC) )
-    		'' '##'?
-    		case CHAR_SHARP
-    			lexSkipToken( LEX_FLAGS )
-    			lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
-    			if *lexGetText( ) <> "_" then     '' Is only '##_'?
-    				DWstrConcatAssignA( text, "##" )
-    			end if
+		'' '#'?
+		case CHAR_SHARP
+			select case lexGetLookAhead( 1, (LEX_FLAGS or LEXCHECK_KWDNAMESPC) and _
+									 		(not LEXCHECK_NOWHITESPC) )
+			'' '##'?
+			case CHAR_SHARP
+				lexSkipToken( LEX_FLAGS )
+				lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
+				if *lexGetText( ) <> "_" then     '' Is only '##_'?
+					DWstrConcatAssignA( text, "##" )
+				end if
 
-    		'' '#' macro?
-    		case FB_TK_PP_MACRO
-    			if( ismultiline ) then
-    				nestedcnt += 1
-    			end if
+			'' '#' macro?
+			case FB_TK_PP_MACRO
+				if( ismultiline ) then
+					nestedcnt += 1
+				end if
 
-    		'' '#' endmacro?
-    		case FB_TK_PP_ENDMACRO
-    			if( ismultiline ) then
-    				'' not nested?
-    				if( nestedcnt = 0 ) then
-    					lexSkipToken( LEX_FLAGS )
-    					'' no LEX_FLAGS, white-spaces must be skipped
-    					lexSkipToken( )
+			'' '#' endmacro?
+			case FB_TK_PP_ENDMACRO
+				if( ismultiline ) then
+					'' not nested?
+					if( nestedcnt = 0 ) then
+						lexSkipToken( LEX_FLAGS )
+						'' no LEX_FLAGS, white-spaces must be skipped
+						lexSkipToken( )
 
 						hRtrimMacroTextW( @text )
 
-    					exit do
-    				end if
+						exit do
+					end if
 
-    				nestedcnt -= 1
-    			end if
+					nestedcnt -= 1
+				end if
 
-   			end select
+			end select
 
-   		'' white space?
-   		case CHAR_SPACE, CHAR_TAB
+		'' white space?
+		case CHAR_SPACE, CHAR_TAB
 
-    		'' only add if it's not at the beginning
-    		if( text.len > 0 ) then
-    			'' condensed to a single white-space
-    			DWstrConcatAssign( text, wstr( " " ) )
-    		end if
+			'' only add if it's not at the beginning
+			if( text.len > 0 ) then
+				'' condensed to a single white-space
+				DWstrConcatAssign( text, wstr( " " ) )
+			end if
 
-    		lexSkipToken( LEX_FLAGS )
+			lexSkipToken( LEX_FLAGS )
 
-    		continue do
+			continue do
 
 	  	case FB_TK_TYPEOF
-	        DWstrConcatAssignA( text, ppTypeOf( ) )
+			DWstrConcatAssignA( text, ppTypeOf( ) )
 			exit do
 
-    	end select
+		end select
 
-        '' anything else..
-    	if( lexGetType( ) = FB_DATATYPE_WCHAR ) then
-    		DWstrConcatAssign( text, lexGetTextW( ) )
-    	else
-    		DWstrConcatAssignA( text, lexGetText( ) )
-    	end if
+		'' anything else..
+		if( lexGetType( ) = FB_DATATYPE_WCHAR ) then
+			DWstrConcatAssign( text, lexGetTextW( ) )
+		else
+			DWstrConcatAssignA( text, lexGetText( ) )
+		end if
 
-    	lexSkipToken( LEX_FLAGS )
+		lexSkipToken( LEX_FLAGS )
 
-    loop
+	loop
 
 	function = text.data
 

--- a/src/compiler/pp.bas
+++ b/src/compiler/pp.bas
@@ -546,6 +546,14 @@ function ppReadLiteral _
     	case CHAR_SHARP
     		select case lexGetLookAhead( 1, (LEX_FLAGS or LEXCHECK_KWDNAMESPC) and _
     								 		(not LEXCHECK_NOWHITESPC) )
+    		'' '##'?
+    		case CHAR_SHARP
+    			lexSkipToken( LEX_FLAGS )
+    			lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
+    			if *lexGetText( ) <> "_" then     '' Is only '##_'?
+    				DZstrConcatAssign( text, "##" )
+    			end if
+
     		'' '#' macro?
     		case FB_TK_PP_MACRO
     			if( ismultiline ) then
@@ -689,6 +697,14 @@ function ppReadLiteralW _
     	case CHAR_SHARP
     		select case lexGetLookAhead( 1, (LEX_FLAGS or LEXCHECK_KWDNAMESPC) and _
     								 		(not LEXCHECK_NOWHITESPC) )
+    		'' '##'?
+    		case CHAR_SHARP
+    			lexSkipToken( LEX_FLAGS )
+    			lexSkipToken( LEX_FLAGS or LEXCHECK_NOLINECONT)
+    			if *lexGetText( ) <> "_" then     '' Is only '##_'?
+    				DWstrConcatAssignA( text, "##" )
+    			end if
+
     		'' '#' macro?
     		case FB_TK_PP_MACRO
     			if( ismultiline ) then

--- a/tests/pp/token-pasting.bas
+++ b/tests/pp/token-pasting.bas
@@ -1,0 +1,170 @@
+#include "fbcunit.bi"
+
+#define tostr(a)   #a
+
+SUITE( fbc_tests.pp.token_pasting )
+
+	TEST( plain )
+
+		#define join1(a,b) a##b
+		#define join2(a,b) a ##b
+		#define join3(a,b) a## b
+		#define join4(a,b) a ## b
+		#define join5(a,b) a  ##  b
+
+		CU_ASSERT_EQUAL( tostr(join1(X,Y)), tostr(XY) )
+		CU_ASSERT_EQUAL( tostr(join2(X,Y)), tostr(X Y) )
+		CU_ASSERT_EQUAL( tostr(join3(X,Y)), tostr(X Y) )
+		CU_ASSERT_EQUAL( tostr(join4(X,Y)), tostr(X  Y) )
+		CU_ASSERT_EQUAL( tostr(join5(X,Y)), tostr(X  Y) )
+
+	END_TEST
+
+	TEST( under1 )
+
+		#define join_01(a) a##_
+		#define join_02(a) _##a
+		#define join_03(a) a##__
+		#define join_04(a) __##a
+
+		CU_ASSERT_EQUAL( tostr(join_01(X)), tostr(X_) )
+		CU_ASSERT_EQUAL( tostr(join_02(X)), tostr(_X) )
+		CU_ASSERT_EQUAL( tostr(join_03(X)), tostr(X__) )
+		CU_ASSERT_EQUAL( tostr(join_04(X)), tostr(__X) )
+
+	END_TEST
+
+	TEST( under_1 )
+
+		#define join_01(_a) _a##_
+		#define join_02(_a) _##_a
+		#define join_03(_a) _a##__
+		#define join_04(_a) __##_a
+
+		CU_ASSERT_EQUAL( tostr(join_01(X)), tostr(X_) )
+		CU_ASSERT_EQUAL( tostr(join_02(X)), tostr(_X) )
+		CU_ASSERT_EQUAL( tostr(join_03(X)), tostr(X__) )
+		CU_ASSERT_EQUAL( tostr(join_04(X)), tostr(__X) )
+
+	END_TEST
+
+	TEST( under1_ )
+
+		#define join_01(a_) a_##_
+		#define join_02(a_) _##a_
+		#define join_03(a_) a_##__
+		#define join_04(a_) __##a_
+
+		CU_ASSERT_EQUAL( tostr(join_01(X)), tostr(X_) )
+		CU_ASSERT_EQUAL( tostr(join_02(X)), tostr(_X) )
+		CU_ASSERT_EQUAL( tostr(join_03(X)), tostr(X__) )
+		CU_ASSERT_EQUAL( tostr(join_04(X)), tostr(__X) )
+
+	END_TEST
+
+	TEST( under_1_ )
+
+		#define join_01(_a_) _a_##_
+		#define join_02(_a_) _##_a_
+		#define join_03(_a_) _a_##__
+		#define join_04(_a_) __##_a_
+
+		CU_ASSERT_EQUAL( tostr(join_01(X)), tostr(X_) )
+		CU_ASSERT_EQUAL( tostr(join_02(X)), tostr(_X) )
+		CU_ASSERT_EQUAL( tostr(join_03(X)), tostr(X__) )
+		CU_ASSERT_EQUAL( tostr(join_04(X)), tostr(__X) )
+
+	END_TEST
+
+	TEST( under2 )
+
+		#define join_01(a,b) a##_##b
+		#define join_02(a,b) a ##_##b
+		#define join_03(a,b) a## _##b
+		#define join_04(a,b) a ## _##b
+		#define join_05(a,b) a##_ ##b
+		#define join_06(a,b) a##_##b
+		#define join_07(a,b) a ##_##b
+		#define join_08(a,b) a## _##b
+		#define join_09(a,b) a ## _##b
+		#define join_10(a,b) a##_ ##b
+
+		CU_ASSERT_EQUAL( tostr(join_01(X,Y)), tostr(X_Y) )
+		CU_ASSERT_EQUAL( tostr(join_02(X,Y)), tostr(X _Y) )
+		CU_ASSERT_EQUAL( tostr(join_03(X,Y)), tostr(X _Y) )
+		CU_ASSERT_EQUAL( tostr(join_04(X,Y)), tostr(X  _Y) )
+		CU_ASSERT_EQUAL( tostr(join_05(X,Y)), tostr(X_ Y) )
+		CU_ASSERT_EQUAL( tostr(join_06(X,Y)), tostr(X_Y) )
+		CU_ASSERT_EQUAL( tostr(join_07(X,Y)), tostr(X _Y) )
+		CU_ASSERT_EQUAL( tostr(join_08(X,Y)), tostr(X _Y) )
+		CU_ASSERT_EQUAL( tostr(join_09(X,Y)), tostr(X  _Y) )
+		CU_ASSERT_EQUAL( tostr(join_10(X,Y)), tostr(X_ Y) )
+
+		'' Parser behaviour:
+		'' - everything after a line continuation token '_' is ignored
+		'' - the following expressions are poorly formed because the line
+		''   continuation either continues to the following define
+		''   or the following statment
+
+		/'
+		#define join_11(a,b) a ##_ ##b
+		#define join_12(a,b) a## _ ##b
+		#define join_13(a,b) a ## _ ##b
+		#define join_14(a,b) a ##_ ##b
+		#define join_15(a,b) a## _ ##b
+		#define join_16(a,b) a ## _ ##b
+
+		CU_ASSERT_EQUAL( tostr(join_11(X,Y)), tostr(X _ Y) )
+		CU_ASSERT_EQUAL( tostr(join_12(X,Y)), tostr(X _ Y) )
+		CU_ASSERT_EQUAL( tostr(join_13(X,Y)), tostr(X  _ Y) )
+		CU_ASSERT_EQUAL( tostr(join_14(X,Y)), tostr(X _ Y) )
+		CU_ASSERT_EQUAL( tostr(join_15(X,Y)), tostr(X _ Y) )
+		CU_ASSERT_EQUAL( tostr(join_16(X,Y)), tostr(X  _ Y) )
+		'/
+
+	END_TEST
+
+	''
+	'' test case from commit: 91e58fe7da978e464f976dc3f94378fbf3d1fbb1
+	''
+
+	Type _MAP_ENTRY
+		id As integer
+		pA As integer
+	End Type
+	#macro BEGIN_ENTRIESMAP()
+	Function _GetMapEntries() As _MAP_ENTRY Ptr
+			Static As _MAP_ENTRY _entries(0 To ...) = { ##_ 
+	#endmacro
+	#macro END_ENTRIESMAP()
+			(0, 0)}
+			Return @_entries(0)
+		End Function
+	#endmacro
+	#define _INTERFACE_ENTRY(x, y) (x, y), ##_
+
+	#macro GENMAP()
+
+	BEGIN_ENTRIESMAP()
+	_INTERFACE_ENTRY(1, 2)
+	_INTERFACE_ENTRY(3, 4)
+	_INTERFACE_ENTRY(5, 6)
+	END_ENTRIESMAP()
+
+	#endmacro
+
+	GENMAP()
+
+	TEST( line_pasting )
+
+		var p = _GetMapEntries()
+		CU_ASSERT_EQUAL( p[0].id, 1 )
+		CU_ASSERT_EQUAL( p[0].pA, 2 )
+		CU_ASSERT_EQUAL( p[1].id, 3 )
+		CU_ASSERT_EQUAL( p[1].pA, 4 )
+		CU_ASSERT_EQUAL( p[2].id, 5 )
+		CU_ASSERT_EQUAL( p[2].pA, 6 )
+
+	END_TEST	
+
+END_SUITE


### PR DESCRIPTION
This change builds on PR #309 to also allow single `'_'` character token pasting.

- previously fbc unable to handle single `'_`' token pasting since in such cases the `'_'` is always seen as line continuation.
Example:
```
#define join1(a,b) a##_ b
#define join2(a,b) a _##b
#define join3(a,b) a##_##b
```

- because `'_'` line continuation and `'##'` token pasting are handled nearly entirely in the lexer, no token checks can be made
- adds lexGetLookAheadChar2( ) so that the sequence `'_##'` can be checked before tokenizing
- plus previous commits in PR #309 (Skyfish) allow handling the sequence `'##_'` to escape the `'_'` character and paste it in on expansion
