### PR TITLE
gfxlib2: github # 315: set parameters when calling SCREENCONTROL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Version 1.08.1
 [added]
 
 [fixed]
+- github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)
 
 
 Version 1.08.0

--- a/src/gfxlib2/gfx_control.c
+++ b/src/gfxlib2/gfx_control.c
@@ -271,19 +271,27 @@ FBCALL void fb_GfxControl_i( int what, ssize_t *param1, ssize_t *param2, ssize_t
 FBCALL void fb_GfxControl_i32( int what, int *param1, int *param2, int *param3, int *param4 )
 {
 	ssize_t p1, p2, p3, p4;
+	if( param1 ) p1 = (ssize_t)*param1;
+	if( param2 ) p2 = (ssize_t)*param2;
+	if( param3 ) p3 = (ssize_t)*param3;
+	if( param4 ) p4 = (ssize_t)*param4;
 	fb_GfxControl_i( what, &p1, &p2, &p3, &p4 );
-	*param1 = (int)p1;
-	*param2 = (int)p2;
-	*param3 = (int)p3;
-	*param4 = (int)p4;
+	if( param1 ) *param1 = (int)p1;
+	if( param2 ) *param2 = (int)p2;
+	if( param3 ) *param3 = (int)p3;
+	if( param4 ) *param4 = (int)p4;
 }
 
 FBCALL void fb_GfxControl_i64( int what, long long *param1, long long *param2, long long *param3, long long *param4 )
 {
 	ssize_t p1, p2, p3, p4;
+	if( param1 ) p1 = (ssize_t)*param1;
+	if( param2 ) p2 = (ssize_t)*param2;
+	if( param3 ) p3 = (ssize_t)*param3;
+	if( param4 ) p4 = (ssize_t)*param4;
 	fb_GfxControl_i( what, &p1, &p2, &p3, &p4 );
-	*param1 = (long long)p1;
-	*param2 = (long long)p2;
-	*param3 = (long long)p3;
-	*param4 = (long long)p4;
+	if( param1 ) *param1 = (long long)p1;
+	if( param2 ) *param2 = (long long)p2;
+	if( param3 ) *param3 = (long long)p3;
+	if( param4 ) *param4 = (long long)p4;
 }


### PR DESCRIPTION
- was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's

Fixes #315
