### PR TITLE
Improve thiscall calling convention for support in 32-bit gcc win32

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ fbc: add initial support for FreeBSD on PowerPC
 - boostrap: add 'freebsd-ppc' and 'freebsd-ppc64' to bootstrap package (lenoil98)
 - fbc: add 'powerpc' and 'powerpc64' cpu families and cpu type for '-arch' command line option (lenoil98)
 - fbc: add the __FB_PPC__ intrinsic constant (lenoil98)
+- fbc: __thiscall declaration support for gcc 32-bit win32 calling g++ classes from fbc
 
 [fixed]
 - github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)

--- a/src/compiler/ast-node-call.bas
+++ b/src/compiler/ast-node-call.bas
@@ -26,10 +26,10 @@ function astNewCALL _
 		byval ptrexpr as ASTNODE ptr = NULL _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr n = any
-    dim as FBRTLCALLBACK callback = any
-    dim as integer dtype = any
-    dim as FBSYMBOL ptr subtype = any
+	dim as ASTNODE ptr n = any
+	dim as FBRTLCALLBACK callback = any
+	dim as integer dtype = any
+	dim as FBSYMBOL ptr subtype = any
 
 	'' sym might be null if user undefined a builtin rtl proc
 	'' and it was undefined.  rtlLookUpProc() a.k.a. PROCLOOKUP()
@@ -82,7 +82,7 @@ function astNewCALL _
 	n->call.args = 0
 
 	if( sym <> NULL ) then
-		n->call.currarg	= symbGetProcHeadParam( sym )
+		n->call.currarg = symbGetProcHeadParam( sym )
 		n->call.isrtl = symbGetIsRTL( sym )
 
 		callback = symbGetProcCallback( sym )
@@ -90,7 +90,7 @@ function astNewCALL _
 			callback( sym )
 		end if
 	else
-		n->call.currarg	= NULL
+		n->call.currarg = NULL
 		n->call.isrtl = FALSE
 	end if
 
@@ -129,8 +129,8 @@ end function
 
 '' Copy-back any fixed-length strings that were passed to BYREF parameters
 private sub hCopyStringsBack( byval f as ASTNODE ptr )
-    dim as ASTNODE ptr t = any
-    dim as AST_TMPSTRLIST_ITEM ptr n = any, p = any
+	dim as ASTNODE ptr t = any
+	dim as AST_TMPSTRLIST_ITEM ptr n = any, p = any
 
 	n = f->call.strtail
 	do while( n <> NULL )
@@ -291,7 +291,7 @@ function astLoadCALL( byval n as ASTNODE ptr ) as IRVREG ptr
 			vr = NULL
 		else
 
-			'' va_list 
+			'' va_list
 			if( typeGetMangleDt( astGetFullType( n ) ) = FB_DATATYPE_VA_LIST ) then
 				'' if dtype has a mangle modifier, let the emitter
 				'' handle the remapping
@@ -358,19 +358,19 @@ sub astCloneCALL _
 	)
 
 	'' copy-back list
-    scope
-    	dim as AST_TMPSTRLIST_ITEM ptr sn = any, sc = any
+	scope
+		dim as AST_TMPSTRLIST_ITEM ptr sn = any, sc = any
 
 		c->call.strtail = NULL
 		sn = n->call.strtail
 		do while( sn <> NULL )
-        	sc = listNewNode( @ast.call.tmpstrlist )
+			sc = listNewNode( @ast.call.tmpstrlist )
 
-        	sc->sym = sn->sym
-        	sc->srctree = astCloneTree( sn->srctree )
-        	sc->prev = c->call.strtail
+			sc->sym = sn->sym
+			sc->srctree = astCloneTree( sn->srctree )
+			sc->prev = c->call.strtail
 
-        	c->call.strtail = sc
+			c->call.strtail = sc
 
 			sn = sn->prev
 		loop
@@ -396,7 +396,7 @@ sub astDelCALL _
 	)
 
 	'' copy-back list
-    scope
+	scope
 	    dim as AST_TMPSTRLIST_ITEM ptr s = any, p = any
 		s = n->call.strtail
 		do while( s <> NULL )
@@ -406,8 +406,8 @@ sub astDelCALL _
 
 			listDelNode( @ast.call.tmpstrlist, s )
 			s = p
-    	loop
-    end scope
+		loop
+	end scope
 
 end sub
 

--- a/src/compiler/ast-node-call.bas
+++ b/src/compiler/ast-node-call.bas
@@ -219,7 +219,7 @@ function astLoadCALL( byval n as ASTNODE ptr ) as IRVREG ptr
 		astDelNode( l )
 
 		if( ast.doemit ) then
-			irEmitPUSHARG( arg->sym, v1, arg->arg.lgt, reclevel )
+			irEmitPUSHARG( arg->sym, v1, arg->arg.lgt, reclevel, NULL ) '' !!! thiscall needs register
 		end if
 		totalstackbytes += argbytes
 
@@ -250,7 +250,7 @@ function astLoadCALL( byval n as ASTNODE ptr ) as IRVREG ptr
 			v1 = astLoad( l )
 			'' (passing NULL param, because no PARAM symbol exists
 			'' for the hidden struct result param)
-			irEmitPUSHARG( NULL, v1, 0, reclevel )
+			irEmitPUSHARG( NULL, v1, 0, reclevel, NULL )
 		end if
 		totalstackbytes += env.pointersize
 	end if

--- a/src/compiler/ast-node-misc.bas
+++ b/src/compiler/ast-node-misc.bas
@@ -9,7 +9,6 @@
 #include once "parser.bi"
 #include once "ir.bi"
 #include once "ast.bi"
-#include once "emit.bi"
 
 '' Labels (l = NULL; r = NULL)
 function astNewLABEL _
@@ -643,7 +642,7 @@ function astLoadSTACK( byval n as ASTNODE ptr ) as IRVREG ptr
 	vr = astLoad( l )
 
 	if( ast.doemit ) then
-		irEmitSTACK( n->stack.op, vr )
+		irEmitSTACK( n->stack.op, vr, NULL )
 	end if
 
 	astDelNode( l )

--- a/src/compiler/ast-node-misc.bas
+++ b/src/compiler/ast-node-misc.bas
@@ -968,7 +968,7 @@ private function hAstNodeToStr _
 	case AST_NODECLASS_MACRO
 		return "MACRO: " & astDumpOpToStr( n->op.op ) & " " & NODE_TYPE
 
-	case AST_NODECLASS_LINK	
+	case AST_NODECLASS_LINK
 		dim s as string = ""
 
 		'' append the return side (left, right, or none)

--- a/src/compiler/edbg_stab.bas
+++ b/src/compiler/edbg_stab.bas
@@ -215,9 +215,9 @@ sub edbgEmitHeader( byval filename as zstring ptr )
 		exit sub
 	end if
 
-	ctx.typecnt 	= 1
-	ctx.label 		= NULL
-	ctx.incfile 	= NULL
+	ctx.typecnt     = 1
+	ctx.label       = NULL
+	ctx.incfile     = NULL
 
 	'' ctx.filename is never used
 	ctx.filename   = *filename

--- a/src/compiler/emit.bi
+++ b/src/compiler/emit.bi
@@ -304,6 +304,14 @@ type EMIT_VTBL
 		byval dtype as integer _
 	) as integer
 
+	getArgReg as sub _
+	( _
+		byval dtype as integer, _
+		byval dclass as integer, _
+		byval argnum as integer, _
+		byref r1 as integer _
+	)
+
 	getResultReg as sub _
 	( _
 		byval dtype as integer, _
@@ -881,6 +889,8 @@ declare sub emitFlush _
 #define emitIsRegPreserved( dclass, reg ) emit.vtbl.isRegPreserved( dclass, reg )
 
 #define emitGetFreePreservedReg( dclass, dtype ) emit.vtbl.getFreePreservedReg( dclass, dtype )
+
+#define emitGetArgReg( dclass, dtype, argnum, reg ) emit.vtbl.getArgReg( dclass, dtype, argnum, reg )
 
 #define emitGetResultReg( dtype, dclass, reg, reg2 ) emit.vtbl.getResultReg( dtype, dclass, reg, reg2 )
 

--- a/src/compiler/emit_x86.bas
+++ b/src/compiler/emit_x86.bas
@@ -6891,6 +6891,30 @@ private function _isRegPreserved _
 end function
 
 '':::::
+private sub _getArgReg _
+	( _
+		byval dtype as integer, _
+		byval dclass as integer, _
+		byval argnum as integer, _
+		byref r1 as integer _
+	)
+
+	''  x86 32bit will pass arguments in registers
+	'' thiscall ECX
+	'' fastcall ECX, EDX
+
+	select case argnum
+	case 1
+		r1 = EMIT_REG_ECX
+	case 2
+		r1 = EMIT_REG_EDX
+	case else
+		r1 = INVALID
+	end select
+
+end sub
+
+'':::::
 private sub _getResultReg _
 	( _
 		byval dtype as integer, _
@@ -7290,6 +7314,7 @@ function emitGasX86_ctor _
 		@_close, _               '' emitClose()
 		@_isRegPreserved, _      '' emitIsRegPreserved()
 		@_getFreePreservedReg, _ '' emitGetFreePreservedReg()
+		@_getArgReg,           _ '' emitGetArgReg()_
 		@_getResultReg, _        '' emitGetResultReg()
 		@_procGetFrameRegName, _ '' emitProcGetFrameRegName()
 		@_procBegin, _           '' emitProcBegin()

--- a/src/compiler/ir-private.bi
+++ b/src/compiler/ir-private.bi
@@ -32,7 +32,8 @@ declare sub irhlEmitPushArg _
 		byval param as FBSYMBOL ptr, _
 		byval vr as IRVREG ptr, _
 		byval udtlen as longint, _
-		byval level as integer _
+		byval level as integer, _
+		byval lreg as IRVREG ptr _ _
 	)
 
 declare function irhlNewVreg _

--- a/src/compiler/ir-tac.bas
+++ b/src/compiler/ir-tac.bas
@@ -571,6 +571,29 @@ private sub _emitPushArg _
 		byval lreg as IRVREG ptr _
 	)
 
+	'' passing argument in register?
+	if( lreg <> NULL ) then
+		dim as integer vr_dclass = any, vr_dtype = any, vr_typ = any
+		dim as integer reg1 = INVALID
+
+		hGetVREG( vr, vr_dtype, vr_dclass, vr_typ )
+		emitGetArgReg( vr_dclass, vr_typ, param->param.argnum, reg1 )
+
+		if( reg1 <> INVALID ) then
+			lreg->reg = reg1
+			if( irIsREG( vr ) ) then
+				lreg->dtype = vr->dtype
+			end if
+			regTB(vr_dclass)->ensure( regTB(vr_dclass), lreg, NULL, typeGetSize( vr_dtype ) )
+
+			'' Even if the argument is to be passed in register, still use the AST_OP_PUSH operation:
+			'' The proper register will get allocated when we flush the argument stack
+			_emitStack( AST_OP_PUSH, vr, lreg )
+
+			exit sub
+		end if
+	end if
+
 	if( udtlen = 0 ) then
 		_emitStack( AST_OP_PUSH, vr, NULL )
 	else

--- a/src/compiler/ir-tac.bas
+++ b/src/compiler/ir-tac.bas
@@ -567,7 +567,8 @@ private sub _emitPushArg _
 		byval param as FBSYMBOL ptr, _
 		byval vr as IRVREG ptr, _
 		byval udtlen as longint, _
-		byval level as integer _
+		byval level as integer, _
+		byval lreg as IRVREG ptr _
 	)
 
 	if( udtlen = 0 ) then

--- a/src/compiler/ir.bas
+++ b/src/compiler/ir.bas
@@ -54,7 +54,8 @@ sub irhlEmitPushArg _
 		byval param as FBSYMBOL ptr, _
 		byval vr as IRVREG ptr, _
 		byval udtlen as longint, _
-		byval level as integer _
+		byval level as integer, _
+		byval lreg as IRVREG ptr _ _
 	)
 
 	'' Remember for later, so during _emitCall[Ptr] we can emit the whole
@@ -63,6 +64,9 @@ sub irhlEmitPushArg _
 	arg->param = param
 	arg->vr = vr
 	arg->level = level
+
+	'' ignore udtlen, it's only used by ir-tac.bas:_emitPushArg()
+	'' ignore lreg, it's only used by ir-tac.bas:_emitPushArg()
 
 end sub
 

--- a/src/compiler/ir.bi
+++ b/src/compiler/ir.bi
@@ -3,10 +3,10 @@
 
 #include once "ast-op.bi"
 
-const IR_INITADDRNODES		= 2048
-const IR_INITVREGNODES		= IR_INITADDRNODES*3
+const IR_INITADDRNODES      = 2048
+const IR_INITVREGNODES      = IR_INITADDRNODES*3
 
-const IR_MAXDIST			= 2147483647
+const IR_MAXDIST            = 2147483647
 
 '' when changing, update vregDumpToStr():vregtypes()
 enum IRVREGTYPE_ENUM
@@ -25,9 +25,9 @@ enum IR_SECTION
 	IR_SECTION_BSS
 	IR_SECTION_CODE
 	IR_SECTION_DIRECTIVE
-    IR_SECTION_CONSTRUCTOR
-    IR_SECTION_DESTRUCTOR
-    IR_SECTION_INFO
+	IR_SECTION_CONSTRUCTOR
+	IR_SECTION_DESTRUCTOR
+	IR_SECTION_INFO
 end enum
 
 enum IR_REGFAMILY
@@ -36,7 +36,7 @@ enum IR_REGFAMILY
 end enum
 
 enum IR_OPTIONVALUE
-	IR_OPTIONVALUE_MAXMEMBLOCKLEN				= 1
+	IR_OPTIONVALUE_MAXMEMBLOCKLEN               = 1
 end enum
 
 
@@ -45,53 +45,53 @@ type IRVREG_ as IRVREG
 type IRTAC_ as IRTAC
 
 type IRTACVREG
-	vreg		as IRVREG_ ptr
-	parent		as IRVREG_ ptr  '' pointer to parent if idx or aux
-	next		as IRTACVREG ptr				'' next in tac (-> vr, v1 or v2)
+	vreg        as IRVREG_ ptr
+	parent      as IRVREG_ ptr  '' pointer to parent if idx or aux
+	next        as IRTACVREG ptr                '' next in tac (-> vr, v1 or v2)
 end type
 
 type IRTACVREG_GRP
-	reg			as IRTACVREG
-	idx			as IRTACVREG					'' index
-	aux			as IRTACVREG                    '' auxiliary
+	reg         as IRTACVREG
+	idx         as IRTACVREG                    '' index
+	aux         as IRTACVREG                    '' auxiliary
 end type
 
 type IRTAC
-	pos			as integer
+	pos         as integer
 
-	op			as AST_OP						'' opcode
+	op          as AST_OP                       '' opcode
 
-	vr			as IRTACVREG_GRP                '' result
-	v1			as IRTACVREG_GRP                '' operand 1
-	v2			as IRTACVREG_GRP				'' operand 2
+	vr          as IRTACVREG_GRP                '' result
+	v1          as IRTACVREG_GRP                '' operand 1
+	v2          as IRTACVREG_GRP                '' operand 2
 
-	ex1			as FBSYMBOL ptr					'' extra field, used by call/jmp
-	ex2			as integer						'' /
-	ex3			as zstring ptr					'' filename, used by DBG
+	ex1         as FBSYMBOL ptr                 '' extra field, used by call/jmp
+	ex2         as integer                      '' /
+	ex3         as zstring ptr                  '' filename, used by DBG
 end type
 
 type IRVREG
-	typ			as IRVREGTYPE_ENUM				'' VAR, IMM, IDX, etc
+	typ         as IRVREGTYPE_ENUM              '' VAR, IMM, IDX, etc
 
-	dtype		as FB_DATATYPE					'' CHAR, INTEGER, ...
-	subtype		as FBSYMBOL ptr
+	dtype       as FB_DATATYPE                  '' CHAR, INTEGER, ...
+	subtype     as FBSYMBOL ptr
 
-	reg			as integer						'' reg
-	regFamily		as IR_REGFAMILY
-	vector		as integer
+	reg         as integer                      '' reg
+	regFamily       as IR_REGFAMILY
+	vector      as integer
 
-	value		as FBVALUE						'' imm value (hi-word of longint's at vaux->value)
+	value       as FBVALUE                      '' imm value (hi-word of longint's at vaux->value)
 
-	sym			as FBSYMBOL ptr					'' symbol
-	ofs			as longint					'' +offset
-	mult		as integer						'' multipler, only valid for IDX and PTR under ir-tac
+	sym         as FBSYMBOL ptr                 '' symbol
+	ofs         as longint                  '' +offset
+	mult        as integer                      '' multipler, only valid for IDX and PTR under ir-tac
 
-	vidx		as IRVREG ptr					'' index vreg
-	vaux		as IRVREG ptr					'' aux vreg (used with longint's)
+	vidx        as IRVREG ptr                   '' index vreg
+	vaux        as IRVREG ptr                   '' aux vreg (used with longint's)
 
-	tacvhead	as IRTACVREG ptr				'' back-link to tac table
-	tacvtail	as IRTACVREG ptr				'' /
-	taclast		as IRTAC ptr					'' /
+	tacvhead    as IRTACVREG ptr                '' back-link to tac table
+	tacvtail    as IRTACVREG ptr                '' /
+	taclast     as IRTAC ptr                    '' /
 end type
 
 enum AST_ASMTOKTYPE
@@ -100,12 +100,12 @@ enum AST_ASMTOKTYPE
 end enum
 
 type ASTASMTOK
-	type		as AST_ASMTOKTYPE
+	type        as AST_ASMTOKTYPE
 	union
-		sym	as FBSYMBOL ptr
-		text	as zstring ptr
+		sym as FBSYMBOL ptr
+		text    as zstring ptr
 	end union
-	next		as ASTASMTOK ptr
+	next        as ASTASMTOK ptr
 end type
 
 '' if changed, update the _vtbl symbols at ir-*.bas::*_ctor
@@ -468,9 +468,9 @@ enum IR_OPT
 end enum
 
 type IRCTX
-	inited			as integer
-	vtbl			as IR_VTBL
-	options			as IR_OPT
+	inited          as integer
+	vtbl            as IR_VTBL
+	options         as IR_OPT
 end type
 
 ''

--- a/src/compiler/ir.bi
+++ b/src/compiler/ir.bi
@@ -203,7 +203,8 @@ type IR_VTBL
 		byval param as FBSYMBOL ptr, _
 		byval vr as IRVREG ptr, _
 		byval udtlen as longint, _
-		byval level as integer _
+		byval level as integer, _
+		byval lreg as IRVREG ptr _
 	)
 
 	emitAsmLine as sub( byval asmtokenhead as ASTASMTOK ptr )
@@ -558,7 +559,7 @@ declare sub vregDump( byval v as IRVREG ptr )
 
 #define irEmitRETURN(bytestopop) ir.vtbl.emitReturn( bytestopop )
 
-#define irEmitPUSHARG( param, vr, plen, level ) ir.vtbl.emitPushArg( param, vr, plen, level )
+#define irEmitPUSHARG( param, vr, plen, level, lreg ) ir.vtbl.emitPushArg( param, vr, plen, level, lreg )
 
 #define irEmitAsmLine( asmtokenhead ) ir.vtbl.emitAsmLine( asmtokenhead )
 

--- a/src/compiler/ir.bi
+++ b/src/compiler/ir.bi
@@ -249,7 +249,8 @@ type IR_VTBL
 	emitStack as sub _
 	( _
 		byval op as integer, _
-		byval v1 as IRVREG ptr _
+		byval v1 as IRVREG ptr, _
+		byval v2 as IRVREG ptr _
 	)
 
 	emitAddr as sub _
@@ -585,7 +586,7 @@ declare sub vregDump( byval v as IRVREG ptr )
 
 #define irEmitLOADRES(v1, vr) ir.vtbl.emitLoadRes( v1, vr )
 
-#define irEmitSTACK(op, v1) ir.vtbl.emitStack( op, v1 )
+#define irEmitSTACK(op, v1, v2) ir.vtbl.emitStack( op, v1, v2 )
 
 #define irEmitPUSH(v1) ir.vtbl.emitStack( AST_OP_PUSH, v1 )
 

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -10,19 +10,19 @@
 #include once "ir.bi"
 
 type FB_MANGLEABBR
-	idx				as integer
-	dtype			as integer
-	subtype			as FBSYMBOL ptr
+	idx             as integer
+	dtype           as integer
+	subtype         as FBSYMBOL ptr
 end type
 
 type FB_MANGLECTX
-	flist			as TFLIST					'' of FB_MANGLEABBR
-	cnt				as integer
+	flist               as TFLIST                   '' of FB_MANGLEABBR
+	cnt                 as integer
 
-	tempstr			as zstring * 6 + 10 + 1
-	uniqueidcount		as integer
-	uniquelabelcount	as integer
-	profilelabelcount	as integer
+	tempstr             as zstring * 6 + 10 + 1
+	uniqueidcount       as integer
+	uniquelabelcount    as integer
+	profilelabelcount   as integer
 end type
 
 const FB_INITMANGARGS = 96
@@ -101,7 +101,7 @@ function symbMakeProfileLabelName( ) as zstring ptr
 end function
 
 function symbGetDBGName( byval sym as FBSYMBOL ptr ) as zstring ptr
-    '' GDB will demangle the symbols automatically
+	'' GDB will demangle the symbols automatically
 	if( hDoCppMangling( sym ) ) then
 		select case as const symbGetClass( sym )
 		'' but UDT's, they shouldn't include any mangling at all..
@@ -277,15 +277,15 @@ private function hAbbrevAdd _
 
 	dim as FB_MANGLEABBR ptr n = any
 
-    n = flistNewItem( @ctx.flist )
-    n->idx = ctx.cnt
+	n = flistNewItem( @ctx.flist )
+	n->idx = ctx.cnt
 
-    n->dtype = dtype
-    n->subtype = subtype
+	n->dtype = dtype
+	n->subtype = subtype
 
-    ctx.cnt += 1
+	ctx.cnt += 1
 
-    function = n
+	function = n
 end function
 
 private sub hAbbrevGet( byref mangled as string, byval idx as integer )
@@ -667,7 +667,7 @@ private function hDoCppMangling( byval sym as FBSYMBOL ptr ) as integer
 	if( sym->class = FB_SYMBCLASS_PROC ) then
 		'' overloaded? (this will handle operators too)
 		if( symbIsOverloaded( sym ) ) then
-    		return TRUE
+			return TRUE
 		end if
 	end if
 
@@ -1249,7 +1249,7 @@ private sub hMangleProc( byval sym as FBSYMBOL ptr )
 		'' not just the ones with @N suffix due the leading underscore handling
 		select case( env.clopt.target )
 		case FB_COMPTARGET_WIN32, FB_COMPTARGET_CYGWIN, FB_COMPTARGET_XBOX
-			if(	quote_mangled_name = false ) then
+			if( quote_mangled_name = false ) then
 				mangled += """"
 				quote_mangled_name = true
 			end if
@@ -1257,7 +1257,7 @@ private sub hMangleProc( byval sym as FBSYMBOL ptr )
 			'' chr(1) will escape the name so it's passed through to assembler as-is
 			mangled += chr(1)
 		end select
-		
+
 	end if
 
 	'' Win32 underscore prefix

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -1218,7 +1218,7 @@ private sub hMangleProc( byval sym as FBSYMBOL ptr )
 	docpp = hDoCppMangling( sym )
 
 	'' Should the @N win32 stdcall suffix be added for this procedure?
-	'' * only for stdcall, not stdcallms/cdecl/pascal
+	'' * only for stdcall, not stdcallms/cdecl/pascal/thiscall
 	''   (that also makes it win32-only)
 	'' * only on x86, since these calling conventions matter there only
 	'' * only for ASM/LLVM backends, but not for the C backend, because gcc

--- a/src/compiler/symb-proc.bas
+++ b/src/compiler/symb-proc.bas
@@ -162,7 +162,7 @@ function symbProcCalcBytesToPop( byval proc as FBSYMBOL ptr ) as longint
 	dim as longint bytestopop = 0
 	var notcdecl = (symbGetProcMode( proc ) <> FB_FUNCMODE_CDECL) and (symbGetProcMode( proc ) <> FB_FUNCMODE_THISCALL)
 
-	'' Need to pop parameters in case of stdcall/pascal, but not for cdecl
+	'' Need to pop parameters in case of stdcall/pascal/thiscall, but not for cdecl
 	if( notcdecl ) then
 		var param = symbGetProcHeadParam( proc )
 		while( param )
@@ -216,6 +216,12 @@ function symbAddProcParam _
 	proc->proc.params += 1
 
 	param->lgt = symbCalcParamLen( dtype, subtype, mode )
+
+	'' Store the argument number in the param symbol.  We could calculate it later
+	'' but it will remain constant throughout the lifetime of the parameter so
+	'' it is very convenient to cache it now
+	param->param.argnum = proc->proc.params
+
 	param->param.mode = mode
 	param->param.optexpr = NULL
 	param->param.bydescdimensions = dimensions

--- a/src/compiler/symb-proc.bas
+++ b/src/compiler/symb-proc.bas
@@ -1,7 +1,7 @@
 '' symbol table module for procedures
 ''
 '' chng: sep/2004 written [v1ctor]
-''		 jan/2005 updated to use real linked-lists [v1ctor]
+''       jan/2005 updated to use real linked-lists [v1ctor]
 
 
 #include once "fb.bi"
@@ -240,7 +240,7 @@ function symbAddProcParam _
 		end if
 	end if
 
-    function = param
+	function = param
 end function
 
 sub symbMakeParamOptional _
@@ -857,7 +857,7 @@ add_proc:
 	end if
 
 	''
-	proc->proc.mode	= mode
+	proc->proc.mode = mode
 
 	'' last compound was an EXTERN?
 	if( fbGetCompStmtId( ) = FB_TK_EXTERN ) then
@@ -1223,7 +1223,7 @@ function symbAddProcPtrFromFunction _
 
 	'' attribs to copy from the proc to the procptr
 	'' (anything needed for procptr call checking)
-	
+
 	var attribmask = FB_SYMBATTRIB_CONST '' THIS CONSTness, needed for symbCalcProcMatch() type checking
 
 	var pattribmask = FB_PROCATTRIB_RETURNBYREF '' return byref
@@ -1692,8 +1692,8 @@ private function hCalcTypesDiff _
 		byval param_ptrcnt as integer, _
 		byval arg_dtype_in as integer, _
 		byval arg_subtype as FBSYMBOL ptr, _
-	  	byval arg_expr as ASTNODE ptr, _
-	  	byval mode as FB_PARAMMODE = 0 _
+		byval arg_expr as ASTNODE ptr, _
+		byval mode as FB_PARAMMODE = 0 _
 	) as FB_OVLPROC_MATCH_SCORE
 
 	dim as integer arg_dclass = any, param_dt = any, arg_dt = any
@@ -1711,8 +1711,8 @@ private function hCalcTypesDiff _
 	'' STRING MATCHING
 	'' (F=FB_OVLPROC_FULLMATCH, H=FB_OVLPROC_HALFMATCH)
 	''
-	'' from / to -> string      zstring     zstring ptr wstring     wstring ptr  
-	'' ------------ ----------- ----------- ----------- ----------- -----------  	          
+	'' from / to -> string      zstring     zstring ptr wstring     wstring ptr
+	'' ------------ ----------- ----------- ----------- ----------- -----------
 	'' string       F-0         F-1         F-2         H-3         H-4
 	'' zstring      F-2         F-0         F-1         H-3         H-4
 	'' zstring ptr  F-2         F-1         F-0         H-3         H-4
@@ -1765,7 +1765,7 @@ private function hCalcTypesDiff _
 					'' zstring => zstring ptr
 					return FB_OVLPROC_FULLMATCH - OvlMatchScore( 0, 1 )
 				case FB_DATATYPE_WCHAR
-					'' wstring => zstring ptr 
+					'' wstring => zstring ptr
 					return FB_OVLPROC_HALFMATCH - OvlMatchScore( 0, 4 )
 				end select
 			case typeAddrOf( FB_DATATYPE_WCHAR )
@@ -1925,7 +1925,7 @@ private function hCheckOvlParam _
 	( _
 		byval parent as FBSYMBOL ptr, _
 		byval param as FBSYMBOL ptr, _
-	  	byval arg_expr as ASTNODE ptr, _
+		byval arg_expr as ASTNODE ptr, _
 		byval arg_mode as integer _
 	) as FB_OVLPROC_MATCH_SCORE
 
@@ -1964,7 +1964,7 @@ private function hCheckOvlParam _
 		if( match < FB_OVLPROC_TYPEMATCH ) then
 			return FB_OVLPROC_NO_MATCH
 		end if
-	
+
 		assert( astIsVAR( arg_expr ) or astIsFIELD( arg_expr ) )
 		array = arg_expr->sym
 		assert( symbIsArray( array ) )
@@ -2243,21 +2243,21 @@ function symbFindBopOvlProc _
 	dim as FB_CALL_ARG arg1 = any, arg2 = any
 	dim as FBSYMBOL ptr proc = any
 
-   	*err_num = FB_ERRMSG_OK
+	*err_num = FB_ERRMSG_OK
 
 	'' at least one must be an UDT
-   	select case astGetDataType( l )
-   	case FB_DATATYPE_STRUCT, FB_DATATYPE_ENUM
+	select case astGetDataType( l )
+	case FB_DATATYPE_STRUCT, FB_DATATYPE_ENUM
 
-   	case else
-   		'' try the 2nd one..
-   		select case astGetDataType( r )
-   		case FB_DATATYPE_STRUCT, FB_DATATYPE_ENUM
+	case else
+		'' try the 2nd one..
+		select case astGetDataType( r )
+		case FB_DATATYPE_STRUCT, FB_DATATYPE_ENUM
 
-   		case else
-   			return NULL
-   		end select
-   	end select
+		case else
+			return NULL
+		end select
+	end select
 
 	'' try (l, r)
 	arg1.expr = l
@@ -2292,28 +2292,28 @@ function symbFindSelfBopOvlProc _
 	dim as FB_CALL_ARG arg1 = any
 	dim as FBSYMBOL ptr proc = any, head_proc = any
 
-   	*err_num = FB_ERRMSG_OK
+	*err_num = FB_ERRMSG_OK
 
 	'' lhs must be an UDT
-   	select case astGetDataType( l )
-   	case FB_DATATYPE_STRUCT
-   		dim as FBSYMBOL ptr subtype = astGetSubType( l )
+	select case astGetDataType( l )
+	case FB_DATATYPE_STRUCT
+		dim as FBSYMBOL ptr subtype = astGetSubType( l )
 
-   		if( subtype->udt.ext = NULL ) then
+		if( subtype->udt.ext = NULL ) then
 			return NULL
 		end if
 
-   		head_proc = symbGetUDTOpOvlTb( subtype )(op - AST_OP_SELFBASE)
+		head_proc = symbGetUDTOpOvlTb( subtype )(op - AST_OP_SELFBASE)
 
-   	'case FB_DATATYPE_CLASS
+	'case FB_DATATYPE_CLASS
 
-   	case else
-   		return NULL
-   	end select
+	case else
+		return NULL
+	end select
 
-   	if( head_proc = NULL ) then
-   		return NULL
-   	end if
+	if( head_proc = NULL ) then
+		return NULL
+	end if
 
 	'' try (l, r) -- don't pass the instance ptr
 	arg1.expr = r
@@ -2352,16 +2352,16 @@ function symbFindUopOvlProc _
 	dim as FB_CALL_ARG arg1 = any
 	dim as FBSYMBOL ptr proc = any
 
-   	*err_num = FB_ERRMSG_OK
+	*err_num = FB_ERRMSG_OK
 
 	'' arg must be an UDT
-   	select case astGetDataType( l )
-   	case FB_DATATYPE_STRUCT, FB_DATATYPE_ENUM
+	select case astGetDataType( l )
+	case FB_DATATYPE_STRUCT, FB_DATATYPE_ENUM
 
-   	case else
-   		'' note: the CAST op shouldn't be passed to this function
-   		return NULL
-   	end select
+	case else
+		'' note: the CAST op shouldn't be passed to this function
+		return NULL
+	end select
 
 	arg1.expr = l
 	arg1.mode = INVALID
@@ -2389,28 +2389,28 @@ function symbFindSelfUopOvlProc _
 
 	dim as FBSYMBOL ptr proc = any, head_proc = any
 
-   	*err_num = FB_ERRMSG_OK
+	*err_num = FB_ERRMSG_OK
 
 	'' lhs must be an UDT
-   	select case astGetDataType( l )
-   	case FB_DATATYPE_STRUCT
-   		dim as FBSYMBOL ptr subtype = astGetSubType( l )
+	select case astGetDataType( l )
+	case FB_DATATYPE_STRUCT
+		dim as FBSYMBOL ptr subtype = astGetSubType( l )
 
-   		if( subtype->udt.ext = NULL ) then
+		if( subtype->udt.ext = NULL ) then
 			return NULL
 		end if
 
-   		head_proc = symbGetUDTOpOvlTb( subtype )(op - AST_OP_SELFBASE)
+		head_proc = symbGetUDTOpOvlTb( subtype )(op - AST_OP_SELFBASE)
 
-   	'case FB_DATATYPE_CLASS
+	'case FB_DATATYPE_CLASS
 
-   	case else
-   		return NULL
-   	end select
+	case else
+		return NULL
+	end select
 
-   	if( head_proc = NULL ) then
-   		return NULL
-   	end if
+	if( head_proc = NULL ) then
+		return NULL
+	end if
 
 	'' try (l) -- don't pass the instance ptr
 
@@ -2453,7 +2453,7 @@ private function hCheckCastOvl _
 
 	'' same types?
 	if( typeGetDtAndPtrOnly( proc_dtype ) = typeGetDtAndPtrOnly( to_dtype ) ) then
-		
+
 		'' same subtype?
 		if( proc_subtype = to_subtype ) then
 
@@ -2512,29 +2512,29 @@ function symbFindCastOvlProc _
 
 	dim as FBSYMBOL ptr proc_head = any
 
-   	*err_num = FB_ERRMSG_OK
+	*err_num = FB_ERRMSG_OK
 
 	'' arg must be an UDT
-   	select case astGetDataType( l )
-   	case FB_DATATYPE_STRUCT
-   		dim as FBSYMBOL ptr subtype = astGetSubType( l )
-   		if( subtype = NULL ) then
-   			return NULL
-   		end if
-
-   		if( subtype->udt.ext = NULL ) then
+	select case astGetDataType( l )
+	case FB_DATATYPE_STRUCT
+		dim as FBSYMBOL ptr subtype = astGetSubType( l )
+		if( subtype = NULL ) then
 			return NULL
 		end if
 
-   		proc_head = symbGetUDTOpOvlTb( subtype )(AST_OP_CAST - AST_OP_SELFBASE)
+		if( subtype->udt.ext = NULL ) then
+			return NULL
+		end if
 
-   	case else
-   		return NULL
-   	end select
+		proc_head = symbGetUDTOpOvlTb( subtype )(AST_OP_CAST - AST_OP_SELFBASE)
 
-   	if( proc_head = NULL ) then
-   		return NULL
-   	end if
+	case else
+		return NULL
+	end select
+
+	if( proc_head = NULL ) then
+		return NULL
+	end if
 
 	dim as FBSYMBOL ptr p = any, proc = any, closest_proc = any
 	dim as FB_OVLPROC_MATCH_SCORE matchscore = any, max_matchscore = any
@@ -2552,8 +2552,8 @@ function symbFindCastOvlProc _
 
 			matchscore = hCheckCastOvl( proc, to_dtype, to_subtype, is_explicit )
 			if( matchscore > max_matchscore ) then
-		   		closest_proc = proc
-		   		max_matchscore = matchscore
+				closest_proc = proc
+				max_matchscore = matchscore
 				matchcount = 1
 
 			'' same? ambiguity..
@@ -2578,8 +2578,8 @@ function symbFindCastOvlProc _
 				if( symbGetType( proc ) <= FB_DATATYPE_DOUBLE ) then
 					'' more precise than the last?
 					if( symbGetType( proc ) > to_dtype ) then
-		   				closest_proc = proc
-		   				to_dtype = symbGetType( proc )
+						closest_proc = proc
+						to_dtype = symbGetType( proc )
 					end if
 				end if
 			end if
@@ -2620,17 +2620,20 @@ function symbFindCtorOvlProc _
 		byval err_num as FB_ERRMSG ptr _
 	) as FBSYMBOL ptr
 
- 	dim as FB_CALL_ARG arg1 = any
+	dim as FB_CALL_ARG arg1 = any
 
- 	'' don't pass the instance ptr
- 	arg1.expr = expr
- 	arg1.mode = arg_mode
- 	arg1.next = NULL
+	'' don't pass the instance ptr
+	arg1.expr = expr
+	arg1.mode = arg_mode
+	arg1.next = NULL
 
- 	function = symbFindClosestOvlProc( symbGetCompCtorHead( sym ), _
- 								   	   1, _
- 								   	   @arg1, _
- 								   	   err_num )
+	function = symbFindClosestOvlProc _
+		( _
+			symbGetCompCtorHead( sym ), _
+			1, _
+			@arg1, _
+			err_num _
+		)
 
 end function
 
@@ -3104,7 +3107,7 @@ function symbGetFullProcName( byval proc as FBSYMBOL ptr ) as zstring ptr
 	loop
 
 	if( symbIsConstructor( proc ) ) then
-	 	res += "constructor"
+		res += "constructor"
 	elseif( symbIsDestructor1( proc ) ) then
 		res += "destructor"
 	elseif( symbIsDestructor0( proc ) ) then

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -55,19 +55,19 @@ end enum
 
 const FB_DATATYPES = (FB_DATATYPE_XMMWORD - FB_DATATYPE_VOID) + 1
 
-const FB_DT_TYPEMASK 		= &b00000000000000000000000000011111 '' max 32 built-in dts
-const FB_DT_PTRMASK  		= &b00000000000000000000000111100000 '' level of pointer indirection
-const FB_DT_CONSTMASK		= &b00000000000000111111111000000000 '' PTRLEVELS + 1 bit-masks
-const FB_DATATYPE_REFERENCE	= &b00000000000010000000000000000000 '' used for mangling BYREF parameters
-const FB_DT_MANGLEMASK		= &b00000001111100000000000000000000 '' used to modify mangling for builtin types
-const FB_DATATYPE_INVALID	= &b10000000000000000000000000000000
+const FB_DT_TYPEMASK        = &b00000000000000000000000000011111 '' max 32 built-in dts
+const FB_DT_PTRMASK         = &b00000000000000000000000111100000 '' level of pointer indirection
+const FB_DT_CONSTMASK       = &b00000000000000111111111000000000 '' PTRLEVELS + 1 bit-masks
+const FB_DATATYPE_REFERENCE = &b00000000000010000000000000000000 '' used for mangling BYREF parameters
+const FB_DT_MANGLEMASK      = &b00000001111100000000000000000000 '' used to modify mangling for builtin types
+const FB_DATATYPE_INVALID   = &b10000000000000000000000000000000
 
-const FB_DT_PTRLEVELS		= 8					'' max levels of pointer indirection
+const FB_DT_PTRLEVELS       = 8                 '' max levels of pointer indirection
 
-const FB_DT_PTRPOS			= 5
-const FB_DT_CONSTPOS		= FB_DT_PTRPOS + 4
+const FB_DT_PTRPOS          = 5
+const FB_DT_CONSTPOS        = FB_DT_PTRPOS + 4
 
-const FB_DT_MANGLEPOS		= 20
+const FB_DT_MANGLEPOS       = 20
 
 const FB_OVLPROC_MINORSCALE = 10
 
@@ -100,7 +100,7 @@ end enum
 '' symbol classes
 '' When changing, update symb.bas:classnames() and symb.bas:classnamesPretty()
 enum FB_SYMBCLASS
-	FB_SYMBCLASS_VAR			= 1
+	FB_SYMBCLASS_VAR            = 1
 	FB_SYMBCLASS_CONST
 	FB_SYMBCLASS_PROC
 	FB_SYMBCLASS_PARAM
@@ -113,9 +113,9 @@ enum FB_SYMBCLASS
 	FB_SYMBCLASS_CLASS
 	FB_SYMBCLASS_FIELD
 	FB_SYMBCLASS_TYPEDEF
-	FB_SYMBCLASS_FWDREF							'' forward definition
+	FB_SYMBCLASS_FWDREF                         '' forward definition
 	FB_SYMBCLASS_SCOPE
-	FB_SYMBCLASS_NSIMPORT						'' namespace import (an USING)
+	FB_SYMBCLASS_NSIMPORT                       '' namespace import (an USING)
 end enum
 
 '' symbol state mask
@@ -163,7 +163,7 @@ end enum
 
 '' symbol attributes mask
 enum FB_SYMBATTRIB
-	FB_SYMBATTRIB_NONE			   = &h00000000
+	FB_SYMBATTRIB_NONE             = &h00000000
 
 	FB_SYMBATTRIB_SHARED           = &h00000001  '' all symbols
 	FB_SYMBATTRIB_STATIC           = &h00000002  '' all symbols
@@ -311,13 +311,13 @@ type EMIT_NODE_ as EMIT_NODE
 
 ''
 type FBSYMLIST
-	head			as FBSYMBOL_ ptr
-	tail			as FBSYMBOL_ ptr
+	head            as FBSYMBOL_ ptr
+	tail            as FBSYMBOL_ ptr
 end type
 
 type FBARRAYDIM
-	lower			as longint
-	upper			as longint
+	lower           as longint
+	upper           as longint
 end type
 
 '' Special value to represent the case where '...' ellipsis was given as ubound
@@ -325,71 +325,71 @@ const FB_ARRAYDIM_UNKNOWN = &h8000000000000000ll
 
 ''
 type FBSYMCHAIN
-	sym				as FBSYMBOL_ ptr			'' first symbol
-	next			as FBSYMCHAIN ptr
-	isimport		as integer
+	sym             as FBSYMBOL_ ptr            '' first symbol
+	next            as FBSYMCHAIN ptr
+	isimport        as integer
 
 	'' all fields below are only set when importing (with USING) a ns
-	prev			as FBSYMCHAIN ptr
-	item			as HASHITEM ptr
-	imp_next		as FBSYMCHAIN ptr
+	prev            as FBSYMCHAIN ptr
+	item            as HASHITEM ptr
+	imp_next        as FBSYMCHAIN ptr
 end type
 
 ''
 type FBHASHTB
-	owner			as FBSYMBOL_ ptr            '' back link
-	tb				as THASH
-	prev			as FBHASHTB ptr				'' prev node in the current hash tbs lookup list
-	next			as FBHASHTB ptr				'' next  //
+	owner           as FBSYMBOL_ ptr            '' back link
+	tb              as THASH
+	prev            as FBHASHTB ptr             '' prev node in the current hash tbs lookup list
+	next            as FBHASHTB ptr             '' next  //
 end type
 
 type FBSYMHASH
-	tb				as FBHASHTB ptr             '' parent's hash tb
-	item			as HASHITEM ptr				'' hash item, for fast deletion
-	index			as uinteger					'' ditto
-	prev			as FBSYMBOL_ ptr			'' prev duplicated symbol
-	next			as FBSYMBOL_ ptr			'' next //
+	tb              as FBHASHTB ptr             '' parent's hash tb
+	item            as HASHITEM ptr             '' hash item, for fast deletion
+	index           as uinteger                 '' ditto
+	prev            as FBSYMBOL_ ptr            '' prev duplicated symbol
+	next            as FBSYMBOL_ ptr            '' next //
 end type
 
 ''
 type FBSYMBOLTB
-	owner			as FBSYMBOL_ ptr			'' back link
-	head			as FBSYMBOL_ ptr			'' first node
-	tail			as FBSYMBOL_ ptr			'' last node
+	owner           as FBSYMBOL_ ptr            '' back link
+	head            as FBSYMBOL_ ptr            '' first node
+	tail            as FBSYMBOL_ ptr            '' last node
 end type
 
 ''
 type FBNAMESPC_EXT
-	implist			as FBSYMLIST  				'' all namespaces imported by this ns
-	explist			as FBSYMLIST  				'' all namespaces importing this ns
-	cnt				as integer					'' times this ns was imported/nested
-	impsym_head		as FBSYMCHAIN ptr			'' imported symbols by the last USING
-	impsym_tail		as FBSYMCHAIN ptr			'' /
+	implist         as FBSYMLIST                '' all namespaces imported by this ns
+	explist         as FBSYMLIST                '' all namespaces importing this ns
+	cnt             as integer                  '' times this ns was imported/nested
+	impsym_head     as FBSYMCHAIN ptr           '' imported symbols by the last USING
+	impsym_tail     as FBSYMCHAIN ptr           '' /
 end type
 
 type FBNAMESPC
-	symtb			as FBSYMBOLTB
-	hashtb			as FBHASHTB
-	ext				as FBNAMESPC_EXT ptr
+	symtb           as FBSYMBOLTB
+	hashtb          as FBHASHTB
+	ext             as FBNAMESPC_EXT ptr
 end type
 
 union FBVALUE
-	s			as FBSYMBOL_ ptr
-	i			as longint
-	f			as double
+	s           as FBSYMBOL_ ptr
+	i           as longint
+	f           as double
 end union
 
 '' keyword
 type FBS_KEYWORD
-	id				as integer
-	tkclass			as FB_TKCLASS
+	id              as integer
+	tkclass         as FB_TKCLASS
 end type
 
 '' define or macro
 type FB_DEFPARAM
-	name			as zstring ptr
-	num				as integer
-	next			as FB_DEFPARAM ptr
+	name            as zstring ptr
+	num             as integer
+	next            as FB_DEFPARAM ptr
 end type
 
 enum FB_DEFTOK_TYPE
@@ -400,16 +400,16 @@ enum FB_DEFTOK_TYPE
 end enum
 
 type FB_DEFTOK
-	type			as FB_DEFTOK_TYPE
+	type            as FB_DEFTOK_TYPE
 
 	union
-		text		as zstring ptr
-		textw		as wstring ptr
-		paramnum	as integer
+		text        as zstring ptr
+		textw       as wstring ptr
+		paramnum    as integer
 	end union
 
-	prev			as FB_DEFTOK ptr
-	next			as FB_DEFTOK ptr
+	prev            as FB_DEFTOK ptr
+	next            as FB_DEFTOK ptr
 end type
 
 enum FB_DEFINE_FLAGS
@@ -427,59 +427,59 @@ type FBS_MACRO_PROCZ as function( byval argtb as LEXPP_ARGTB_, byval errnum as i
 type FBS_MACRO_PROCW as function( byval argtb as LEXPP_ARGTB_, byval errnum as integer ptr ) as wstring ptr
 
 type FBS_DEFINE
-	params			as integer
-	paramhead 		as FB_DEFPARAM ptr
+	params          as integer
+	paramhead       as FB_DEFPARAM ptr
 
 	union
-		tokhead		as FB_DEFTOK ptr			'' only if args > 0
-		text		as zstring ptr				'' //           = 0
-		textw		as wstring ptr
+		tokhead     as FB_DEFTOK ptr            '' only if args > 0
+		text        as zstring ptr              '' //           = 0
+		textw       as wstring ptr
 	end union
 
-	isargless		as integer
-	flags           as FB_DEFINE_FLAGS			'' bit 0: 1=numeric, 0=string
+	isargless       as integer
+	flags           as FB_DEFINE_FLAGS          '' bit 0: 1=numeric, 0=string
 	union
-		dprocz			as FBS_DEFINE_PROCZ
-		mprocz			as FBS_MACRO_PROCZ
+		dprocz          as FBS_DEFINE_PROCZ
+		mprocz          as FBS_MACRO_PROCZ
 	end union
 	union
-		mprocw			as FBS_MACRO_PROCW
+		mprocw          as FBS_MACRO_PROCW
 	end union
 end type
 
 '' forward definition
 type FBFWDREF
-	ref				as FBSYMBOL_ ptr    '' The user that has to be backpatched
-	prev			as FBFWDREF ptr
+	ref             as FBSYMBOL_ ptr    '' The user that has to be backpatched
+	prev            as FBFWDREF ptr
 end type
 
 type FBS_FWDREF
-	tail			as FBFWDREF ptr     '' List of users of this fwdref
+	tail            as FBFWDREF ptr     '' List of users of this fwdref
 end type
 
 '' label
 type FBS_LABEL
-	parent			as FBSYMBOL_ ptr			'' parent block, not always a proc
-	declared		as integer
-	stmtnum			as integer					'' can't use colnum as it's unreliable
+	parent          as FBSYMBOL_ ptr            '' parent block, not always a proc
+	declared        as integer
+	stmtnum         as integer                  '' can't use colnum as it's unreliable
 
 	gosub           as boolean                  '' if label is used for gosub with gas64
 end type
 
 '' structure
 enum FB_UDTOPT
-	FB_UDTOPT_ISUNION			= &h0001
-	FB_UDTOPT_ISANON			= &h0002
-	FB_UDTOPT_HASPTRFIELD		= &h0004
-	FB_UDTOPT_HASCTORFIELD		= &h0008
-	FB_UDTOPT_HASDTORFIELD		= &h0010
+	FB_UDTOPT_ISUNION           = &h0001
+	FB_UDTOPT_ISANON            = &h0002
+	FB_UDTOPT_HASPTRFIELD       = &h0004
+	FB_UDTOPT_HASCTORFIELD      = &h0008
+	FB_UDTOPT_HASDTORFIELD      = &h0010
 	FB_UDTOPT_HASRECBYVALPARAM  = &h0020
-	FB_UDTOPT_HASRECBYVALRES 	= &h0040
-	FB_UDTOPT_HASGETPROPERTY	= &h0080
-	FB_UDTOPT_HASSETPROPERTY	= &h0100
-	FB_UDTOPT_HASIDXGETPROPERTY	= &h0200
-	FB_UDTOPT_HASIDXSETPROPERTY	= &h0400
-	FB_UDTOPT_HASKWDFIELD		= &h0800
+	FB_UDTOPT_HASRECBYVALRES    = &h0040
+	FB_UDTOPT_HASGETPROPERTY    = &h0080
+	FB_UDTOPT_HASSETPROPERTY    = &h0100
+	FB_UDTOPT_HASIDXGETPROPERTY = &h0200
+	FB_UDTOPT_HASIDXSETPROPERTY = &h0400
+	FB_UDTOPT_HASKWDFIELD       = &h0800
 	FB_UDTOPT_HASINITEDFIELD        = &h1000
 	FB_UDTOPT_HASANONUNION          = &h2000
 	FB_UDTOPT_HASSTATICVAR          = &h4000
@@ -490,7 +490,7 @@ enum FB_UDTOPT
 end enum
 
 type FB_STRUCT_DBG
-	typenum			as integer
+	typenum         as integer
 end type
 
 type FB_STRUCTEXT
@@ -511,113 +511,113 @@ end type
 
 type FBS_STRUCT
 	'' extends FBNAMESCP
-	ns 				as FBNAMESPC
-	
-	base			as FBSYMBOL_ ptr			'' base class
-	anonparent		as FBSYMBOL_ ptr
-	natalign		as integer					'' UDT's natural alignment based on largest natural field alignment
-	unpadlgt		as longint					'' unpadded len
-	options			as long						'' FB_UDTOPT
-	bitpos			as ubyte
-	align			as ubyte
+	ns              as FBNAMESPC
+
+	base            as FBSYMBOL_ ptr            '' base class
+	anonparent      as FBSYMBOL_ ptr
+	natalign        as integer                  '' UDT's natural alignment based on largest natural field alignment
+	unpadlgt        as longint                  '' unpadded len
+	options         as long                     '' FB_UDTOPT
+	bitpos          as ubyte
+	align           as ubyte
 
 	'' real type used to return this UDT from functions
-	retdtype		as FB_DATATYPE
+	retdtype        as FB_DATATYPE
 	retin2regs      as FB_STRUCT_INREG ''for gas64
-	dbg				as FB_STRUCT_DBG
-	ext				as FB_STRUCTEXT ptr
+	dbg             as FB_STRUCT_DBG
+	ext             as FB_STRUCTEXT ptr
 end type
 
 '' enumeration
 type FBS_ENUM
 	'' extends FBNAMESPC
-	ns				as FBNAMESPC
+	ns              as FBNAMESPC
 
-	elements		as integer
-	dbg				as FB_STRUCT_DBG
+	elements        as integer
+	dbg             as FB_STRUCT_DBG
 end type
 
-type FB_CALL_ARG								'' used by overloaded function calls
-	expr			as ASTNODE_ ptr
-	mode			as FB_PARAMMODE
-	next			as FB_CALL_ARG ptr
+type FB_CALL_ARG                                '' used by overloaded function calls
+	expr            as ASTNODE_ ptr
+	mode            as FB_PARAMMODE
+	next            as FB_CALL_ARG ptr
 end type
 
 type FB_CALL_ARG_LIST
-	args			as integer
-	head			as FB_CALL_ARG ptr
-	tail			as FB_CALL_ARG ptr
+	args            as integer
+	head            as FB_CALL_ARG ptr
+	tail            as FB_CALL_ARG ptr
 end type
 
 '' function param
 type FBS_PARAM
-	mode			as FB_PARAMMODE
-	var				as FBSYMBOL_ ptr			'' link to decl var in func bodies
-	optexpr			as ASTNODE_ ptr				'' default value
-	bydescdimensions	as integer
-	bydescrealsubtype	as FBSYMBOL_ ptr        '' bydesc array descriptor type
-	argnum			as integer                  '' argument number (1 is first)
+	mode            as FB_PARAMMODE
+	var             as FBSYMBOL_ ptr            '' link to decl var in func bodies
+	optexpr         as ASTNODE_ ptr             '' default value
+	bydescdimensions    as integer
+	bydescrealsubtype   as FBSYMBOL_ ptr        '' bydesc array descriptor type
+	argnum          as integer                  '' argument number (1 is first)
 end type
 
 '' function
 type FBRTLCALLBACK as function( byval sym as FBSYMBOL_ ptr ) as integer
 
 type FB_PROCOVL
-	minparams		as short
-	maxparams		as short
-	next			as FBSYMBOL_ ptr
+	minparams       as short
+	maxparams       as short
+	next            as FBSYMBOL_ ptr
 end type
 
 '' used by x86 ASM emitter only
 type FB_PROCSTK
-	argofs			as integer
-	localofs		as integer
-	localmax		as integer
+	argofs          as integer
+	localofs        as integer
+	localmax        as integer
 end type
 
 type FB_PROCDBG
-	iniline			as integer					'' sub|function
-	endline			as integer					'' end sub|function
-	incfile			as zstring ptr
+	iniline         as integer                  '' sub|function
+	endline         as integer                  '' end sub|function
+	incfile         as zstring ptr
 end type
 
 type FB_PROCERR
-	lasthnd			as FBSYMBOL_ ptr			'' last error handler
-	lastmod			as FBSYMBOL_ ptr			'' last module name
-	lastfun			as FBSYMBOL_ ptr			'' last function name
+	lasthnd         as FBSYMBOL_ ptr            '' last error handler
+	lastmod         as FBSYMBOL_ ptr            '' last module name
+	lastfun         as FBSYMBOL_ ptr            '' last function name
 end type
 
 type FB_PROCOPOVL
-	op				as AST_OP
+	op              as AST_OP
 end type
 
 type FB_DTORWRAPPER
-	proc			as FBSYMBOL_ ptr
-	sym				as FBSYMBOL_ ptr			'' for symbol
+	proc            as FBSYMBOL_ ptr
+	sym             as FBSYMBOL_ ptr            '' for symbol
 end type
 
 enum FB_PROCSTATS
-	FB_PROCSTATS_RETURNUSED		= &h0001
-	FB_PROCSTATS_ASSIGNUSED		= &h0002
-	FB_PROCSTATS_GOSUBUSED		= &h0004
+	FB_PROCSTATS_RETURNUSED     = &h0001
+	FB_PROCSTATS_ASSIGNUSED     = &h0002
+	FB_PROCSTATS_GOSUBUSED      = &h0004
 end enum
 
 type FB_PROCGSB
-	ctx				as FBSYMBOL_ ptr			'' local pointer for gosub stack
+	ctx             as FBSYMBOL_ ptr            '' local pointer for gosub stack
 end type
 
 type FB_PROCEXT
-	res				as FBSYMBOL_ ptr			'' result, if any
-	stk				as FB_PROCSTK 				'' to keep track of the stack frame
-	dbg				as FB_PROCDBG 				'' debugging
-	err				as FB_PROCERR
-	opovl			as FB_PROCOPOVL
-	statdtor		as TLIST ptr				'' list of static instances with dtors
-	stats			as FB_PROCSTATS
-	stmtnum			as integer
-	priority		as integer
-	gosub			as FB_PROCGSB
-	base_initree		as ASTNODE_ ptr  '' base() ctorcall/initializer given in constructor bodies
+	res             as FBSYMBOL_ ptr            '' result, if any
+	stk             as FB_PROCSTK               '' to keep track of the stack frame
+	dbg             as FB_PROCDBG               '' debugging
+	err             as FB_PROCERR
+	opovl           as FB_PROCOPOVL
+	statdtor        as TLIST ptr                '' list of static instances with dtors
+	stats           as FB_PROCSTATS
+	stmtnum         as integer
+	priority        as integer
+	gosub           as FB_PROCGSB
+	base_initree        as ASTNODE_ ptr  '' base() ctorcall/initializer given in constructor bodies
 
 	'' virtual methods:
 	''    vtable array index, location of the procptr in the vtbl
@@ -627,59 +627,59 @@ type FB_PROCEXT
 	''    0
 	'' A valid index must be >= 2 since the first two vtable elements are
 	'' the null pointer and the rtti pointer.
-	vtableindex		as integer
+	vtableindex     as integer
 
 	'' For methods that override a virtual method: the method that's
 	'' overridden (if any); or else NULL.
-	overridden		as FBSYMBOL_ ptr
+	overridden      as FBSYMBOL_ ptr
 end type
 
 type FB_PROCRTL
-	callback		as FBRTLCALLBACK
+	callback        as FBRTLCALLBACK
 end type
 
 enum FB_PROC_RETURN_METHOD
 	FB_RETURN_FPU
 	FB_RETURN_SSE
-	FB_RETURN_DEFAULT			'' if none specified, take from the proto
+	FB_RETURN_DEFAULT           '' if none specified, take from the proto
 end enum
 
 
 type FBS_PROC
-	symtb			as FBSYMBOLTB				'' local symbols table
-	params			as short
-	optparams		as short					'' number of optional/default params
-	paramtb			as FBSYMBOLTB				'' parameters symbol tb
-	mode			as FB_FUNCMODE				'' calling convention
+	symtb           as FBSYMBOLTB               '' local symbols table
+	params          as short
+	optparams       as short                    '' number of optional/default params
+	paramtb         as FBSYMBOLTB               '' parameters symbol tb
+	mode            as FB_FUNCMODE              '' calling convention
 
 	'' result type remapped to what it will be emitted as, including CONSTs
-	realdtype		as FB_DATATYPE
-	realsubtype		as FBSYMBOL_ ptr
+	realdtype       as FB_DATATYPE
+	realsubtype     as FBSYMBOL_ ptr
 
-	returnMethod	as FB_PROC_RETURN_METHOD
-	rtl				as FB_PROCRTL
-	ovl				as FB_PROCOVL				'' overloading
-	ext				as FB_PROCEXT ptr           '' extra fields, not used with prototypes
+	returnMethod    as FB_PROC_RETURN_METHOD
+	rtl             as FB_PROCRTL
+	ovl             as FB_PROCOVL               '' overloading
+	ext             as FB_PROCEXT ptr           '' extra fields, not used with prototypes
 end type
 
 '' scope
 type FB_SCOPEDBG
-	iniline			as integer					'' scope
-	endline			as integer					'' end scope
-	inilabel		as FBSYMBOL_ ptr
-	endlabel		as FBSYMBOL_ ptr
+	iniline         as integer                  '' scope
+	endline         as integer                  '' end scope
+	inilabel        as FBSYMBOL_ ptr
+	endlabel        as FBSYMBOL_ ptr
 end type
 
 '' used by x86 ASM emitter only
 type FB_SCOPEEMIT
-	baseofs			as integer
+	baseofs         as integer
 end type
 
 type FBS_SCOPE
-	backnode		as ASTNODE_ ptr
-	symtb			as FBSYMBOLTB
-	dbg				as FB_SCOPEDBG
-	emit			as FB_SCOPEEMIT
+	backnode        as ASTNODE_ ptr
+	symtb           as FBSYMBOLTB
+	dbg             as FB_SCOPEDBG
+	emit            as FB_SCOPEEMIT
 end type
 
 enum FBARRAY_FLAGS
@@ -694,235 +694,235 @@ type FBS_ARRAY
 	'' 0 = none (not an array),
 	'' -1 = () = not yet known (should be filled in ASAP),
 	'' 1..n = known dimensions (fixed-size or dynamic arrays)
-	dimensions		as integer
+	dimensions      as integer
 
 	'' Dynamically allocated array of dimension bounds (static arrays only)
-	dimtb			as FBARRAYDIM ptr
+	dimtb           as FBARRAYDIM ptr
 
-	diff			as longint
-	elements		as longint
-	desc			as FBSYMBOL_ ptr
+	diff            as longint
+	elements        as longint
+	desc            as FBSYMBOL_ ptr
 
 	'' Array descriptor type (useful especially for BYDESC param vars, which
 	'' don't have a descriptor var associated, but still need to know the
 	'' exact descriptor type sometimes)
-	desctype		as FBSYMBOL_ ptr
+	desctype        as FBSYMBOL_ ptr
 end type
 
 type FBVAR_DESC
-	array			as FBSYMBOL_ ptr			'' back-link
+	array           as FBSYMBOL_ ptr            '' back-link
 end type
 
 type FBVAR_DATA
-	prev			as FBSYMBOL_ ptr
+	prev            as FBSYMBOL_ ptr
 end type
 
 type FBS_VAR
 	union
-		littext		as zstring ptr
-		littextw	as wstring ptr
-		initree		as ASTNODE_ ptr
+		littext     as zstring ptr
+		littextw    as wstring ptr
+		initree     as ASTNODE_ ptr
 	end union
-	array			as FBS_ARRAY
-	desc			as FBVAR_DESC
-	stmtnum			as integer					'' can't use colnum as it's unreliable
-	align			as integer					'' 0 = use default alignment
-	data			as FBVAR_DATA				'' used with DATA stmts
-	bitpos			as integer  '' bitfields only: bit offset in container field
-	bits			as integer  '' bitfields only: size in bits
+	array           as FBS_ARRAY
+	desc            as FBVAR_DESC
+	stmtnum         as integer                  '' can't use colnum as it's unreliable
+	align           as integer                  '' 0 = use default alignment
+	data            as FBVAR_DATA               '' used with DATA stmts
+	bitpos          as integer  '' bitfields only: bit offset in container field
+	bits            as integer  '' bitfields only: size in bits
 end type
 
 '' namespace
 type FBS_NAMESPACE
 	'' extends FBNAMESPC
-	ns				as FBNAMESPC
+	ns              as FBNAMESPC
 
-	cnt				as integer					'' times this ns was re-opened
-	last_tail		as FBSYMBOL_ ptr			'' point to last tail
+	cnt             as integer                  '' times this ns was re-opened
+	last_tail       as FBSYMBOL_ ptr            '' point to last tail
 end type
 
 '' namespace import (USING)
 type FBS_NSIMPORT
 	'' imported ns (src)
-	imp_ns			as FBSYMBOL_ ptr
-	imp_prev		as FBSYMBOL_ ptr
-	imp_next		as FBSYMBOL_ ptr
+	imp_ns          as FBSYMBOL_ ptr
+	imp_prev        as FBSYMBOL_ ptr
+	imp_next        as FBSYMBOL_ ptr
 	'' exported ns (dst)
-	exp_ns			as FBSYMBOL_ ptr
-	exp_prev		as FBSYMBOL_ ptr
-	exp_next		as FBSYMBOL_ ptr
+	exp_ns          as FBSYMBOL_ ptr
+	exp_prev        as FBSYMBOL_ ptr
+	exp_next        as FBSYMBOL_ ptr
 end type
 
 ''
 type FB_SYMBID
-	name			as zstring ptr				'' upper-cased name, shared by hash tb
-	alias			as zstring ptr              '' alias/preserved (if EXTERN was used) name
-	mangled			as zstring ptr				'' mangled name
+	name            as zstring ptr              '' upper-cased name, shared by hash tb
+	alias           as zstring ptr              '' alias/preserved (if EXTERN was used) name
+	mangled         as zstring ptr              '' mangled name
 end type
 
 ''
 type FBSYMBOL
-	class			as FB_SYMBCLASS
-	attrib			as FB_SYMBATTRIB
-	pattrib			as FB_PROCATTRIB
-	stats			as FB_SYMBSTATS
+	class           as FB_SYMBCLASS
+	attrib          as FB_SYMBATTRIB
+	pattrib         as FB_PROCATTRIB
+	stats           as FB_SYMBSTATS
 
-	id				as FB_SYMBID
+	id              as FB_SYMBID
 
-	typ				as FB_DATATYPE
-	subtype			as FBSYMBOL ptr
+	typ             as FB_DATATYPE
+	subtype         as FBSYMBOL ptr
 
-	scope			as ushort
-	mangling		as short 					'' FB_MANGLING
+	scope           as ushort
+	mangling        as short                    '' FB_MANGLING
 
-	lgt			as longint
-	ofs			as longint					'' for local vars, args, UDT's and fields
+	lgt         as longint
+	ofs         as longint                  '' for local vars, args, UDT's and fields
 
 	union
-		var_		as FBS_VAR
-		val			as FBVALUE  '' constants
-		udt			as FBS_STRUCT
-		enum_		as FBS_ENUM
-		proc		as FBS_PROC
-		param		as FBS_PARAM
-		lbl			as FBS_LABEL
-		def			as FBS_DEFINE
-		key			as FBS_KEYWORD
-		fwd			as FBS_FWDREF
-		scp			as FBS_SCOPE
-		nspc		as FBS_NAMESPACE
-		nsimp 		as FBS_NSIMPORT
+		var_        as FBS_VAR
+		val         as FBVALUE  '' constants
+		udt         as FBS_STRUCT
+		enum_       as FBS_ENUM
+		proc        as FBS_PROC
+		param       as FBS_PARAM
+		lbl         as FBS_LABEL
+		def         as FBS_DEFINE
+		key         as FBS_KEYWORD
+		fwd         as FBS_FWDREF
+		scp         as FBS_SCOPE
+		nspc        as FBS_NAMESPACE
+		nsimp       as FBS_NSIMPORT
 	end union
 
-	hash			as FBSYMHASH				'' hash tb (namespace) it's part of
+	hash            as FBSYMHASH                '' hash tb (namespace) it's part of
 
-	symtb			as FBSYMBOLTB ptr			'' symbol tb it's part of
+	symtb           as FBSYMBOLTB ptr           '' symbol tb it's part of
 
 	parent          as FBSYMBOL Ptr
-	
-	prev			as FBSYMBOL ptr				'' next in symbol tb list
-	next			as FBSYMBOL ptr             '' prev /
+
+	prev            as FBSYMBOL ptr             '' next in symbol tb list
+	next            as FBSYMBOL ptr             '' prev /
 end type
 
 type FBHASHTBLIST
-	head			as FBHASHTB ptr
-	tail			as FBHASHTB ptr
+	head            as FBHASHTB ptr
+	tail            as FBHASHTB ptr
 end type
 
 type SYMB_DEF_PARAM
-	item			as HASHITEM ptr
-	index			as uinteger
+	item            as HASHITEM ptr
+	index           as uinteger
 end type
 
 type SYMB_DEF_UniqueId_Elm
-	name			as zstring ptr
-	prev			as SYMB_DEF_UniqueId_Elm ptr
+	name            as zstring ptr
+	prev            as SYMB_DEF_UniqueId_Elm ptr
 end type
 
 type SYMB_DEF_UniqueId_Stack
-	top				as SYMB_DEF_UniqueId_Elm ptr
+	top             as SYMB_DEF_UniqueId_Elm ptr
 end type
 
 type SYMB_DEF_UniqueId
-	dict			as THASH					'' of SYMB_DEF_UniqueId_Stack
+	dict            as THASH                    '' of SYMB_DEF_UniqueId_Stack
 end type
 
 type SYMB_DEF_CTX
-	paramlist		as TLIST					'' define parameters
-	toklist			as TLIST					'' define tokens
-	uniqueid		as SYMB_DEF_UniqueId
+	paramlist       as TLIST                    '' define parameters
+	toklist         as TLIST                    '' define tokens
+	uniqueid        as SYMB_DEF_UniqueId
 
 	'' macros only..
-	param			as integer					'' param count
-	paramhash		as THASH
+	param           as integer                  '' param count
+	paramhash       as THASH
 	hash(0 to FB_MAXDEFINEARGS-1) as SYMB_DEF_PARAM
 end type
 
 type SYMB_OVLOP
-	head			as FBSYMBOL ptr				'' head proc
+	head            as FBSYMBOL ptr             '' head proc
 end type
 
 type FB_GLOBCTORLIST_ITEM
-	sym				as FBSYMBOL ptr
-	next			as FB_GLOBCTORLIST_ITEM ptr
+	sym             as FBSYMBOL ptr
+	next            as FB_GLOBCTORLIST_ITEM ptr
 end type
 
 type FB_GLOBCTORLIST
-	head			as FB_GLOBCTORLIST_ITEM ptr
-	tail			as FB_GLOBCTORLIST_ITEM ptr
-	list			as TLIST
+	head            as FB_GLOBCTORLIST_ITEM ptr
+	tail            as FB_GLOBCTORLIST_ITEM ptr
+	list            as TLIST
 end type
 
 type FB_RTTICTX
-	fb_rtti			as FBSYMBOL ptr
-	fb_object		as FBSYMBOL ptr
+	fb_rtti         as FBSYMBOL ptr
+	fb_object       as FBSYMBOL ptr
 End Type
 
 const CHAINPOOL_SIZE = 1 shl 12
 
 type SYMBCTX
-	inited			as integer
+	inited          as integer
 
-	symlist			as TLIST					'' (of FBSYMBOL)
-	hashlist		as FBHASHTBLIST
+	symlist         as TLIST                    '' (of FBSYMBOL)
+	hashlist        as FBHASHTBLIST
 
 	'' FBSYMCHAIN's are allocated from this buffer
 	chainpool(0 to (CHAINPOOL_SIZE - 1)) as FBSYMCHAIN
-	chainpoolhead		as integer
+	chainpoolhead       as integer
 
-	globnspc		as FBSYMBOL					'' global namespace
+	globnspc        as FBSYMBOL                 '' global namespace
 
-	namespc			as FBSYMBOL ptr				'' current ns
-	hashtb			as FBHASHTB ptr				'' current hash tb
-	symtb			as FBSYMBOLTB ptr			'' current symbol tb
+	namespc         as FBSYMBOL ptr             '' current ns
+	hashtb          as FBHASHTB ptr             '' current hash tb
+	symtb           as FBSYMBOLTB ptr           '' current symbol tb
 
-	neststk			as TSTACK					'' nest stack (namespace/class nesting)
-	imphashtb		as THASH					'' imported symbol (USING) tb
-	imphashlist		as TLIST					'' (of FBSYMHASH)
+	neststk         as TSTACK                   '' nest stack (namespace/class nesting)
+	imphashtb       as THASH                    '' imported symbol (USING) tb
+	imphashlist     as TLIST                    '' (of FBSYMHASH)
 
-	namepool		as TPOOL
+	namepool        as TPOOL
 
-	fwdlist			as TLIST					'' forward typedef refs
+	fwdlist         as TLIST                    '' forward typedef refs
 
-	nsextlist		as TLIST					'' of FBNAMESPC_EXT
+	nsextlist       as TLIST                    '' of FBNAMESPC_EXT
 
-	fwdrefcnt 		as integer
+	fwdrefcnt       as integer
 
-	def				as SYMB_DEF_CTX				'' #define context
+	def             as SYMB_DEF_CTX             '' #define context
 
-	lastlbl			as FBSYMBOL ptr
+	lastlbl         as FBSYMBOL ptr
 
-	globctorlist	as FB_GLOBCTORLIST			'' global ctors list
-	globdtorlist	as FB_GLOBCTORLIST			'' global dtors list
+	globctorlist    as FB_GLOBCTORLIST          '' global ctors list
+	globdtorlist    as FB_GLOBCTORLIST          '' global dtors list
 
 	globOpOvlTb ( _
 					0 to AST_OPCODES-1 _
-				)	as SYMB_OVLOP				'' global operator overloading
+				)   as SYMB_OVLOP               '' global operator overloading
 
-	fbarray_data		as integer			'' offsetof( FBARRAY, data )
-	fbarray_ptr		as integer			'' offsetof( FBARRAY, ptr )
-	fbarray_size		as integer			'' offsetof( FBARRAY, size )
-	fbarray_dimtb		as integer			'' offsetof( FBARRAY, dimTB )
-	fbarraydim		as FBSYMBOL ptr			'' FBARRAYDIM (dimTB element structure)
-	fbarraydim_lbound	as integer			'' offsetof( FBARRAYDIM, lbound )
-	fbarraydim_ubound	as integer			'' offsetof( FBARRAYDIM, ubound )
+	fbarray_data        as integer          '' offsetof( FBARRAY, data )
+	fbarray_ptr     as integer          '' offsetof( FBARRAY, ptr )
+	fbarray_size        as integer          '' offsetof( FBARRAY, size )
+	fbarray_dimtb       as integer          '' offsetof( FBARRAY, dimTB )
+	fbarraydim      as FBSYMBOL ptr         '' FBARRAYDIM (dimTB element structure)
+	fbarraydim_lbound   as integer          '' offsetof( FBARRAYDIM, lbound )
+	fbarraydim_ubound   as integer          '' offsetof( FBARRAYDIM, ubound )
 
-	rtti			as FB_RTTICTX 
+	rtti            as FB_RTTICTX
 end type
 
 type SYMB_DATATYPE
-	class			as FB_DATACLASS				'' INTEGER, FPOINT
-	size			as integer					'' in bytes
-	signed			as integer					'' TRUE or FALSE
+	class           as FB_DATACLASS             '' INTEGER, FPOINT
+	size            as integer                  '' in bytes
+	signed          as integer                  '' TRUE or FALSE
 
 	'' For basic integer types only: ranking value, to establish a proper
 	'' target-specific (32bit/64bit) order (the FB_DATATYPE enum order is
 	'' not enough because it's not target-specific)
-	intrank			as integer
+	intrank         as integer
 
-	remaptype		as FB_DATATYPE				'' remapped type for ENUM, POINTER, etc
-	sizetype		as integer      '' FB_SIZETYPE_*
-	name			as const zstring ptr
+	remaptype       as FB_DATATYPE              '' remapped type for ENUM, POINTER, etc
+	sizetype        as integer      '' FB_SIZETYPE_*
+	name            as const zstring ptr
 end type
 
 '' Data passed from symbUdtDeclareDefaultMembers() to symbUdtImplementDefaultMembers()
@@ -1307,7 +1307,7 @@ declare sub symbInsertInnerUDT _
 declare sub symbStructEnd _
 	( _
 		byval t as FBSYMBOL ptr, _
-		byval isnested as integer = FALSE _ 
+		byval isnested as integer = FALSE _
 	)
 
 declare function symbAddEnum _
@@ -2609,22 +2609,22 @@ declare sub symbProcRecalcRealType( byval proc as FBSYMBOL ptr )
 	 (((dt and FB_DT_CONSTMASK) shr cnt) and FB_DT_CONSTMASK) or _
 	 (dt and FB_DT_MANGLEMASK))
 
-#define	typeIsPtr( dt ) (((dt and FB_DT_PTRMASK) <> 0))
+#define typeIsPtr( dt ) (((dt and FB_DT_PTRMASK) <> 0))
 #define typeGetPtrCnt( dt ) ((dt and FB_DT_PTRMASK) shr FB_DT_PTRPOS)
 
-#define	typeIsConstAt( dt, at ) ((dt and (1 shl (FB_DT_CONSTPOS + at))) <> 0)
-#define	typeIsConst( dt ) typeIsConstAt(dt, 0)
-#define	typeSetIsConst( dt ) (dt or (1 shl FB_DT_CONSTPOS))
-#define	typeUnsetIsConst( dt ) (dt and not (1 shl FB_DT_CONSTPOS))
-#define	typeGetConstMask( dt ) (dt and FB_DT_CONSTMASK)
-#define	typeGetPtrConstMask( dt ) _
+#define typeIsConstAt( dt, at ) ((dt and (1 shl (FB_DT_CONSTPOS + at))) <> 0)
+#define typeIsConst( dt ) typeIsConstAt(dt, 0)
+#define typeSetIsConst( dt ) (dt or (1 shl FB_DT_CONSTPOS))
+#define typeUnsetIsConst( dt ) (dt and not (1 shl FB_DT_CONSTPOS))
+#define typeGetConstMask( dt ) (dt and FB_DT_CONSTMASK)
+#define typeGetPtrConstMask( dt ) _
 	(typeGetConstMask( dt ) and not (1 shl FB_DT_CONSTPOS))
 
-#define	typeIsRef( dt ) ((dt and FB_DATATYPE_REFERENCE) <> 0)
-#define	typeSetIsRef( dt ) (dt or FB_DATATYPE_REFERENCE)
-#define	typeUnsetIsRef( dt ) (dt and not FB_DATATYPE_REFERENCE)
+#define typeIsRef( dt ) ((dt and FB_DATATYPE_REFERENCE) <> 0)
+#define typeSetIsRef( dt ) (dt or FB_DATATYPE_REFERENCE)
+#define typeUnsetIsRef( dt ) (dt and not FB_DATATYPE_REFERENCE)
 
-#define	typeHasMangleDt( dt ) (((dt and FB_DT_MANGLEMASK) <> 0))
+#define typeHasMangleDt( dt ) (((dt and FB_DT_MANGLEMASK) <> 0))
 #define typeGetMangleDt( dt ) ((dt and FB_DT_MANGLEMASK) shr FB_DT_MANGLEPOS)
 #define typeSetMangleDt( dt, mangle_dt ) ((dt and not FB_DT_MANGLEMASK) or ((mangle_dt shl FB_DT_MANGLEPOS) and FB_DT_MANGLEMASK ))
 

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -555,7 +555,8 @@ type FBS_PARAM
 	var				as FBSYMBOL_ ptr			'' link to decl var in func bodies
 	optexpr			as ASTNODE_ ptr				'' default value
 	bydescdimensions	as integer
-	bydescrealsubtype	as FBSYMBOL_ ptr  '' bydesc array descriptor type
+	bydescrealsubtype	as FBSYMBOL_ ptr        '' bydesc array descriptor type
+	argnum			as integer                  '' argument number (1 is first)
 end type
 
 '' function

--- a/tests/cpp/this-fbc.bas
+++ b/tests/cpp/this-fbc.bas
@@ -4,14 +4,6 @@
 '' has same address as the instance parameter
 '' in the callee
 
-#if ENABLE_CHECK_BUGS
-	#define DOTEST
-#else
-	'' thiscall is not supported in -gen gas
-	#if __FB_BACKEND__ <> "gas"
-		#define DOTEST
-	#endif
-#endif
 
 extern "c++"
 	'' getters to retrieve call information
@@ -107,8 +99,6 @@ end extern
 	assert( r2 = getPtr2() )
 	assert( r3 = getPtr3() )
 #endmacro
-
-#ifdef DOTEST
 
 '' !!! TODO !!! combine duplicate code to #macro
 '' currently separate to track assert locatons
@@ -216,5 +206,3 @@ end scope
 
 '' check results of destructor called
 checkResults( p1, 0, 0 )
-
-#endif '' DOTEST

--- a/todo.txt
+++ b/todo.txt
@@ -71,10 +71,11 @@ o ABI
     [ ] use __thiscall calling by default for mingw gcc 32-bit, currently
         currently, users must manage this explicitly, recommend using a 
         #define thiscall __thiscall depending on target platform
-    [ ] silently ignore on 64-bit, but warn if declare & procedure is different
-    [ ] implement in -gen gas 32-bit. Hard to do, AST/IR/EMIT currently doesn't
-        have enough information or implementation for passing arguments in registers.
     [ ] more tests and documentation for mangling/calling conventions, not every
+        calling convention is tested or documented completely - also hard to test
+    [x] silently ignore on 64-bit, but warn if declare & procedure is different
+    [x] implement in -gen gas 32-bit. Hard to do, AST/IR/EMIT currently doesn't
+        have enough information or implementation for passing arguments in registers.
     [x] add the __thiscall keyword
     [x] add '-z no-thiscall' to ignore "thiscall" and revert to default calling
         convention


### PR DESCRIPTION
Previously, `-gen gas` would have generated bad code for calling members of g++ classes on win32 + 32-bit + gcc.

This update should handle the `thiscall` calling convention when declaring and using c++ classes linked to fbc.

Remaining work to be completed is defining procedures on fbc side that correctly use the thiscall calling convention when using the `-gen gas` backend.

Affects `-gen gas` backend only.
