### PR TITLE
fbc: sf.net # 483 fblite: Can't call LEN with nested WITH block string member

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ Version 1.09.0
 - gfxlib2: fix d2d scaling issues for high dpi (adeyblue)
 - fbc: improve error message on statement between SELECT and first CASE inside a subroutine and don't allow CONST/ENUM between any SELECT & first CASE.
 - sf.net #843: Implicit casting of argument to string works for Instr() and Mid() but not for Left() and Right() 
+- sf.net #483 fblite: Can't call LEN with nested WITH block string member 
 
 
 Version 1.08.0

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -279,9 +279,12 @@ function cTypeOrExpression _
 	'' If a simple identifier is given to sizeof/len, then collect
 	'' information about the symbols which it could refer to. If it could
 	'' refer to both a type and a non-type symbol, we may want to show a
-	'' warning later.
+	'' warning later. Allow FB_LANG_OPT_PERIODS to control lexing the first
+	'' token but not the look ahead.  Only in the qb dialect could variables
+	'' possibly have periods in the name.  In all other cases (like for types)
+	'' we need to return each identifier between periods.
 	dim ambigioussizeof as AmbigiousSizeofInfo
-	if( (lexGetToken( ) = FB_TK_ID) and (lexGetLookAhead( 1 ) = CHAR_RPRNT) ) then
+	if( (lexGetToken( ) = FB_TK_ID) and (lexGetLookAhead( 1, LEXCHECK_NOPERIOD ) = CHAR_RPRNT) ) then
 		var chain_ = lexGetSymChain( )
 		'' Known symbol(s)?
 		if( chain_ ) then

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -50,10 +50,10 @@ endif
 # build sub-targets based on FB_LANG option
 #
 ifeq ($(FB_LANG),)
-REQ_MOSTLYCLEAN := mostlyclean-unit mostlyclean-fb mostlyclean-qb mostlyclean-deprecated
-REQ_CLEAN := clean-unit clean-fb clean-qb clean-deprecated
-REQ_TESTS := log-tests-fb log-tests-qb log-tests-deprecated
-REQ_FAILED := failed-tests-fb failed-tests-qb failed-tests-deprecated
+REQ_MOSTLYCLEAN := mostlyclean-unit mostlyclean-fb mostlyclean-fblite mostlyclean-qb mostlyclean-deprecated
+REQ_CLEAN := clean-unit clean-fb clean-fblite clean-qb clean-deprecated
+REQ_TESTS := log-tests-fb log-tests-fblite log-tests-qb log-tests-deprecated
+REQ_FAILED := failed-tests-fb failed-tests-fblite failed-tests-qb failed-tests-deprecated
 else
 REQ_MOSTLYCLEAN := mostlyclean-unit mostlyclean-$(FB_LANG)
 REQ_CLEAN := clean-unit clean-$(FB_LANG)
@@ -175,6 +175,12 @@ log-tests-fb :
 	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) all FB_LANG=fb
 	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) results FB_LANG=fb
 
+.PHONY: log-tests-fblite
+log-tests-fblite :
+	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) mostlyclean FB_LANG=fblite
+	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) all FB_LANG=fblite
+	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) results FB_LANG=fblite
+
 .PHONY: log-tests-qb
 log-tests-qb :
 	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) mostlyclean FB_LANG=qb
@@ -195,6 +201,12 @@ failed-tests-fb :
 	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) mostlyclean FAILED_ONLY=1 FB_LANG=fb
 	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) all FAILED_ONLY=1 FB_LANG=fb
 	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) results FB_LANG=fb
+
+.PHONY: failed-tests-fblite
+failed-tests-fblite :
+	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) mostlyclean FAILED_ONLY=1 FB_LANG=fblite
+	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) all FAILED_ONLY=1 FB_LANG=fblite
+	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) results FB_LANG=fblite
 
 .PHONY: failed-tests-qb
 failed-tests-qb :
@@ -222,6 +234,10 @@ mostlyclean-unit :
 mostlyclean-fb :
 	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) mostlyclean FB_LANG=fb
 
+.PHONY: mostlyclean-fblite
+mostlyclean-fblite :
+	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) mostlyclean FB_LANG=fblite
+
 .PHONY: mostlyclean-qb
 mostlyclean-qb :
 	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) mostlyclean FB_LANG=qb
@@ -241,6 +257,10 @@ clean-unit :
 .PHONY: clean-fb
 clean-fb :
 	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) clean FB_LANG=fb
+
+.PHONY: clean-fblite
+clean-fblite :
+	cd . && $(MAKE) -f $(LOGTESTS_MAKEFILE) clean FB_LANG=fblite
 
 .PHONY: clean-qb
 clean-qb :

--- a/tests/dirlist.mk
+++ b/tests/dirlist.mk
@@ -41,6 +41,9 @@ virtual \
 visibility \
 wstring
 
+DIRLIST_FBLITE := \
+fblite
+
 DIRLIST_QB := \
 qb
 

--- a/tests/fblite/len.bas
+++ b/tests/fblite/len.bas
@@ -1,0 +1,86 @@
+' TEST_MODE : COMPILE_AND_RUN_OK
+
+#lang "fblite"
+
+type inner_t
+	member as string
+end type
+
+type outer_t
+	inner as inner_t
+end type
+
+sub test_scoped
+	dim outer as outer_t
+	outer.inner.member = "blarg"
+	
+	ASSERT( len( outer.inner.member ) = 5 )
+	
+	with outer
+		ASSERT( len(.inner.member) = 5 )
+	end with
+	
+	with outer.inner
+		ASSERT( len(.member) = 5 )
+	end with
+	
+	ASSERT( len(inner_t) = sizeof(string) )
+	ASSERT( len(outer_t) = sizeof(string) )
+	
+	
+	dim variable.string as string
+	variable.string = "klonk"
+	
+	ASSERT( len(variable.string) = 5 )
+	ASSERT( len(short) = 2 )
+end sub
+
+namespace NS
+	type inner_t
+		member as string
+	end type
+	
+	type outer_t
+		inner as inner_t
+	end type
+
+	dim shared outer as outer_t
+
+	sub test_NS_implicit		
+		outer.inner.member = "blarg"
+		
+		ASSERT( len( outer.inner.member ) = 5 )
+		
+		with outer
+			ASSERT( len(.inner.member) = 5 )
+		end with
+		
+		with outer.inner
+			ASSERT( len(.member) = 5 )
+		end with
+		
+		ASSERT( len(inner_t) = sizeof(string) )
+		ASSERT( len(outer_t) = sizeof(string) )
+	end sub
+end namespace
+
+sub test_NS_explicit
+	NS.outer.inner.member = "blarg"
+	
+	ASSERT( len( NS.outer.inner.member ) = 5 )
+	
+	with NS.outer
+		ASSERT( len(.inner.member) = 5 )
+	end with
+	
+	with NS.outer.inner
+		ASSERT( len(.member) = 5 )
+	end with
+	
+	ASSERT( len(NS.inner_t) = sizeof(string) )
+	ASSERT( len(NS.outer_t) = sizeof(string) )
+end sub
+
+test_scoped
+NS.test_NS_implicit
+test_NS_explicit

--- a/tests/log-tests.mk
+++ b/tests/log-tests.mk
@@ -54,6 +54,10 @@ ifeq ($(FB_LANG),qb)
 DIRLIST := $(DIRLIST_QB)
 endif
 
+ifeq ($(FB_LANG),fblite)
+DIRLIST := $(DIRLIST_FBLITE)
+endif
+
 ifeq ($(FB_LANG),deprecated)
 DIRLIST := $(DIRLIST_DEPRECATED)
 endif

--- a/tests/readme.txt
+++ b/tests/readme.txt
@@ -30,6 +30,7 @@ $ make unit-tests
 
 $ make log-tests
    generates failed-test-fb.log
+   generates failed-test-fblite.log
    generates failed-test-qb.log
    generates failed-test-deprecated.log
    if all tests passed, the log file reports "None found"
@@ -55,7 +56,7 @@ rescan directories for new or dropped test files.
 Use 'make mostlyclean' to clean-up nearly all the files when it is
 known that no tests have been added or dropped between test sessions.
 
-Use 'make log-tests FB_LANG=fb | qb | deprecated' to make a specific
+Use 'make log-tests FB_LANG=fb | fblite | qb | deprecated' to make a specific
 set of -lang tests.
 
 
@@ -67,7 +68,7 @@ OS=DOS
 FBC=/path/fbc
    Specify the location of the fbc compiler
 
-FB_LANG=fb | qb | deprecated
+FB_LANG=fb | fblite | qb | deprecated
    Specify the compiler dialect
 
 DEBUG=1


### PR DESCRIPTION
Bug fix for : [sf.net # 483 fblite: Can't call LEN with nested WITH block string member](https://sourceforge.net/p/fbc/bugs/483/)

- Also shows up in qb dialect between `__with : end __with` block since both the qb and fblite dialects support periods in variable names.
- with outer: len(.inner.member): end with, is incorrectly seen as len( outer.'inner.member' ) where 'inner.member' is taken as the full name of the member of outer.
- this bug is due to `CTypeOrExpression()` function looking ahead for a right parenthesis without specifying the `LEXCHECK_NOPERIODS` option.  The look ahead token is cached and when the logic falls though, the parser no longer has access to the individual identifiers in the expression and treats it as all one identifier

Example:
~~~
#lang "fblite" '' or "qb" or "fb"

#ifndef __with
#define __with with
#endif

type inner_t
	member as string
end type

type outer_t
	inner as inner_t
end type

dim outer as outer_t
outer.inner.member = "blarg"
? len( outer.inner.member ) '' 5

__with outer
? len(.inner.member) '' 5
end __with

__with outer.inner
? len(.member) '' 5
end __with
~~~