### PR TITLE
fbc internal changes to track binary tools used by fbc

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@ Version 1.09.0
 - fbc: internal function fbcQueryGcc() to ask gcc for the correct as & ld to use (TeeEmCee)
 - rtlib: freebsd: minimum thread stacksize 8192 KiB
 - sf.net #666: allow overload 'as string' with 'as zstring ptr' parameters
-- fbc: internal changes to restructure fbctools table, cache search results in fbctoolTB()
+- fbc: internal changes to restructure fbctools table, cache search results in fbctoolTB(), solve out fbcFindBin() parameters
 
 [added]
 - fbc: add '-z fbrt' command line option to link against libfbrt*.a instead of libfb*.a

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@ Version 1.09.0
 - fbc: internal function fbcQueryGcc() to ask gcc for the correct as & ld to use (TeeEmCee)
 - rtlib: freebsd: minimum thread stacksize 8192 KiB
 - sf.net #666: allow overload 'as string' with 'as zstring ptr' parameters
+- fbc: internal changes to restructure fbctools table
 
 [added]
 - fbc: add '-z fbrt' command line option to link against libfbrt*.a instead of libfb*.a

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@ Version 1.09.0
 - fbc: internal function fbcQueryGcc() to ask gcc for the correct as & ld to use (TeeEmCee)
 - rtlib: freebsd: minimum thread stacksize 8192 KiB
 - sf.net #666: allow overload 'as string' with 'as zstring ptr' parameters
-- fbc: internal changes to restructure fbctools table
+- fbc: internal changes to restructure fbctools table, cache search results in fbctoolTB()
 
 [added]
 - fbc: add '-z fbrt' command line option to link against libfbrt*.a instead of libfb*.a


### PR DESCRIPTION
This PR expands on ideas discussed in #279 to restructure some fbc internals to use a table of information to track and invoke binary tools - like AS, LD, GCC, etc.

- name FBCTOOLS_* in the enum FBCTOOL
- add enum FBCTOOLFLAG to specify tool options
- add FBCTOOLINFO structure to track additional information for each tool
- rename toolnames() to fbctoolTB()
- refactor fbcFindBin() to solve out variables lasttool, last_relying_on_system, and lastpath and store in fbcToolTB()
- refactor fbcFindBin() to solve out relying_on_system parameter

Intent of the change is to provide some structure for future improvements such as querying the system for available tools or versions of tools, tracking information about tools as it is discovered, or allowing multiple versions / variations of a particular tool.
