### PR TITLE
gas-x86 cleanups

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 Version 1.09.0
 
+fbc: add initial support for FreeBSD on PowerPC
+
 [changed]
 - github #314: fbc: pass '-T scriptfile' option to linker LD and add 'INSERT AFTER .data;' to fbextra.x linker script to quiet warning on LD version 2.36 and higher
 - gas64: .a64 replaced by .asm to be coherent with documentation
@@ -27,6 +29,10 @@ Version 1.09.0
 - added objinfo support for ELF files on freebsd
 - PROCPTR( identifier, type ) syntax to allow getting procedure pointer for based on sub/function type
 - sf.net #666: overload matching for UDT's with CAST() operators as [w|z]string type and implicit conversions
+- makefile: add initial support for powerpc and powerpc64 on FreeBSD (lenoil98)
+- boostrap: add 'freebsd-ppc' and 'freebsd-ppc64' to bootstrap package (lenoil98)
+- fbc: add 'powerpc' and 'powerpc64' cpu families and cpu type for '-arch' command line option (lenoil98)
+- fbc: add the __FB_PPC__ intrinsic constant (lenoil98)
 
 [fixed]
 - github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)

--- a/makefile
+++ b/makefile
@@ -313,12 +313,12 @@ ifneq ($(filter arm%,$(TARGET_ARCH)),)
   TARGET_ARCH := arm
 endif
 
-# Normalize TARGET_ARCH to arm
+# Normalize TARGET_ARCH to powerpc
 ifneq ($(filter powerpc,$(TARGET_ARCH)),)
   TARGET_ARCH := powerpc
 endif
 
-# Normalize TARGET_ARCH to arm
+# Normalize TARGET_ARCH to powerpc64
 ifneq ($(filter powerpc%,$(TARGET_ARCH)),)
   TARGET_ARCH := powerpc64
 endif

--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -12,18 +12,18 @@
 #include once "stabs.bi"
 
 type EDBGCTX
-	typecnt			as uinteger
+	typecnt         as uinteger
 
-	label 			as FBSYMBOL ptr
-	lnum 			as integer
-	pos 			as integer
-	isnewline		as integer
+	label           as FBSYMBOL ptr
+	lnum            as integer
+	pos             as integer
+	isnewline       as integer
 
-	firstline		as integer					'' first non-decl line
-	lastline		as integer					'' last  /
+	firstline       as integer                  '' first non-decl line
+	lastline        as integer                  '' last  /
 
-	filename		as zstring * FB_MAXPATHLEN+1
-	incfile			as zstring ptr
+	filename        as zstring * FB_MAXPATHLEN+1
+	incfile         as zstring ptr
 end type
 
 declare sub hDeclUDT _
@@ -32,13 +32,15 @@ declare sub hDeclUDT _
 		byval dimtbelements as integer _
 	)
 
-declare sub 	 hDeclENUM				( _
-											byval sym as FBSYMBOL ptr _
-										)
+declare sub hDeclENUM _
+	( _
+		byval sym as FBSYMBOL ptr _
+	)
 
-declare function hDeclPointer			( _
-											byref dtype as integer _
-										) as string
+declare function hDeclPointer _
+	( _
+		byref dtype as integer _
+	) as string
 
 declare function hGetDataType _
 	( _
@@ -53,7 +55,7 @@ declare function hGetDataType _
 	'' Mapping dtype => stabs type tag (t*) as declared in the strings in the stabsTb()
 	dim shared remapTB(0 to FB_DATATYPES-1) as integer = _
 	{ _
-		 7, _									'' void
+		 7, _                                   '' void
 		16, _                                   '' boolean
 		 2, _                                   '' byte
 		 3, _                                   '' ubyte
@@ -198,7 +200,7 @@ private sub hSTABLABEL _
 		byval label as zstring ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = *label
 	ostr += ":"
@@ -230,7 +232,7 @@ sub edbgEmitHeader( byval filename as zstring ptr )
 	end if
 
 	'' file name
-    hEmitSTABS( STAB_TYPE_SO, filename, 0, 0, lname )
+	hEmitSTABS( STAB_TYPE_SO, filename, 0, 0, lname )
 
 	''
 	emitSetSection( IR_SECTION_CODE, 0 )
@@ -274,26 +276,26 @@ sub edbgLineBegin _
 	)
 
 	if( env.clopt.debuginfo = FALSE ) then
-    	exit sub
+		exit sub
 	end if
 
-    if( ctx.lnum > 0 ) then
-    	ctx.pos = pos_ - ctx.pos
-    	if( ctx.pos > 0 ) then
-    		edbgEmitLine( proc, ctx.lnum, ctx.label )
-    		ctx.isnewline = TRUE
-    	end if
-    end if
+	if( ctx.lnum > 0 ) then
+		ctx.pos = pos_ - ctx.pos
+		if( ctx.pos > 0 ) then
+			edbgEmitLine( proc, ctx.lnum, ctx.label )
+			ctx.isnewline = TRUE
+		end if
+	end if
 
-    edbgInclude( filename )
-   
-    ctx.pos = pos_
-    ctx.lnum = lnum
-    if( ctx.isnewline ) then
-    	ctx.label = symbAddLabel( NULL )
-    	hSTABLABEL( symbGetMangledName( ctx.label ) )
-    	ctx.isnewline = FALSE
-    end if
+	edbgInclude( filename )
+
+	ctx.pos = pos_
+	ctx.lnum = lnum
+	if( ctx.isnewline ) then
+		ctx.label = symbAddLabel( NULL )
+		hSTABLABEL( symbGetMangledName( ctx.label ) )
+		ctx.isnewline = FALSE
+	end if
 
 end sub
 
@@ -306,17 +308,17 @@ sub edbgLineEnd _
 	)
 
 	if( env.clopt.debuginfo = FALSE ) then
-    	exit sub
-    end if
+		exit sub
+	end if
 
-    if( ctx.lnum > 0 ) then
-    	ctx.pos = pos_ - ctx.pos
-    	if( ctx.pos > 0 ) then
-   			edbgEmitLine( proc, ctx.lnum, ctx.label )
-   			ctx.isnewline = TRUE
-   		end if
-    	ctx.lnum = 0
-    end if
+	if( ctx.lnum > 0 ) then
+		ctx.pos = pos_ - ctx.pos
+		if( ctx.pos > 0 ) then
+			edbgEmitLine( proc, ctx.lnum, ctx.label )
+			ctx.isnewline = TRUE
+		end if
+		ctx.lnum = 0
+	end if
 
 end sub
 
@@ -328,7 +330,7 @@ sub edbgEmitLine _
 		byval label as FBSYMBOL ptr _
 	) static
 
-    dim as zstring ptr s
+	dim as zstring ptr s
 
 	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
@@ -378,11 +380,11 @@ sub edbgScopeBegin _
 	'' called by ir->ast
 
 	if( env.clopt.debuginfo = FALSE ) then
-    	exit sub
-    end if
+		exit sub
+	end if
 
 	s->scp.dbg.iniline = lexLineNum( )
-    s->scp.dbg.inilabel = symbAddLabel( NULL )
+	s->scp.dbg.inilabel = symbAddLabel( NULL )
 
 end sub
 
@@ -395,11 +397,11 @@ sub edbgScopeEnd _
 	'' called by ir->ast
 
 	if( env.clopt.debuginfo = FALSE ) then
-    	exit sub
-    end if
+		exit sub
+	end if
 
 	s->scp.dbg.endline = lexLineNum( )
-    s->scp.dbg.endlabel = symbAddLabel( NULL )
+	s->scp.dbg.endlabel = symbAddLabel( NULL )
 
 end sub
 
@@ -410,10 +412,10 @@ sub edbgEmitScopeINI _
 	) static
 
 	if( env.clopt.debuginfo = FALSE ) then
-    	exit sub
-    end if
+		exit sub
+	end if
 
-    hSTABLABEL( symbGetMangledName( s->scp.dbg.inilabel ) )
+	hSTABLABEL( symbGetMangledName( s->scp.dbg.inilabel ) )
 
 end sub
 
@@ -424,10 +426,10 @@ sub edbgEmitScopeEND _
 	) static
 
 	if( env.clopt.debuginfo = FALSE ) then
-    	exit sub
-    end if
+		exit sub
+	end if
 
-    hSTABLABEL( symbGetMangledName( s->scp.dbg.endlabel ) )
+	hSTABLABEL( symbGetMangledName( s->scp.dbg.endlabel ) )
 
 end sub
 
@@ -487,7 +489,7 @@ sub edbgEmitProcHeader _
 		byval proc as FBSYMBOL ptr _
 	) static
 
-    dim as string desc, procname
+	dim as string desc, procname
 
 	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
@@ -507,17 +509,17 @@ sub edbgEmitProcHeader _
 					1, _
 					*symbGetMangledName( proc ) )
 
-    	'' set the entry line
-    	hEmitSTABD( STAB_TYPE_SLINE, 0, 1 )
+		'' set the entry line
+		hEmitSTABD( STAB_TYPE_SLINE, 0, 1 )
 
-    	'' also correct the end and start lines
-    	proc->proc.ext->dbg.iniline = 1
-    	proc->proc.ext->dbg.endline = lexLineNum( )
+		'' also correct the end and start lines
+		proc->proc.ext->dbg.iniline = 1
+		proc->proc.ext->dbg.endline = lexLineNum( )
 
-    	desc = fbGetEntryPoint( )
-    else
-    	desc = *symbGetDBGName( proc )
-    end if
+		desc = fbGetEntryPoint( )
+	else
+		desc = *symbGetDBGName( proc )
+	end if
 
 	''
 	procname = *symbGetMangledName( proc )
@@ -536,9 +538,9 @@ sub edbgEmitProcHeader _
 
 	''
 	ctx.isnewline = TRUE
-	ctx.lnum      = 0
-	ctx.pos	  	  = 0
-	ctx.label	  = NULL
+	ctx.lnum = 0
+	ctx.pos = 0
+	ctx.label = NULL
 
 end sub
 
@@ -568,9 +570,9 @@ private sub hDeclLocalVars _
 	s = shead
 	do while( s <> NULL )
 
-    	select case symbGetClass( s )
-    	'' variable?
-    	case FB_SYMBCLASS_VAR
+		select case symbGetClass( s )
+		'' variable?
+		case FB_SYMBCLASS_VAR
 
 			'' Don't emit debug info for parameter variables (the
 			'' parameters will be emitted instead), temporaries,
@@ -608,13 +610,13 @@ private sub hDeclLocalVars _
 		'' for each scope..
 		s = shead
 		do while( s <> NULL )
-    		if( symbIsScope( s ) ) then
-    			hDeclLocalVars( proc, s, s->scp.dbg.inilabel, s->scp.dbg.endlabel )
-    		end if
+			if( symbIsScope( s ) ) then
+				hDeclLocalVars( proc, s, s->scp.dbg.inilabel, s->scp.dbg.endlabel )
+			end if
 
 			s = s->next
-    	loop
-    end if
+		loop
+	end if
 
 	hEmitSTABN( STAB_TYPE_RBRAC, _
 				0, _
@@ -631,7 +633,7 @@ sub edbgEmitProcFooter _
 		byval exitlabel as FBSYMBOL ptr _
 	) static
 
-    dim as string procname, lname
+	dim as string procname, lname
 
 	if( env.clopt.debuginfo = FALSE ) then
 		exit sub
@@ -640,8 +642,8 @@ sub edbgEmitProcFooter _
 	''
 	procname = *symbGetMangledName( proc )
 
-    ''
-    hDeclLocalVars( proc, proc, initlabel, exitlabel )
+	''
+	hDeclLocalVars( proc, proc, initlabel, exitlabel )
 
 	lname = *symbUniqueLabel( )
 	hSTABLABEL( lname )
@@ -651,9 +653,9 @@ sub edbgEmitProcFooter _
 
 	''
 	ctx.isnewline = TRUE
-	ctx.lnum      = 0
-	ctx.pos	  	  = 0
-	ctx.label	  = NULL
+	ctx.lnum = 0
+	ctx.pos = 0
+	ctx.label = NULL
 
 end sub
 
@@ -663,16 +665,16 @@ private function hDeclPointer _
 		byref dtype as integer _
 	) as string static
 
-    dim as string desc
+	dim as string desc
 
-    desc = ""
-    do while( typeIsPtr( dtype ) )
-    	dtype = typeDeref( dtype )
-    	desc += str( ctx.typecnt ) + "=*"
-    	ctx.typecnt += 1
-    loop
+	desc = ""
+	do while( typeIsPtr( dtype ) )
+		dtype = typeDeref( dtype )
+		desc += str( ctx.typecnt ) + "=*"
+		ctx.typecnt += 1
+	loop
 
-    function = desc
+	function = desc
 
 end function
 
@@ -686,9 +688,9 @@ private function hGetDataType _
 	dim as FBSYMBOL ptr subtype = any
 	dim as string desc
 
-    if( sym = NULL ) then
-    	return str( remapTB(FB_DATATYPE_VOID) )
-    end if
+	if( sym = NULL ) then
+		return str( remapTB(FB_DATATYPE_VOID) )
+	end if
 
 	''
 	'' HACK: When emitting array descriptor types, we don't always emit the
@@ -767,48 +769,48 @@ private function hGetDataType _
 		dimtbelements = 1
 	end if
 
-    '' pointer?
-    if( typeIsPtr( dtype ) ) then
-    	desc += hDeclPointer( dtype )
-    end if
+	'' pointer?
+	if( typeIsPtr( dtype ) ) then
+		desc += hDeclPointer( dtype )
+	end if
 
-    '' the const qualifier isn't taken into account
-    dtype = typeUnsetIsConst( dtype )
+	'' the const qualifier isn't taken into account
+	dtype = typeUnsetIsConst( dtype )
 
-    select case as const dtype
-    '' UDT?
-    case FB_DATATYPE_STRUCT
+	select case as const dtype
+	'' UDT?
+	case FB_DATATYPE_STRUCT
 		if( subtype->udt.dbg.typenum = INVALID ) then
 			hDeclUDT( subtype, dimtbelements )
 		end if
 
 		desc += str( subtype->udt.dbg.typenum )
 
-    '' ENUM?
-    case FB_DATATYPE_ENUM
-    	if( subtype->enum_.dbg.typenum = INVALID ) then
-    		hDeclENUM( subtype )
-    	end if
+	'' ENUM?
+	case FB_DATATYPE_ENUM
+		if( subtype->enum_.dbg.typenum = INVALID ) then
+			hDeclENUM( subtype )
+		end if
 
-    	desc += str( subtype->enum_.dbg.typenum )
+		desc += str( subtype->enum_.dbg.typenum )
 
-    '' function pointer?
-    case FB_DATATYPE_FUNCTION
-    	desc += str( ctx.typecnt ) + "=f"
-    	ctx.typecnt += 1
-    	desc += hGetDataType( subtype )
+	'' function pointer?
+	case FB_DATATYPE_FUNCTION
+		desc += str( ctx.typecnt ) + "=f"
+		ctx.typecnt += 1
+		desc += hGetDataType( subtype )
 
-    '' forward reference?
-    case FB_DATATYPE_FWDREF
-    	desc += str( remapTB(FB_DATATYPE_VOID) )
+	'' forward reference?
+	case FB_DATATYPE_FWDREF
+		desc += str( remapTB(FB_DATATYPE_VOID) )
 
-    '' ordinary type..
-    case else
-    	desc += str( remapTB(dtype) )
+	'' ordinary type..
+	case else
+		desc += str( remapTB(dtype) )
 
-    end select
+	end select
 
-    function = desc
+	function = desc
 
 end function
 
@@ -862,8 +864,8 @@ private sub hDeclENUM _
 		byval sym as FBSYMBOL ptr _
 	)
 
-    dim as FBSYMBOL ptr e
-    dim as string desc
+	dim as FBSYMBOL ptr e
+	dim as string desc
 
 	sym->enum_.dbg.typenum = ctx.typecnt
 	ctx.typecnt += 1
@@ -874,7 +876,7 @@ private sub hDeclENUM _
 
 	e = symbGetENUMFirstElm( sym )
 	do while( e <> NULL )
-        desc += *symbGetName( e ) + ":" + str( symbGetConstInt( e ) ) + ","
+		desc += *symbGetName( e ) + ":" + str( symbGetConstInt( e ) ) + ","
 
 		e = symbGetENUMNextElm( e )
 	loop
@@ -931,9 +933,9 @@ sub edbgEmitGlobalVar _
 		t = STAB_TYPE_STSYM
 	end select
 
-    desc = *symbGetDBGName( sym )
+	desc = *symbGetDBGName( sym )
 
-    '' allocation type (static, global, etc)
+	'' allocation type (static, global, etc)
 	if( symbIsPublic( sym ) or symbIsCommon( sym ) ) then
 		desc += ":G"
 	elseif( symbIsStatic( sym ) ) then
@@ -942,8 +944,8 @@ sub edbgEmitGlobalVar _
 		desc += ":"
 	end if
 
-    '' data type
-    desc += hGetDataType( sym )
+	'' data type
+	desc += hGetDataType( sym )
 
 	hEmitSTABS( t, desc, 0, 0, *symbGetMangledName( sym ) )
 
@@ -962,7 +964,7 @@ sub edbgEmitLocalVar _
 		exit sub
 	end if
 
-    desc = *symbGetName( sym )
+	desc = *symbGetName( sym )
 
 	'' (no fake dynamic array symbols - the descriptor is emitted instead)
 	assert( symbIsDynamic( sym ) = FALSE )
@@ -988,10 +990,10 @@ sub edbgEmitLocalVar _
 		value = str( symbGetOfs( sym ) )
 	end if
 
-    '' data type
-    desc += hGetDataType( sym )
+	'' data type
+	desc += hGetDataType( sym )
 
-    hEmitSTABS( t, desc, 0, 0, value )
+	hEmitSTABS( t, desc, 0, 0, value )
 end sub
 
 '' should rename to param?
@@ -1002,7 +1004,7 @@ sub edbgEmitProcArg( byval sym as FBSYMBOL ptr )
 		exit sub
 	end if
 
-    desc = *symbGetName( sym ) + ":"
+	desc = *symbGetName( sym ) + ":"
 
 	if( symbIsParamByVal( sym ) ) then
 		desc += "p"
@@ -1012,10 +1014,10 @@ sub edbgEmitProcArg( byval sym as FBSYMBOL ptr )
 		desc += "v"
 	end if
 
-    '' data type
-    desc += hGetDataType( sym )
+	'' data type
+	desc += hGetDataType( sym )
 
-    hEmitSTABS( STAB_TYPE_PSYM, desc, 0, 0, str( symbGetOfs( sym ) ) )
+	hEmitSTABS( STAB_TYPE_PSYM, desc, 0, 0, str( symbGetOfs( sym ) ) )
 end sub
 
 sub edbgInclude( byval incfile as zstring ptr )

--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -193,7 +193,7 @@ private sub hEmitSTABD _
 end sub
 
 '':::::
-private sub hLABEL _
+private sub hSTABLABEL _
 	( _
 		byval label as zstring ptr _
 	) static
@@ -233,8 +233,8 @@ sub edbgEmitHeader( byval filename as zstring ptr )
     hEmitSTABS( STAB_TYPE_SO, filename, 0, 0, lname )
 
 	''
-	emitSECTION( IR_SECTION_CODE, 0 )
-	hLABEL( lname )
+	emitSetSection( IR_SECTION_CODE, 0 )
+	hSTABLABEL( lname )
 
 	'' (known) type definitions
 	for i as integer = lbound( stabsTb ) to ubound( stabsTb )
@@ -254,13 +254,13 @@ sub edbgEmitFooter( ) static
 		exit sub
 	end if
 
-	emitSECTION( IR_SECTION_CODE, 0 )
+	emitSetSection( IR_SECTION_CODE, 0 )
 
 	'' no checkings after this
 	lname = *symbUniqueLabel( )
 	hEmitSTABS( STAB_TYPE_SO, "", 0, 0, lname )
 
-	hLABEL( lname )
+	hSTABLABEL( lname )
 
 end sub
 
@@ -291,7 +291,7 @@ sub edbgLineBegin _
     ctx.lnum = lnum
     if( ctx.isnewline ) then
     	ctx.label = symbAddLabel( NULL )
-    	hLABEL( symbGetMangledName( ctx.label ) )
+    	hSTABLABEL( symbGetMangledName( ctx.label ) )
     	ctx.isnewline = FALSE
     end if
 
@@ -413,7 +413,7 @@ sub edbgEmitScopeINI _
     	exit sub
     end if
 
-    hLABEL( symbGetMangledName( s->scp.dbg.inilabel ) )
+    hSTABLABEL( symbGetMangledName( s->scp.dbg.inilabel ) )
 
 end sub
 
@@ -427,7 +427,7 @@ sub edbgEmitScopeEND _
     	exit sub
     end if
 
-    hLABEL( symbGetMangledName( s->scp.dbg.endlabel ) )
+    hSTABLABEL( symbGetMangledName( s->scp.dbg.endlabel ) )
 
 end sub
 
@@ -644,7 +644,7 @@ sub edbgEmitProcFooter _
     hDeclLocalVars( proc, proc, initlabel, exitlabel )
 
 	lname = *symbUniqueLabel( )
-	hLABEL( lname )
+	hSTABLABEL( lname )
 
 	'' emit end proc (FUN with a null string)
 	hEmitSTABS( STAB_TYPE_FUN, "", 0, 0, lname + "-" + procname )
@@ -1028,7 +1028,7 @@ sub edbgInclude( byval incfile as zstring ptr )
 	'' fbc only emits types actually used, the end result is that
 	'' type information from a header (.BI) is often different from
 	'' one object module to another is generally not used in the
-	'' way that BINCL/EINCL/EXCL was intented.
+	'' way that BINCL/EINCL/EXCL was intended.
 
 	'' incfile is the new include file or main file name
 
@@ -1042,10 +1042,10 @@ sub edbgInclude( byval incfile as zstring ptr )
 		exit sub
 	end If
 
-	emitSECTION( IR_SECTION_CODE, 0 )
+	emitSetSection( IR_SECTION_CODE, 0 )
 	lname = *symbUniqueLabel( )
 	hEmitSTABS( STAB_TYPE_SOL, incfile, 0, 0, lname )
-	hLABEL( lname )
+	hSTABLABEL( lname )
 
 	ctx.incfile = incfile
 end sub

--- a/src/compiler/emit.bas
+++ b/src/compiler/emit.bas
@@ -11,6 +11,16 @@
 #include once "emit.bi"
 #include once "symb.bi"
 
+/'
+	From the point of view of emit.bas and EMIT_NODEOP,
+	only x86 32 bit emitter is available.
+	The one letter codes in the EMIT_OP_* enum names have
+	the meaning:
+
+		I = 32 bit or smaller
+		L = 64 bit
+'/
+
 declare function emitGasX86_ctor	_
 	( _
 	) as integer

--- a/src/compiler/emit.bas
+++ b/src/compiler/emit.bas
@@ -21,7 +21,7 @@
 		L = 64 bit
 '/
 
-declare function emitGasX86_ctor	_
+declare function emitGasX86_ctor _
 	( _
 	) as integer
 
@@ -633,7 +633,7 @@ function emitSTORE _
 		case else
 			function = hNewBOP( EMIT_OP_STORI2F, dvreg, svreg )
 		end select
-	
+
 	'' boolean?
 	case FB_SIZETYPE_BOOLEAN
 
@@ -1468,7 +1468,7 @@ sub emitASM( byval text as zstring ptr )
 
 	'' reset reg usage
 	for c as integer = 0 to EMIT_REGCLASSES-1
-		EMIT_REGTRASHALL( c )						'' can't check the reg usage
+		EMIT_REGTRASHALL( c )                       '' can't check the reg usage
 	next
 end sub
 

--- a/src/compiler/emit.bas
+++ b/src/compiler/emit.bas
@@ -1,7 +1,7 @@
 '' emit abstract interface
 ''
 '' chng: jun/2005 written [v1ctor]
-''
+'' chng: jun/2018 use FB_SIZETYPE_* for emitter calls [jeffm]
 
 #include once "fb.bi"
 #include once "fbint.bi"
@@ -486,21 +486,21 @@ function emitLOAD _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case as const typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 
-		select case as const svreg->dtype
+		select case as const typeGetSizeType( svreg->dtype )
 		'' longint?
-		case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+		case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 			function = hNewBOP( EMIT_OP_LOADL2L, dvreg, svreg )
 
 		'' float?
-		case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+		case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 			function = hNewBOP( EMIT_OP_LOADF2L, dvreg, svreg )
 
 		'' boolean?
-		case FB_DATATYPE_BOOLEAN
+		case FB_SIZETYPE_BOOLEAN
 			function = hNewBOP( EMIT_OP_LOADB2L, dvreg, svreg )
 
 		case else
@@ -508,19 +508,19 @@ function emitLOAD _
 		end select
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 
-		select case as const svreg->dtype
+		select case as const typeGetSizeType( svreg->dtype )
 		'' longint?
-		case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+		case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 			function = hNewBOP( EMIT_OP_LOADL2F, dvreg, svreg )
 
 		'' float?
-		case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+		case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 			function = hNewBOP( EMIT_OP_LOADF2F, dvreg, svreg )
 
 		'' boolean?
-		case FB_DATATYPE_BOOLEAN
+		case FB_SIZETYPE_BOOLEAN
 			function = hNewBOP( EMIT_OP_LOADB2F, dvreg, svreg )
 
 		case else
@@ -528,19 +528,19 @@ function emitLOAD _
 		end select
 
 	'' boolean?
-	case FB_DATATYPE_BOOLEAN
+	case FB_SIZETYPE_BOOLEAN
 
-		select case as const svreg->dtype
+		select case as const typeGetSizeType( svreg->dtype )
 		'' longint?
-		case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+		case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 			function = hNewBOP( EMIT_OP_LOADL2B, dvreg, svreg )
 
 		'' float?
-		case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+		case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 			function = hNewBOP( EMIT_OP_LOADF2B, dvreg, svreg )
 
 		'' boolean?
-		case FB_DATATYPE_BOOLEAN
+		case FB_SIZETYPE_BOOLEAN
 			function = hNewBOP( EMIT_OP_LOADB2B, dvreg, svreg )
 
 		case else
@@ -549,17 +549,17 @@ function emitLOAD _
 
 	case else
 
-		select case as const svreg->dtype
+		select case as const typeGetSizeType( svreg->dtype )
 		'' longint?
-		case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+		case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 			function = hNewBOP( EMIT_OP_LOADL2I, dvreg, svreg )
 
 		'' float?
-		case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+		case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 			function = hNewBOP( EMIT_OP_LOADF2I, dvreg, svreg )
 
 		'' boolean?
-		case FB_DATATYPE_BOOLEAN
+		case FB_SIZETYPE_BOOLEAN
 			function = hNewBOP( EMIT_OP_LOADB2I, dvreg, svreg )
 
 		case else
@@ -577,21 +577,21 @@ function emitSTORE _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case as const typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 
-		select case as const svreg->dtype
+		select case as const typeGetSizeType( svreg->dtype )
 		'' longint?
-		case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+		case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 			function = hNewBOP( EMIT_OP_STORL2L, dvreg, svreg )
 
 		'' float?
-		case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+		case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 			function = hNewBOP( EMIT_OP_STORF2L, dvreg, svreg )
 
 		'' boolean?
-		case FB_DATATYPE_BOOLEAN
+		case FB_SIZETYPE_BOOLEAN
 			function = hNewBOP( EMIT_OP_STORB2L, dvreg, svreg )
 
 		case else
@@ -599,19 +599,19 @@ function emitSTORE _
 		end select
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 
-		select case as const svreg->dtype
+		select case as const typeGetSizeType( svreg->dtype )
 		'' longint?
-		case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+		case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 			function = hNewBOP( EMIT_OP_STORL2F, dvreg, svreg )
 
 		'' float?
-		case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+		case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 			function = hNewBOP( EMIT_OP_STORF2F, dvreg, svreg )
 
 		'' boolean?
-		case FB_DATATYPE_BOOLEAN
+		case FB_SIZETYPE_BOOLEAN
 			function = hNewBOP( EMIT_OP_STORB2F, dvreg, svreg )
 
 		case else
@@ -619,19 +619,19 @@ function emitSTORE _
 		end select
 	
 	'' boolean?
-	case FB_DATATYPE_BOOLEAN
+	case FB_SIZETYPE_BOOLEAN
 
-		select case as const svreg->dtype
+		select case as const typeGetSizeType( svreg->dtype )
 		'' longint?
-		case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+		case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 			function = hNewBOP( EMIT_OP_STORL2B, dvreg, svreg )
 
 		'' float?
-		case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+		case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 			function = hNewBOP( EMIT_OP_STORF2B, dvreg, svreg )
 
 		'' boolean?
-		case FB_DATATYPE_BOOLEAN
+		case FB_SIZETYPE_BOOLEAN
 			function = hNewBOP( EMIT_OP_STORB2B, dvreg, svreg )
 
 		case else
@@ -640,17 +640,17 @@ function emitSTORE _
 
 	case else
 
-		select case as const svreg->dtype
+		select case as const typeGetSizeType( svreg->dtype )
 		'' longint?
-		case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+		case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 			function = hNewBOP( EMIT_OP_STORL2I, dvreg, svreg )
 
 		'' float?
-		case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+		case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 			function = hNewBOP( EMIT_OP_STORF2I, dvreg, svreg )
 
 		'' boolean?
-		case FB_DATATYPE_BOOLEAN
+		case FB_SIZETYPE_BOOLEAN
 			function = hNewBOP( EMIT_OP_STORB2I, dvreg, svreg )
 
 		case else
@@ -672,13 +672,13 @@ function emitMOV _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case as const typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_MOVL, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewBOP( EMIT_OP_MOVF, dvreg, svreg )
 
 	case else
@@ -694,13 +694,13 @@ function emitADD _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case as const typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_ADDL, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewBOP( EMIT_OP_ADDF, dvreg, svreg )
 
 	case else
@@ -716,13 +716,13 @@ function emitSUB _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case as const typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_SUBL, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewBOP( EMIT_OP_SUBF, dvreg, svreg )
 
 	case else
@@ -738,13 +738,13 @@ function emitMUL _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case as const typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_MULL, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewBOP( EMIT_OP_MULF, dvreg, svreg )
 
 	case else
@@ -793,9 +793,9 @@ function emitSHL _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_SHLL, dvreg, svreg )
 
 	case else
@@ -811,9 +811,9 @@ function emitSHR _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_SHRL, dvreg, svreg )
 
 	case else
@@ -829,9 +829,9 @@ function emitAND _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_ANDL, dvreg, svreg )
 
 	case else
@@ -847,9 +847,9 @@ function emitOR _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_ORL, dvreg, svreg )
 
 	case else
@@ -865,9 +865,9 @@ function emitXOR _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_XORL, dvreg, svreg )
 
 	case else
@@ -883,9 +883,9 @@ function emitEQV _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_EQVL, dvreg, svreg )
 
 	case else
@@ -901,9 +901,9 @@ function emitIMP _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewBOP( EMIT_OP_IMPL, dvreg, svreg )
 
 	case else
@@ -969,13 +969,13 @@ function emitGT _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewREL( EMIT_OP_CGTL, rvreg, label, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewREL( EMIT_OP_CGTF, rvreg, label, dvreg, svreg )
 
 	case else
@@ -993,13 +993,13 @@ function emitLT _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewREL( EMIT_OP_CLTL, rvreg, label, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewREL( EMIT_OP_CLTF, rvreg, label, dvreg, svreg )
 
 	case else
@@ -1017,13 +1017,13 @@ function emitEQ _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewREL( EMIT_OP_CEQL, rvreg, label, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewREL( EMIT_OP_CEQF, rvreg, label, dvreg, svreg )
 
 	case else
@@ -1041,13 +1041,13 @@ function emitNE _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewREL( EMIT_OP_CNEL, rvreg, label, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewREL( EMIT_OP_CNEF, rvreg, label, dvreg, svreg )
 
 	case else
@@ -1065,13 +1065,13 @@ function emitGE _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewREL( EMIT_OP_CGEL, rvreg, label, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewREL( EMIT_OP_CGEF, rvreg, label, dvreg, svreg )
 
 	case else
@@ -1089,13 +1089,13 @@ function emitLE _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewREL( EMIT_OP_CLEL, rvreg, label, dvreg, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewREL( EMIT_OP_CLEF, rvreg, label, dvreg, svreg )
 
 	case else
@@ -1114,13 +1114,13 @@ function emitNEG _
 		byval dvreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewUOP( EMIT_OP_NEGL, dvreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewUOP( EMIT_OP_NEGF, dvreg )
 
 	case else
@@ -1135,9 +1135,9 @@ function emitNOT _
 		byval dvreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewUOP( EMIT_OP_NOTL, dvreg )
 
 	case else
@@ -1152,9 +1152,9 @@ function emitHADD _
 		byval dvreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewUOP( EMIT_OP_HADDF, dvreg )
 
 	case else
@@ -1169,13 +1169,13 @@ function emitABS _
 		byval dvreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewUOP( EMIT_OP_ABSL, dvreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewUOP( EMIT_OP_ABSF, dvreg )
 
 	case else
@@ -1190,13 +1190,13 @@ function emitSGN _
 		byval dvreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewUOP( EMIT_OP_SGNL, dvreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewUOP( EMIT_OP_SGNF, dvreg )
 
 	case else
@@ -1388,13 +1388,13 @@ function emitPUSH _
 		byval svreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const svreg->dtype
+	select case as const typeGetSizeType( svreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewSTK( EMIT_OP_PUSHL, svreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewSTK( EMIT_OP_PUSHF, svreg )
 
 	case else
@@ -1409,13 +1409,13 @@ function emitPOP _
 		byval dvreg as IRVREG ptr _
 	) as EMIT_NODE ptr static
 
-	select case as const dvreg->dtype
+	select case as const typeGetSizeType( dvreg->dtype )
 	'' longint?
-	case FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT
+	case FB_SIZETYPE_INT64, FB_SIZETYPE_UINT64
 		function = hNewSTK( EMIT_OP_POPL, dvreg )
 
 	'' float?
-	case FB_DATATYPE_SINGLE, FB_DATATYPE_DOUBLE
+	case FB_SIZETYPE_FLOAT32, FB_SIZETYPE_FLOAT64
 		function = hNewSTK( EMIT_OP_POPF, dvreg )
 
 	case else

--- a/src/compiler/emit.bas
+++ b/src/compiler/emit.bas
@@ -60,7 +60,7 @@ sub emitWriteStr _
 		byval addtab as integer _
 	)
 
-    static as string ostr
+	static as string ostr
 
 	if( addtab ) then
 		ostr = TABCHAR
@@ -124,7 +124,7 @@ end function
 
 '':::::
 private sub hPeepHoleOpt( )
-    dim as EMIT_NODE ptr n = any, p = any
+	dim as EMIT_NODE ptr n = any, p = any
 
 	p = NULL
 	n = flistGetHead( @emit.nodeTB )
@@ -154,9 +154,9 @@ end sub
 
 '':::::
 sub emitFlush( )
-    dim as EMIT_NODE ptr n = any
+	dim as EMIT_NODE ptr n = any
 
-    hPeepHoleOpt( )
+	hPeepHoleOpt( )
 
 	n = flistGetHead( @emit.nodeTB )
 	do while( n <> NULL )
@@ -167,26 +167,30 @@ sub emitFlush( )
 		case EMIT_NODECLASS_NOP
 
 		case EMIT_NODECLASS_BOP
-			cast( EMIT_BOPCB, emit.opFnTb[n->bop.op] )( n->bop.dvreg, _
-												   		n->bop.svreg )
+			cast( EMIT_BOPCB, emit.opFnTb[n->bop.op] )( _
+				n->bop.dvreg, _
+				n->bop.svreg )
 
 		case EMIT_NODECLASS_UOP
 			cast( EMIT_UOPCB, emit.opFnTb[n->uop.op ] )( n->uop.dvreg )
 
 		case EMIT_NODECLASS_REL
-			cast( EMIT_RELCB, emit.opFnTb[n->rel.op] )( n->rel.rvreg, _
-												   		n->rel.label, _
-												   		n->rel.dvreg, _
-												   		n->rel.svreg )
+			cast( EMIT_RELCB, emit.opFnTb[n->rel.op] )( _
+				n->rel.rvreg, _
+				n->rel.label, _
+				n->rel.dvreg, _
+				n->rel.svreg )
 
 		case EMIT_NODECLASS_STK
-			cast( EMIT_STKCB, emit.opFnTb[n->stk.op] )( n->stk.vreg, _
-												   n->stk.extra )
+			cast( EMIT_STKCB, emit.opFnTb[n->stk.op] )( _
+				n->stk.vreg, _
+				n->stk.extra )
 
 		case EMIT_NODECLASS_BRC
-			cast( EMIT_BRCCB, emit.opFnTb[n->brc.op] )( n->brc.vreg, _
-												   		n->brc.sym, _
-												   		n->brc.extra )
+			cast( EMIT_BRCCB, emit.opFnTb[n->brc.op] )( _
+				n->brc.vreg, _
+				n->brc.sym, _
+				n->brc.extra )
 
 		case EMIT_NODECLASS_SOP
 			cast( EMIT_SOPCB, emit.opFnTb[n->sop.op] )( n->sop.sym )
@@ -206,16 +210,18 @@ sub emitFlush( )
 			deallocate( n->jtb.labels )
 
 		case EMIT_NODECLASS_MEM
-			cast( EMIT_MEMCB, emit.opFnTb[n->mem.op] )( n->mem.dvreg, _
-												   		n->mem.svreg, _
-												   		n->mem.bytes, _
-												   		n->mem.extra )
+			cast( EMIT_MEMCB, emit.opFnTb[n->mem.op] )( _
+				n->mem.dvreg, _
+				n->mem.svreg, _
+				n->mem.bytes, _
+				n->mem.extra )
 
 		case EMIT_NODECLASS_DBG
-			cast( EMIT_DBGCB, emit.opFnTb[n->dbg.op] )( n->dbg.sym, _
-												   		n->dbg.lnum, _
-												   		n->dbg.pos, _
-												   		n->dbg.filename )
+			cast( EMIT_DBGCB, emit.opFnTb[n->dbg.op] )( _
+				n->dbg.sym, _
+				n->dbg.lnum, _
+				n->dbg.pos, _
+				n->dbg.filename )
 
 		end select
 
@@ -244,8 +250,8 @@ private function hNewVR _
 		byval v as IRVREG ptr _
 	) as IRVREG ptr
 
-    dim as IRVREG ptr n = any
-    dim as integer dclass = any
+	dim as IRVREG ptr n = any
+	dim as integer dclass = any
 
 	if( v = NULL ) then
 		return NULL
@@ -468,7 +474,7 @@ private function hNewDBG _
 		byval sym as FBSYMBOL ptr, _
 		byval lnum as integer = 0, _
 		byval pos_ as integer = 0, _
-		byval filename As zstring ptr = 0  _
+		byval filename As zstring ptr = 0 _
 	) as EMIT_NODE ptr static
 
 	dim as EMIT_NODE ptr n

--- a/src/compiler/emit.bi
+++ b/src/compiler/emit.bi
@@ -10,7 +10,7 @@ const EMIT_INITNODES	= 2048
 const EMIT_INITVREGNODES= EMIT_INITNODES*3
 
 '' x86 specific: FB_DATACLASS_INTEGER and FB_DATACLASS_FPOINT
-const EMIT_REGCLASSES	= 2						'' assuming FB_DATACLASS_ will start at 0!
+const EMIT_REGCLASSES = 2                       '' assuming FB_DATACLASS_ will start at 0!
 
 '' if changed, update the _opFnTB() arrays at emit_*.bas
 enum EMIT_NODEOP
@@ -298,7 +298,7 @@ type EMIT_VTBL
 		byval reg as integer _
 	) as integer
 
-	getFreePreservedReg as function  _
+	getFreePreservedReg as function _
 	( _
 		byval dclass as integer, _
 		byval dtype as integer _

--- a/src/compiler/emit.bi
+++ b/src/compiler/emit.bi
@@ -6,7 +6,7 @@
 #include once "ast.bi"
 #include once "ir.bi"
 
-const EMIT_INITNODES	= 2048
+const EMIT_INITNODES    = 2048
 const EMIT_INITVREGNODES= EMIT_INITNODES*3
 
 '' x86 specific: FB_DATACLASS_INTEGER and FB_DATACLASS_FPOINT
@@ -133,93 +133,93 @@ enum EMIT_NODECLASS_ENUM
 end enum
 
 type EMIT_BOPNODE
-	op			as integer
-	dvreg		as IRVREG ptr
-	svreg		as IRVREG ptr
+	op          as integer
+	dvreg       as IRVREG ptr
+	svreg       as IRVREG ptr
 end type
 
 type EMIT_UOPNODE
-	op			as integer
-	dvreg		as IRVREG ptr
+	op          as integer
+	dvreg       as IRVREG ptr
 end type
 
 type EMIT_RELNODE
-	op			as integer
-	rvreg		as IRVREG ptr
-	label		as FBSYMBOL ptr
-	dvreg		as IRVREG ptr
-	svreg		as IRVREG ptr
+	op          as integer
+	rvreg       as IRVREG ptr
+	label       as FBSYMBOL ptr
+	dvreg       as IRVREG ptr
+	svreg       as IRVREG ptr
 end type
 
 type EMIT_STKNODE
-	op			as integer
-	vreg		as IRVREG ptr
-	extra		as integer
+	op          as integer
+	vreg        as IRVREG ptr
+	extra       as integer
 end type
 
 type EMIT_BRCNODE
-	op			as integer
-	vreg		as IRVREG ptr
-	sym			as FBSYMBOL ptr
-	extra		as integer
+	op          as integer
+	vreg        as IRVREG ptr
+	sym         as FBSYMBOL ptr
+	extra       as integer
 end type
 
 type EMIT_SOPNODE
-	op			as integer
-	sym			as FBSYMBOL ptr
+	op          as integer
+	sym         as FBSYMBOL ptr
 end type
 
 type EMIT_LITNODE
-	isasm		as integer
-	text		as zstring ptr
+	isasm       as integer
+	text        as zstring ptr
 end type
 
 type EMIT_JTBNODE
-	tbsym				as FBSYMBOL ptr
+	tbsym               as FBSYMBOL ptr
 
 	'' Dynamically allocated buffer holding the jmptb's value/label pairs
-	values				as ulongint ptr
-	labels				as FBSYMBOL ptr ptr
-	labelcount			as integer
+	values              as ulongint ptr
+	labels              as FBSYMBOL ptr ptr
+	labelcount          as integer
 
-	deflabel			as FBSYMBOL ptr
-	bias				as ulongint
-	span				as ulongint
+	deflabel            as FBSYMBOL ptr
+	bias                as ulongint
+	span                as ulongint
 end type
 
 type EMIT_MEMNODE
-	op			as integer
-	dvreg		as IRVREG ptr
-	svreg		as IRVREG ptr
-	bytes		as integer
-	extra		as integer
+	op          as integer
+	dvreg       as IRVREG ptr
+	svreg       as IRVREG ptr
+	bytes       as integer
+	extra       as integer
 end type
 
 type EMIT_DBGNODE
-	op			as integer
-	sym			as FBSYMBOL ptr
-	lnum		as integer
-	filename 	as zstring ptr
-	pos			as integer
+	op          as integer
+	sym         as FBSYMBOL ptr
+	lnum        as integer
+	filename    as zstring ptr
+	pos         as integer
 end type
 
 type EMIT_NODE
-	class							as EMIT_NODECLASS_ENUM
+	class                           as EMIT_NODECLASS_ENUM
 
 	union
-		bop							as EMIT_BOPNODE
-		uop							as EMIT_UOPNODE
-		rel							as EMIT_RELNODE
-		stk						 	as EMIT_STKNODE
-		brc							as EMIT_BRCNODE
-		sop							as EMIT_SOPNODE
-		lit							as EMIT_LITNODE
-		jtb							as EMIT_JTBNODE
-		mem							as EMIT_MEMNODE
-		dbg							as EMIT_DBGNODE
+		bop                         as EMIT_BOPNODE
+		uop                         as EMIT_UOPNODE
+		rel                         as EMIT_RELNODE
+		stk                         as EMIT_STKNODE
+		brc                         as EMIT_BRCNODE
+		sop                         as EMIT_SOPNODE
+		lit                         as EMIT_LITNODE
+		jtb                         as EMIT_JTBNODE
+		mem                         as EMIT_MEMNODE
+		dbg                         as EMIT_DBGNODE
 	end union
 
-	regFreeTB(EMIT_REGCLASSES-1) 	as REG_FREETB
+	regFreeTB(EMIT_REGCLASSES-1)    as REG_FREETB
 end type
 
 

--- a/src/compiler/emit.bi
+++ b/src/compiler/emit.bi
@@ -878,7 +878,7 @@ declare sub emitFlush _
 
 #define emitGetResultReg( dtype, dclass, reg, reg2 ) emit.vtbl.getResultReg( dtype, dclass, reg, reg2 )
 
-#define emitSection( sec, priority ) emit.vtbl.setSection( sec, priority )
+#define emitSetSection( sec, priority ) emit.vtbl.setSection( sec, priority )
 
 ''::::
 #define EMIT_REGSETUSED(c,r) emit.regUsedTB(c) or= (1 shl r)

--- a/src/compiler/emit.bi
+++ b/src/compiler/emit.bi
@@ -92,9 +92,9 @@ enum EMIT_NODEOP
 	'' branch
 	EMIT_OP_CALL
 	EMIT_OP_CALLPTR
-    EMIT_OP_BRANCH
-    EMIT_OP_JUMP
-    EMIT_OP_JUMPPTR
+	EMIT_OP_BRANCH
+	EMIT_OP_JUMP
+	EMIT_OP_JUMPPTR
 	EMIT_OP_RET
 
 	'' misc
@@ -255,15 +255,21 @@ type EMIT_JTBCB as sub _
 		byval span as ulongint _
 	)
 
-type EMIT_MEMCB as sub( byval dvreg as IRVREG ptr, _
-						byval svreg as IRVREG ptr, _
-						byval bytes as integer, _
-						byval extra as integer )
+type EMIT_MEMCB as sub _
+	( _
+		byval dvreg as IRVREG ptr, _
+		byval svreg as IRVREG ptr, _
+		byval bytes as integer, _
+		byval extra as integer _
+	)
 
-type EMIT_DBGCB as sub( byval sym as FBSYMBOL ptr, _
-						byval lnum as integer, _
-                  byval pos as Integer, _
-                  ByVal filename As ZString Ptr =0 )
+type EMIT_DBGCB as sub _
+	( _
+		byval sym as FBSYMBOL ptr, _
+		byval lnum as integer, _
+		byval pos as Integer, _
+		ByVal filename As ZString Ptr = 0 _
+	)
 
 '' if changed, update the _vtbl symbols at emit_*.bas::*_ctor
 type EMIT_VTBL
@@ -377,26 +383,26 @@ type EMIT_VTBL
 end type
 
 type EMITCTX
-	inited								as integer
+	inited                              as integer
 
-	pos									as integer			'' to help debugging
+	pos                                 as integer          '' to help debugging
 
-	regTB(0 to EMIT_REGCLASSES-1) 		as REGCLASS ptr		'' reg classes
+	regTB(0 to EMIT_REGCLASSES-1)       as REGCLASS ptr     '' reg classes
 
 	'' node tb
-	nodeTB								as TFLIST
-	vregTB								as TFLIST
-	curnode								as EMIT_NODE ptr
+	nodeTB                              as TFLIST
+	vregTB                              as TFLIST
+	curnode                             as EMIT_NODE ptr
 
-	regUsedTB(EMIT_REGCLASSES-1) 		as REG_FREETB       '' keep track of register usage
+	regUsedTB(EMIT_REGCLASSES-1)        as REG_FREETB       '' keep track of register usage
 
 	'' platform-dependent
-	lastsection							as integer
+	lastsection                         as integer
 	lastpriority                        as integer
 
 	''
-	vtbl								as EMIT_VTBL
-	opFnTb								as any ptr ptr
+	vtbl                                as EMIT_VTBL
+	opFnTb                              as any ptr ptr
 end type
 
 ''
@@ -792,8 +798,8 @@ declare function emitSTKCLEAR _
 declare function emitDBGLineBegin _
 	( _
 		byval proc as FBSYMBOL ptr, _
-      byval ex as Integer, _
-      ByVal filename As ZString Ptr _
+		byval ex as integer, _
+		byval filename as zstring ptr _
 	) as EMIT_NODE ptr
 
 declare function emitDBGLineEnd _

--- a/src/compiler/emit_SSE.bas
+++ b/src/compiler/emit_SSE.bas
@@ -220,8 +220,8 @@ private sub _emitSTORL2F_SSE _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src, aux
-    dim as string ostr
+	dim as string dst, src, aux
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -283,9 +283,9 @@ private sub _emitSTORI2F_SSE _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src, aux
-    dim as integer ddsize, sdsize, reg, isfree
-    dim as string ostr
+	dim as string dst, src, aux
+	dim as integer ddsize, sdsize, reg, isfree
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -669,8 +669,8 @@ private sub _emitLOADL2F_SSE _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src, aux
-    dim as string ostr
+	dim as string dst, src, aux
+	dim as string ostr
 	dim as integer ddsize
 
 	hPrepOperand( dvreg, dst )
@@ -975,7 +975,7 @@ end sub
 
 
 '':::::
-'' emit code to convert operands, if necessary.  return TRUE if conversion occured
+'' emit code to convert operands, if necessary. return TRUE if conversion occured
 private function hEmitConvertOperands_SSE _
 	( _
 		byval dvreg as IRVREG ptr, _
@@ -1551,7 +1551,7 @@ private sub hCMPF_SSE _
 	'' no result to be set? just branch
 	if( rvreg = NULL ) then
 		ostr = "j" + *mnemonic
-    		hBRANCH( ostr, lname )
+			hBRANCH( ostr, lname )
 		exit sub
 	end if
 
@@ -1592,11 +1592,11 @@ private sub hCMPF_SSE _
 		outp ostr
 	else
 		'' old (and slow) boolean set
-    		ostr = "mov " + rname + ", -1"
-    		outp ostr
+			ostr = "mov " + rname + ", -1"
+			outp ostr
 
-    		ostr = "j" + *mnemonic
-    		hBRANCH( ostr, lname )
+			ostr = "j" + *mnemonic
+			hBRANCH( ostr, lname )
 
 		ostr = "xor " + rname + COMMA + rname
 		outp ostr
@@ -2497,11 +2497,11 @@ private sub _emitLOG_SSE _
 	end if
 
 
-    outp "fldln2"
-    outp "fxch"
-    outp "fyl2x"
+	outp "fldln2"
+	outp "fxch"
+	outp "fyl2x"
 
-   	if( dvreg->regFamily = IR_REG_FPU_STACK ) then
+	if( dvreg->regFamily = IR_REG_FPU_STACK ) then
 		outp "sub esp" + COMMA + str( ddsize )
 	end if
 
@@ -2554,7 +2554,7 @@ private sub _emitEXP_SSE _
 	outp "fstp st(1)"
 
 
-   	if( dvreg->regFamily = IR_REG_FPU_STACK ) then
+	if( dvreg->regFamily = IR_REG_FPU_STACK ) then
 		outp "sub esp" + COMMA + str( ddsize )
 	end if
 
@@ -2816,8 +2816,8 @@ private sub _emitPUSHF_SSE _
 		byval unused as integer _
 	) static
 
-    dim src as string, sdsize as integer
-    dim ostr as string
+	dim src as string, sdsize as integer
+	dim ostr as string
 
 	hPrepOperand( svreg, src )
 
@@ -2832,7 +2832,7 @@ private sub _emitPUSHF_SSE _
 			ostr = "push " + src
 			outp ostr
 
-    			hPrepOperand( svreg, src, FB_DATATYPE_INTEGER, 0 )
+				hPrepOperand( svreg, src, FB_DATATYPE_INTEGER, 0 )
 			ostr = "push " + src
 			outp ostr
 		end if
@@ -2866,8 +2866,8 @@ private sub _emitPOPF_SSE _
 		byval unused as integer _
 	) static
 
-    dim as string dst, ostr
-    dim as integer dsize
+	dim as string dst, ostr
+	dim as integer dsize
 
 	hPrepOperand( dvreg, dst )
 

--- a/src/compiler/emit_SSE.bas
+++ b/src/compiler/emit_SSE.bas
@@ -44,10 +44,10 @@ private sub _emitLOADB2F_SSE( byval dvreg as IRVREG ptr, byval svreg as IRVREG p
 
 	dim as string dst
 	dim as integer ddsize = any
-	
+
 	'' load source to ST(0)
 	_emitLOADB2F_x86( dvreg, svreg )
-	
+
 	hPrepOperand( dvreg, dst )
 	ddsize = typeGetSize( dvreg->dtype )
 
@@ -211,8 +211,8 @@ end sub
 
 
 
-'' NOTE:	this is identical to the FPU code, which is probably
-'' 		faster than any SSE implementation
+'' NOTE:    this is identical to the FPU code, which is probably
+''      faster than any SSE implementation
 '':::::
 private sub _emitSTORL2F_SSE _
 	( _
@@ -799,7 +799,7 @@ private sub _emitLOADI2F_SSE _
 	if( (svreg->typ <> IR_VREGTYPE_IMM) and (sdsize = 4) ) then
 		'' src is 32-bit mem or register
 		isfree = TRUE
-		aux = src			'' just use it
+		aux = src           '' just use it
 	else
 		'' src is not 32-bit mem or register
 		'' find a register
@@ -1016,7 +1016,7 @@ private function hEmitConvertOperands_SSE _
 	end if
 
 end function
-	
+
 
 
 '':::::
@@ -1243,7 +1243,7 @@ private sub _emitMULF_SSE _
 	if( hEmitConvertOperands_SSE( dvreg, svreg ) ) then
 		src = "xmm7"
 	end if
-	
+
 	if( typeGetClass( svreg->dtype ) = FB_DATACLASS_FPOINT ) then
 		if( ddsize > 4 ) then
 			'' multiply them as double-precision
@@ -1324,7 +1324,7 @@ private sub _emitDIVF_SSE _
 	if( hEmitConvertOperands_SSE( dvreg, svreg ) ) then
 		src = "xmm7"
 	end if
-	
+
 	if( typeGetClass( svreg->dtype ) = FB_DATACLASS_FPOINT ) then
 		if( ddsize > 4 ) then
 			'' divide them as double-precision
@@ -1874,15 +1874,15 @@ private sub _emitSGNF_SSE _
 		sym->var_.align = 16
 		tempVreg = irAllocVRVAR( FB_DATATYPE_UINT, NULL, sym, symbGetOfs( sym ) )
 		hPrepOperand( tempVreg, src, FB_DATATYPE_XMMWORD )
-		outp "orps " + dst + COMMA + src		'' set bits 31-0, sign is unchanged"
+		outp "orps " + dst + COMMA + src        '' set bits 31-0, sign is unchanged"
 
 		sym = symbAllocIntConst(&hBF800000, FB_DATATYPE_UINT)
 		sym->var_.align = 16
 		tempVreg = irAllocVRVAR( FB_DATATYPE_UINT, NULL, sym, symbGetOfs( sym ) )
 		hPrepOperand( tempVreg, src, FB_DATATYPE_XMMWORD )
-		outp "andps xmm7" + COMMA + src			'' load -1.0f, kill if == 0.0f"
+		outp "andps xmm7" + COMMA + src         '' load -1.0f, kill if == 0.0f"
 
-		outp "andps " + dst + COMMA + "xmm7"	'' get +/-1.0f or 0.0f"
+		outp "andps " + dst + COMMA + "xmm7"    '' get +/-1.0f or 0.0f"
 	end if
 end sub
 
@@ -1903,7 +1903,7 @@ private sub _emitSINCOS_FAST_SSE _
 
 	hPrepOperand( dvreg, dst )
 
-	stackSize = 4		'' 4 bytes always needed
+	stackSize = 4       '' 4 bytes always needed
 
 	if( dvreg->regFamily = IR_REG_FPU_STACK ) then
 		stackSize += 4
@@ -2009,70 +2009,70 @@ private sub _emitSINCOS_FAST_SSE _
 	next i
 
 if( iscos = FALSE ) then
-	outp "movss	[esp]" + COMMA + dst
+	outp "movss [esp]" + COMMA + dst
 
 	hPrepOperand( vReg_twoOverPI, src )
-	outp "mulss	" + dst + COMMA + src
+	outp "mulss " + dst + COMMA + src
 
-	outp "and		dword ptr [esp], 0x80000000"
+	outp "and       dword ptr [esp], 0x80000000"
 end if
 
 	hPrepOperand( vReg_invSignBitMask, src, FB_DATATYPE_XMMWORD )
-	outp "andps	" + dst + COMMA + src
+	outp "andps " + dst + COMMA + src
 
 if( iscos = TRUE ) then
 	hPrepOperand( vReg_piOverTwo, src )
-	outp "addss	" + dst + COMMA + src
+	outp "addss " + dst + COMMA + src
 
 	hPrepOperand( vReg_twoOverPI, src )
-	outp "mulss	" + dst + COMMA + src
+	outp "mulss " + dst + COMMA + src
 end if
 
-	outp "cvttss2si	" + regName(0) + COMMA + dst
+	outp "cvttss2si " + regName(0) + COMMA + dst
 
 	hPrepOperand( vReg_one, src )
-	outp "movss	xmm7" + COMMA + src
-	outp "mov		" + regName(1) + COMMA + regName(0)
-	outp "cvtsi2ss	" + regName(2) + COMMA + regName(0)
-	outp "shl		" + regName(1) + COMMA + "30"
-	outp "not		" + regName(0)
-	outp "and		" + regName(1) + COMMA + "0x80000000"
-	outp "and		" + regName(0) + COMMA + "0x1"
-	outp "subss	" + dst + COMMA + regName(2)
-	outp "dec		" + regName(0)
-	outp "minss	" + dst + COMMA + "xmm7"
-	outp "movd		" + regName(2) + COMMA + regName(0)
-	outp "subss	xmm7" + COMMA + dst
-	outp "andps	xmm7" + COMMA + regName(2)
-	outp "andnps	" + regName(2) + COMMA + dst
-	outp "orps		xmm7" + COMMA + regName(2)
+	outp "movss xmm7" + COMMA + src
+	outp "mov       " + regName(1) + COMMA + regName(0)
+	outp "cvtsi2ss  " + regName(2) + COMMA + regName(0)
+	outp "shl       " + regName(1) + COMMA + "30"
+	outp "not       " + regName(0)
+	outp "and       " + regName(1) + COMMA + "0x80000000"
+	outp "and       " + regName(0) + COMMA + "0x1"
+	outp "subss " + dst + COMMA + regName(2)
+	outp "dec       " + regName(0)
+	outp "minss " + dst + COMMA + "xmm7"
+	outp "movd      " + regName(2) + COMMA + regName(0)
+	outp "subss xmm7" + COMMA + dst
+	outp "andps xmm7" + COMMA + regName(2)
+	outp "andnps    " + regName(2) + COMMA + dst
+	outp "orps      xmm7" + COMMA + regName(2)
 if( iscos = FALSE ) then
-	outp "xor		" + regName(1) + COMMA + "[esp]"
+	outp "xor       " + regName(1) + COMMA + "[esp]"
 end if
-	outp "movd		" + regName(0) + COMMA + "xmm7"
+	outp "movd      " + regName(0) + COMMA + "xmm7"
 
-	outp "mulss	xmm7, xmm7"
+	outp "mulss xmm7, xmm7"
 
-	outp "or		" + regName(1) + COMMA + regName(0)
-	
-	outp "movss	" + regName(2) + COMMA + "xmm7"
+	outp "or        " + regName(1) + COMMA + regName(0)
+
+	outp "movss " + regName(2) + COMMA + "xmm7"
 
 	hPrepOperand( vReg_sin_c3, src )
-	outp "mulss	xmm7" + COMMA + src
+	outp "mulss xmm7" + COMMA + src
 
 	hPrepOperand( vReg_sin_c2, src )
-	outp "addss	xmm7" + COMMA + src
-	outp "mulss	xmm7" + COMMA + regName(2)
+	outp "addss xmm7" + COMMA + src
+	outp "mulss xmm7" + COMMA + regName(2)
 
-	outp "movd		" + dst + COMMA + regName(1)
+	outp "movd      " + dst + COMMA + regName(1)
 
 	hPrepOperand( vReg_sin_c1, src )
-	outp "addss	xmm7" + COMMA + src
-	outp "mulss	xmm7" + COMMA + regName(2)
+	outp "addss xmm7" + COMMA + src
+	outp "mulss xmm7" + COMMA + regName(2)
 
 	hPrepOperand( vReg_sin_c0, src )
-	outp "addss	xmm7" + COMMA + src
-	outp "mulss	" + dst + COMMA + "xmm7"
+	outp "addss xmm7" + COMMA + src
+	outp "mulss " + dst + COMMA + "xmm7"
 
 	stackPointer = 4
 	for i = 0 to 2
@@ -2619,11 +2619,11 @@ private sub _emitFLOOR_SSE _
 
 	outp "fistp qword ptr [esp]"
 	outp "fild qword ptr [esp]"
-	outp "fstp " + dtypeTB(dvreg->dtype).mname + " [esp]"	'' round(f)
+	outp "fstp " + dtypeTB(dvreg->dtype).mname + " [esp]"   '' round(f)
 	outp "xorp" + suffix + dst + COMMA + dst
-	outp "subs" + suffix + "xmm7" + COMMA + "[esp]"	'' f - round(f)
-	outp "cmpnles" + suffix + dst + COMMA + "xmm7"	'' 0 > f - round(f) ? 1 : 0
-	outp "andp" + suffix + dst + COMMA + neg1		'' F > I ? -1.0 : 0.0
+	outp "subs" + suffix + "xmm7" + COMMA + "[esp]" '' f - round(f)
+	outp "cmpnles" + suffix + dst + COMMA + "xmm7"  '' 0 > f - round(f) ? 1 : 0
+	outp "andp" + suffix + dst + COMMA + neg1       '' F > I ? -1.0 : 0.0
 	outp "adds" + suffix + dst + COMMA + "[esp]"
 
 	outp "add esp, 8"
@@ -2692,23 +2692,23 @@ private sub _emitFIX_SSE _
 
 	outp "xorp" + suffix + "xmm7, xmm7"
 	if( ddsize > 4 ) then
-		outp "movlpd [esp+8], xmm7"							'' 0.0
+		outp "movlpd [esp+8], xmm7"                         '' 0.0
 	else
-		outp "movss [esp+8], xmm7"							'' 0.0
+		outp "movss [esp+8], xmm7"                          '' 0.0
 	end if
 
 	outp "fistp qword ptr [esp]"
-	outp "cmpnles" + suffix + "xmm7" + COMMA + dst			'' f < 0 ? 1 : 0
+	outp "cmpnles" + suffix + "xmm7" + COMMA + dst          '' f < 0 ? 1 : 0
 	outp "fild qword ptr [esp]"
-	outp "andp" + suffix + "xmm7" + COMMA + absval			'' f < 0 ? -/+ : 0
-	outp "fstp " + dtypeTB(dvreg->dtype).mname + " [esp]"		'' round(f)
-	outp "subs" + suffix + dst + COMMA + "[esp]"				'' difference = (f - round(f))
-	outp "xorp" + suffix + dst + COMMA + "xmm7"				'' f < 0 ? -difference : difference
-	outp "xorp" + suffix + "xmm7" + COMMA + neg1				'' f < 0 ? 1.0 : -1.0
+	outp "andp" + suffix + "xmm7" + COMMA + absval          '' f < 0 ? -/+ : 0
+	outp "fstp " + dtypeTB(dvreg->dtype).mname + " [esp]"       '' round(f)
+	outp "subs" + suffix + dst + COMMA + "[esp]"                '' difference = (f - round(f))
+	outp "xorp" + suffix + dst + COMMA + "xmm7"             '' f < 0 ? -difference : difference
+	outp "xorp" + suffix + "xmm7" + COMMA + neg1                '' f < 0 ? 1.0 : -1.0
 	'' difference < 0 ? 1 : 0
 	outp "cmplts" + suffix + dst + COMMA + "[esp+8]"
-	outp "andp" + suffix + dst + COMMA + "xmm7"				'' difference < 0 ? +/- 1.0 : 0.0
-	outp "adds" + suffix + dst + COMMA + "[esp]"				'' round(f) +/- 1
+	outp "andp" + suffix + dst + COMMA + "xmm7"             '' difference < 0 ? +/- 1.0 : 0.0
+	outp "adds" + suffix + dst + COMMA + "[esp]"                '' round(f) +/- 1
 	outp "add esp" + COMMA + str( ddsize + 8 )
 
 end sub
@@ -2742,7 +2742,7 @@ private sub _emitFRAC_SSE _
 		absval_sym = symbAllocIntConst(&h80000000, FB_DATATYPE_UINT)
 		absval_vreg = irAllocVRVAR( FB_DATATYPE_UINT, NULL, absval_sym, symbGetOfs( absval_sym ) )
 
-		suffix = "s "		
+		suffix = "s "
 	end if
 	neg1_sym->var_.align = 16
 	absval_sym->var_.align = 16
@@ -2774,30 +2774,30 @@ private sub _emitFRAC_SSE _
 	outp "xorp" + suffix + "xmm7, xmm7"
 	if( ddsize > 4 ) then
 		outp "shufpd " + dst + COMMA + dst + COMMA + "0"
-		outp "movlpd [esp+8], xmm7"							'' 0.0
+		outp "movlpd [esp+8], xmm7"                         '' 0.0
 	else
 		outp "movlhps " + dst + COMMA + dst
-		outp "movss [esp+8], xmm7"							'' 0.0
+		outp "movss [esp+8], xmm7"                          '' 0.0
 	end if
 
 	outp "fistp qword ptr [esp]"
-	outp "cmpnles" + suffix + "xmm7" + COMMA + dst			'' f < 0 ? 1 : 0
+	outp "cmpnles" + suffix + "xmm7" + COMMA + dst          '' f < 0 ? 1 : 0
 	outp "fild qword ptr [esp]"
-	outp "andp" + suffix + "xmm7" + COMMA + absval					'' f < 0 ? - : +
-	outp "fstp " + dtypeTB(dvreg->dtype).mname + " [esp]"	'' round(f)
-	outp "subs" + suffix + dst + COMMA + "[esp]"			'' difference = (f - round(f))
-	outp "xorp" + suffix + dst + COMMA + "xmm7"				'' f < 0 ? -difference : difference
-	outp "xorp" + suffix + "xmm7" + COMMA + neg1				'' f < 0 ? 1.0 : -1.0
+	outp "andp" + suffix + "xmm7" + COMMA + absval          '' f < 0 ? - : +
+	outp "fstp " + dtypeTB(dvreg->dtype).mname + " [esp]"   '' round(f)
+	outp "subs" + suffix + dst + COMMA + "[esp]"            '' difference = (f - round(f))
+	outp "xorp" + suffix + dst + COMMA + "xmm7"             '' f < 0 ? -difference : difference
+	outp "xorp" + suffix + "xmm7" + COMMA + neg1            '' f < 0 ? 1.0 : -1.0
 	'' difference < 0 ? 1 : 0
 	outp "cmplts" + suffix + dst + COMMA + "[esp+8]"
-	outp "andp" + suffix + "xmm7" + COMMA + dst				'' difference < 0 ? +/- 1.0 : 0.0
+	outp "andp" + suffix + "xmm7" + COMMA + dst             '' difference < 0 ? +/- 1.0 : 0.0
 	if( ddsize > 4 ) then
-		outp "shufpd " + dst + COMMA + dst + COMMA + "1"		'' restore dst
+		outp "shufpd " + dst + COMMA + dst + COMMA + "1"    '' restore dst
 	else
-		outp "movhlps " + dst + COMMA + dst				'' restore dst
+		outp "movhlps " + dst + COMMA + dst                 '' restore dst
 	end if
-	outp "adds" + suffix + "xmm7" + COMMA + "[esp]"			'' round(f) +/- 1
-	outp "subs" + suffix + dst + COMMA + "xmm7"				'' dst - fix(dst)
+	outp "adds" + suffix + "xmm7" + COMMA + "[esp]"         '' round(f) +/- 1
+	outp "subs" + suffix + dst + COMMA + "xmm7"             '' dst - fix(dst)
 	outp "add esp" + COMMA + str( ddsize+8 )
 
 end sub

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -634,15 +634,15 @@ private sub hPUBLIC _
 
 ' PENDING: shared lib compatibility between win32/linux
 '          rtlib/gfxlib needs -fvisibility=hidden, only available in gcc 4
-'	if( env.clopt.target = FB_COMPTARGET_LINUX ) then
-'		if( isexport ) then
-'			ostr += NEWLINE + ".protected "
-'			ostr += *label
-'		else
-'			ostr += NEWLINE + ".hidden "
-'			ostr += *label
-'		end if
-'	end if
+'   if( env.clopt.target = FB_COMPTARGET_LINUX ) then
+'       if( isexport ) then
+'           ostr += NEWLINE + ".protected "
+'           ostr += *label
+'       else
+'           ostr += NEWLINE + ".hidden "
+'           ostr += *label
+'       end if
+'   end if
 
 	ostr += NEWLINE
 	outEx( ostr )
@@ -2915,16 +2915,16 @@ private sub _emitMULL _
 	outp "add esp, 8"
 
 	'' code:
-	'' mov	eax, low(dst)
-	'' mul	low(src)
-	'' mov	ebx, low(dst)
-	'' imul	ebx, high(src)
-	'' add	ebx, edx
-	'' mov	edx, high(dst)
-	'' imul	edx, low(src)
-	'' add	edx, ebx
-	'' mov	low(dst), eax
-	'' mov	high(dst), edx
+	'' mov  eax, low(dst)
+	'' mul  low(src)
+	'' mov  ebx, low(dst)
+	'' imul ebx, high(src)
+	'' add  ebx, edx
+	'' mov  edx, high(dst)
+	'' imul edx, low(src)
+	'' add  edx, ebx
+	'' mov  low(dst), eax
+	'' mov  high(dst), edx
 
 end sub
 
@@ -3143,10 +3143,10 @@ private sub _emitDIVI _
 		if( ecxindest and ecxtrashed ) then
 			if( dvreg->typ <> IR_VREGTYPE_REG ) then
 				if( eaxfree = FALSE ) then
-					hPOP "ecx"					'' ecx= tos (eax)
-					outp "xchg ecx, [esp]"			'' tos= ecx; ecx= dst
+					hPOP "ecx"                  '' ecx= tos (eax)
+					outp "xchg ecx, [esp]"      '' tos= ecx; ecx= dst
 				else
-					hPOP "ecx"					'' ecx= tos (ecx)
+					hPOP "ecx"                  '' ecx= tos (ecx)
 				end if
 			end if
 		end if
@@ -3160,14 +3160,14 @@ private sub _emitDIVI _
 	else
 		if( dvreg->typ <> IR_VREGTYPE_REG ) then
 			if( (ecxfree = FALSE) and (ecxtrashed = FALSE) ) then
-				outp "xchg ecx, [esp]"			'' tos= ecx; ecx= dst
-				outp "xchg ecx, eax"			'' ecx= res; eax= dst
+				outp "xchg ecx, [esp]"          '' tos= ecx; ecx= dst
+				outp "xchg ecx, eax"            '' ecx= res; eax= dst
 			else
-				hMOV "ecx", "eax"			'' ecx= eax
-				hPOP "eax"					'' restore eax
+				hMOV "ecx", "eax"           '' ecx= eax
+				hPOP "eax"                  '' restore eax
 			end if
 
-			hMOV dst, ecx					'' [eax+...] = ecx
+			hMOV dst, ecx                   '' [eax+...] = ecx
 
 			if( (ecxfree = FALSE) and (ecxtrashed = FALSE) ) then
 				hPOP "ecx"
@@ -3299,10 +3299,10 @@ private sub _emitMODI _
 		if( ecxindest and ecxtrashed ) then
 			if( dvreg->typ <> IR_VREGTYPE_REG ) then
 				if( eaxfree = FALSE ) then
-					hPOP "ecx"					'' ecx= tos (eax)
-					outp "xchg ecx, [esp]"			'' tos= ecx; ecx= dst
+					hPOP "ecx"                  '' ecx= tos (eax)
+					outp "xchg ecx, [esp]"      '' tos= ecx; ecx= dst
 				else
-					hPOP "ecx"					'' ecx= tos (ecx)
+					hPOP "ecx"                  '' ecx= tos (ecx)
 				end if
 			end if
 		end if
@@ -3316,14 +3316,14 @@ private sub _emitMODI _
 	else
 		if( dvreg->typ <> IR_VREGTYPE_REG ) then
 			if( (ecxfree = FALSE) and (ecxtrashed = FALSE) ) then
-				outp "xchg ecx, [esp]"			'' tos= ecx; ecx= dst
-				outp "xchg ecx, eax"			'' ecx= res; eax= dst
+				outp "xchg ecx, [esp]"          '' tos= ecx; ecx= dst
+				outp "xchg ecx, eax"            '' ecx= res; eax= dst
 			else
-				hMOV "ecx", "eax"			'' ecx= eax
-				hPOP "eax"					'' restore eax
+				hMOV "ecx", "eax"           '' ecx= eax
+				hPOP "eax"                  '' restore eax
 			end if
 
-			hMOV dst, ecx					'' [eax+...] = ecx
+			hMOV dst, ecx                   '' [eax+...] = ecx
 
 			if( (ecxfree = FALSE) and (ecxtrashed = FALSE) ) then
 				hPOP "ecx"
@@ -3486,122 +3486,122 @@ private sub hSHIFTL _
 		isecxfree = hIsRegFree( FB_DATACLASS_INTEGER, EMIT_REG_ECX )
 
 		eaxindest = hIsRegInVreg( dvreg, EMIT_REG_EAX )
- 		edxindest = hIsRegInVreg( dvreg, EMIT_REG_EDX )
- 		ecxindest = hIsRegInVreg( dvreg, EMIT_REG_ECX )
+		edxindest = hIsRegInVreg( dvreg, EMIT_REG_EDX )
+		ecxindest = hIsRegInVreg( dvreg, EMIT_REG_ECX )
 
 		if( (svreg->typ <> IR_VREGTYPE_REG) or (svreg->reg <> EMIT_REG_ECX) ) then
 			'' handle src < dword
 			if( typeGetSize( svreg->dtype ) <> 4 ) then
- 				'' if it's not a reg, the right size was already set at the hPrepOperand() above
- 				if( svreg->typ = IR_VREGTYPE_REG ) then
- 					src = *hGetRegName( FB_DATATYPE_INTEGER, svreg->reg )
- 				end if
- 			end if
+				'' if it's not a reg, the right size was already set at the hPrepOperand() above
+				if( svreg->typ = IR_VREGTYPE_REG ) then
+					src = *hGetRegName( FB_DATATYPE_INTEGER, svreg->reg )
+				end if
+			end if
 
- 			if( isecxfree = FALSE ) then
- 				if( ecxindest and dvreg->typ = IR_VREGTYPE_REG ) then
- 					hMOV( "ecx", src )
- 					isecxfree = TRUE
- 				else
- 					hPUSH( src )
- 					outp "xchg ecx, [esp]"
- 					ofs += 4
- 				end if
- 			else
- 				hMOV( "ecx", src )
- 			end if
- 		else
- 			isecxfree = TRUE
- 		end if
+			if( isecxfree = FALSE ) then
+				if( ecxindest and dvreg->typ = IR_VREGTYPE_REG ) then
+					hMOV( "ecx", src )
+					isecxfree = TRUE
+				else
+					hPUSH( src )
+					outp "xchg ecx, [esp]"
+					ofs += 4
+				end if
+			else
+				hMOV( "ecx", src )
+			end if
+		else
+			isecxfree = TRUE
+		end if
 
 		'' load dst1 to eax
- 		if( eaxindest ) then
- 			if( dvreg->typ <> IR_VREGTYPE_REG ) then
- 				outp "xchg eax, [esp+" + str( ofs+0 ) + "]"
- 			else
- 				outp "mov eax, [esp+" + str( ofs+0 ) + "]"
- 			end if
- 		else
- 			if( iseaxfree = FALSE ) then
- 				outp "xchg eax, [esp+" + str( ofs+0 ) + "]"
- 			else
- 				outp "mov eax, [esp+" + str( ofs+0 ) + "]"
- 			end if
- 		end if
+		if( eaxindest ) then
+			if( dvreg->typ <> IR_VREGTYPE_REG ) then
+				outp "xchg eax, [esp+" + str( ofs+0 ) + "]"
+			else
+				outp "mov eax, [esp+" + str( ofs+0 ) + "]"
+			end if
+		else
+			if( iseaxfree = FALSE ) then
+				outp "xchg eax, [esp+" + str( ofs+0 ) + "]"
+			else
+				outp "mov eax, [esp+" + str( ofs+0 ) + "]"
+			end if
+		end if
 
- 		'' load dst2 to edx
- 		if( edxindest ) then
- 			if( dvreg->typ <> IR_VREGTYPE_REG ) then
- 				outp "xchg edx, [esp+" + str( ofs+4 ) + "]"
- 			else
- 				outp "mov edx, [esp+" + str( ofs+4 ) + "]"
- 			end if
- 		else
- 			if( isedxfree = FALSE ) then
- 				outp "xchg edx, [esp+" + str( ofs+4 ) + "]"
- 			else
- 				outp "mov edx, [esp+" + str( ofs+4 ) + "]"
- 			end if
- 		end if
+		'' load dst2 to edx
+		if( edxindest ) then
+			if( dvreg->typ <> IR_VREGTYPE_REG ) then
+				outp "xchg edx, [esp+" + str( ofs+4 ) + "]"
+			else
+				outp "mov edx, [esp+" + str( ofs+4 ) + "]"
+			end if
+		else
+			if( isedxfree = FALSE ) then
+				outp "xchg edx, [esp+" + str( ofs+4 ) + "]"
+			else
+				outp "mov edx, [esp+" + str( ofs+4 ) + "]"
+			end if
+		end if
 
 		if( op = AST_OP_SHL ) then
- 			outp "shld edx, eax, cl"
- 			outp mnemonic32 + " eax, cl"
- 		else
- 			outp "shrd eax, edx, cl"
- 			outp mnemonic32 + " edx, cl"
- 		end if
+			outp "shld edx, eax, cl"
+			outp mnemonic32 + " eax, cl"
+		else
+			outp "shrd eax, edx, cl"
+			outp mnemonic32 + " edx, cl"
+		end if
 
- 		outp "test cl, 32"
- 		hBRANCH( "jz", label )
+		outp "test cl, 32"
+		hBRANCH( "jz", label )
 
- 		if( op = AST_OP_SHL ) then
- 			outp "mov edx, eax"
- 			outp "xor eax, eax"
- 		else
- 			outp "mov eax, edx"
- 			if( typeIsSigned( dvreg->dtype ) ) then
- 				outp "sar edx, 31"
- 			else
- 				outp "xor edx, edx"
- 			end if
- 		end if
+		if( op = AST_OP_SHL ) then
+			outp "mov edx, eax"
+			outp "xor eax, eax"
+		else
+			outp "mov eax, edx"
+			if( typeIsSigned( dvreg->dtype ) ) then
+				outp "sar edx, 31"
+			else
+				outp "xor edx, edx"
+			end if
+		end if
 
- 		hLABEL( label )
+		hLABEL( label )
 
- 		if( isecxfree = FALSE ) then
- 			hPOP "ecx"
- 		end if
+		if( isecxfree = FALSE ) then
+			hPOP "ecx"
+		end if
 
 		'' save dst2
- 		if( edxindest ) then
- 			if( dvreg->typ <> IR_VREGTYPE_REG ) then
- 				outp "xchg edx, [esp+4]"
- 			else
- 				outp "mov [esp+4], edx"
- 			end if
- 		else
- 			if( isedxfree = FALSE ) then
- 				outp "xchg edx, [esp+4]"
- 			else
- 				outp "mov [esp+4], edx"
- 			end if
- 		end if
+		if( edxindest ) then
+			if( dvreg->typ <> IR_VREGTYPE_REG ) then
+				outp "xchg edx, [esp+4]"
+			else
+				outp "mov [esp+4], edx"
+			end if
+		else
+			if( isedxfree = FALSE ) then
+				outp "xchg edx, [esp+4]"
+			else
+				outp "mov [esp+4], edx"
+			end if
+		end if
 
- 		'' save dst1
- 		if( eaxindest ) then
- 			if( dvreg->typ <> IR_VREGTYPE_REG ) then
- 				outp "xchg eax, [esp+0]"
- 			else
- 				outp "mov [esp+0], eax"
- 			end if
- 		else
- 			if( iseaxfree = FALSE ) then
- 				outp "xchg eax, [esp+0]"
- 			else
- 				outp "mov [esp+0], eax"
- 			end if
- 		end if
+		'' save dst1
+		if( eaxindest ) then
+			if( dvreg->typ <> IR_VREGTYPE_REG ) then
+				outp "xchg eax, [esp+0]"
+			else
+				outp "mov [esp+0], eax"
+			end if
+		else
+			if( iseaxfree = FALSE ) then
+				outp "xchg eax, [esp+0]"
+			else
+				outp "mov [esp+0], eax"
+			end if
+		end if
 
 		hPOP( dst1 )
 		hPOP( dst2 )
@@ -3693,9 +3693,9 @@ private sub hSHIFTI _
 			'' tmp not free?
 			if( eaxfree = FALSE ) then
 				eaxpreserved = TRUE
-				outp "xchg eax, [esp]"		'' eax= dst; push eax
+				outp "xchg eax, [esp]"      '' eax= dst; push eax
 			else
-				hPOP "eax"				'' eax= dst; pop tos
+				hPOP "eax"              '' eax= dst; pop tos
 			end if
 
 			tmp = rnameTB(dtypeTB(dvreg->dtype).rnametb, EMIT_REG_EAX )
@@ -3715,7 +3715,7 @@ private sub hSHIFTI _
 		if( dvreg->typ <> IR_VREGTYPE_REG ) then
 			hPOP "ecx"
 			if( eaxpreserved ) then
-				outp "xchg ecx, [esp]"		'' ecx= tos; tos= eax
+				outp "xchg ecx, [esp]"      '' ecx= tos; tos= eax
 			end if
 		end if
 		hMOV dst, rnameTB(dtypeTB(dvreg->dtype).rnametb, EMIT_REG_EAX)
@@ -4197,7 +4197,7 @@ private sub hCMPI _
 			outp ostr
 		end if
 
-		if( rvreg->dtype <> FB_DATATYPE_BOOLEAN ) then 
+		if( rvreg->dtype <> FB_DATATYPE_BOOLEAN ) then
 			'' convert 1 to -1 (TRUE in QB/FB)
 			ostr = "shr " + rname + ", 1"
 			outp ostr
@@ -4209,7 +4209,7 @@ private sub hCMPI _
 	'' old (and slow) boolean set
 	else
 
-		if( rvreg->dtype = FB_DATATYPE_BOOLEAN ) then 
+		if( rvreg->dtype = FB_DATATYPE_BOOLEAN ) then
 			ostr = "mov " + rname + ", 1"
 		else
 			ostr = "mov " + rname + ", -1"
@@ -4750,7 +4750,7 @@ private sub _emitNOTI _
 	else
 		ostr = "not " + dst
 	end if
-	
+
 	outp ostr
 
 end sub
@@ -4852,22 +4852,22 @@ end sub
 
 ''
 '' Algorithm:
-''	select case( highdword )
-''	case is < 0
-''		highdword = -1
-''		lowdword  = -1
-''	case is > 0
-''		highdword = 0
-''		lowdword  = 1
-''	case else
-''		if( lowdword <> 0 ) then
-''			highdword = 0
-''			lowdword  = 1
-''		else
-''			highdword = 0
-''			lowdword  = 0
-''		end if
-''	end select
+''  select case( highdword )
+''  case is < 0
+''      highdword = -1
+''      lowdword  = -1
+''  case is > 0
+''      highdword = 0
+''      lowdword  = 1
+''  case else
+''      if( lowdword <> 0 ) then
+''          highdword = 0
+''          lowdword  = 1
+''      else
+''          highdword = 0
+''          lowdword  = 0
+''      end if
+''  end select
 ''
 '' - Result is stored into the input registers, so must be careful
 ''   about overwriting
@@ -6109,7 +6109,7 @@ end sub
 private sub _emitLOADB2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 	'' Assumes that booleans are stored as 0|1 only, and any other value
 	'' is undefined.  Also assume src and dst are always same size.
-	
+
 	dim as string dst, src
 
 	hPrepOperand( dvreg, dst )
@@ -6120,7 +6120,7 @@ private sub _emitLOADB2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 end sub
 
 private sub _emitSTORB2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
-	'' storing boolean to boolean same as loading to boolean.  See LOADB2B 
+	'' storing boolean to boolean same as loading to boolean.  See LOADB2B
 	'' for assumptions
 	_emitLOADB2B( dvreg, svreg )
 end sub
@@ -6128,7 +6128,7 @@ end sub
 private sub _emitLOADB2I( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 
 	dim as string src, dst
-	
+
 	hPrepOperand( svreg, src )
 	hPrepOperand( dvreg, dst )
 
@@ -6166,7 +6166,7 @@ private sub _emitLOADI2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 
 	dim as string src, dst, dst8
 	dim as integer ddsize = any
-	
+
 	hPrepOperand( svreg, src )
 	hPrepOperand( dvreg, dst )
 
@@ -6263,14 +6263,14 @@ private sub _emitLOADF2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 	if( svreg->typ <> IR_VREGTYPE_REG ) then
 		outp "fld " + src
 	end if
-	
+
 	if( isfree = FALSE ) then
 		outp "push eax"
 	end if
 
 	outp "ftst"
 	outp "fnstsw ax"
-	
+
 	#if 1
 	outp "sahf"
 	outp "setnz al"
@@ -6278,7 +6278,7 @@ private sub _emitLOADF2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 	outp "test ah, 0b01000000"
 	outp "setz al"
 	#endif
-	
+
 	outp "fstp st(0)"
 
 	if( ddsize = 1 ) then
@@ -6298,10 +6298,10 @@ private sub _emitSTORF2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 end sub
 
 private sub _emitLOADB2F( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
-	
+
 	dim as string src, dst
 	dim as integer sdsize = any
-	
+
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
 
@@ -6355,7 +6355,7 @@ private sub _emitSTORB2F( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 
 	dim as string src, dst
 	dim as integer sdsize = any
-	
+
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
 
@@ -6486,7 +6486,7 @@ private sub _emitLOADL2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 		if( ddsize <> 1 ) then
 			outp( "movzx " + aux + ", " + aux8 )
 		end if
-	
+
 	'' use an extra reg
 	else
 
@@ -6520,7 +6520,7 @@ private sub _emitLOADL2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 			hMOV( aux, src1 )
 			outp( "or " + aux + ", " + src2 )
 		end if
-	
+
 		'' if (src1 or src2) is non-zero, produce 0|1 and store it into dst
 		outp( "cmp " + aux + ", 0" )
 		outp( "setne " + aux8 )
@@ -6907,7 +6907,7 @@ private sub _getResultReg _
 			r2 = INVALID
 		end if
 	else
-		r1 = 0							'' st(0)
+		r1 = 0                          '' st(0)
 		r2 = INVALID
 	end if
 

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -28,6 +28,7 @@ declare function _getSectionString _
 		byval priority as integer _
 	) as const zstring ptr
 
+'' emitSetSection() called privately as _setSection
 declare sub _setSection _
 	( _
 		byval section as integer, _
@@ -7282,27 +7283,27 @@ function emitGasX86_ctor _
 
 	static as EMIT_VTBL _vtbl = _
 	( _
-		@_init, _
-		@_end, _
-		@_getOptionValue, _
-		@_open, _
-		@_close, _
-		@_isRegPreserved, _
-		@_getFreePreservedReg, _
-		@_getResultReg, _
-		@_procGetFrameRegName, _
-		@_procBegin, _
-		@_procEnd, _
-		@_procHeader, _
-		@_procFooter, _
-		@_procAllocArg, _
-		@_procAllocLocal, _
-		@_procAllocStaticVars, _
-		@_scopeBegin, _
-		@_scopeEnd, _
-		@_setSection, _
-		@_getTypeString, _
-		@_getSectionString _
+		@_init, _                '' called by emitInit()
+		@_end, _                 '' called by emitEnd()
+		@_getOptionValue, _      '' emitGetOptionValue()
+		@_open, _                '' emitOpen()
+		@_close, _               '' emitClose()
+		@_isRegPreserved, _      '' emitIsRegPreserved()
+		@_getFreePreservedReg, _ '' emitGetFreePreservedReg()
+		@_getResultReg, _        '' emitGetResultReg()
+		@_procGetFrameRegName, _ '' emitProcGetFrameRegName()
+		@_procBegin, _           '' emitProcBegin()
+		@_procEnd, _             '' emitProcEnd()
+		@_procHeader, _          '' emitProcHeader()
+		@_procFooter, _          '' emitProcFooter()
+		@_procAllocArg, _        '' emitProcAllocArg()
+		@_procAllocLocal, _      '' emitProcAllocLocal()
+		@_procAllocStaticVars, _ '' emitProcAllocStaticVars(), also called privately
+		@_scopeBegin, _          '' emitScopeBegin()
+		@_scopeEnd, _            '' emitScopeEnd()
+		@_setSection, _          '' emitSetSection(),
+		@_getTypeString, _       '' only called privately
+		@_getSectionString _     '' only called privately
 	)
 
 	emit.vtbl = _vtbl
@@ -7315,5 +7316,3 @@ function emitGasX86_ctor _
 	function = TRUE
 
 end function
-
-

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -1,8 +1,8 @@
 '' code generation for x86, GNU assembler (GAS/Intel arch)
 ''
 '' chng: sep/2004 written [v1ctor]
-''  	 mar/2005 longint support added [v1ctor]
-''  	 may/2008 SSE/SSE2 instructions [Bryan Stoeberl]
+''       mar/2005 longint support added [v1ctor]
+''       may/2008 SSE/SSE2 instructions [Bryan Stoeberl]
 ''       may/2008 boolean support added [jeffm]
 
 #include once "fb.bi"
@@ -279,11 +279,11 @@ private function hGetIdxName _
 		byval vreg as IRVREG ptr _
 	) as zstring ptr static
 
-    static as zstring * FB_MAXINTNAMELEN+1+8+1+1+1+8+1 iname
-    dim as FBSYMBOL ptr sym
-    dim as IRVREG ptr vi
-    dim as integer addone, mult
-    dim as zstring ptr rname
+	static as zstring * FB_MAXINTNAMELEN+1+8+1+1+1+8+1 iname
+	dim as FBSYMBOL ptr sym
+	dim as IRVREG ptr vi
+	dim as integer addone, mult
+	dim as zstring ptr rname
 
 	sym = vreg->sym
 	vi  = vreg->vidx
@@ -307,8 +307,8 @@ private function hGetIdxName _
 
 	iname += *rname
 
-    if( vi <> NULL ) then
-    	mult = vreg->mult
+	if( vi <> NULL ) then
+		mult = vreg->mult
 		''
 		'' For x86 ASM, a multiplier/scaling factor can be given right
 		'' as part of the address/indexing expression. It can be a power
@@ -378,14 +378,14 @@ sub hPrepOperand _
 		byval addprefix as integer = TRUE _
 	) static
 
-    if( vreg = NULL ) then
-    	operand = ""
-    	exit sub
-    end if
+	if( vreg = NULL ) then
+		operand = ""
+		exit sub
+	end if
 
-    if( dtype = FB_DATATYPE_INVALID ) then
-    	dtype = vreg->dtype
-    end if
+	if( dtype = FB_DATATYPE_INVALID ) then
+		dtype = vreg->dtype
+	end if
 
 	select case as const vreg->typ
 	case IR_VREGTYPE_VAR, IR_VREGTYPE_IDX, IR_VREGTYPE_PTR
@@ -405,12 +405,12 @@ sub hPrepOperand _
 		if( vreg->typ = IR_VREGTYPE_VAR ) then
 			idx_op = symbGetMangledName( vreg->sym )
 		else
-        	idx_op = hGetIdxName( vreg )
+			idx_op = hGetIdxName( vreg )
 		end if
 
-        if( idx_op <> NULL ) then
-        	operand += *idx_op
-        end if
+		if( idx_op <> NULL ) then
+			operand += *idx_op
+		end if
 
 		'' offset
 		ofs += vreg->ofs
@@ -472,7 +472,7 @@ sub hPrepOperand _
 		end if
 
 	case else
-    	operand = ""
+		operand = ""
 	end select
 
 end sub
@@ -512,7 +512,7 @@ sub outp _
 		byval s as zstring ptr _
 	)
 
-    static as string ostr
+	static as string ostr
 
 	if( env.clopt.debuginfo ) then
 		ostr = TABCHAR
@@ -534,7 +534,7 @@ sub hBRANCH _
 		byval label as zstring ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = *mnemonic
 	ostr += " "
@@ -549,7 +549,7 @@ sub hPUSH _
 		byval rname as zstring ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = "push "
 	ostr += *rname
@@ -563,10 +563,10 @@ sub hPOP _
 		byval rname as zstring ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
-    ostr = "pop "
-    ostr += *rname
+	ostr = "pop "
+	ostr += *rname
 	outp( ostr )
 
 end sub
@@ -578,7 +578,7 @@ sub hMOV _
 		byval sname as zstring ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = "mov "
 	ostr += *dname
@@ -595,7 +595,7 @@ private sub hXCHG _
 		byval sname as zstring ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = "xchg "
 	ostr += *dname
@@ -611,11 +611,11 @@ private sub hCOMMENT _
 		byval s as zstring ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
-    ostr = TABCHAR + "#"
-    ostr += *s
-    ostr += NEWLINE
+	ostr = TABCHAR + "#"
+	ostr += *s
+	ostr += NEWLINE
 	outEX( ostr )
 
 end sub
@@ -627,7 +627,7 @@ private sub hPUBLIC _
 		byval isexport as integer _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = NEWLINE + ".globl "
 	ostr += *label
@@ -655,7 +655,7 @@ sub hLABEL _
 		byval label as zstring ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = *label
 	ostr += ":" + NEWLINE
@@ -669,9 +669,9 @@ private sub hALIGN _
 		byval bytes as integer _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
-    ostr = ".balign " + str( bytes ) + NEWLINE
+	ostr = ".balign " + str( bytes ) + NEWLINE
 	outEx( ostr )
 
 end sub
@@ -685,12 +685,12 @@ private sub hInitRegTB
 
 	static as REG_SIZEMASK int_bitsmask(0 to int_regs-1) = _
 	{ _
-		REG_SIZEMASK_8 or REG_SIZEMASK_16 or REG_SIZEMASK_32, _		'' edx
-						  REG_SIZEMASK_16 or REG_SIZEMASK_32, _		'' edi
-						  REG_SIZEMASK_16 or REG_SIZEMASK_32, _		'' esi
-		REG_SIZEMASK_8 or REG_SIZEMASK_16 or REG_SIZEMASK_32, _		'' ecx
-		REG_SIZEMASK_8 or REG_SIZEMASK_16 or REG_SIZEMASK_32, _		'' ebx
-		REG_SIZEMASK_8 or REG_SIZEMASK_16 or REG_SIZEMASK_32 _		'' eax
+		REG_SIZEMASK_8 or REG_SIZEMASK_16 or REG_SIZEMASK_32, _     '' edx
+		                  REG_SIZEMASK_16 or REG_SIZEMASK_32, _     '' edi
+		                  REG_SIZEMASK_16 or REG_SIZEMASK_32, _     '' esi
+		REG_SIZEMASK_8 or REG_SIZEMASK_16 or REG_SIZEMASK_32, _     '' ecx
+		REG_SIZEMASK_8 or REG_SIZEMASK_16 or REG_SIZEMASK_32, _     '' ebx
+		REG_SIZEMASK_8 or REG_SIZEMASK_16 or REG_SIZEMASK_32 _      '' eax
 	}
 
 	emit.regTB(FB_DATACLASS_INTEGER) = _
@@ -704,22 +704,22 @@ private sub hInitRegTB
 
 	static as REG_SIZEMASK flt_bitsmask(0 to flt_regs-1) = _
 	{ _
-		REG_SIZEMASK_32 or REG_SIZEMASK_64, _						'' st(0)
-		REG_SIZEMASK_32 or REG_SIZEMASK_64, _						'' st(1)
-		REG_SIZEMASK_32 or REG_SIZEMASK_64, _						'' st(2)
-		REG_SIZEMASK_32 or REG_SIZEMASK_64, _						'' st(3)
-		REG_SIZEMASK_32 or REG_SIZEMASK_64, _						'' st(4)
-		REG_SIZEMASK_32 or REG_SIZEMASK_64, _						'' st(5)
-		REG_SIZEMASK_32 or REG_SIZEMASK_64 _						'' st(6)
+		REG_SIZEMASK_32 or REG_SIZEMASK_64, _                       '' st(0)
+		REG_SIZEMASK_32 or REG_SIZEMASK_64, _                       '' st(1)
+		REG_SIZEMASK_32 or REG_SIZEMASK_64, _                       '' st(2)
+		REG_SIZEMASK_32 or REG_SIZEMASK_64, _                       '' st(3)
+		REG_SIZEMASK_32 or REG_SIZEMASK_64, _                       '' st(4)
+		REG_SIZEMASK_32 or REG_SIZEMASK_64, _                       '' st(5)
+		REG_SIZEMASK_32 or REG_SIZEMASK_64 _                        '' st(6)
 	}
 
 	'' create non-stacked floating-point registers
 	if( env.clopt.fputype = FB_FPUTYPE_SSE ) then
 		emit.regTB(FB_DATACLASS_FPOINT) = _
 			regNewClass( FB_DATACLASS_FPOINT, _
-						 flt_regs, _
-						 flt_bitsmask( ), _
-						 FALSE )
+				flt_regs, _
+				flt_bitsmask( ), _
+				FALSE )
 
 		'' change floating-point register names to SSE registers
 		for i = 0 to EMIT_MAXRNAMES - 1
@@ -728,16 +728,16 @@ private sub hInitRegTB
 	else
 		emit.regTB(FB_DATACLASS_FPOINT) = _
 			regNewClass( FB_DATACLASS_FPOINT, _
-						 flt_regs, _
-						 flt_bitsmask( ), _
-						 TRUE )
+				flt_regs, _
+				flt_bitsmask( ), _
+				TRUE )
 	end if
 
 end sub
 
 '':::::
 private sub hEndRegTB
-    dim i as integer
+	dim i as integer
 
 	for i = 0 to EMIT_REGCLASSES-1
 		regDelClass( emit.regTB(i) )
@@ -767,7 +767,7 @@ private sub hEmitVarBss _
 		byval s as FBSYMBOL ptr _
 	) static
 
-    dim as string alloc, ostr
+	dim as string alloc, ostr
 	dim as integer attrib
 
 	assert( symbIsExtern( s ) = FALSE )
@@ -777,24 +777,24 @@ private sub hEmitVarBss _
 
 	_setSection( IR_SECTION_BSS, 0 )
 
-    '' allocation modifier
-    if( (attrib and FB_SYMBATTRIB_COMMON) = 0 ) then
-      	if( (attrib and FB_SYMBATTRIB_PUBLIC) > 0 ) then
-       		hPUBLIC( *symbGetMangledName( s ), TRUE )
+	'' allocation modifier
+	if( (attrib and FB_SYMBATTRIB_COMMON) = 0 ) then
+		if( (attrib and FB_SYMBATTRIB_PUBLIC) > 0 ) then
+			hPUBLIC( *symbGetMangledName( s ), TRUE )
 		end if
-       	alloc = ".lcomm"
+		alloc = ".lcomm"
 	else
-       	hPUBLIC( *symbGetMangledName( s ), FALSE )
-       	alloc = ".comm"
-    end if
+		hPUBLIC( *symbGetMangledName( s ), FALSE )
+		alloc = ".comm"
+	end if
 
 	hALIGN( hGetGlobalVarAlign( s ) )
 
 	'' emit
-    ostr = alloc + TABCHAR
-    ostr += *symbGetMangledName( s )
+	ostr = alloc + TABCHAR
+	ostr += *symbGetMangledName( s )
 	ostr += "," + str( symbGetRealSize( s ) )
-    emitWriteStr( ostr, TRUE )
+	emitWriteStr( ostr, TRUE )
 
 	'' Add debug info for public/shared globals, but not local statics
 	edbgEmitGlobalVar( s, IR_SECTION_BSS )
@@ -875,38 +875,38 @@ private sub hWriteCtor _
 		byval is_ctor as integer _
 	)
 
-    if( proc_head = NULL ) then
-    	exit sub
-    end if
+	if( proc_head = NULL ) then
+		exit sub
+	end if
 
-    do
-    	'' was it emitted?
-    	if( symbGetProcIsEmitted( proc_head->sym ) ) then
-    		_setSection( iif( is_ctor, _
-    						  IR_SECTION_CONSTRUCTOR, _
-    						  IR_SECTION_DESTRUCTOR ), _
-    					 symbGetProcPriority( proc_head->sym ) )
-    		emitVARINIOFS( symbGetMangledName( proc_head->sym ), 0 )
-    	end if
+	do
+		'' was it emitted?
+		if( symbGetProcIsEmitted( proc_head->sym ) ) then
+			_setSection( iif( is_ctor, _
+				IR_SECTION_CONSTRUCTOR, _
+				IR_SECTION_DESTRUCTOR ), _
+				symbGetProcPriority( proc_head->sym ) )
+			emitVARINIOFS( symbGetMangledName( proc_head->sym ), 0 )
+		end if
 
-    	proc_head = proc_head->next
-    loop while( proc_head <> NULL )
+		proc_head = proc_head->next
+	loop while( proc_head <> NULL )
 
 end sub
 
 private sub hEmitExport( byval s as FBSYMBOL ptr )
-    if( symbIsExport( s ) ) then
-        _setSection( IR_SECTION_DIRECTIVE, 0 )
+	if( symbIsExport( s ) ) then
+		_setSection( IR_SECTION_DIRECTIVE, 0 )
 
-        dim as zstring ptr sname = symbGetMangledName( s )
-        if( env.underscoreprefix ) then
-            sname += 1
-        end if
+		dim as zstring ptr sname = symbGetMangledName( s )
+		if( env.underscoreprefix ) then
+			sname += 1
+		end if
 
-        emitWriteStr( ".ascii " + QUOTE + " -export:" + _
-                      *sname + (QUOTE + NEWLINE), _
-                      TRUE )
-    end if
+		emitWriteStr( ".ascii " + QUOTE + " -export:" + _
+			*sname + (QUOTE + NEWLINE), _
+			TRUE )
+	end if
 end sub
 
 '':::::
@@ -943,12 +943,12 @@ private sub hDeclVariable _
 
 	'' initialized?
 	if( symbGetTypeIniTree( s ) ) then
-    	'' never referenced?
-    	if( symbGetIsAccessed( s ) = FALSE ) then
+		'' never referenced?
+		if( symbGetIsAccessed( s ) = FALSE ) then
 			'' not public?
-    	    if( symbIsPublic( s ) = FALSE ) then
-    	    	return
-    	    end if
+			if( symbIsPublic( s ) = FALSE ) then
+				return
+			end if
 		end if
 
 		_setSection( IR_SECTION_DATA, 0 )
@@ -968,7 +968,7 @@ private sub hClearLocals _
 	) static
 
 	dim as integer i
-    dim as string lname
+	dim as string lname
 
 	if( bytestoclear = 0 ) then
 		exit sub
@@ -977,9 +977,9 @@ private sub hClearLocals _
 	if( env.clopt.cputype >= FB_CPUTYPE_686 ) then
 		if( cunsg(bytestoclear) \ 8 > 7 ) then
 
-	    	if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) = FALSE ) then
-    			hPUSH( "edi" )
-    		end if
+			if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) = FALSE ) then
+				hPUSH( "edi" )
+			end if
 
 			outp( "lea edi, [ebp-" & baseoffset + bytestoclear & "]" )
 			outp( "mov ecx," & cunsg(bytestoclear) \ 8 )
@@ -992,9 +992,9 @@ private sub hClearLocals _
 			outp( "jnz " + lname )
 			outp( "emms" )
 
-    		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) = FALSE ) then
-    			hPOP( "edi" )
-    		end if
+			if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) = FALSE ) then
+				hPOP( "edi" )
+			end if
 
 		elseif( cunsg(bytestoclear) \ 8 > 0 ) then
 			outp( "pxor mm0, mm0" )
@@ -1014,18 +1014,18 @@ private sub hClearLocals _
 
 	if( cunsg(bytestoclear) \ 4 > 6 ) then
 
-    	if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) = FALSE ) then
-   			hPUSH( "edi" )
-   		end if
+		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) = FALSE ) then
+			hPUSH( "edi" )
+		end if
 
 		outp( "lea edi, [ebp-" & baseoffset + bytestoclear & "]" )
 		outp( "mov ecx," & cunsg(bytestoclear) \ 4 )
 		outp( "xor eax, eax" )
 		outp( "rep stosd" )
 
-   		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) = FALSE ) then
-   			hPOP( "edi" )
-   		end if
+		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) = FALSE ) then
+			hPOP( "edi" )
+		end if
 
 	else
 		for i = cunsg(bytestoclear) \ 4 to 1 step -1
@@ -1044,7 +1044,7 @@ private function hFrameBytesToAlloc _
 
 	dim as integer bytestoalloc, bytespushed = any
 
-    	bytestoalloc = ((proc->proc.ext->stk.localmax - EMIT_LOCSTART) + 3) and (not 3)
+		bytestoalloc = ((proc->proc.ext->stk.localmax - EMIT_LOCSTART) + 3) and (not 3)
 
 	if( (env.target.options and FB_TARGETOPT_STACKALIGN16) <> 0 ) then
 
@@ -1099,14 +1099,14 @@ private sub hCreateFrame _
 		bytestoalloc = hFrameBytesToAlloc( proc )
 
 		'' No locals/temps/padding or arguments?
-    	if( (bytestoalloc <> 0) or _
-    		(proc->proc.ext->stk.argofs <> EMIT_ARGSTART) or _
-        	symbGetIsMainProc( proc ) or _
+		if( (bytestoalloc <> 0) or _
+			(proc->proc.ext->stk.argofs <> EMIT_ARGSTART) or _
+			symbGetIsMainProc( proc ) or _
 			env.clopt.debuginfo or _
 			env.clopt.profile ) then
 
-    		hPUSH( "ebp" )
-    		outp( "mov ebp, esp" )
+			hPUSH( "ebp" )
+			outp( "mov ebp, esp" )
 
 			'' esp is now at -EMIT_ARGSTART modulo alignment if the caller correctly
 			'' aligned the stack; but don't make that assumption for main()
@@ -1115,11 +1115,11 @@ private sub hCreateFrame _
 				bytestoalloc += EMIT_ARGSTART
 			end if
 
-    		if( bytestoalloc > 0 ) then
-    			outp( "sub esp, " + str( bytestoalloc ) )
-    		end if
+			if( bytestoalloc > 0 ) then
+				outp( "sub esp, " + str( bytestoalloc ) )
+			end if
 
-    	end if
+		end if
 
 		if( env.clopt.target = FB_COMPTARGET_DOS ) then
 			if( env.clopt.profile ) then
@@ -1135,15 +1135,15 @@ private sub hCreateFrame _
 			end if
 		end if
 
-    	if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EBX ) ) then
-    		hPUSH( "ebx" )
-    	end if
-    	if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_ESI ) ) then
-    		hPUSH( "esi" )
-    	end if
-    	if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) ) then
-    		hPUSH( "edi" )
-    	end if
+		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EBX ) ) then
+			hPUSH( "ebx" )
+		end if
+		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_ESI ) ) then
+			hPUSH( "esi" )
+		end if
+		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) ) then
+			hPUSH( "edi" )
+		end if
 
 	end if
 
@@ -1166,39 +1166,39 @@ private sub hDestroyFrame _
 	' don't do anything for naked functions, except the .size at the end
 	if( symbIsNaked( proc ) = FALSE ) then
 
-    	dim as integer bytestoalloc
+		dim as integer bytestoalloc
 
-    	bytestoalloc = hFrameBytesToAlloc( proc )
+		bytestoalloc = hFrameBytesToAlloc( proc )
 
-    	if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) ) then
-    		hPOP( "edi" )
-    	end if
-    	if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_ESI ) ) then
-    		hPOP( "esi" )
-    	end if
-    	if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EBX ) ) then
-    		hPOP( "ebx" )
-    	end if
+		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EDI ) ) then
+			hPOP( "edi" )
+		end if
+		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_ESI ) ) then
+			hPOP( "esi" )
+		end if
+		if( EMIT_REGISUSED( FB_DATACLASS_INTEGER, EMIT_REG_EBX ) ) then
+			hPOP( "ebx" )
+		end if
 
-    	if( (bytestoalloc <> 0) or _
-    		(proc->proc.ext->stk.argofs <> EMIT_ARGSTART) or _
-        	symbGetIsMainProc( proc ) or _
+		if( (bytestoalloc <> 0) or _
+			(proc->proc.ext->stk.argofs <> EMIT_ARGSTART) or _
+			symbGetIsMainProc( proc ) or _
 			env.clopt.debuginfo or _
 			env.clopt.profile ) then
-    		outp( "mov esp, ebp" )
-    		hPOP( "ebp" )
-    	end if
+			outp( "mov esp, ebp" )
+			hPOP( "ebp" )
+		end if
 
-    	if( bytestopop > 0 ) then
-    		outp( "ret " + str( bytestopop ) )
-    	else
-    		outp( "ret" )
-    	end if
+		if( bytestopop > 0 ) then
+			outp( "ret " + str( bytestopop ) )
+		else
+			outp( "ret" )
+		end if
 
 	end if
 
 	if( env.clopt.target = FB_COMPTARGET_LINUX ) then
-    	outEx( ".size " + *symbGetMangledName( proc ) + ", .-" + *symbGetMangledName( proc ) + NEWLINE )
+		outEx( ".size " + *symbGetMangledName( proc ) + ", .-" + *symbGetMangledName( proc ) + NEWLINE )
 	end if
 
 end sub
@@ -1279,16 +1279,16 @@ private sub _emitCALL _
 		byval bytestopop as integer _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = "call "
 	ostr += *symbGetMangledName( label )
 	outp( ostr )
 
-    if( bytestopop <> 0 ) then
-    	ostr = "add esp, " + str( bytestopop )
-    	outp( ostr )
-    end if
+	if( bytestopop <> 0 ) then
+		ostr = "add esp, " + str( bytestopop )
+		outp( ostr )
+	end if
 
 end sub
 
@@ -1300,18 +1300,18 @@ private sub _emitCALLPTR _
 		byval bytestopop as integer _
 	) static
 
-    dim src as string
-    dim ostr as string
+	dim src as string
+	dim ostr as string
 
 	hPrepOperand( svreg, src )
 
 	ostr = "call " + src
 	outp( ostr )
 
-    if( bytestopop <> 0 ) then
-    	ostr = "add esp, " + str( bytestopop )
-    	outp( ostr )
-    end if
+	if( bytestopop <> 0 ) then
+		ostr = "add esp, " + str( bytestopop )
+		outp( ostr )
+	end if
 
 end sub
 
@@ -1323,7 +1323,7 @@ private sub _emitBRANCH _
 		byval op as integer _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	select case as const op
 	case AST_OP_JLE
@@ -1353,7 +1353,7 @@ private sub _emitJUMP _
 		byval unused2 as integer _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = "jmp "
 	ostr += *symbGetMangledName( label )
@@ -1369,8 +1369,8 @@ private sub _emitJUMPPTR _
 		byval unused2 as integer _
 	) static
 
-    dim src as string
-    dim ostr as string
+	dim src as string
+	dim ostr as string
 
 	hPrepOperand( svreg, src )
 
@@ -1385,10 +1385,10 @@ private sub _emitRET _
 		byval vreg as IRVREG ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = "ret " + str( vreg->value.i )
-    outp( ostr )
+	outp( ostr )
 
 end sub
 
@@ -1398,7 +1398,7 @@ private sub _emitPUBLIC _
 		byval label as FBSYMBOL ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = NEWLINE + ".globl "
 	ostr += *symbGetMangledName( label )
@@ -1413,7 +1413,7 @@ private sub _emitLABEL _
 		byval label as FBSYMBOL ptr _
 	) static
 
-    dim ostr as string
+	dim ostr as string
 
 	ostr = *symbGetMangledName( label )
 	ostr += ":" + NEWLINE
@@ -1466,7 +1466,7 @@ private sub _emitSTORL2L _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst1, dst2, src1, src2, ostr
+	dim as string dst1, dst2, src1, src2, ostr
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -1486,8 +1486,8 @@ private sub _emitSTORI2L _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst1, dst2, src1, ext, ostr
-    dim sdsize as integer
+	dim as string dst1, dst2, src1, ext, ostr
+	dim sdsize as integer
 
 	sdsize = typeGetSize( svreg->dtype )
 
@@ -1555,8 +1555,8 @@ private sub _emitSTORF2L _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst
-    dim as string ostr
+	dim as string dst
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 
@@ -1577,9 +1577,9 @@ private sub _emitSTORI2I _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src
+	dim as string dst, src
 	dim as integer ddsize, sdsize
-    dim as string ostr
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -1599,7 +1599,7 @@ private sub _emitSTORI2I _
 		outp ostr
 	'' sizes are different..
 	else
-    	dim as string aux
+		dim as string aux
 
 		aux = *hGetRegName( dvreg->dtype, svreg->reg )
 
@@ -1618,19 +1618,19 @@ private sub _emitSTORI2I _
 
 		'' dst size < src size
 		else
-            '' handle DI/SI as source stored into a byte destine
-            dim as integer is_disi
+			'' handle DI/SI as source stored into a byte destine
+			dim as integer is_disi
 
-            is_disi = FALSE
-            if( ddsize = 1 ) then
-            	if( svreg->typ = IR_VREGTYPE_REG ) then
-            		is_disi = (svreg->reg = EMIT_REG_ESI) or (svreg->reg = EMIT_REG_EDI)
-            	end if
-            end if
+			is_disi = FALSE
+			if( ddsize = 1 ) then
+				if( svreg->typ = IR_VREGTYPE_REG ) then
+					is_disi = (svreg->reg = EMIT_REG_ESI) or (svreg->reg = EMIT_REG_EDI)
+				end if
+			end if
 
 			if( is_disi ) then
-    			dim as string aux8
-    			dim as integer reg, isfree
+				dim as string aux8
+				dim as integer reg, isfree
 
 				reg = hFindRegNotInVreg( dvreg, TRUE )
 
@@ -1681,9 +1681,9 @@ private sub _emitSTORF2I _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src
-    dim as integer ddsize
-    dim as string ostr
+	dim as string dst, src
+	dim as integer ddsize
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -1696,16 +1696,16 @@ private sub _emitSTORF2I _
 		outp "sub esp, 4"
 		outp "fistp dword ptr [esp]"
 
-        '' destine is a reg?
-        if( dvreg->typ = IR_VREGTYPE_REG ) then
+		'' destine is a reg?
+		if( dvreg->typ = IR_VREGTYPE_REG ) then
 
-           	hMOV dst, "byte ptr [esp]"
-           	outp "add esp, 4"
+			hMOV dst, "byte ptr [esp]"
+			outp "add esp, 4"
 
 		'' destine is a var/idx/ptr
 		else
-            dim as integer reg, isfree
-            dim as string aux, aux8
+			dim as integer reg, isfree
+			dim as string aux, aux8
 
 			reg = hFindRegNotInVreg( dvreg, TRUE )
 
@@ -1767,8 +1767,8 @@ private sub _emitSTORL2F _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src, aux
-    dim as string ostr
+	dim as string dst, src, aux
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -1829,9 +1829,9 @@ private sub _emitSTORI2F _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src
-    dim as integer sdsize
-    dim as string ostr
+	dim as string dst, src
+	dim as integer sdsize
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -1840,8 +1840,8 @@ private sub _emitSTORI2F _
 
 	'' byte source? damn..
 	if( sdsize = 1 ) then
-    	dim as string aux
-    	dim as integer reg, isfree
+		dim as string aux
+		dim as integer reg, isfree
 
 		reg = hFindRegNotInVreg( svreg )
 
@@ -1963,9 +1963,9 @@ private sub _emitSTORF2F _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src
-    dim as integer ddsize, sdsize
-    dim as string ostr
+	dim as string dst, src
+	dim as integer ddsize, sdsize
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -2023,8 +2023,8 @@ private sub _emitLOADL2L _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst1, dst2, src1, src2
-    dim as string ostr
+	dim as string dst1, dst2, src1, src2
+	dim as string ostr
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -2044,9 +2044,9 @@ private sub _emitLOADI2L _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst1, dst2, src1
-    dim as integer sdsize
-    dim as string ostr
+	dim as string dst1, dst2, src1
+	dim as integer sdsize
+	dim as string ostr
 
 	sdsize = typeGetSize( svreg->dtype )
 
@@ -2056,7 +2056,7 @@ private sub _emitLOADI2L _
 
 	'' immediate?
 	if( svreg->typ = IR_VREGTYPE_IMM ) then
-        hMOV dst1, src1
+		hMOV dst1, src1
 
 		'' negative?
 		if( typeIsSigned( svreg->dtype ) and (svreg->value.i < 0) ) then
@@ -2107,8 +2107,8 @@ private sub _emitLOADF2L _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src, aux
-    dim as string ostr
+	dim as string dst, src, aux
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -2144,8 +2144,8 @@ private sub _emitLOADF2L _
 		iseaxfree orelse= hIsRegInVreg( dvreg, EMIT_REG_EAX )
 
 		outp "sub esp, 8"
-        outp "mov dword ptr [esp], 0x5F000000" '' 2^63
-        outp "fcom dword ptr [esp]"
+		outp "mov dword ptr [esp], 0x5F000000" '' 2^63
+		outp "fcom dword ptr [esp]"
 
 		if( iseaxfree ) then
 			outp "fnstsw ax"
@@ -2160,7 +2160,7 @@ private sub _emitLOADF2L _
 		hBRANCH( "jz", label_geq )
 
 		'' if x < 2^63
-        outp "fistp qword ptr [esp]"
+		outp "fistp qword ptr [esp]"
 		hPOP( dst )
 		hPOP( aux )
 
@@ -2168,11 +2168,11 @@ private sub _emitLOADF2L _
 		hBRANCH( "jmp", label_done )
 		hLABEL( label_geq )
 
-        outp "fsub dword ptr [esp]"
-        outp "fistp qword ptr [esp]"
+		outp "fsub dword ptr [esp]"
+		outp "fistp qword ptr [esp]"
 		hPOP( dst )
 		hPOP( aux )
-        outp "xor " + aux + ", 0x80000000"
+		outp "xor " + aux + ", 0x80000000"
 
 		'' endif
 		hLABEL( label_done )
@@ -2188,9 +2188,9 @@ private sub _emitLOADI2I _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src
+	dim as string dst, src
 	dim as integer ddsize, sdsize
-    dim as string ostr
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -2277,9 +2277,9 @@ private sub _emitLOADF2I _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src
-    dim as integer ddsize
-    dim as string ostr
+	dim as string dst, src
+	dim as integer ddsize
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -2295,17 +2295,17 @@ private sub _emitLOADF2I _
 	if( ddsize = 1 ) then
 
 		outp "sub esp, 4"
-        outp "fistp dword ptr [esp]"
+		outp "fistp dword ptr [esp]"
 
-    	'' destine is a reg
-    	if( dvreg->typ = IR_VREGTYPE_REG ) then
+		'' destine is a reg
+		if( dvreg->typ = IR_VREGTYPE_REG ) then
 			hMOV dst, "byte ptr [esp]"
 			outp "add esp, 4"
 
 		'' destine is a var/idx/ptr
-        else
-    		dim as string aux, aux8
-    		dim as integer reg, isfree
+		else
+			dim as string aux, aux8
+			dim as integer reg, isfree
 
 			reg = hFindRegNotInVreg( dvreg, TRUE )
 
@@ -2328,7 +2328,7 @@ private sub _emitLOADF2I _
 				outp "add esp, 4"
 			end if
 
-        end if
+		end if
 
 	else
 
@@ -2379,8 +2379,8 @@ private sub _emitLOADL2F _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src, aux
-    dim as string ostr
+	dim as string dst, src, aux
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -2441,19 +2441,19 @@ private sub _emitLOADI2F _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src
-    dim as integer sdsize
-    dim as string ostr
+	dim as string dst, src
+	dim as integer sdsize
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
 
-    sdsize = typeGetSize( svreg->dtype )
+	sdsize = typeGetSize( svreg->dtype )
 
 	'' byte source? damn..
 	if( sdsize = 1 ) then
-    	dim as string aux
-    	dim as integer isfree, reg
+		dim as string aux
+		dim as integer isfree, reg
 
 		reg = hFindRegNotInVreg( svreg )
 
@@ -2569,8 +2569,8 @@ private sub _emitLOADF2F _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string src
-    dim as string ostr
+	dim as string src
+	dim as string ostr
 
 	hPrepOperand( svreg, src )
 
@@ -2590,7 +2590,7 @@ private sub _emitMOVL _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst1, dst2, src1, src2, ostr
+	dim as string dst1, dst2, src1, src2, ostr
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -2610,7 +2610,7 @@ private sub _emitMOVI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src, ostr
+	dim as string dst, src, ostr
 
 	'' byte? handle SI, DI used as bytes..
 	if( typeGetSize( dvreg->dtype ) = 1 ) then
@@ -2646,8 +2646,8 @@ private sub _emitADDL _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string, src1 as string, src2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string, src1 as string, src2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -2667,9 +2667,9 @@ private sub _emitADDI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst as string, src as string
-    dim doinc as integer, dodec as integer
-    dim ostr as string
+	dim dst as string, src as string
+	dim doinc as integer, dodec as integer
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -2707,8 +2707,8 @@ private sub _emitADDF _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim src as string
-    dim ostr as string
+	dim src as string
+	dim ostr as string
 
 	hPrepOperand( svreg, src )
 
@@ -2736,8 +2736,8 @@ private sub _emitSUBL _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string, src1 as string, src2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string, src1 as string, src2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -2757,9 +2757,9 @@ private sub _emitSUBI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst as string, src as string
-    dim doinc as integer, dodec as integer
-    dim ostr as string
+	dim dst as string, src as string
+	dim doinc as integer, dodec as integer
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -2797,9 +2797,9 @@ private sub _emitSUBF _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim src as string
-    dim doinc as integer, dodec as integer
-    dim ostr as string
+	dim src as string
+	dim doinc as integer, dodec as integer
+	dim ostr as string
 
 	hPrepOperand( svreg, src )
 
@@ -2826,10 +2826,10 @@ private sub _emitMULL _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string, src1 as string, src2 as string
-    dim iseaxfree as integer, isedxfree as integer
-    dim eaxindest as integer, edxindest as integer
-    dim ofs as integer
+	dim dst1 as string, dst2 as string, src1 as string, src2 as string
+	dim iseaxfree as integer, isedxfree as integer
+	dim eaxindest as integer, edxindest as integer
+	dim ofs as integer
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -2935,9 +2935,9 @@ private sub _emitMULI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim reg as integer, isfree as integer, rname as string
-    dim ostr as string
-    dim dst as string, src as string
+	dim reg as integer, isfree as integer, rname as string
+	dim ostr as string
+	dim dst as string, src as string
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -2978,8 +2978,8 @@ private sub _emitMULF _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim src as string
-    dim ostr as string
+	dim src as string
+	dim ostr as string
 
 	hPrepOperand( svreg, src )
 
@@ -3008,8 +3008,8 @@ private sub _emitDIVF _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim src as string
-    dim ostr as string
+	dim src as string
+	dim ostr as string
 
 	hPrepOperand( svreg, src )
 
@@ -3036,13 +3036,13 @@ private sub _emitDIVI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src
-    dim as integer ecxtrashed
-    dim as integer eaxfree, ecxfree, edxfree
-    dim as integer eaxindest, ecxindest, edxindest
-    dim as integer eaxinsource, edxinsource
-    dim as string eax, ecx, edx
-    dim as string ostr
+	dim as string dst, src
+	dim as integer ecxtrashed
+	dim as integer eaxfree, ecxfree, edxfree
+	dim as integer eaxindest, ecxindest, edxindest
+	dim as integer eaxinsource, edxinsource
+	dim as string eax, ecx, edx
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -3190,13 +3190,13 @@ private sub _emitMODI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string dst, src
-    dim as integer ecxtrashed
-    dim as integer eaxfree, ecxfree, edxfree
-    dim as integer eaxindest, ecxindest, edxindest
-    dim as integer eaxinsource, edxinsource
-    dim as string eax, ecx, edx
-    dim as string ostr
+	dim as string dst, src
+	dim as integer ecxtrashed
+	dim as integer eaxfree, ecxfree, edxfree
+	dim as integer eaxindest, ecxindest, edxindest
+	dim as integer eaxinsource, edxinsource
+	dim as string eax, ecx, edx
+	dim as string ostr
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -3617,11 +3617,11 @@ private sub hSHIFTI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim eaxpreserved as integer, ecxpreserved as integer
-    dim eaxfree as integer, ecxfree as integer
-    dim reg as integer
-    dim ecxindest as integer
-    dim as string ostr, dst, src, tmp, mnemonic
+	dim eaxpreserved as integer, ecxpreserved as integer
+	dim eaxfree as integer, ecxfree as integer
+	dim reg as integer
+	dim ecxindest as integer
+	dim as string ostr, dst, src, tmp, mnemonic
 
 	''
 	if( typeIsSigned( dvreg->dtype ) ) then
@@ -3638,7 +3638,7 @@ private sub hSHIFTI _
 		end if
 	end if
 
-    ''
+	''
 	hPrepOperand( dvreg, dst )
 
 	ecxindest = FALSE
@@ -3659,7 +3659,7 @@ private sub hSHIFTI _
 			reg = INVALID
 		end if
 
-        ecxindest = hIsRegInVreg( dvreg, EMIT_REG_ECX )
+		ecxindest = hIsRegInVreg( dvreg, EMIT_REG_ECX )
 
 		'' ecx in destine?
 		if( ecxindest ) then
@@ -3782,8 +3782,8 @@ private sub _emitANDL _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string, src1 as string, src2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string, src1 as string, src2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -3803,8 +3803,8 @@ private sub _emitANDI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst as string, src as string
-    dim ostr as string
+	dim dst as string, src as string
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -3821,8 +3821,8 @@ private sub _emitORL _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string, src1 as string, src2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string, src1 as string, src2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -3842,8 +3842,8 @@ private sub _emitORI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst as string, src as string
-    dim ostr as string
+	dim dst as string, src as string
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -3860,8 +3860,8 @@ private sub _emitXORL _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string, src1 as string, src2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string, src1 as string, src2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -3881,8 +3881,8 @@ private sub _emitXORI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst as string, src as string
-    dim ostr as string
+	dim dst as string, src as string
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -3899,8 +3899,8 @@ private sub _emitEQVL _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string, src1 as string, src2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string, src1 as string, src2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -3926,8 +3926,8 @@ private sub _emitEQVI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst as string, src as string
-    dim ostr as string
+	dim dst as string, src as string
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -3951,8 +3951,8 @@ private sub _emitIMPL _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string, src1 as string, src2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string, src1 as string, src2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -3978,8 +3978,8 @@ private sub _emitIMPI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim dst as string, src as string
-    dim ostr as string
+	dim dst as string, src as string
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -4004,8 +4004,8 @@ private sub _emitATN2 _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim src as string
-    dim ostr as string
+	dim src as string
+	dim ostr as string
 
 	hPrepOperand( svreg, src )
 
@@ -4068,7 +4068,7 @@ private sub hCMPL _
 		byval isinverse as integer = FALSE _
 	) static
 
-    dim as string dst1, dst2, src1, src2, rname, ostr, lname, falselabel
+	dim as string dst1, dst2, src1, src2, rname, ostr, lname, falselabel
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 	hPrepOperand64( svreg, src1, src2 )
@@ -4131,8 +4131,8 @@ private sub hCMPI _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string rname, rname8, dst, src, ostr, lname
-    dim as integer isedxfree, dotest
+	dim as string rname, rname8, dst, src, ostr, lname
+	dim as integer isedxfree, dotest
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -4240,7 +4240,7 @@ private sub hCMPF _
 	) static
 
 	dim as string rname, rname8, dst, src, ostr, lname
-    dim as integer iseaxfree, isedxfree
+	dim as integer iseaxfree, isedxfree
 
 	hPrepOperand( dvreg, dst )
 	hPrepOperand( svreg, src )
@@ -4265,17 +4265,17 @@ private sub hCMPF _
 		end if
 	end if
 
-    iseaxfree = hIsRegFree( FB_DATACLASS_INTEGER, EMIT_REG_EAX )
-    if( rvreg <> NULL ) then
-    	iseaxfree = (rvreg->reg = EMIT_REG_EAX)
+	iseaxfree = hIsRegFree( FB_DATACLASS_INTEGER, EMIT_REG_EAX )
+	if( rvreg <> NULL ) then
+		iseaxfree = (rvreg->reg = EMIT_REG_EAX)
 	end if
 
-    if( iseaxfree = FALSE ) then
-    	hPUSH( "eax" )
-    end if
+	if( iseaxfree = FALSE ) then
+		hPUSH( "eax" )
+	end if
 
-    '' load fpu flags
-    outp "fnstsw ax"
+	'' load fpu flags
+	outp "fnstsw ax"
 	if( len( *mask ) > 0 ) then
 		ostr = "test ah, " + *mask
 		outp ostr
@@ -4287,14 +4287,14 @@ private sub hCMPF _
 		hPOP( "eax" )
 	end if
 
-    '' no result to be set? just branch
-    if( rvreg = NULL ) then
-    	ostr = "j" + *mnemonic
-    	hBRANCH( ostr, lname )
-    	exit sub
-    end if
+	'' no result to be set? just branch
+	if( rvreg = NULL ) then
+		ostr = "j" + *mnemonic
+		hBRANCH( ostr, lname )
+		exit sub
+	end if
 
-    hPrepOperand( rvreg, rname )
+	hPrepOperand( rvreg, rname )
 
 	'' can it be optimized?
 	if( env.clopt.cputype >= FB_CPUTYPE_486 ) then
@@ -4332,11 +4332,11 @@ private sub hCMPF _
 
 	'' old (and slow) boolean set
 	else
-    	ostr = "mov " + rname + ", -1"
-    	outp ostr
+		ostr = "mov " + rname + ", -1"
+		outp ostr
 
-    	ostr = "j" + *mnemonic
-    	hBRANCH( ostr, lname )
+		ostr = "j" + *mnemonic
+		hBRANCH( ostr, lname )
 
 		ostr = "xor " + rname + COMMA + rname
 		outp ostr
@@ -4671,8 +4671,8 @@ private sub _emitNEGL _
 		byval dvreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 
@@ -4693,8 +4693,8 @@ private sub _emitNEGI _
 		byval dvreg as IRVREG ptr _
 	) static
 
-    dim dst as string
-    dim ostr as string
+	dim dst as string
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 
@@ -4720,8 +4720,8 @@ private sub _emitNOTL _
 		byval dvreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 
@@ -4739,8 +4739,8 @@ private sub _emitNOTI _
 		byval dvreg as IRVREG ptr _
 	) static
 
-    dim dst as string
-    dim ostr as string
+	dim dst as string
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 
@@ -4761,9 +4761,9 @@ private sub _emitABSL _
 		byval dvreg as IRVREG ptr _
 	) static
 
-    dim dst1 as string, dst2 as string
-    dim reg as integer, isfree as integer, rname as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string
+	dim reg as integer, isfree as integer, rname as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 
@@ -4805,9 +4805,9 @@ private sub _emitABSI _
 		byval dvreg as IRVREG ptr _
 	) static
 
-    dim dst as string
-    dim reg as integer, isfree as integer, rname as string, bits as integer
-    dim ostr as string
+	dim dst as string
+	dim reg as integer, isfree as integer, rname as string, bits as integer
+	dim ostr as string
 
 	hPrepOperand( dvreg, dst )
 
@@ -4934,11 +4934,11 @@ private sub _emitSGNF( byval dvreg as IRVREG ptr )
 
 	label = *symbUniqueLabel( )
 
-    iseaxfree = hIsRegFree( FB_DATACLASS_INTEGER, EMIT_REG_EAX )
+	iseaxfree = hIsRegFree( FB_DATACLASS_INTEGER, EMIT_REG_EAX )
 
-    if( iseaxfree = FALSE ) then
-    	hPUSH( "eax" )
-    end if
+	if( iseaxfree = FALSE ) then
+		hPUSH( "eax" )
+	end if
 
 	outp "ftst"
 	outp "fnstsw ax"
@@ -4978,8 +4978,8 @@ private sub _emitASIN _
 
 	'' asin( x ) = atn( sqr( (x*x) / (1-x*x) ) )
 	outp "fld st(0)"
-    outp "fmul st(0), st(0)"
-    outp "fld1"
+	outp "fmul st(0), st(0)"
+	outp "fld1"
 	outp "fsubrp"
 	outp "fsqrt"
 	outp "fpatan"
@@ -5004,8 +5004,8 @@ private sub _emitACOS _
 
 	'' acos( x ) = atn( sqr( (1-x*x) / (x*x) ) )
 	outp "fld st(0)"
-    outp "fmul st(0), st(0)"
-    outp "fld1"
+	outp "fmul st(0), st(0)"
+	outp "fld1"
 	outp "fsubrp"
 	outp "fsqrt"
 	outp "fxch"
@@ -5053,9 +5053,9 @@ private sub _emitLOG _
 
 	'' log( x ) = log2( x ) / log2( e ).
 
-    outp "fldln2"
-    outp "fxch"
-    outp "fyl2x"
+	outp "fldln2"
+	outp "fxch"
+	outp "fyl2x"
 
 end sub
 
@@ -5068,7 +5068,7 @@ private sub _emitEXP _
 	outp "fldl2e"
 	outp "fmulp st(1), st"
 	outp "fld st"
-    outp "frndint"
+	outp "frndint"
 	outp "fsub st(1), st"
 	outp "fxch"
 	outp "f2xm1"
@@ -5171,8 +5171,8 @@ private sub _emitXchgTOS _
 		byval svreg as IRVREG ptr _
 	) static
 
-    dim as string src
-    dim as string ostr
+	dim as string src
+	dim as string ostr
 
 	hPrepOperand( svreg, src )
 
@@ -5200,8 +5200,8 @@ private sub _emitPUSHL _
 		byval unused as integer _
 	) static
 
-    dim src1 as string, src2 as string
-    dim ostr as string
+	dim src1 as string, src2 as string
+	dim ostr as string
 
 	hPrepOperand64( svreg, src1, src2 )
 
@@ -5277,8 +5277,8 @@ private sub _emitPUSHF _
 		byval unused as integer _
 	) static
 
-    dim src as string, sdsize as integer
-    dim ostr as string
+	dim src as string, sdsize as integer
+	dim ostr as string
 
 	hPrepOperand( svreg, src )
 
@@ -5293,7 +5293,7 @@ private sub _emitPUSHF _
 			ostr = "push " + src
 			outp ostr
 
-    		hPrepOperand( svreg, src, FB_DATATYPE_INTEGER, 0 )
+			hPrepOperand( svreg, src, FB_DATATYPE_INTEGER, 0 )
 			ostr = "push " + src
 			outp ostr
 		end if
@@ -5429,8 +5429,8 @@ private sub _emitPOPL _
 		byval unused as integer _
 	) static
 
-    dim dst1 as string, dst2 as string
-    dim ostr as string
+	dim dst1 as string, dst2 as string
+	dim ostr as string
 
 	hPrepOperand64( dvreg, dst1, dst2 )
 
@@ -5449,8 +5449,8 @@ private sub _emitPOPI _
 		byval unused as integer _
 	) static
 
-    dim as string dst, ostr
-    dim as integer dsize
+	dim as string dst, ostr
+	dim as integer dsize
 
 	hPrepOperand( dvreg, dst )
 
@@ -5534,8 +5534,8 @@ private sub _emitPOPF _
 		byval unused as integer _
 	) static
 
-    dim as string dst, ostr
-    dim as integer dsize
+	dim as string dst, ostr
+	dim as integer dsize
 
 	hPrepOperand( dvreg, dst )
 
@@ -5651,7 +5651,7 @@ private sub hMemMoveRep _
 		else
 			'' not esi already?
 			if( dvreg->reg <> EMIT_REG_EDI ) then
-           		hMOV( "edi", dst )
+				hMOV( "edi", dst )
 			end if
 		end if
 
@@ -5672,7 +5672,7 @@ private sub hMemMoveRep _
 	else
 		'' not esi already?
 		if( svreg->reg <> EMIT_REG_ESI ) then
-           	hMOV( "esi", src )
+			hMOV( "esi", src )
 		end if
 	end if
 
@@ -5851,8 +5851,8 @@ private sub hMemClearRepIMM _
 	else
 		'' not edi already?
 		if( dvreg->reg <> EMIT_REG_EDI ) then
-           	hMOV( "edi", dst )
-        end if
+			hMOV( "edi", dst )
+		end if
 	end if
 
 	outp "xor eax, eax"
@@ -5962,8 +5962,8 @@ private sub hMemClear _
 		else
 			'' not edi already?
 			if( dvreg->reg <> EMIT_REG_EDI ) then
-            	hMOV( "edi", dst )
-            end if
+				hMOV( "edi", dst )
+			end if
 		end if
 
 		if( bytes_vreg->typ <> IR_VREGTYPE_REG ) then
@@ -5971,8 +5971,8 @@ private sub hMemClear _
 		else
 			'' not ecx already?
 			if( bytes_vreg->reg <> EMIT_REG_ECX ) then
-            	hMOV( "ecx", bytes )
-            end if
+				hMOV( "ecx", bytes )
+			end if
 		end if
 
 	else
@@ -6024,7 +6024,7 @@ private sub _emitMEMCLEAR _
 		end if
 
 	else
-    	hMemClear( dvreg, svreg )
+		hMemClear( dvreg, svreg )
 	end if
 
 end sub
@@ -6246,8 +6246,8 @@ end sub
 
 private sub _emitLOADF2B( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 
-    dim as string dst, src
-    dim as integer ddsize = any
+	dim as string dst, src
+	dim as integer ddsize = any
 	dim as integer isfree = any
 
 	hPrepOperand( dvreg, dst )
@@ -6322,8 +6322,8 @@ private sub _emitLOADB2F( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 
 	'' byte source? damn..
 	if( sdsize = 1 ) then
-    	dim as string aux
-    	dim as integer isfree, reg
+		dim as string aux
+		dim as integer isfree, reg
 
 		reg = hFindRegNotInVreg( svreg )
 
@@ -6377,8 +6377,8 @@ private sub _emitSTORB2F( byval dvreg as IRVREG ptr, byval svreg as IRVREG ptr )
 
 	'' byte source? damn..
 	if( sdsize = 1 ) then
-    	dim as string aux
-    	dim as integer isfree, reg
+		dim as string aux
+		dim as integer isfree, reg
 
 		reg = hFindRegNotInVreg( svreg )
 
@@ -6557,7 +6557,7 @@ sub emitVARINIBEGIN( byval sym as FBSYMBOL ptr )
 
 	'' public?
 	if( symbIsPublic( sym ) ) then
-		hPUBLIC( *symbGetMangledName( sym ), symbIsExport( sym )  )
+		hPUBLIC( *symbGetMangledName( sym ), symbIsExport( sym ) )
 	end if
 
 	hLABEL( *symbGetMangledName( sym ) )
@@ -6657,7 +6657,7 @@ end sub
 		EMIT_CBENTRY(STORI2F), EMIT_CBENTRY(STORF2F), EMIT_CBENTRY(STORL2F), EMIT_CBENTRY(STORB2F), _
 		EMIT_CBENTRY(STORI2L), EMIT_CBENTRY(STORF2L), EMIT_CBENTRY(STORL2L), EMIT_CBENTRY(STORB2L), _
 		EMIT_CBENTRY(STORI2B), EMIT_CBENTRY(STORF2B), EMIT_CBENTRY(STORL2B), EMIT_CBENTRY(STORB2B), _
-        _
+		_
 		EMIT_CBENTRY(MOVI), EMIT_CBENTRY(MOVF), EMIT_CBENTRY(MOVL), _
 		EMIT_CBENTRY(ADDI), EMIT_CBENTRY(ADDF), EMIT_CBENTRY(ADDL), _
 		EMIT_CBENTRY(SUBI), EMIT_CBENTRY(SUBF), EMIT_CBENTRY(SUBL), _
@@ -6675,64 +6675,64 @@ end sub
 		EMIT_CBENTRY(POW), _
 		EMIT_CBENTRY(ADDROF), _
 		EMIT_CBENTRY(DEREF), _
-        _
+		_
 		EMIT_CBENTRY(CGTI), EMIT_CBENTRY(CGTF), EMIT_CBENTRY(CGTL), _
 		EMIT_CBENTRY(CLTI), EMIT_CBENTRY(CLTF), EMIT_CBENTRY(CLTL), _
 		EMIT_CBENTRY(CEQI), EMIT_CBENTRY(CEQF), EMIT_CBENTRY(CEQL), _
 		EMIT_CBENTRY(CNEI), EMIT_CBENTRY(CNEF), EMIT_CBENTRY(CNEL), _
 		EMIT_CBENTRY(CGEI), EMIT_CBENTRY(CGEF), EMIT_CBENTRY(CGEL), _
 		EMIT_CBENTRY(CLEI), EMIT_CBENTRY(CLEF), EMIT_CBENTRY(CLEL), _
-        _
+		_
 		EMIT_CBENTRY(NEGI), EMIT_CBENTRY(NEGF), EMIT_CBENTRY(NEGL), _
 		EMIT_CBENTRY(NOTI), EMIT_CBENTRY(NOTL), _
-	   _
+		_
 		NULL, _
-        _
+		_
 		EMIT_CBENTRY(ABSI), EMIT_CBENTRY(ABSF), EMIT_CBENTRY(ABSL), _
 		EMIT_CBENTRY(SGNI), EMIT_CBENTRY(SGNF), EMIT_CBENTRY(SGNL), _
-        _
+		_
 		EMIT_CBENTRY(FIX), _
 		EMIT_CBENTRY(FRAC), _
 		EMIT_CBENTRY(CONVFD2FS), _
-	   _
+		_
 		NULL, _
-	   _
+		_
 		EMIT_CBENTRY(SIN), EMIT_CBENTRY(ASIN), _
 		EMIT_CBENTRY(COS), EMIT_CBENTRY(ACOS), _
 		EMIT_CBENTRY(TAN), EMIT_CBENTRY(ATAN), _
 		EMIT_CBENTRY(SQRT), _
-	   _
+		_
 		NULL, _
 		NULL, _
-	   _
+		_
 		EMIT_CBENTRY(LOG), _
 		EMIT_CBENTRY(EXP), _
 		EMIT_CBENTRY(FLOOR), _
 		EMIT_CBENTRY(XCHGTOS), _
-        _
+		_
 		EMIT_CBENTRY(STACKALIGN), _
 		EMIT_CBENTRY(PUSHI), EMIT_CBENTRY(PUSHF), EMIT_CBENTRY(PUSHL), _
 		EMIT_CBENTRY(POPI), EMIT_CBENTRY(POPF), EMIT_CBENTRY(POPL), _
 		EMIT_CBENTRY(PUSHUDT), _
 		EMIT_CBENTRY(POPST0), _
-        _
+		_
 		EMIT_CBENTRY(CALL), _
 		EMIT_CBENTRY(CALLPTR), _
 		EMIT_CBENTRY(BRANCH), _
 		EMIT_CBENTRY(JUMP), _
 		EMIT_CBENTRY(JUMPPTR), _
 		EMIT_CBENTRY(RET), _
-        _
+		_
 		EMIT_CBENTRY(LABEL), _
 		EMIT_CBENTRY(PUBLIC), _
 		EMIT_CBENTRY(LIT), _
 		EMIT_CBENTRY(JMPTB), _
-        _
+		_
 		EMIT_CBENTRY(MEMMOVE), _
 		EMIT_CBENTRY(MEMSWAP), _
 		EMIT_CBENTRY(MEMCLEAR), _
 		EMIT_CBENTRY(STKCLEAR), _
-        _
+		_
 		EMIT_CBENTRY(LINEINI), _
 		EMIT_CBENTRY(LINEEND), _
 		EMIT_CBENTRY(SCOPEINI), _
@@ -6876,16 +6876,16 @@ private function _isRegPreserved _
 		byval reg as integer _
 	) as integer static
 
-    '' fp? fpu stack *must* be cleared before calling any function
-    if( dclass = FB_DATACLASS_FPOINT ) then
-    	return FALSE
-    end if
+	'' fp? fpu stack *must* be cleared before calling any function
+	if( dclass = FB_DATACLASS_FPOINT ) then
+		return FALSE
+	end if
 
-    select case as const reg
-    case EMIT_REG_EAX, EMIT_REG_ECX, EMIT_REG_EDX
-    	return FALSE
-    case else
-    	return TRUE
+	select case as const reg
+	case EMIT_REG_EAX, EMIT_REG_ECX, EMIT_REG_EDX
+		return FALSE
+	case else
+		return TRUE
 	end select
 
 end function
@@ -6950,8 +6950,8 @@ private sub _procBegin _
 		byval proc as FBSYMBOL ptr _
 	)
 
-    proc->proc.ext->stk.localofs = EMIT_LOCSTART
-    proc->proc.ext->stk.localmax = EMIT_LOCSTART
+	proc->proc.ext->stk.localofs = EMIT_LOCSTART
+	proc->proc.ext->stk.localmax = EMIT_LOCSTART
 	proc->proc.ext->stk.argofs = EMIT_ARGSTART
 
 	edbgProcBegin( proc )
@@ -7008,13 +7008,13 @@ private sub _procAllocLocal _
 
 	lgt = symbGetRealSize( sym )
 
-    proc->proc.ext->stk.localofs += ((lgt + 3) and not 3)
+	proc->proc.ext->stk.localofs += ((lgt + 3) and not 3)
 
 	ofs = -proc->proc.ext->stk.localofs
 
-    if( -ofs > proc->proc.ext->stk.localmax ) then
-    	proc->proc.ext->stk.localmax = -ofs
-    end if
+	if( -ofs > proc->proc.ext->stk.localmax ) then
+		proc->proc.ext->stk.localmax = -ofs
+	end if
 
 	sym->ofs = ofs
 
@@ -7038,7 +7038,7 @@ private sub _procAllocArg _
 	end if
 
 	sym->ofs = proc->proc.ext->stk.argofs
-    proc->proc.ext->stk.argofs += ((lgt + 3) and not 3)
+	proc->proc.ext->stk.argofs += ((lgt + 3) and not 3)
 
 end sub
 
@@ -7066,9 +7066,9 @@ private sub _procFooter _
 		byval exitlabel as FBSYMBOL ptr _
 	)
 
-    dim as integer oldpos = any, ispublic = any
+	dim as integer oldpos = any, ispublic = any
 
-    ispublic = symbIsPublic( proc )
+	ispublic = symbIsPublic( proc )
 
 	_setSection( IR_SECTION_CODE, 0 )
 
@@ -7091,17 +7091,17 @@ private sub _procFooter _
 	'' frame
 	hCreateFrame( proc )
 
-    edbgEmitLineFlush( proc, proc->proc.ext->dbg.iniline, proc )
+	edbgEmitLineFlush( proc, proc->proc.ext->dbg.iniline, proc )
 
-    ''
-    emitFlush( )
+	''
+	emitFlush( )
 
 	''
 	hDestroyFrame( proc, bytestopop )
 
-    edbgEmitLineFlush( proc, proc->proc.ext->dbg.endline, exitlabel )
+	edbgEmitLineFlush( proc, proc->proc.ext->dbg.endline, exitlabel )
 
-    edbgEmitProcFooter( proc, initlabel, exitlabel )
+	edbgEmitProcFooter( proc, initlabel, exitlabel )
 
 end sub
 
@@ -7137,7 +7137,7 @@ private sub _setSection _
 		exit sub
 	end if
 
-    static as string ostr
+	static as string ostr
 
 	ostr = *sec
 	ostr += NEWLINE
@@ -7258,7 +7258,7 @@ private function _getSectionString _
 				ostr += "." + right( "00000" + str( 65535 - priority ), 5 )
 			end if
 			if( env.clopt.target = FB_COMPTARGET_LINUX ) then
-				ostr += ", " + QUOTE +  "aw" + QUOTE + ", @progbits"
+				ostr += ", " + QUOTE + "aw" + QUOTE + ", @progbits"
 			end if
 		end if
 

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -943,7 +943,7 @@ function fbIdentifyFbcArch( byref fbcarch as string ) as integer
 		'' default, which is always safe for the host.
 		function = FB_DEFAULT_CPUTYPE
 
-		#if (not defined( __FB_64BIT__ )) and defined( __FB_X86__ ) and (not defined(__FB_PPC__))
+		#if (not defined( __FB_64BIT__ )) and defined( __FB_X86__ )
 			select case( fb_CpuDetect( ) shr 28 )
 			case 3 : function = FB_CPUTYPE_386
 			case 4 : function = FB_CPUTYPE_486

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -3118,8 +3118,8 @@ private function hCompileStage2Module( byval module as FBCIOFILE ptr ) as intege
 		end select
 
 		if( fbGetOption( FB_COMPOPT_TARGET ) <> FB_COMPTARGET_JS ) then
-            '' GCC doesn't recognize the -march option and PowerPC combination and recommendeds
-            '' the -mcpu option be used for PowerPC.
+			'' GCC doesn't recognize the -march option and PowerPC combination and recommendeds
+			'' the -mcpu option be used for PowerPC.
 			if( (fbGetCpuFamily( ) = FB_CPUFAMILY_PPC) orelse (fbGetCpuFamily( ) = FB_CPUFAMILY_PPC64) ) then
 				if( fbc.cputype_is_native ) then
 					ln += "-mcpu=native "

--- a/src/compiler/ir-tac.bas
+++ b/src/compiler/ir-tac.bas
@@ -197,12 +197,12 @@ private function _getOptionValue _
 		byval opt as IR_OPTIONVALUE _
 	) as integer
 
-    function = emitGetOptionValue( opt )
+	function = emitGetOptionValue( opt )
 
 end function
 
 private sub hLoadIDX( byval vreg as IRVREG ptr )
-    dim as IRVREG ptr vi = any
+	dim as IRVREG ptr vi = any
 
 	if( vreg = NULL ) then
 		exit sub
@@ -262,29 +262,29 @@ end sub
 '' Setup an IRTAC's vr, v1 or v2 fields for the given IRVREG and its idx/aux
 '' sub-IRVREGs.
 #macro hRelinkVreg(v,t)
-    t->v.reg.parent = NULL
-    t->v.reg.next = NULL
+	t->v.reg.parent = NULL
+	t->v.reg.next = NULL
 
-    if( v <> NULL ) then
-    	hRelink( v, @t->v.reg )
-    	v->taclast = t
+	if( v <> NULL ) then
+		hRelink( v, @t->v.reg )
+		v->taclast = t
 
-    	if( v->vidx <> NULL ) then
-    		t->v.idx.vreg = v->vidx
-    		t->v.idx.parent = v
-    		t->v.idx.next = NULL
-    		hRelink( v->vidx, @t->v.idx )
-    		v->vidx->taclast = t
-    	end if
+		if( v->vidx <> NULL ) then
+			t->v.idx.vreg = v->vidx
+			t->v.idx.parent = v
+			t->v.idx.next = NULL
+			hRelink( v->vidx, @t->v.idx )
+			v->vidx->taclast = t
+		end if
 
-    	if( v->vaux <> NULL ) then
-    		t->v.aux.vreg = v->vaux
-    		t->v.aux.parent = v
-    		t->v.aux.next = NULL
-    		hRelink( v->vaux, @t->v.aux )
-    		v->vaux->taclast = t
-    	end if
-    end if
+		if( v->vaux <> NULL ) then
+			t->v.aux.vreg = v->vaux
+			t->v.aux.parent = v
+			t->v.aux.next = NULL
+			hRelink( v->vaux, @t->v.aux )
+			v->vaux->taclast = t
+		end if
+	end if
 #endmacro
 
 '':::::
@@ -299,29 +299,29 @@ private sub _emit _
 		byval ex3 as zstring ptr = 0 _
 	) static
 
-    dim as IRTAC ptr t
+	dim as IRTAC ptr t
 
 	'' Add a new IRTAC node to represent the three operand vregs
-    t = flistNewItem( @ctx.tacTB )
+	t = flistNewItem( @ctx.tacTB )
 
-    t->pos = ctx.taccnt
+	t->pos = ctx.taccnt
 
-    t->op = op
+	t->op = op
 
-    t->v1.reg.vreg = v1
-    hRelinkVreg( v1, t )
+	t->v1.reg.vreg = v1
+	hRelinkVreg( v1, t )
 
-    t->v2.reg.vreg = v2
-    hRelinkVreg( v2, t )
+	t->v2.reg.vreg = v2
+	hRelinkVreg( v2, t )
 
-    t->vr.reg.vreg = vr
-    hRelinkVreg( vr, t )
+	t->vr.reg.vreg = vr
+	hRelinkVreg( vr, t )
 
-    t->ex1 = ex1
-    t->ex2 = ex2
-    t->ex3 = ex3
+	t->ex1 = ex1
+	t->ex2 = ex2
+	t->ex3 = ex3
    
-    ctx.taccnt += 1
+	ctx.taccnt += 1
 
 end sub
 
@@ -1220,8 +1220,8 @@ private sub hRename _
 		byval vnew as IRVREG ptr _
 	)
 
-    dim as IRTACVREG ptr t = any
-    dim as IRVREG ptr v = any
+	dim as IRTACVREG ptr t = any
+	dim as IRVREG ptr v = any
 
 	'' reassign tac table vregs
 	'' (assuming res, v1 and v2 will never point to the same vreg!)
@@ -1252,11 +1252,11 @@ private sub hReuse _
 		byval t as IRTAC ptr _
 	)
 
-    dim as IRVREG ptr v1 = any, v2 = any, vr = any
-    dim as integer v1_dtype = any, v1_dclass = any, v1_typ = any
-    dim as integer v2_dtype = any, v2_dclass = any, v2_typ = any
-    dim as integer vr_dtype = any, vr_dclass = any, vr_typ = any
-    dim as integer op = any
+	dim as IRVREG ptr v1 = any, v2 = any, vr = any
+	dim as integer v1_dtype = any, v1_dclass = any, v1_typ = any
+	dim as integer v2_dtype = any, v2_dclass = any, v2_typ = any
+	dim as integer vr_dtype = any, vr_dclass = any, vr_typ = any
+	dim as integer op = any
 
 	op = t->op
 	v1 = t->v1.reg.vreg
@@ -1265,7 +1265,7 @@ private sub hReuse _
 
 	hGetVREG( v1, v1_dtype, v1_dclass, v1_typ )
 	hGetVREG( v2, v2_dtype, v2_dclass, v2_typ )
-    hGetVREG( vr, vr_dtype, vr_dclass, vr_typ )
+	hGetVREG( vr, vr_dtype, vr_dclass, vr_typ )
 
 	'' Allow operand reg to be re-used as result reg (to avoid allocating yet another reg)
 	'' but only if the dtype is similar (same size, same signedness),
@@ -1275,10 +1275,10 @@ private sub hReuse _
 	case AST_NODECLASS_UOP
 		if( vr <> v1 ) then
 			if( typeGetSizeType( vr_dtype ) = typeGetSizeType( v1_dtype ) ) then
-           		if( irGetDistance( v1 ) = IR_MAXDIST ) then
-           			hRename( vr, v1 )
-           		end if
-           	end if
+				if( irGetDistance( v1 ) = IR_MAXDIST ) then
+					hRename( vr, v1 )
+				end if
+			end if
 		end if
 
 	case AST_NODECLASS_BOP, AST_NODECLASS_COMP
@@ -1296,10 +1296,10 @@ private sub hReuse _
 		v1rename = FALSE
 		if( vr <> v1 ) then
 			if( typeGetSizeType( vr_dtype ) = typeGetSizeType( v1_dtype ) ) then
-           		if( irGetDistance( v1 ) = IR_MAXDIST ) then
-           			v1rename = TRUE
-           		end if
-           	end if
+				if( irGetDistance( v1 ) = IR_MAXDIST ) then
+					v1rename = TRUE
+				end if
+			end if
 		end if
 
 		v2rename = FALSE
@@ -1307,22 +1307,22 @@ private sub hReuse _
 			if( vr <> v2 ) then
 				if( typeGetSizeType( vr_dtype ) = typeGetSizeType( v2_dtype ) ) then
 					if( v2_typ <> IR_VREGTYPE_IMM ) then
-           				if( irGetDistance( v2 ) = IR_MAXDIST ) then
-           					v2rename = TRUE
-           				end if
-           			end if
-           		end if
+						if( irGetDistance( v2 ) = IR_MAXDIST ) then
+							v2rename = TRUE
+						end if
+					end if
+				end if
 			end if
 		end if
 
 		if( v1rename and v2rename ) then
 			if( irIsREG( v1 ) = FALSE ) then
-           		v1rename = FALSE
+				v1rename = FALSE
 			end if
 		end if
 
 		if( v1rename ) then
-           	hRename( vr, v1 )
+			hRename( vr, v1 )
 
 		elseif( v2rename ) then
 		 	swap t->v1, t->v2
@@ -1336,9 +1336,9 @@ end sub
 
 '':::::
 private sub _flush static
-    dim as integer op
-    dim as IRTAC ptr t
-    dim as IRVREG ptr v1, v2, vr
+	dim as integer op
+	dim as IRTAC ptr t
+	dim as IRVREG ptr v1, v2, vr
 
 	if( ctx.taccnt = 0 ) then
 		exit sub
@@ -1358,7 +1358,7 @@ private sub _flush static
 		''
 		'hDump( op, v1, v2, vr )
 
-        ''
+		''
 		select case as const astGetOpClass( op )
 		case AST_NODECLASS_UOP
 			hFlushUOP( op, v1, vr )
@@ -1421,8 +1421,8 @@ private sub _flush static
 	''
 	flistReset( @ctx.vregTB )
 
-    ''
-    hFreePreservedRegs( )
+	''
+	hFreePreservedRegs( )
 
 end sub
 
@@ -1453,7 +1453,7 @@ end sub
 
 '':::::
 private sub hFreePreservedRegs( ) static
-    dim as integer class_, reg
+	dim as integer class_, reg
 
 	'' for each reg class
 	for class_ = 0 to EMIT_REGCLASSES-1
@@ -1464,15 +1464,15 @@ private sub hFreePreservedRegs( ) static
 			'' if not free
 			if( regTB(class_)->isFree( regTB(class_), reg ) = FALSE ) then
 
-        		assert( emitIsRegPreserved( class_, reg ) )
+				assert( emitIsRegPreserved( class_, reg ) )
 
-        		'' free reg
-        		regTB(class_)->free( regTB(class_), reg )
+				'' free reg
+				regTB(class_)->free( regTB(class_), reg )
 
 			end if
 
-        	'' next reg
-        	reg = regTB(class_)->getNext( regTB(class_), reg )
+			'' next reg
+			reg = regTB(class_)->getNext( regTB(class_), reg )
 		loop
 
 	next
@@ -1583,26 +1583,26 @@ private sub hPreserveRegs( byval ptrvreg as IRVREG ptr = NULL )
 
 	'' for each reg class
 	for class_ as integer = 0 to EMIT_REGCLASSES-1
-    	'' set the register that shouldn't be preserved (used for CALLPTR only)
+		'' set the register that shouldn't be preserved (used for CALLPTR only)
 
-    	npreg = INVALID
-    	if( class_ = FB_DATACLASS_INTEGER ) then
-    		if( ptrvreg <> NULL ) then
+		npreg = INVALID
+		if( class_ = FB_DATACLASS_INTEGER ) then
+			if( ptrvreg <> NULL ) then
 
-    			select case ptrvreg->typ
-    			case IR_VREGTYPE_REG
-    				npreg = ptrvreg->reg
+				select case ptrvreg->typ
+				case IR_VREGTYPE_REG
+					npreg = ptrvreg->reg
 
-    			case IR_VREGTYPE_IDX, IR_VREGTYPE_PTR
-    				ptrvreg = ptrvreg->vidx
-    				if( ptrvreg <> NULL ) then
-    					npreg = ptrvreg->reg
-    				end if
-    			end select
+				case IR_VREGTYPE_IDX, IR_VREGTYPE_PTR
+					ptrvreg = ptrvreg->vidx
+					if( ptrvreg <> NULL ) then
+						npreg = ptrvreg->reg
+					end if
+				end select
 
-    			ptrvreg = NULL
-    		end if
-    	end if
+				ptrvreg = NULL
+			end if
+		end if
 
 		'' for each register on that class
 		reg = regTB(class_)->getFirst( regTB(class_) )
@@ -1755,7 +1755,7 @@ private sub hFlushSTACK _
 		emitPOP( v1 )
 	end select
 
-    ''
+	''
 	hFreeREG( v1 )
 
 end sub
@@ -1782,8 +1782,8 @@ private sub hFlushUOP _
 	hLoadIDX( v1 )
 	hLoadIDX( vr )
 
-    ''
-    if ( vr <> NULL ) then
+	''
+	if ( vr <> NULL ) then
 		if( v1 <> vr ) then
 			'' handle longint
 			if( ISLONGINT( vr_dtype ) ) then
@@ -1868,14 +1868,14 @@ private sub hFlushUOP _
 
 	end select
 
-    ''
-    if ( vr <> NULL ) then
+	''
+	if ( vr <> NULL ) then
 		if( v1 <> vr ) then
 			emitMOV( vr, v1 )
 		end if
 	end if
 
-    ''
+	''
 	hFreeREG( v1 )
 	hFreeREG( vr )
 
@@ -1936,7 +1936,7 @@ private sub hFlushBOP _
 		regTB(v1_dclass)->ensure( regTB(v1_dclass), v1, NULL, typeGetSize( v1_dtype ) )
 	end if
 
-    ''
+	''
 	select case as const op
 	case AST_OP_ADD
 		emitADD( v1, v2 )
@@ -1945,9 +1945,9 @@ private sub hFlushBOP _
 	case AST_OP_MUL
 		emitMUL( v1, v2 )
 	case AST_OP_DIV
-        emitDIV( v1, v2 )
+		emitDIV( v1, v2 )
 	case AST_OP_INTDIV
-        emitINTDIV( v1, v2 )
+		emitINTDIV( v1, v2 )
 	case AST_OP_MOD
 		emitMOD( v1, v2 )
 
@@ -1968,12 +1968,12 @@ private sub hFlushBOP _
 		emitIMP( v1, v2 )
 
 	case AST_OP_ATAN2
-        emitATN2( v1, v2 )
-    case AST_OP_POW
-    	emitPOW( v1, v2 )
+		emitATN2( v1, v2 )
+	case AST_OP_POW
+		emitPOW( v1, v2 )
 	end select
 
-    '' not BOP to self?
+	'' not BOP to self?
 	if ( vr <> NULL ) then
 		'' result not equal destine? (can happen with DAG optimizations)
 		if( (v1 <> vr) ) then
@@ -1988,7 +1988,7 @@ private sub hFlushBOP _
 		end if
 	end if
 
-    ''
+	''
 	hFreeREG( v1 )
 	hFreeREG( v2 )
 	hFreeREG( vr )
@@ -2096,7 +2096,7 @@ private sub hFlushCOMP _
 		emitGE( vr, label, v1, v2 )
 	end select
 
-    ''
+	''
 	hFreeREG( v1 )
 	hFreeREG( v2 )
 	if( vr <> NULL ) then
@@ -2156,7 +2156,7 @@ private sub hFlushSTORE _
 	hLoadIDX( v1 )
 	hLoadIDX( v2 )
 
-    '' if dst is a fpoint, only load src if its a reg (x86 assumption)
+	'' if dst is a fpoint, only load src if its a reg (x86 assumption)
 	if( (v2_typ = IR_VREGTYPE_REG) or _
 		((v2_typ <> IR_VREGTYPE_IMM) and (v1_dclass = FB_DATACLASS_INTEGER)) ) then
 		'' handle longint
@@ -2171,7 +2171,7 @@ private sub hFlushSTORE _
 	''
 	emitSTORE( v1, v2 )
 
-    ''
+	''
 	hFreeREG( v1 )
 	hFreeREG( v2 )
 
@@ -2245,7 +2245,7 @@ private sub hFlushLOAD _
 			''
 			hFreeREG( vr )						'' assuming this is the last operation
 		end if
-    end select
+	end select
 
 	''
 	hFreeREG( v1 )
@@ -2272,8 +2272,8 @@ private sub hFlushCONVERT _
 	hLoadIDX( v1 )
 	hLoadIDX( v2 )
 
-    '' x86 assumption: if src is a reg and if classes are the same and
-    ''                 src won't be used (DAG?), reuse src
+	'' x86 assumption: if src is a reg and if classes are the same and
+	''                 src won't be used (DAG?), reuse src
 	reuse = FALSE
 	if( (v1_dclass = v2_dclass) and (v2_typ = IR_VREGTYPE_REG) ) then
 
@@ -2384,7 +2384,7 @@ private sub hFlushADDR _
 		emitDEREF( vr, v1 )
 	end select
 
-    ''
+	''
 	hFreeREG( v1 )
 	hFreeREG( vr )
 
@@ -2419,7 +2419,7 @@ private sub hFlushMEM _
 		emitSTKCLEAR( bytes, cint( extra ) )
 	end select
 
-    ''
+	''
 	hFreeREG( v1 )
 	hFreeREG( v2 )
 
@@ -2477,10 +2477,10 @@ private sub hFreeIDX _
 	end if
 
 	vidx = vreg->vidx
-    if( vidx <> NULL ) then
-    	if( vidx->reg <> INVALID ) then
-    		hFreeREG( vidx, force )				'' recursively
-    		vreg->vidx = NULL
+	if( vidx <> NULL ) then
+		if( vidx->reg <> INVALID ) then
+			hFreeREG( vidx, force )				'' recursively
+			vreg->vidx = NULL
 		end if
 	end if
 
@@ -2503,7 +2503,7 @@ private sub hFreeREG _
 	'' free any attached index
 	hFreeIDX( vreg, force )
 
-    ''
+	''
 	if( vreg->typ <> IR_VREGTYPE_REG ) then
 		exit sub
 	end if
@@ -2540,9 +2540,9 @@ private function _GetDistance _
 		byval vreg as IRVREG ptr _
 	) as uinteger
 
-    dim as IRVREG ptr v
-    dim as IRTAC ptr t
-    dim as integer dist
+	dim as IRVREG ptr v
+	dim as IRTAC ptr t
+	dim as integer dist
 
 	if( vreg = NULL ) then
 		return IR_MAXDIST
@@ -2589,11 +2589,11 @@ private sub _loadVR _
 			emitLOAD( @rvreg, vreg )
 		end if
 
-    	'' free any attached reg, forcing if needed
-    	hFreeIDX( vreg, TRUE )
+		'' free any attached reg, forcing if needed
+		hFreeIDX( vreg, TRUE )
 
-    	vreg->typ = IR_VREGTYPE_REG
-    end if
+		vreg->typ = IR_VREGTYPE_REG
+	end if
 
 	vreg->reg = reg
 
@@ -2669,7 +2669,7 @@ private sub _xchgTOS _
 		byval reg as integer _
 	) static
 
-    dim as IRVREG rvreg
+	dim as IRVREG rvreg
 
 	rvreg.typ 	= IR_VREGTYPE_REG
 	rvreg.dtype = FB_DATATYPE_DOUBLE

--- a/src/compiler/ir-tac.bas
+++ b/src/compiler/ir-tac.bas
@@ -12,11 +12,11 @@
 #include once "hlp.bi"
 
 type IRTAC_CTX
-	tacTB			as TFLIST
-	taccnt			as integer
-	tacidx			as IRTAC ptr
+	tacTB           as TFLIST
+	taccnt          as integer
+	tacidx          as IRTAC ptr
 
-	vregTB			as TFLIST
+	vregTB          as TFLIST
 end type
 
 declare sub hFlushUOP _
@@ -126,7 +126,7 @@ declare sub hFreeREG _
 
 declare sub hFreePreservedRegs _
 	( _
- 		_
+		_
 	)
 
 #if __FB_DEBUG__
@@ -320,7 +320,7 @@ private sub _emit _
 	t->ex1 = ex1
 	t->ex2 = ex2
 	t->ex3 = ex3
-   
+
 	ctx.taccnt += 1
 
 end sub
@@ -883,8 +883,8 @@ private function hNewVR _
 	v->sym = NULL
 	v->ofs = 0
 	v->mult = 0
-	v->vidx	= NULL
-	v->vaux	= NULL
+	v->vidx = NULL
+	v->vaux = NULL
 	v->tacvhead = NULL
 	v->tacvtail = NULL
 	v->taclast = NULL
@@ -1325,7 +1325,7 @@ private sub hReuse _
 			hRename( vr, v1 )
 
 		elseif( v2rename ) then
-		 	swap t->v1, t->v2
+			swap t->v1, t->v2
 
 			hRename( vr, v2 )
 		end if
@@ -1906,7 +1906,7 @@ private sub hFlushBOP _
 
 	'' BOP to self? (x86 assumption at AST)
 	if( vr = NULL ) then
-		if( v2_typ <> IR_VREGTYPE_IMM ) then		'' x86 assumption
+		if( v2_typ <> IR_VREGTYPE_IMM ) then        '' x86 assumption
 			'' handle longint
 			if( ISLONGINT( v2_dtype ) ) then
 				va = v2->vaux
@@ -1916,7 +1916,7 @@ private sub hFlushBOP _
 			regTB(v2_dclass)->ensure( regTB(v2_dclass), v2, NULL, typeGetSize( v2_dtype ) )
 		end if
 	else
-		if( v2_typ = IR_VREGTYPE_REG ) then			'' x86 assumption
+		if( v2_typ = IR_VREGTYPE_REG ) then         '' x86 assumption
 			'' handle longint
 			if( ISLONGINT( v2_dtype ) ) then
 				va = v2->vaux
@@ -2023,9 +2023,9 @@ private sub hFlushCOMP _
 
 	'' load source if it's a reg, or if result was not allocated
 	doload = FALSE
-	if( vr = NULL ) then							'' x86 assumption
-		if( v2_dclass = FB_DATACLASS_INTEGER ) then	'' /
-			if( v2_typ <> IR_VREGTYPE_IMM ) then	'' /
+	if( vr = NULL ) then                            '' x86 assumption
+		if( v2_dclass = FB_DATACLASS_INTEGER ) then '' /
+			if( v2_typ <> IR_VREGTYPE_IMM ) then    '' /
 				if( v1_dclass <> FB_DATACLASS_FPOINT ) then
 					doload = TRUE
 				end if
@@ -2046,9 +2046,9 @@ private sub hFlushCOMP _
 
 	'' destine allocation comes *after* source, 'cause the FPU stack
 	doload = FALSE
-	if( (vr <> NULL) and (vr = v1) ) then			'' x86 assumption
+	if( (vr <> NULL) and (vr = v1) ) then           '' x86 assumption
 		doload = TRUE
-	elseif( v1_dclass = FB_DATACLASS_FPOINT ) then	'' /
+	elseif( v1_dclass = FB_DATACLASS_FPOINT ) then  '' /
 		doload = TRUE
 	elseif( v1_typ = IR_VREGTYPE_IMM) then          '' /
 		doload = TRUE
@@ -2243,7 +2243,7 @@ private sub hFlushLOAD _
 			emitLOAD( vr, v1 )
 
 			''
-			hFreeREG( vr )						'' assuming this is the last operation
+			hFreeREG( vr )                      '' assuming this is the last operation
 		end if
 	end select
 
@@ -2313,7 +2313,7 @@ private sub hFlushCONVERT _
 		v1->typ = IR_VREGTYPE_REG
 		regTB(v1_dclass)->setOwner( regTB(v1_dclass), v1->reg, v1, NULL )
 	else
-		if( v2_typ = IR_VREGTYPE_REG ) then			'' x86 assumption
+		if( v2_typ = IR_VREGTYPE_REG ) then         '' x86 assumption
 			'' handle longint
 			if( ISLONGINT( v2_dtype ) ) then
 				va = v2->vaux
@@ -2368,7 +2368,7 @@ private sub hFlushADDR _
 	hLoadIDX( vr )
 
 	''
-	if( v1_typ = IR_VREGTYPE_REG ) then				'' x86 assumption
+	if( v1_typ = IR_VREGTYPE_REG ) then             '' x86 assumption
 		regTB(v1_dclass)->ensure( regTB(v1_dclass), v1, NULL, typeGetSize( v1_dtype ) )
 	end if
 
@@ -2479,7 +2479,7 @@ private sub hFreeIDX _
 	vidx = vreg->vidx
 	if( vidx <> NULL ) then
 		if( vidx->reg <> INVALID ) then
-			hFreeREG( vidx, force )				'' recursively
+			hFreeREG( vidx, force )             '' recursively
 			vreg->vidx = NULL
 		end if
 	end if
@@ -2581,10 +2581,10 @@ private sub _loadVR _
 		'' Don't load aux vregs now - they'll be loaded when their
 		'' parent vreg is loaded
 		if( vauxparent = NULL ) then
-			rvreg.typ 	= IR_VREGTYPE_REG
+			rvreg.typ   = IR_VREGTYPE_REG
 			rvreg.dtype = vreg->dtype
-			rvreg.reg	= reg
-			rvreg.vaux	= vreg->vaux
+			rvreg.reg   = reg
+			rvreg.vaux  = vreg->vaux
 			rvreg.regFamily = vreg->regFamily
 			emitLOAD( @rvreg, vreg )
 		end if
@@ -2671,9 +2671,9 @@ private sub _xchgTOS _
 
 	dim as IRVREG rvreg
 
-	rvreg.typ 	= IR_VREGTYPE_REG
+	rvreg.typ   = IR_VREGTYPE_REG
 	rvreg.dtype = FB_DATATYPE_DOUBLE
-	rvreg.reg	= reg
+	rvreg.reg   = reg
 
 	emitXchgTOS( @rvreg )
 


### PR DESCRIPTION
This PR is a subset of changes based off of some development I have in my local repo going back years.

It seemed like a good idea to get some of it out of the way and committed to the main fbc branch before working on some changes needed for `thiscall` calling convention needed to complete gcc 32-bit win32.

Internal changes are as follows:
* gas-x86: cosmetic changes to whitespace in emit* files
* gas-x86: cosmetic changes to whitespace in emit*.bas files
* gas-x86: update comment, I & L emitter suffixes
* gas-x86: prefer sizetypes over datatypes in emit.bas
* gas-x86: cosmetic changes to whitespace in emit.bi and edbg_stab.bas
* gas-x86: add source notes to EMIT_VTBL in src/compiler/emit_x86.bas
* gas-x86: cosmetic changes to function names in edbg_stab.bas

The changes are internal and affect gas backend emitter only.