### PR TITLE
fbc: don't allow labels or EXIT statments between SELECT CASE and first CASE statement

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ Version 1.09.0
 - darwin: a variety of improvements to allow compiling and linking (TeeEmCee)
 - gfxlib2: fix d2d scaling issues for high dpi (adeyblue)
 - fbc: improve error message on statement between SELECT and first CASE inside a subroutine and don't allow CONST/ENUM between any SELECT & first CASE.
+- fbc: don't allow labels or EXIT statements between SELECT and first CASE statement
 - sf.net #843: Implicit casting of argument to string works for Instr() and Mid() but not for Left() and Right() 
 - sf.net #483 fblite: Can't call LEN with nested WITH block string member 
 

--- a/src/compiler/parser-compound.bas
+++ b/src/compiler/parser-compound.bas
@@ -187,6 +187,11 @@ sub cExitStatement( )
 	'' EXIT
 	lexSkipToken( LEXCHECK_POST_SUFFIX )
 
+	'' between SELECT CASE and first CASE? ... that's not allowed
+	if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_DECL or FB_CMPSTMT_MASK_CODE ) = FALSE ) then
+		hSkipStmt( )
+	end if
+
 	'' (FOR | DO | WHILE | SELECT | SUB | FUNCTION) (',')*
 	var tk = lexGetToken( )
 	select case as const( tk )

--- a/src/compiler/parser-label.bas
+++ b/src/compiler/parser-label.bas
@@ -13,14 +13,14 @@
 ''                |   ID ':' .
 ''
 function cLabel as integer
-    dim as FBSYMBOL ptr l = NULL
-    dim as FBSYMCHAIN ptr chain_ = any
+	dim as FBSYMBOL ptr l = NULL
+	dim as FBSYMCHAIN ptr chain_ = any
 
-    function = FALSE
+	function = FALSE
 
-    '' NUM_LIT
-    select case as const lexGetClass( )
-    case FB_TKCLASS_NUMLITERAL
+	'' NUM_LIT
+	select case as const lexGetClass( )
+	case FB_TKCLASS_NUMLITERAL
 
 		'' between SELECT CASE and first CASE? ... that's not allowed
 		if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_CODE ) = FALSE ) then
@@ -28,7 +28,7 @@ function cLabel as integer
 			exit function
 		end if
 
-    	if( fbLangOptIsSet( FB_LANG_OPT_NUMLABEL ) = FALSE ) then
+		if( fbLangOptIsSet( FB_LANG_OPT_NUMLABEL ) = FALSE ) then
 			errReportNotAllowed( FB_LANG_OPT_NUMLABEL )
 			'' error recovery: skip stmt
 			hSkipStmt( )
@@ -76,14 +76,14 @@ function cLabel as integer
 			'' skip ':'
 			lexSkipToken( )
 		end if
-    end select
+	end select
 
-    if( l <> NULL ) then
-    	astAdd( astNewLABEL( l ) )
+	if( l <> NULL ) then
+		astAdd( astNewLABEL( l ) )
 
-    	symbSetLastLabel( l )
+		symbSetLastLabel( l )
 
-    	function = TRUE
-    end if
+		function = TRUE
+	end if
 
 end function

--- a/src/compiler/parser-label.bas
+++ b/src/compiler/parser-label.bas
@@ -22,6 +22,12 @@ function cLabel as integer
     select case as const lexGetClass( )
     case FB_TKCLASS_NUMLITERAL
 
+		'' between SELECT CASE and first CASE? ... that's not allowed
+		if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_CODE ) = FALSE ) then
+			hSkipStmt( )
+			exit function
+		end if
+
     	if( fbLangOptIsSet( FB_LANG_OPT_NUMLABEL ) = FALSE ) then
 			errReportNotAllowed( FB_LANG_OPT_NUMLABEL )
 			'' error recovery: skip stmt
@@ -45,6 +51,13 @@ function cLabel as integer
 	case FB_TKCLASS_IDENTIFIER
 		'' ':'
 		if( lexGetLookAhead( 1 ) = FB_TK_STMTSEP ) then
+
+			'' between SELECT CASE and first CASE? ... that's not allowed
+			if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_CODE ) = FALSE ) then
+				hSkipStmt( )
+				exit function
+			end if
+
 			'' ambiguity: it could be a proc call followed by a ':' stmt separator..
 			'' no need to call Identifier(), ':' wouldn't follow 'ns.symbol' ids
 			chain_ = lexGetSymChain( )

--- a/tests/compound/select-bad-const.bas
+++ b/tests/compound/select-bad-const.bas
@@ -1,0 +1,8 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+dim x as integer
+select case x
+	const c = 0
+case 1
+case else
+end select

--- a/tests/compound/select-bad-exit.bas
+++ b/tests/compound/select-bad-exit.bas
@@ -1,0 +1,8 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+dim x as integer
+select case x
+	exit select
+case 1
+case else
+end select

--- a/tests/compound/select-bad-label.bas
+++ b/tests/compound/select-bad-label.bas
@@ -1,0 +1,8 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+dim x as integer
+select case x
+	label:
+case 1
+case else
+end select


### PR DESCRIPTION
Builds on [6c8a2bc849609c2a22effa1883885039b97b9726] to generate an error message for labels or EXIT statements appearing between SELECT CASE and first CASE statement.

Example 'bad.bas'
~~~
sub s()
	dim as integer x
	select case x
		exit sub
	case 1
	case else
	end select  
end sub

dim as integer x
select case x
	label:
case 1
case else
end select 
~~~
Output:
~~~
bad.bas(4) error 62: Statement in between SELECT and first CASE in 'exit sub'
bad.bas(12) error 62: Statement in between SELECT and first CASE in 'label:'
~~~
