### PR TITLE
bug fixes for #cmdline

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -39,11 +39,11 @@ Version 1.09.0
 - objinfo: check ELF files for little endian or big endian signature
 - fbc: __thiscall declaration support for gcc/gas 32-bit x86 calling g++ classes from fbc passing first argument in ECX register, caller cleans up stack except on win32 x86
 - fbc: add __FB_OPTIMIZE__ intrinisic define - always defined and will have a value from 0 to 3 to indicate the optimization level passed to the backend compiler
-- github #341: fbc: #cmdline "args..." directive to specify command line arguments within source files, restarting the parser from some options
+- github #341: fbc: #cmdline "args..." directive to specify command line arguments within source files, restarting the parser for some options, and restarting fbc for others
 - github #341: fbc: #cmdline "-end" will trigger a parser or fbc restart if needed.  fbc can't detect the end of reading all the #cmdlines to do this automatically
-- github #341: fbc: #cmdline "-restart" will always trigger an fbc restart
-- github #341: fbc: only process #cmdline in the first source module (which must be specified on the real command line)
-- github #341: fbc: add '-z nocmdline' command line option to ignore #cmdline directives - allows overriding source directives with real fbc command line
+- github #341: fbc: #cmdline "-restart" will always trigger one fbc restart
+- github #341: fbc: only process #cmdline in the first pass of the source module (which must be specified on the real command line)
+- github #341: fbc: '-z nocmdline' command line option to ignore #cmdline directives, allows overriding source directives with real fbc command line, show warning if used with '-w all'
 
 [fixed]
 - github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)

--- a/changelog.txt
+++ b/changelog.txt
@@ -39,7 +39,7 @@ Version 1.09.0
 - objinfo: check ELF files for little endian or big endian signature
 - fbc: __thiscall declaration support for gcc/gas 32-bit x86 calling g++ classes from fbc passing first argument in ECX register, caller cleans up stack except on win32 x86
 - fbc: add __FB_OPTIMIZE__ intrinisic define - always defined and will have a value from 0 to 3 to indicate the optimization level passed to the backend compiler
-- github #341: fbc: #cmdline "args..." directive to specify command line arguments within source files, restarting the parser for some options, and restarting fbc for others
+- github #341: fbc: #cmdline "args..." directive to specify command line arguments within source files, restarting the parser for some options, and restarting fbc for others.  Don't allow '-print', '-help' options
 - github #341: fbc: #cmdline "-end" will trigger a parser or fbc restart if needed.  fbc can't detect the end of reading all the #cmdlines to do this automatically
 - github #341: fbc: #cmdline "-restart" will always trigger one fbc restart
 - github #341: fbc: only process #cmdline in the first pass of the source module (which must be specified on the real command line)

--- a/src/compiler/error.bas
+++ b/src/compiler/error.bas
@@ -420,6 +420,10 @@ declare function hMakeParamDesc _
 	}
 
 
+sub errPreInit( )
+	errctx.hide_further_messages = FALSE
+end sub
+
 sub errInit( )
 	'' fbc.bas will call err*() even before errInit() or after errEnd()
 	errctx.inited += 1

--- a/src/compiler/error.bi
+++ b/src/compiler/error.bi
@@ -396,6 +396,7 @@ enum FB_ERRMSGOPT
 	FB_ERRMSGOPT_DEFAULT    = FB_ERRMSGOPT_ADDCOMMA
 end enum
 
+declare sub errPreInit( )
 declare sub errInit( )
 declare sub errEnd( )
 declare sub errHideFurtherErrors( )

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -814,7 +814,7 @@ sub fbChangeOption(byval opt as integer, byval value as integer)
 						fbRestartBeginRequest( FB_RESTART_PARSER_LANG )
 						fbRestartAcceptRequest( FB_RESTART_PARSER_LANG )
 
-						'' and don't show any more errors
+						'' and don't show any more errors until we've restarted
 						errHideFurtherErrors()
 
 					'' Second pass? Show a warning and ignore
@@ -1275,7 +1275,7 @@ function fbShouldRestart() as integer
 			'' tell parser / fbc to restart as soon as possible
 			fbRestartAcceptRequest( FB_RESTART_CMDLINE )
 
-			'' and don't show any more errors
+			'' and don't show any more errors until we've restarted
 			errHideFurtherErrors()
 
 			return TRUE

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -1306,6 +1306,8 @@ sub fbRestartCloseRequest( byval filter as FB_RESTART_FLAGS )
 	'' update status, action is completed
 	env.restart_status or= (env.restart_action and filter)
 
+	env.pass_id += 1
+
 	'' clear the action
 	env.restart_action and= not filter
 end sub

--- a/src/compiler/fb.bas
+++ b/src/compiler/fb.bas
@@ -386,7 +386,10 @@ sub fbInit _
 	strsetInit( @env.libpaths, FB_INITLIBNODES \ 4 )
 
 	'' when starting a compile, reset the restart requests
-	'' env.restart_status preserves state from previous runs
+	'' env.restart_status preserves state from previous runs 
+	''     and would have been initialized to 0 (FB_RESTART_NONE)
+	'' env.restart_count is preserved between runs (passes) so don't
+	''    re-initialize it here.
 	env.restart_request = FB_RESTART_NONE
 	env.restart_action = FB_RESTART_NONE
 
@@ -1302,15 +1305,19 @@ sub fbRestartAcceptRequest( byval filter as FB_RESTART_FLAGS )
 	env.restart_request and= not filter
 end sub
 
-sub fbRestartCloseRequest( byval filter as FB_RESTART_FLAGS )
+sub fbRestartEndRequest( byval filter as FB_RESTART_FLAGS )
 	'' update status, action is completed
 	env.restart_status or= (env.restart_action and filter)
 
-	env.pass_id += 1
+	env.restart_count += 1
 
 	'' clear the action
 	env.restart_action and= not filter
 end sub
+
+function fbRestartGetCount() as integer
+	return env.restart_count
+end function
 
 sub fbSetLibs(byval libs as TSTRSET ptr, byval libpaths as TSTRSET ptr)
 	strsetCopy(@env.libs, libs)

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -473,6 +473,16 @@ declare sub fbRestartBeginRequest( byval flags as FB_RESTART_FLAGS )
 declare sub fbRestartAcceptRequest( byval flags as FB_RESTART_FLAGS )
 declare sub fbRestartCloseRequest( byval flags as FB_RESTART_FLAGS )
 
+#macro fbRestartableStaticVariable( datatype, varname, defaultvalue )
+	'' create a local static variable, but reset it to the default if fb is restarted
+	static as integer pass_id
+	static as datatype varname = defaultvalue
+	if( pass_id <> env.pass_id ) then
+		pass_id = env.pass_id
+		varname = defaultvalue
+	end if
+#endmacro
+
 declare sub fbGlobalInit()
 declare sub fbAddIncludePath(byref path as string)
 declare sub fbAddPreDefine(byref def as string)

--- a/src/compiler/fb.bi
+++ b/src/compiler/fb.bi
@@ -471,14 +471,15 @@ declare function fbShouldRestart() as integer
 declare function fbShouldContinue() as integer
 declare sub fbRestartBeginRequest( byval flags as FB_RESTART_FLAGS )
 declare sub fbRestartAcceptRequest( byval flags as FB_RESTART_FLAGS )
-declare sub fbRestartCloseRequest( byval flags as FB_RESTART_FLAGS )
+declare sub fbRestartEndRequest( byval flags as FB_RESTART_FLAGS )
+declare function fbRestartGetCount() as integer
 
 #macro fbRestartableStaticVariable( datatype, varname, defaultvalue )
 	'' create a local static variable, but reset it to the default if fb is restarted
-	static as integer pass_id
+	static as integer restart_count
 	static as datatype varname = defaultvalue
-	if( pass_id <> env.pass_id ) then
-		pass_id = env.pass_id
+	if( restart_count <> fbRestartGetCount() ) then
+		restart_count = fbRestartGetCount()
 		varname = defaultvalue
 	end if
 #endmacro

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -4027,6 +4027,10 @@ end sub
 
 
 		else
+			if( fbc.verbose ) then
+				print "Restarting fbc ..."
+			end if
+
 			if( fbc.showversion ) then
 				'' hPrintVersion( fbc.verbose )
 			end if

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -4003,6 +4003,9 @@ end sub
 	hParseArgs( __FB_ARGC__, __FB_ARGV__ )
 
 	do
+		'' we are restarting, so show errors
+		errPreInit( )
+
 		hCheckArgs( )
 
 		'' first pass?

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -4021,6 +4021,10 @@ end sub
 				hPrintOptions( fbc.verbose )
 				fbcEnd( 1 )
 			end if
+		else
+			if( fbc.showversion ) then
+				hPrintVersion( fbc.verbose )
+			end if
 		end if
 
 		fbcDeterminePrefix( )

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -1680,7 +1680,7 @@ dim shared as FBC_CMDLINE_OPTION cmdlineOptionTB(0 to (OPT__COUNT - 1)) = _
 { _
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_A            add files to link, affects link
 	( TRUE , TRUE , TRUE , TRUE  ), _ '' OPT_ARCH         affects major initialization
-	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_ASM          affects second stage compile
+	( TRUE , TRUE , FALSE, TRUE  ), _ '' OPT_ASM          affects major initialization,affects second stage compile
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_B            adds files to compile
 	( FALSE, TRUE , FALSE, FALSE ), _ '' OPT_C            affects compile / assemble /link process
 	( FALSE, TRUE , FALSE, FALSE ), _ '' OPT_CKEEPOBJ     affects removal of temporary files
@@ -1699,10 +1699,10 @@ dim shared as FBC_CMDLINE_OPTION cmdlineOptionTB(0 to (OPT__COUNT - 1)) = _
 	( FALSE, TRUE , TRUE , FALSE ), _ '' OPT_EXX          affects code generation
 	( FALSE, TRUE , TRUE , FALSE ), _ '' OPT_EXPORT       affects code generation
 	( TRUE , TRUE , TRUE , FALSE ), _ '' OPT_FORCELANG    never allow, command line only
-	( TRUE , TRUE , TRUE , FALSE ), _ '' OPT_FPMODE       affects code generation
-	( TRUE , TRUE , TRUE , FALSE ), _ '' OPT_FPU          affects code generation, affects second stage compile, affects link
+	( TRUE , TRUE , TRUE , TRUE  ), _ '' OPT_FPMODE       affects major initialization, affects code generation
+	( TRUE , TRUE , TRUE , TRUE  ), _ '' OPT_FPU          affects major initialization,affects code generation, affects second stage compile, affects link
 	( FALSE, TRUE , TRUE , FALSE ), _ '' OPT_G            affects code generation, affects link
-	( TRUE , TRUE , TRUE , FALSE ), _ '' OPT_GEN          affects initialization
+	( TRUE , TRUE , TRUE , TRUE  ), _ '' OPT_GEN          affects major initialization
 	( FALSE, FALSE, FALSE, FALSE ), _ '' OPT_HELP         never allow, real command line only, makes no sense to have in source
 	( TRUE , TRUE , TRUE , TRUE  ), _ '' OPT_I            add include path before the default one
 	( TRUE , TRUE , TRUE , TRUE  ), _ '' OPT_INCLUDE      restart required to inject preInclude
@@ -1720,11 +1720,11 @@ dim shared as FBC_CMDLINE_OPTION cmdlineOptionTB(0 to (OPT__COUNT - 1)) = _
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_O            affects input file naming
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_OPTIMIZE     affects link
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_P            affects link, same as #libpath
-	( FALSE, TRUE , FALSE, FALSE ), _ '' OPT_PIC          affects link
+	( FALSE, TRUE , FALSE, TRUE  ), _ '' OPT_PIC          affects major initialization, affects link
 	( FALSE, TRUE , FALSE, TRUE  ), _ '' OPT_PP           affects major initialization
 	( TRUE , TRUE , FALSE, TRUE  ), _ '' OPT_PREFIX       affects major initialization
 	( TRUE , FALSE, FALSE, FALSE ), _ '' OPT_PRINT        never allow, makes no sense to have in source
-	( FALSE, TRUE , TRUE , FALSE ), _ '' OPT_PROFILE      affects initialization, affects code generation, affects link
+	( FALSE, TRUE , TRUE , TRUE  ), _ '' OPT_PROFILE      affects major initialization, affects initialization, affects code generation, affects link
 	( FALSE, TRUE , FALSE, FALSE ), _ '' OPT_R            affects compile / assmble /link process
 	( FALSE, TRUE , FALSE, FALSE ), _ '' OPT_RKEEPASM     affects removal of temporary files
 	( FALSE, TRUE , FALSE, FALSE ), _ '' OPT_RR           affects compile / assmble /link process
@@ -1737,14 +1737,14 @@ dim shared as FBC_CMDLINE_OPTION cmdlineOptionTB(0 to (OPT__COUNT - 1)) = _
 	( TRUE , TRUE , TRUE , TRUE  ), _ '' OPT_TARGET       affects major initialization
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_TITLE        affects link
 	( FALSE, TRUE , FALSE, FALSE ), _ '' OPT_V            affects nothing
-	( TRUE , TRUE , TRUE , FALSE ), _ '' OPT_VEC          affects code generation
-	( FALSE, TRUE , FALSE, FALSE ), _ '' OPT_VERSION      affects nothing
+	( TRUE , TRUE , TRUE , TRUE  ), _ '' OPT_VEC          affects major initialization, affects code generation
+	( FALSE, TRUE , FALSE, TRUE  ), _ '' OPT_VERSION      must restart fbc to get the version message
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_W            affects compiler display output
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_WA           affects assembly
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_WC           affects second stage compile
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_WL           affects link
 	( TRUE , TRUE , FALSE, FALSE ), _ '' OPT_X            affects output file
-	( TRUE , TRUE , TRUE , FALSE )  _ '' OPT_Z            affects various - code generation
+	( TRUE , TRUE , TRUE , TRUE  )  _ '' OPT_Z            affects various - code generation
 }
 
 private sub handleOpt _
@@ -2976,7 +2976,7 @@ private sub hCompileBas _
 		end if
 
 		'' Close the request to restart the parser
-		fbRestartCloseRequest( FB_RESTART_PARSER )
+		fbRestartEndRequest( FB_RESTART_PARSER )
 
 		'' Shutdown the parser before restarting
 		fbEnd( )
@@ -4002,11 +4002,11 @@ end sub
 
 	hParseArgs( __FB_ARGC__, __FB_ARGV__ )
 
-	dim restarted as boolean = FALSE
 	do
 		hCheckArgs( )
 
-		if( restarted = FALSE ) then
+		'' first pass?
+		if( fbRestartGetCount() = 0 ) then
 			if( fbc.showversion ) then
 				hPrintVersion( fbc.verbose )
 				fbcEnd( 0 )
@@ -4021,9 +4021,11 @@ end sub
 				hPrintOptions( fbc.verbose )
 				fbcEnd( 1 )
 			end if
+
+
 		else
 			if( fbc.showversion ) then
-				hPrintVersion( fbc.verbose )
+				'' hPrintVersion( fbc.verbose )
 			end if
 		end if
 
@@ -4085,8 +4087,7 @@ end sub
 			exit do
 		end if
 
-		fbRestartCloseRequest( FB_RESTART_FBC_CMDLINE )
-		restarted = TRUE
+		fbRestartEndRequest( FB_RESTART_FBC_CMDLINE )
 	loop
 
 	if( hCompileXpm( ) = FALSE ) then

--- a/src/compiler/fbint.bi
+++ b/src/compiler/fbint.bi
@@ -644,6 +644,7 @@ type FBENV
 	restart_request  as FB_RESTART_FLAGS        '' request parser or fbc restart on a trigger later (e.g #cmdline "-end")
 	restart_action   as FB_RESTART_FLAGS        '' restart as soon as possible
 	restart_status   as FB_RESTART_FLAGS        '' current status of restarts #lang/#cmdline/parser/fbc
+	pass_id          as integer                 '' number of restarts
 
 	'' Lists to collect #inclibs and #libpaths
 	libs            as TSTRSET

--- a/src/compiler/fbint.bi
+++ b/src/compiler/fbint.bi
@@ -644,7 +644,7 @@ type FBENV
 	restart_request  as FB_RESTART_FLAGS        '' request parser or fbc restart on a trigger later (e.g #cmdline "-end")
 	restart_action   as FB_RESTART_FLAGS        '' restart as soon as possible
 	restart_status   as FB_RESTART_FLAGS        '' current status of restarts #lang/#cmdline/parser/fbc
-	pass_id          as integer                 '' number of restarts
+	restart_count    as integer                 '' number of restarts
 
 	'' Lists to collect #inclibs and #libpaths
 	libs            as TSTRSET

--- a/src/compiler/ir.bas
+++ b/src/compiler/ir.bas
@@ -27,6 +27,11 @@ end sub
 
 sub irEnd( )
 	ir.vtbl.end( )
+
+	'' !!!TODO!!! - reset the vtbl? 
+	dim x as IR_VTBL
+	ir.vtbl = x
+ 	ir.options = 0
 end sub
 
 dim shared irhl as IRHLCONTEXT

--- a/src/compiler/ir.bas
+++ b/src/compiler/ir.bas
@@ -22,16 +22,25 @@ sub irInit( )
 		assert( env.clopt.backend = FB_BACKEND_GAS )
 		ir.vtbl = irtac_vtbl
 	end select
+
+	'' reset ir.options becasue irSetOption() will merge (OR) values
+	ir.options = 0
+
 	ir.vtbl.init( )
 end sub
 
 sub irEnd( )
 	ir.vtbl.end( )
 
-	'' !!!TODO!!! - reset the vtbl? 
-	dim x as IR_VTBL
-	ir.vtbl = x
- 	ir.options = 0
+	ir.options = 0
+
+	#if __FB_DEBUG__
+		'' debugging - reset the vtable - shouldn't matter in production
+		'' because ir.vtbl calls should never be called outside irInit()/irEnd()
+		dim null_vtbl as IR_VTBL
+		ir.vtbl = null_vtbl
+	#endif
+
 end sub
 
 dim shared irhl as IRHLCONTEXT

--- a/src/compiler/ir.bi
+++ b/src/compiler/ir.bi
@@ -468,7 +468,6 @@ enum IR_OPT
 end enum
 
 type IRCTX
-	inited          as integer
 	vtbl            as IR_VTBL
 	options         as IR_OPT
 end type

--- a/src/compiler/parser-decl-proc-params.bas
+++ b/src/compiler/parser-decl-proc-params.bas
@@ -206,7 +206,8 @@ private function hParamDecl _
 	) as FBSYMBOL ptr
 
 	static as zstring * FB_MAXNAMELEN+1 idTB(0 to FB_MAXARGRECLEVEL-1)
-	static as integer reclevel = 0
+	fbRestartableStaticVariable( integer, reclevel, 0 )
+
 	dim as zstring ptr id = any
 	dim as integer dtype = any, mode = any, attrib = any, dimensions = any
 	dim as integer readid = any, dotpos = any, doskip = any

--- a/src/compiler/parser-decl-proc-params.bas
+++ b/src/compiler/parser-decl-proc-params.bas
@@ -206,7 +206,7 @@ private function hParamDecl _
 	) as FBSYMBOL ptr
 
 	static as zstring * FB_MAXNAMELEN+1 idTB(0 to FB_MAXARGRECLEVEL-1)
-	fbRestartableStaticVariable( integer, reclevel, 0 )
+	static as integer reclevel = 0
 
 	dim as zstring ptr id = any
 	dim as integer dtype = any, mode = any, attrib = any, dimensions = any

--- a/src/compiler/parser-decl-symb-init.bas
+++ b/src/compiler/parser-decl-symb-init.bas
@@ -327,7 +327,7 @@ private function hArrayInit _
 end function
 
 private function hUDTInit( byref ctx as FB_INITCTX ) as integer
-	fbRestartableStaticVariable( integer, rec_cnt, 0 )
+	static as integer rec_cnt = 0
 
 	dim as integer elm_cnt = any
 	dim as longint lgt = any, baseofs = any, pad_lgt = any

--- a/src/compiler/parser-decl-symb-init.bas
+++ b/src/compiler/parser-decl-symb-init.bas
@@ -327,7 +327,7 @@ private function hArrayInit _
 end function
 
 private function hUDTInit( byref ctx as FB_INITCTX ) as integer
-	static as integer rec_cnt
+	fbRestartableStaticVariable( integer, rec_cnt, 0 )
 
 	dim as integer elm_cnt = any
 	dim as longint lgt = any, baseofs = any, pad_lgt = any

--- a/src/compiler/pp.bas
+++ b/src/compiler/pp.bas
@@ -870,7 +870,7 @@ private sub ppCmdline( )
 		'' The restart request will have been stored in env.restart_request
 		fbRestartAcceptRequest( FB_RESTART_CMDLINE )
 
-		'' and don't show any more errors
+		'' and don't show any more errors until we've restarted
 		errHideFurtherErrors()
 
 	'' #cmdline "-restart" ?
@@ -880,7 +880,7 @@ private sub ppCmdline( )
 		fbRestartBeginRequest( FB_RESTART_FBC_CMDLINE )
 		fbRestartAcceptRequest( FB_RESTART_CMDLINE )
 
-		'' and don't show any more errors
+		'' and don't show any more errors until we've restarted
 		errHideFurtherErrors()
 
 	'' must be first pass in the first module, so process the option

--- a/src/compiler/rtl-gfx.bas
+++ b/src/compiler/rtl-gfx.bas
@@ -1408,7 +1408,8 @@ private function hPorts_cb _
 		byval sym as FBSYMBOL ptr _
 	) as integer
 
-    static as integer libsAdded = FALSE
+	'' minor optimization to avoid having to lookup env.libs hash
+	fbRestartableStaticVariable( integer, libsAdded, FALSE )
 
 	if( libsadded = FALSE ) then
 		libsAdded = TRUE

--- a/src/compiler/rtl-math.bas
+++ b/src/compiler/rtl-math.bas
@@ -518,15 +518,16 @@ function rtlMathBop _
 end function
 
 private function hRndCallback( byval sym as FBSYMBOL ptr ) as integer
-	static as integer added = FALSE
+	'' minor optimization to avoid having to lookup env.libs hash
+	fbRestartableStaticVariable( integer, libsAdded, FALSE )
 
-	if( added = FALSE ) then
-		added = TRUE
+	if( libsAdded = FALSE ) then
+		libsAdded = TRUE
 		select case env.clopt.target
 		case FB_COMPTARGET_WIN32, FB_COMPTARGET_CYGWIN
 			fbAddLib( "advapi32" )
 		end select
 	end if
 
-        return TRUE
+	return TRUE
 end function

--- a/src/compiler/rtl-print.bas
+++ b/src/compiler/rtl-print.bas
@@ -1200,11 +1200,11 @@ function rtlPrinter_cb _
 		byval sym as FBSYMBOL ptr _
 	) as integer
 
-    static as integer libsAdded = FALSE
+	'' minor optimization to avoid having to lookup env.libs hash
+	fbRestartableStaticVariable( integer, libsAdded, FALSE )
 
 	if( libsadded = FALSE ) then
-
-        libsAdded = TRUE
+		libsAdded = TRUE
 
 		select case env.clopt.target
 		case FB_COMPTARGET_WIN32, FB_COMPTARGET_CYGWIN
@@ -1214,6 +1214,6 @@ function rtlPrinter_cb _
 
 	end if
 
-    function = TRUE
+	function = TRUE
 
 end function

--- a/src/compiler/rtl-system.bas
+++ b/src/compiler/rtl-system.bas
@@ -736,14 +736,15 @@ private function hThreadCall_cb _
 		byval sym as FBSYMBOL ptr _
 	) as integer
 
-    static as integer libsAdded = FALSE
+	'' minor optimization to avoid having to lookup env.libs hash
+	fbRestartableStaticVariable( integer, libsAdded, FALSE )
 
 	if( libsadded = FALSE ) then
 		libsAdded = TRUE
 		fbAddLib( "ffi" )
 	end if
 
-        return hMultithread_cb( sym )
+	return hMultithread_cb( sym )
 end function
 
 '':::::
@@ -752,18 +753,18 @@ function rtlAtExit _
 		byval procexpr as ASTNODE ptr _
 	) as ASTNODE ptr static
 
-    dim as ASTNODE ptr proc
+	dim as ASTNODE ptr proc
 
 	function = NULL
 
 	'' atexit( proc )
-    proc = astNewCALL( PROCLOOKUP( ATEXIT ) )
+	proc = astNewCALL( PROCLOOKUP( ATEXIT ) )
 
-    if( astNewARG( proc, procexpr ) = NULL ) then
-    	exit function
-    end if
+	if( astNewARG( proc, procexpr ) = NULL ) then
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -723,7 +723,10 @@ private sub hMangleNamespace _
 end sub
 
 private sub hMangleVariable( byval sym as FBSYMBOL ptr )
+	'' local optimization for 'id' allocation - it's always initialized by logic below
 	static as string id
+
+	'' !!!TODO!!! should varcounter  reset between modules and on restarts with fbRestartableStaticVariable()?
 	static as integer varcounter
 	dim as string mangled
 	dim as zstring ptr p = any

--- a/todo.txt
+++ b/todo.txt
@@ -227,7 +227,7 @@ o -exx should catch...
         [X] painful to add
         [X] added as '#cmdline "args..."'
         [ ] painful to complete
-        [ ] don't allow #cmdline if any line was parsed already
+        [ ] don't allow #cmdline if any line was parsed already that emits backend code
         [X] add '-z nocmdline' to ignore #cmdline directives
         [X] reset parser for command line options that require it
         [X] reset fbc for command line options that require it (-target, -arch, -lib, etc)


### PR DESCRIPTION
This PR fixes several issues with recently added `#cmdline` in #341.

- libraries missing from the libraries list after a restart
- error messages hidden after a restart
- bad initialization of IR when switching between backends on a restart
- more options now trigger a full restart due to dependencies at the top end of initialization
