### PR TITLE
fbc: add syntax for PROCPTR( identifier, type )

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@ Version 1.09.0
 - darwin: Implemented objinfo for Darwin/OSX Mach-O .o files, so #inclib etc. work (TeeEmCee)
 - fbc: add '-entry name' command line option to set program entry point (TeeEmCee)
 - added objinfo support for ELF files on freebsd
+- PROCPTR( identifier, type ) syntax to allow getting procedure pointer for based on sub/function type
 
 [fixed]
 - github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)

--- a/tests/pointers/procptr-type.bas
+++ b/tests/pointers/procptr-type.bas
@@ -1,0 +1,117 @@
+#include "fbcunit.bi"
+
+dim shared id as string
+
+sub s overload ()
+	id = "s()"
+end sub
+
+sub s( byval arg as byte )
+	id = "s( byval arg as byte )"
+end sub
+
+sub s( byval arg as short )
+	id = "s( byval arg as short )"
+end sub
+
+sub s( byval arg as long )
+	id = "s( byval arg as long )"
+end sub
+
+sub s( byval arg as longint )
+	id = "s( byval arg as longint )"
+end sub
+
+sub s( byval arg as single )
+	id = "s( byval arg as single )"
+end sub
+
+sub s( byval arg as double )
+	id = "s( byval arg as double )"
+end sub
+
+
+SUITE( fbc_tests.pointers.procptr_type )
+
+	TEST( subs )
+
+		scope
+			var p1 = procptr(s)
+			p1()
+			CU_ASSERT( id = "s()" )
+		end scope
+
+		scope
+			var p1 = procptr(s, sub() )
+			p1()
+			CU_ASSERT( id = "s()" )
+		end scope
+
+		scope
+			var p1 = procptr(s, sub( byval as byte ) )
+			p1(0)
+			CU_ASSERT( id = "s( byval arg as byte )" )
+		end scope
+
+		scope
+			var p1 = procptr(s, sub( byval as short ) )
+			p1(0)
+			CU_ASSERT( id = "s( byval arg as short )" )
+		end scope
+
+		scope
+			var p1 = procptr(s, sub( byval as long ) )
+			p1(0)
+			CU_ASSERT( id = "s( byval arg as long )" )
+		end scope
+
+		scope
+			var p1 = procptr(s, sub( byval as longint ) )
+			p1(0)
+			CU_ASSERT( id = "s( byval arg as longint )" )
+		end scope
+
+		scope
+			var p1 = procptr(s, sub( byval as single ) )
+			p1(0)
+			CU_ASSERT( id = "s( byval arg as single )" )
+		end scope
+
+		scope
+			var p1 = procptr(s, sub( byval as double ) )
+			p1(0)
+			CU_ASSERT( id = "s( byval arg as double )" )
+		end scope
+
+	END_TEST
+
+	TEST( types )
+
+		type t as sub( byval as single )
+
+		scope
+			var p1 = procptr(s, sub( byval as single ) )
+			p1(0)
+			CU_ASSERT( id = "s( byval arg as single )" )
+		end scope
+
+		scope
+			var p1 = procptr(s, t )
+			p1(0)
+			CU_ASSERT( id = "s( byval arg as single )" )
+		end scope
+
+		scope
+			var p1 = procptr(s, typeof(t) )
+			p1(0)
+			CU_ASSERT( id = "s( byval arg as single )" )
+
+			var p2 = procptr(s, typeof(p1) )
+			p2(0)
+			CU_ASSERT( id = "s( byval arg as single )" )
+		end scope
+
+		
+	END_TEST
+
+END_SUITE

--- a/todo.txt
+++ b/todo.txt
@@ -269,6 +269,16 @@ o -exx should catch...
         prototypes don't require a name and because overloading
       - := must be a new token because the "foo bar : baz" ambiguity
 
+[ ] method pointers / delegates
+    - extend PROCPTR( id, type ) to allow pointers to methods
+    - fbc handles method pointers fairly well but the syntax is not symmetrical with
+      invoking a method on a TYPE (class)
+    - var x = procptr( T.method ) could return a method pointer but must currently be
+      invoked with x( instance, [params]... ).  This is a different syntax from other
+      languages that support method pointers.
+    - delegates would need to aggregate the instance and method pointer which will
+      likely requre a new built-in type to handle by the compiler
+
 *** *** *** *** ***
 [ ] All functions returning STRING should actually return the FBSTRING object
     - it must be coded in plain C to avoid C++ dependencies


### PR DESCRIPTION
- PROCPTR( identifier, type ) syntax to allow getting procedure pointer for based on sub/function type
- can optionally specify 'type' of the sub/function; to resolve function overloads or make a check for compatible sub/function on non-overloaded functions

previously was only possible with:

    sub s overload()
    end sub
    sub s( byval i as integer )
    end sub

    dim s1 as sub( byval i as integer)
    s1 = procptr( s )

    dim s2 as sub()
    s2 = procptr( s )

Now is possible with:

    var s1 = procptr( s, sub() )
    var s2 = procptr( s, sub( byval i as integer ) )