### PR TITLE
Add '#pragma reserve' to reserve keywords and avoid backend compile / runtime errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@ Version 1.09.0
 - github #341: fbc: only process #cmdline in the first pass of the source module (which must be specified on the real command line)
 - github #341: fbc: '-z nocmdline' command line option to ignore #cmdline directives, allows overriding source directives with real fbc command line, show warning if used with '-w all'
 - fbc: #cmdline "-version" will immediately print the fbc version information if it was not already printed.  To get verbose version information '-v' option must appear before '-version'.  fbc command line  option '-v' option behaviour overrides #cmdline "-v"
+- fbc: '#pragma reserve [shared] name' statement will reserve a symbol name in the current scope / namespace
 
 [fixed]
 - github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)

--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,7 @@ Version 1.09.0
 - github #341: fbc: '-z nocmdline' command line option to ignore #cmdline directives, allows overriding source directives with real fbc command line, show warning if used with '-w all'
 - fbc: #cmdline "-version" will immediately print the fbc version information if it was not already printed.  To get verbose version information '-v' option must appear before '-version'.  fbc command line  option '-v' option behaviour overrides #cmdline "-v"
 - fbc: '#pragma reserve [shared] name' statement will reserve a symbol name in the current scope / namespace
+- fbc: '#pragma reserve asm name' statement will reserve an ASM symbol name in for all ASM statements and blocks
 
 [fixed]
 - github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)

--- a/changelog.txt
+++ b/changelog.txt
@@ -45,8 +45,8 @@ Version 1.09.0
 - github #341: fbc: only process #cmdline in the first pass of the source module (which must be specified on the real command line)
 - github #341: fbc: '-z nocmdline' command line option to ignore #cmdline directives, allows overriding source directives with real fbc command line, show warning if used with '-w all'
 - fbc: #cmdline "-version" will immediately print the fbc version information if it was not already printed.  To get verbose version information '-v' option must appear before '-version'.  fbc command line  option '-v' option behaviour overrides #cmdline "-v"
-- fbc: '#pragma reserve [shared] name' statement will reserve a symbol name in the current scope / namespace
-- fbc: '#pragma reserve asm name' statement will reserve an ASM symbol name in for all ASM statements and blocks
+- fbc: '#pragma reserve (shared) symbol' statement will reserve a symbol name in the current scope / namespace
+- fbc: '#pragma reserve (asm) symbol' statement will reserve an ASM symbol name in for all ASM statements and blocks
 
 [fixed]
 - github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)

--- a/src/compiler/hash.bas
+++ b/src/compiler/hash.bas
@@ -150,7 +150,7 @@ end function
 function hashLookup _
 	( _
 		byval hash as THASH ptr, _
-		byval symbol as zstring ptr _
+		byval symbol as const zstring ptr _
 	) as any ptr
 
     function = hashLookupEx( hash, symbol, hashHash( symbol ) )

--- a/src/compiler/hash.bas
+++ b/src/compiler/hash.bas
@@ -12,8 +12,8 @@ type HASHITEMPOOL
 end type
 
 
-declare function 	hashNewItem	( byval list as HASHLIST ptr ) as HASHITEM ptr
-declare sub 		hashDelItem	( byval list as HASHLIST ptr, _
+declare function    hashNewItem ( byval list as HASHLIST ptr ) as HASHITEM ptr
+declare sub         hashDelItem ( byval list as HASHLIST ptr, _
 								  byval item as HASHITEM ptr )
 
 dim shared as HASHITEMPOOL itempool
@@ -58,15 +58,15 @@ end sub
 
 sub hashEnd(byval hash as THASH ptr)
 
-    dim as integer i = any
-    dim as HASHITEM ptr item = any, nxt = any
-    dim as HASHLIST ptr list = any
+	dim as integer i = any
+	dim as HASHITEM ptr item = any, nxt = any
+	dim as HASHLIST ptr list = any
 
-    '' for each item on each list, deallocate it and the name string
-    list = hash->list
+	'' for each item on each list, deallocate it and the name string
+	list = hash->list
 
 	if( hash->delstr ) then
-    	for i = 0 to hash->nodes-1
+		for i = 0 to hash->nodes-1
 			item = list->head
 			do while( item <> NULL )
 				nxt = item->next
@@ -82,7 +82,7 @@ sub hashEnd(byval hash as THASH ptr)
 		next
 
 	else
-    	for i = 0 to hash->nodes-1
+		for i = 0 to hash->nodes-1
 			item = list->head
 			do while( item <> NULL )
 				nxt = item->next
@@ -122,12 +122,12 @@ function hashLookupEx _
 		byval index as uinteger _
 	) as any ptr
 
-    dim as HASHITEM ptr item = any
-    dim as HASHLIST ptr list = any
+	dim as HASHITEM ptr item = any
+	dim as HASHLIST ptr list = any
 
-    function = NULL
+	function = NULL
 
-    index mod= hash->nodes
+	index mod= hash->nodes
 
 	'' get the start of list
 	list = @hash->list[index]
@@ -153,7 +153,7 @@ function hashLookup _
 		byval symbol as const zstring ptr _
 	) as any ptr
 
-    function = hashLookupEx( hash, symbol, hashHash( symbol ) )
+	function = hashLookupEx( hash, symbol, hashHash( symbol ) )
 
 end function
 
@@ -227,26 +227,26 @@ function hashAdd _
 		byval index as uinteger _
 	) as HASHITEM ptr
 
-    dim as HASHITEM ptr item = any
+	dim as HASHITEM ptr item = any
 
 	'' calc hash?
 	if( index = cuint( INVALID ) ) then
 		index = hashHash( symbol )
 	end if
 
-    index mod= hash->nodes
+	index mod= hash->nodes
 
-    '' allocate a new node
-    item = hashNewItem( @hash->list[index] )
+	'' allocate a new node
+	item = hashNewItem( @hash->list[index] )
 
-    function = item
-    if( item = NULL ) then
-    	exit function
+	function = item
+	if( item = NULL ) then
+		exit function
 	end if
 
-    '' fill node
-    item->name = symbol
-    item->data = userdata
+	'' fill node
+	item->name = symbol
+	item->data = userdata
 
 end function
 
@@ -258,7 +258,7 @@ sub hashDel _
 		byval index as uinteger _
 	)
 
-    dim as HASHLIST ptr list = any
+	dim as HASHLIST ptr list = any
 
 	if( item = NULL ) then
 		exit sub

--- a/src/compiler/hash.bi
+++ b/src/compiler/hash.bi
@@ -4,21 +4,21 @@
 #include once "list.bi"
 
 type HASHITEM
-	name		as const zstring ptr			'' shared
-	data		as any ptr				'' user data
-	prev		as HASHITEM ptr
-	next		as HASHITEM ptr
+	name        as const zstring ptr      '' shared
+	data        as any ptr                '' user data
+	prev        as HASHITEM ptr
+	next        as HASHITEM ptr
 end type
 
 type HASHLIST
-	head		as HASHITEM ptr
-	tail		as HASHITEM ptr
+	head        as HASHITEM ptr
+	tail        as HASHITEM ptr
 end type
 
 type THASH
-	list		as HASHLIST ptr
-	nodes		as integer
-	delstr		as integer
+	list        as HASHLIST ptr
+	nodes       as integer
+	delstr      as integer
 end type
 
 declare sub hashInit _

--- a/src/compiler/hash.bi
+++ b/src/compiler/hash.bi
@@ -38,7 +38,7 @@ declare function hashHash _
 declare function hashLookup _
 	( _
 		byval hash as THASH ptr, _
-		byval symbol as zstring ptr _
+		byval symbol as const zstring ptr _
 	) as any ptr
 
 declare function hashLookupEx _

--- a/src/compiler/parser-inlineasm.bas
+++ b/src/compiler/parser-inlineasm.bas
@@ -217,7 +217,7 @@ sub cAsmCode()
 
 					chain_ = symbChainGetNext( chain_ )
 				loop
-            end if
+			end if
 
 		'' lit number?
 		case FB_TKCLASS_NUMLITERAL
@@ -230,18 +230,18 @@ sub cAsmCode()
 		case FB_TKCLASS_STRLITERAL
 			 expr = cStrLiteral( FALSE )
 			 if( expr <> NULL ) then
-             	dim as FBSYMBOL ptr litsym = astGetStrLitSymbol( expr )
-             	if( litsym <> NULL ) then
-                    text = """"
-                    if( symbGetType( litsym ) <> FB_DATATYPE_WCHAR ) then
-             			text += *symbGetVarLitText( litsym )
-             		else
-             			text += *symbGetVarLitTextW( litsym )
-             		end if
-             		text += """"
-			 	end if
+				dim as FBSYMBOL ptr litsym = astGetStrLitSymbol( expr )
+				if( litsym <> NULL ) then
+					text = """"
+					if( symbGetType( litsym ) <> FB_DATATYPE_WCHAR ) then
+						text += *symbGetVarLitText( litsym )
+					else
+						text += *symbGetVarLitTextW( litsym )
+					end if
+					text += """"
+				end if
 
-			 	astDelTree( expr )
+				astDelTree( expr )
 			 end if
 
 		''
@@ -249,13 +249,13 @@ sub cAsmCode()
 			select case thisTok
 			case FB_TK_FUNCTION
 			'' FUNCTION?
-    			sym = symbGetProcResult( parser.currproc )
-    			if( sym = NULL ) then
+				sym = symbGetProcResult( parser.currproc )
+				if( sym = NULL ) then
 					errReport( FB_ERRMSG_SYNTAXERROR )
 					doskip = TRUE
-    			else
-    				symbSetIsAccessed( sym )
-    			end if
+				else
+					symbSetIsAccessed( sym )
+				end if
 
 			case FB_TK_CINT
 				'' CINT( valid expression )?
@@ -302,9 +302,9 @@ end sub
 '':::::
 ''AsmBlock        =   ASM Comment? SttSeparator
 ''                        (AsmCode Comment? NewLine)+
-''					  END ASM .
+''                    END ASM .
 function cAsmBlock as integer
-    dim as integer issingleline = any
+	dim as integer issingleline = any
 
 	function = FALSE
 
@@ -313,11 +313,11 @@ function cAsmBlock as integer
 		exit function
 	end if
 
-    if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_CODE ) = FALSE ) then
-    	'' error recovery: skip the whole compound stmt
-    	hSkipCompound( FB_TK_ASM )
-    	exit function
-    end if
+	if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_CODE ) = FALSE ) then
+		'' error recovery: skip the whole compound stmt
+		hSkipCompound( FB_TK_ASM )
+		exit function
+	end if
 
 	'' ASM
 	lexSkipToken( LEXCHECK_POST_SUFFIX )
@@ -336,13 +336,13 @@ function cAsmBlock as integer
 	else
 		if( cStmtSeparator( ) = FALSE ) then
 			issingleline = TRUE
-        end if
+		end if
 	end if
 
 	'' (AsmCode Comment? NewLine)+
 	do
 		if( issingleline = FALSE ) then
-         astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ), env.inf.incfile ))
+		astAdd( astNewDBG( AST_OP_DBG_LINEINI, lexLineNum( ), env.inf.incfile ))
 		end if
 
 		cAsmCode( )

--- a/src/compiler/parser-inlineasm.bas
+++ b/src/compiler/parser-inlineasm.bas
@@ -107,7 +107,7 @@ private function hIsAsmKeyword( byval text as const zstring ptr ) as integer
 	function = (hashLookup( @asmkeywords.hash, text ) <> NULL)
 end function
 
-function addAsmKeyword( byval id as const zstring ptr ) as integer
+function parserInlineAsmAddKeyword( byval id as const zstring ptr ) as integer
 	hInitAsmKeywords( )
 	if( hIsAsmKeyword( id ) ) then
 		return FALSE

--- a/src/compiler/parser.bi
+++ b/src/compiler/parser.bi
@@ -243,6 +243,8 @@ end enum
 
 declare sub parserInlineAsmEnd( )
 
+declare function parserInlineAsmAddKeyword( byval id as const zstring ptr ) as integer
+
 declare sub cProgram()
 
 declare function cLabel _

--- a/src/compiler/pp-pragma.bas
+++ b/src/compiler/pp-pragma.bas
@@ -132,6 +132,12 @@ private sub pragmaReserve( )
 	chain_ = cIdentifier( base_parent, FB_IDOPT_NONE )
 	id = lexGetText( )
 
+	if( hIsValidSymbolName( id ) = FALSE ) then
+		errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
+		'' error recovery: skip line
+		hSkipUntil( FB_TK_EOL )
+	end if
+
 	if( env.ppfile_num > 0 ) then
 		lexPPOnlyEmitToken( )
 	end if
@@ -139,6 +145,8 @@ private sub pragmaReserve( )
 	if( isASM ) then
 		if( parserInlineAsmAddKeyword( id ) = FALSE ) then
 			errReportEx( FB_ERRMSG_DUPDEFINITION, id )
+			'' error recovery: skip line
+			hSkipUntil( FB_TK_EOL )
 		end if
 	else
 		sym = symbNewSymbol( FB_SYMBOPT_DOHASH, _
@@ -151,6 +159,8 @@ private sub pragmaReserve( )
 
 		if( sym = NULL ) then
 			errReportEx( FB_ERRMSG_DUPDEFINITION, id )
+			'' error recovery: skip line
+			hSkipUntil( FB_TK_EOL )
 		end if
 
 	end if

--- a/src/compiler/pp-pragma.bas
+++ b/src/compiler/pp-pragma.bas
@@ -24,9 +24,9 @@ enum LEXPP_PRAGMAFLAG_ENUM
 end enum
 
 type LEXPP_PRAGMAOPT
-	tk		as zstring * 16
-	opt 	as integer
-	flags	as integer
+	tk      as zstring * 16
+	opt     as integer
+	flags   as integer
 end type
 
 enum LEXPP_PRAGMAOPT_ENUM
@@ -39,7 +39,7 @@ enum LEXPP_PRAGMAOPT_ENUM
 end enum
 
 type LEXPP_PRAGMASTK
-	tos 	as integer
+	tos     as integer
 	stk(0 to FB_MAXPRAGMARECLEVEL-1) as longint
 end type
 
@@ -129,7 +129,7 @@ private sub pragmaReserve( )
 			if( env.ppfile_num > 0 ) then
 				lexPPOnlyEmitText( "#pragma reserve asm " + *id )
 			end if
-		end if	
+		end if
 	else
 		sym = symbNewSymbol( FB_SYMBOPT_DOHASH, _
 			NULL, _
@@ -156,11 +156,11 @@ end sub
 
 
 '':::::
-'' Pragma			=	PRAGMA
+'' Pragma           =   PRAGMA
 ''                            ONCE
-''							| PUSH '(' symbol (',' expression{int})? ')'
-''							| POP '(' symbol ')'
-''							| symbol ('=' expression{int})?
+''                          | PUSH '(' symbol (',' expression{int})? ')'
+''                          | POP '(' symbol ')'
+''                          | symbol ('=' expression{int})?
 ''                          | RESERVE (SHARED|ASM)? symbol
 ''
 sub ppPragma( )

--- a/src/compiler/pp-pragma.bas
+++ b/src/compiler/pp-pragma.bas
@@ -175,6 +175,7 @@ private sub pragmaReserve( )
 			errReportEx( FB_ERRMSG_DUPDEFINITION, id )
 			'' error recovery: skip line
 			hSkipUntil( FB_TK_EOL )
+			exit sub
 		end if
 	end if
 
@@ -191,6 +192,7 @@ private sub pragmaReserve( )
 			errReportEx( FB_ERRMSG_DUPDEFINITION, id )
 			'' error recovery: skip line
 			hSkipUntil( FB_TK_EOL )
+			exit sub
 		end if
 
 	end if

--- a/src/compiler/pp.bas
+++ b/src/compiler/pp.bas
@@ -200,6 +200,7 @@ sub ppParse( )
 		dim as FBSYMCHAIN ptr chain_ = any
 		dim as FBSYMBOL ptr base_parent = any
 
+		'' #undef
 		lexSkipToken( LEXCHECK_NODEFINE or LEXCHECK_POST_SUFFIX )
 
 		chain_ = cIdentifier( base_parent, FB_IDOPT_NONE )

--- a/src/compiler/symb.bas
+++ b/src/compiler/symb.bas
@@ -10,43 +10,43 @@
 #include once "list.bi"
 #include once "pool.bi"
 
-declare sub			symbDelGlobalTb 	( )
+declare sub         symbDelGlobalTb     ( )
 
-declare sub 		symbKeywordInit		( )
+declare sub         symbKeywordInit     ( )
 
-declare sub 		symbDefineInit		( _
+declare sub         symbDefineInit      ( _
 											byval ismain as integer _
 										)
 
-declare sub 		symbDefineEnd		( )
+declare sub         symbDefineEnd       ( )
 
-declare sub 		symbFwdRefInit		( )
+declare sub         symbFwdRefInit      ( )
 
-declare sub 		symbFwdRefEnd		( )
+declare sub         symbFwdRefEnd       ( )
 
-declare sub 		symbVarInit			( )
+declare sub         symbVarInit         ( )
 
-declare sub 		symbVarEnd			( )
+declare sub         symbVarEnd          ( )
 
-declare sub 		symbProcInit		( )
+declare sub         symbProcInit        ( )
 
-declare sub 		symbProcEnd			( )
+declare sub         symbProcEnd         ( )
 
-declare sub 		symbMangleInit		( )
+declare sub         symbMangleInit      ( )
 
-declare sub 		symbMangleEnd		( )
+declare sub         symbMangleEnd       ( )
 
-declare sub 		symbCompInit		( )
+declare sub         symbCompInit        ( )
 
-declare sub 		symbCompEnd			( )
+declare sub         symbCompEnd         ( )
 
-declare sub 		symbCompRTTIInit	( )
+declare sub         symbCompRTTIInit    ( )
 
-declare sub 		symbCompRTTIEnd		( )
+declare sub         symbCompRTTIEnd     ( )
 
-declare sub 		symbKeywordConstsInit ( )
+declare sub         symbKeywordConstsInit ( )
 
-declare sub			symbKeywordTypeInit	( )    
+declare sub         symbKeywordTypeInit ( )
 
 declare function hGetNamespacePrefix( byval sym as FBSYMBOL ptr ) as string
 
@@ -74,14 +74,14 @@ sub symbInitSymbols static
 	listInit( @symb.nsextlist, FB_INITSYMBOLNODES \ 16, len( FBNAMESPC_EXT ), LIST_FLAGS_CLEAR )
 
 	'' global namespace - not complete, just a mock symbol
-    symb.globnspc.class = FB_SYMBCLASS_NAMESPACE
-    symb.globnspc.scope = FB_MAINSCOPE
+	symb.globnspc.class = FB_SYMBCLASS_NAMESPACE
+	symb.globnspc.scope = FB_MAINSCOPE
 
-    with symb.globnspc.nspc
-        symbSymbTbInit( .ns.symtb, @symb.globnspc )
+	with symb.globnspc.nspc
+		symbSymbTbInit( .ns.symtb, @symb.globnspc )
 		symbHashTbInit( .ns.hashtb, @symb.globnspc, FB_INITSYMBOLNODES )
-    	.ns.ext = symbCompAllocExt( )
-    end with
+		.ns.ext = symbCompAllocExt( )
+	end with
 
 	''
 	symb.namespc = @symb.globnspc
@@ -107,7 +107,7 @@ end sub
 
 '':::::
 private sub hInitDefTypeTb
-    dim as integer dtype, i
+	dim as integer dtype, i
 
 	if( fbLangIsSet( FB_LANG_QB ) ) then
 		dtype = FB_DATATYPE_SINGLE
@@ -159,7 +159,7 @@ sub symbInit _
 
 	''
 	hInitDefTypeTb( )
-	
+
 	''
 	symbCompRTTIInit( )
 
@@ -169,17 +169,17 @@ sub symbInit _
 	''
 	symbKeywordTypeInit( )
 
-    ''
-    symb.inited = TRUE
+	''
+	symb.inited = TRUE
 
 end sub
 
 '':::::
 sub symbEnd
 
-    if( symb.inited = FALSE ) then
-    	exit sub
-    end if
+	if( symb.inited = FALSE ) then
+		exit sub
+	end if
 
 	''
 	symbDelGlobalTb( )
@@ -196,7 +196,7 @@ sub symbEnd
 
 	''
 	symbCompRTTIEnd( )
-	
+
 	''
 	symbProcEnd( )
 
@@ -317,7 +317,7 @@ function symbCanDuplicate _
 					if( symbGetIsRTL( head_sym ) = FALSE ) then
 						exit function
 					else
-						'' both RTL? don't allow dup so overloaded procs 
+						'' both RTL? don't allow dup so overloaded procs
 						'' will get chained
 						if( symbGetIsRTL( head_sym ) ) then
 							exit function
@@ -487,9 +487,9 @@ function symbNewSymbol _
 		byval pattrib as FB_PROCATTRIB _
 	) as FBSYMBOL ptr
 
-    dim as integer slen = any, delok = any
+	dim as integer slen = any, delok = any
 
-    function = NULL
+	function = NULL
 
 	if( symtb = NULL ) then
 		symtb = symb.symtb
@@ -514,31 +514,31 @@ function symbNewSymbol _
 		end if
 	end if
 
-    if( hashtb = NULL ) then
-    	hashtb = symb.hashtb
-    end if
+	if( hashtb = NULL ) then
+		hashtb = symb.hashtb
+	end if
 
-    '' alloc symbol node?
-    delok = FALSE
-    if( s = NULL ) then
-    	delok = TRUE
-    	s = listNewNode( @symb.symlist )
-    end if
+	'' alloc symbol node?
+	delok = FALSE
+	if( s = NULL ) then
+		delok = TRUE
+		s = listNewNode( @symb.symlist )
+	end if
 
-    ''
-    s->class = class_
+	''
+	s->class = class_
 	s->attrib = attrib
 	s->pattrib = pattrib
 	s->stats = 0
 	s->mangling = parser.mangling
 
-    s->typ = dtype
-    s->subtype = subtype
+	s->typ = dtype
+	s->subtype = subtype
 
-    '' QB quirks
+	'' QB quirks
 	if( (options and FB_SYMBOPT_UNSCOPE) <> 0 ) then
 		if( (parser.currproc->stats and (FB_SYMBSTATS_MAINPROC or _
-									  	 FB_SYMBSTATS_MODLEVELPROC)) <> 0 ) then
+										 FB_SYMBSTATS_MODLEVELPROC)) <> 0 ) then
 			s->scope = FB_MAINSCOPE
 		else
 			s->scope = parser.currproc->scope + 1
@@ -547,33 +547,33 @@ function symbNewSymbol _
 		s->scope = parser.scope
 	end if
 
-    '' name
-    slen = iif( id <> NULL, len( *id ), 0 )
-    if( slen > 0 ) then
-    	s->id.name = poolNewItem( @symb.namepool, slen + 1 ) 'ZstrAllocate( slen )
-    	if( (options and FB_SYMBOPT_PRESERVECASE) = 0 ) then
-    		hUcase( id, s->id.name )
-    	else
-    	    *s->id.name = *id
+	'' name
+	slen = iif( id <> NULL, len( *id ), 0 )
+	if( slen > 0 ) then
+		s->id.name = poolNewItem( @symb.namepool, slen + 1 ) 'ZstrAllocate( slen )
+		if( (options and FB_SYMBOPT_PRESERVECASE) = 0 ) then
+			hUcase( id, s->id.name )
+		else
+		    *s->id.name = *id
 		end if
-    else
-    	s->id.name = NULL
-    	options and= not FB_SYMBOPT_DOHASH
-    end if
+	else
+		s->id.name = NULL
+		options and= not FB_SYMBOPT_DOHASH
+	end if
 
-    '' alias
-    if( id_alias <> NULL ) then
-    	s->id.alias = ZstrAllocate( len( *id_alias ) )
-    	*s->id.alias = *id_alias
-    else
-    	s->id.alias = NULL
-    end if
+	'' alias
+	if( id_alias <> NULL ) then
+		s->id.alias = ZstrAllocate( len( *id_alias ) )
+		*s->id.alias = *id_alias
+	else
+		s->id.alias = NULL
+	end if
 
-    s->id.mangled = NULL
+	s->id.mangled = NULL
 
-    ''
-    s->lgt = 0
-    s->ofs = 0
+	''
+	s->lgt = 0
+	s->ofs = 0
 
 	'' add to hash table
 	s->hash.tb = hashtb
@@ -588,8 +588,8 @@ function symbNewSymbol _
 		if( head_sym = NULL ) then
 			'' add to hash table
 			s->hash.item = hashAdd( @hashtb->tb, s->id.name, s, s->hash.index )
-            s->hash.prev = NULL
-            s->hash.next = NULL
+			s->hash.prev = NULL
+			s->hash.next = NULL
 
 		else
 			'' can it be duplicated?
@@ -609,17 +609,17 @@ function symbNewSymbol _
 
 			'' add to head so no scope resolution is needed
 
-    		'' QB mode?
-    		if( env.clopt.lang = FB_LANG_QB ) then
-    			'' keywords must stay at the head
-    			dim as FBSYMBOL ptr prev = NULL
-    			do while( symbIsKeyword( head_sym ) )
-    				prev = head_sym
-    				head_sym = head_sym->hash.next
-    				if( head_sym = NULL ) then
-    					exit do
-    				end if
-    			loop
+			'' QB mode?
+			if( env.clopt.lang = FB_LANG_QB ) then
+				'' keywords must stay at the head
+				dim as FBSYMBOL ptr prev = NULL
+				do while( symbIsKeyword( head_sym ) )
+					prev = head_sym
+					head_sym = head_sym->hash.next
+					if( head_sym = NULL ) then
+						exit do
+					end if
+				loop
 
 				if( prev = NULL ) then
 					goto add_prev
@@ -632,20 +632,20 @@ function symbNewSymbol _
 					head_sym->hash.prev = s
 				end if
 
-    		else
-add_prev:		head_sym->hash.item->data = s
+			else
+add_prev:       head_sym->hash.item->data = s
 				head_sym->hash.item->name = s->id.name
 				head_sym->hash.prev = s
 				s->hash.prev = NULL
 				s->hash.next = head_sym
-    		end if
+			end if
 
 		end if
 
 	else
 		s->hash.item = NULL
 		s->hash.prev = NULL
-        s->hash.next = NULL
+		s->hash.next = NULL
 	end if
 
 	'' add to symbol table
@@ -669,8 +669,8 @@ add_prev:		head_sym->hash.item->data = s
 		symbAddToFwdRef( subtype, s )
 	end if
 
-    ''
-    function = s
+	''
+	function = s
 
 end function
 
@@ -754,7 +754,7 @@ sub symbHashListInsertNamespace _
 
 	'' for each symbol in the ns being imported..
 	dim as FBSYMBOL ptr s = src_head
-    do until( s = NULL )
+	do until( s = NULL )
 		'' if symbol has a name..
 		if( s->hash.item <> NULL ) then
 			'' only add the head symbol if it's duplicated
@@ -765,15 +765,15 @@ sub symbHashListInsertNamespace _
 				chain_->isimport = TRUE
 
 				dim as FBSYMCHAIN ptr head = hashLookupEx( @symb.imphashtb, _
-													   	   s->id.name, _
-													   	   s->hash.index )
+														   s->id.name, _
+														   s->hash.index )
 				'' not defined yet? create a new hash node
 				if( head = NULL ) then
-           			chain_->item = hashAdd( @symb.imphashtb, _
-            								s->id.name, _
-            								chain_, _
-            								s->hash.index )
-            		chain_->next = NULL
+					chain_->item = hashAdd( @symb.imphashtb, _
+											s->id.name, _
+											chain_, _
+											s->hash.index )
+					chain_->next = NULL
 
 				'' already defined..
 				else
@@ -784,16 +784,16 @@ sub symbHashListInsertNamespace _
 					chain_->next = head
 				end if
 
-            	''
-            	if( imp_tail <> NULL ) then
-            		imp_tail->imp_next = chain_
-            	else
-            		imp_head = chain_
-            	end if
-            	chain_->imp_next = NULL
-            	imp_tail = chain_
-        	end if
-        end if
+				''
+				if( imp_tail <> NULL ) then
+					imp_tail->imp_next = chain_
+				else
+					imp_head = chain_
+				end if
+				chain_->imp_next = NULL
+				imp_tail = chain_
+			end if
+		end if
 
 		s = s->next
 	loop
@@ -812,33 +812,33 @@ sub symbHashListRemoveNamespace _
 	dim as FBSYMCHAIN ptr chain_ = symbGetCompExt( ns )->impsym_head
 
 	do until( chain_ = NULL )
-       	dim as FBSYMCHAIN ptr prv = any, nxt = any
+		dim as FBSYMCHAIN ptr prv = any, nxt = any
 
-    	prv = chain_->prev
-    	nxt = chain_->next
+		prv = chain_->prev
+		nxt = chain_->next
 
-    	if( prv <> NULL ) then
-    		prv->next = nxt
-    		if( nxt <> NULL ) then
-    			nxt->prev = prv
-    		end if
-    	else
-    		'' symbol was the head node?
-    		if( nxt <> NULL ) then
-    			nxt->prev = NULL
+		if( prv <> NULL ) then
+			prv->next = nxt
+			if( nxt <> NULL ) then
+				nxt->prev = prv
+			end if
+		else
+			'' symbol was the head node?
+			if( nxt <> NULL ) then
+				nxt->prev = NULL
 
-       			'' update list head
-       			chain_->item->data = nxt
+				'' update list head
+				chain_->item->data = nxt
 
-    		'' nothing left? remove from hash table
-    		else
-    			hashDel( @symb.imphashtb, chain_->item, chain_->sym->hash.index )
-    		end if
-    	end if
+			'' nothing left? remove from hash table
+			else
+				hashDel( @symb.imphashtb, chain_->item, chain_->sym->hash.index )
+			end if
+		end if
 
-       	nxt = chain_->imp_next
-       	listDelNode( @symb.imphashlist, chain_ )
-       	chain_ = nxt
+		nxt = chain_->imp_next
+		listDelNode( @symb.imphashlist, chain_ )
+		chain_ = nxt
 	loop
 
 	symbGetCompExt( ns )->impsym_head = NULL
@@ -862,7 +862,7 @@ function symbLookup _
 		byref tk_class as FB_TKCLASS _
 	) as FBSYMCHAIN ptr
 
-    static as zstring * FB_MAXNAMELEN+1 sname
+	static as zstring * FB_MAXNAMELEN+1 sname
 
 	'' assume it's an unknown identifier
 	tk = FB_TK_ID
@@ -871,15 +871,15 @@ function symbLookup _
 	hUcase( *id, sname )
 	id = @sname
 
-    dim as uinteger index = hashHash( id )
-    dim as FBSYMCHAIN ptr chain_ = NULL
+	dim as uinteger index = hashHash( id )
+	dim as FBSYMCHAIN ptr chain_ = NULL
 
-    '' for each nested hash tb, starting from last
-    dim as FBHASHTB ptr hashtb = symb.hashlist.tail
+	'' for each nested hash tb, starting from last
+	dim as FBHASHTB ptr hashtb = symb.hashlist.tail
 
-    do
-    	dim as FBSYMBOL ptr sym = hashLookupEx( @hashtb->tb, id, index )
-        if( sym <> NULL ) then
+	do
+		dim as FBSYMBOL ptr sym = hashLookupEx( @hashtb->tb, id, index )
+		if( sym <> NULL ) then
 			chain_ = chainpoolNext()
 
 			chain_->sym = sym
@@ -910,12 +910,12 @@ function symbLookup _
 				'' check (and add) the imports..
 				exit do
 			end if
-        end if
+		end if
 
-    	hashtb = hashtb->prev
-    loop while( hashtb <> NULL )
+		hashtb = hashtb->prev
+	loop while( hashtb <> NULL )
 
-    '' now try the imported namespaces..
+	'' now try the imported namespaces..
 	dim as FBSYMCHAIN ptr imp_chain = hashLookupEx( @symb.imphashtb, id, index )
 	if( chain_ = NULL ) then
 		return imp_chain
@@ -935,20 +935,20 @@ private function hLookupImportHash _
 		byval index as uinteger _
 	) as FBSYMCHAIN ptr
 
-    dim as FBSYMCHAIN ptr chain_head = hashLookupEx( @symb.imphashtb, id, index )
-    if( chain_head = NULL ) then
-    	return NULL
-    end if
+	dim as FBSYMCHAIN ptr chain_head = hashLookupEx( @symb.imphashtb, id, index )
+	if( chain_head = NULL ) then
+		return NULL
+	end if
 
 	dim as FBSYMCHAIN ptr head = NULL, tail = NULL
 
 	'' for each namespace found..
 	dim as FBSYMCHAIN ptr chain_ = chain_head
 	do
-    	'' for each namespace that imports that namespace..
-    	dim as FBSYMBOL ptr exp_ = symbGetCompExportHead( symbGetNamespace( chain_->sym ) )
-    	do
-    		if( symbGetExportNamespc( exp_ ) = ns ) then
+		'' for each namespace that imports that namespace..
+		dim as FBSYMBOL ptr exp_ = symbGetCompExportHead( symbGetNamespace( chain_->sym ) )
+		do
+			if( symbGetExportNamespc( exp_ ) = ns ) then
 				dim as FBSYMCHAIN ptr node = chainpoolNext()
 
 				node->sym = chain_->sym
@@ -972,7 +972,7 @@ private function hLookupImportHash _
 		chain_ = chain_->next
 	loop while( chain_ <> NULL )
 
-    return head
+	return head
 
 end function
 
@@ -994,12 +994,12 @@ private function hLookupImportList _
 										symbGetImportNamespc( imp_ ) ).tb, _
 									id, _
 									index )
-    	if( sym <> NULL ) then
+		if( sym <> NULL ) then
 			dim as FBSYMCHAIN ptr chain_ = chainpoolNext()
 
 			chain_->sym = sym
-            chain_->next = NULL
-            chain_->isimport = TRUE
+			chain_->next = NULL
+			chain_->isimport = TRUE
 
 			if( head = NULL ) then
 				head = chain_
@@ -1028,7 +1028,7 @@ function symbLookupAt _
 		byval search_imports as integer _
 	) as FBSYMCHAIN ptr
 
-    static as zstring * FB_MAXNAMELEN+1 sname
+	static as zstring * FB_MAXNAMELEN+1 sname
 
 	assert( symbIsStruct( ns ) or symbIsNamespace( ns ) or symbIsEnum( ns ) )
 
@@ -1036,45 +1036,45 @@ function symbLookupAt _
 		exit function
 	end if
 
-    if( preserve_case = FALSE ) then
-    	hUcase( *id, sname )
-    	id = @sname
-    end if
+	if( preserve_case = FALSE ) then
+		hUcase( *id, sname )
+		id = @sname
+	end if
 
-    dim as uinteger index = hashHash( id )
+	dim as uinteger index = hashHash( id )
 
-    '' search in UDT's (NAMESPACE, TYPE, CLASS or ENUM) hash tb first
-    dim as FBSYMBOL ptr sym = hashLookupEx( @symbGetCompHashTb( ns ).tb, id, index )
-    if( sym = NULL ) then
-    	if( search_imports = FALSE ) then
-    		return NULL
-    	end if
+	'' search in UDT's (NAMESPACE, TYPE, CLASS or ENUM) hash tb first
+	dim as FBSYMBOL ptr sym = hashLookupEx( @symbGetCompHashTb( ns ).tb, id, index )
+	if( sym = NULL ) then
+		if( search_imports = FALSE ) then
+			return NULL
+		end if
 
-    else
+	else
 		dim as FBSYMCHAIN ptr chain_ = chainpoolNext()
-    	chain_->sym = sym
-    	chain_->next = NULL
-    	chain_->isimport = FALSE
-    	return chain_
-    end if
-	
-    '' nothing found, now search the imports (if any)..
-    if( symbGetCompExt( ns ) = NULL ) then
-    	return NULL
-    end if
+		chain_->sym = sym
+		chain_->next = NULL
+		chain_->isimport = FALSE
+		return chain_
+	end if
+
+	'' nothing found, now search the imports (if any)..
+	if( symbGetCompExt( ns ) = NULL ) then
+		return NULL
+	end if
 
 	if( symbGetCompImportHead( ns ) = NULL ) then
 		return NULL
 	end if
 
-    '' special cases: the global ns
-    if( ns = @symbGetGlobalNamespc( ) ) then
-    	return hLookupImportHash( ns, id, index )
+	'' special cases: the global ns
+	if( ns = @symbGetGlobalNamespc( ) ) then
+		return hLookupImportHash( ns, id, index )
 
-    '' do a per-hash slow search..
-    else
-    	return hLookupImportList( ns, id, index )
-    end if
+	'' do a per-hash slow search..
+	else
+		return hLookupImportList( ns, id, index )
+	end if
 
 end function
 
@@ -1083,22 +1083,22 @@ function symbLookupByNameAndClass _
 	( _
 		byval ns as FBSYMBOL ptr, _
 		byval id as const zstring ptr, _
-	  	byval class_ as integer, _
-	  	byval preserve_case as integer, _
-	  	byval search_imports as integer _
+		byval class_ as integer, _
+		byval preserve_case as integer, _
+		byval search_imports as integer _
 	) as FBSYMBOL ptr
 
 	dim as FBSYMCHAIN ptr chain_ = any
 
-    chain_ = symbLookupAt( ns, id, preserve_case, search_imports )
+	chain_ = symbLookupAt( ns, id, preserve_case, search_imports )
 
-    '' any found?
-    if( chain_ <> NULL ) then
-    	'' check if classes match
-    	function = symbFindByClass( chain_, class_ )
-    else
-    	function = NULL
-    end if
+	'' any found?
+	if( chain_ <> NULL ) then
+		'' check if classes match
+		function = symbFindByClass( chain_, class_ )
+	else
+		function = NULL
+	end if
 
 end function
 
@@ -1109,14 +1109,14 @@ function symbFindByClass _
 		byval class_ as integer _
 	) as FBSYMBOL ptr
 
-    dim as FBSYMBOL ptr sym = any
-    dim as integer match = FALSE
+	dim as FBSYMBOL ptr sym = any
+	dim as integer match = FALSE
 
-    '' lookup a symbol with the same class
-    do while( chain_ <> NULL )
-    	sym = chain_->sym
-    	do
-    		if( sym->class = class_ ) then
+	'' lookup a symbol with the same class
+	do while( chain_ <> NULL )
+		sym = chain_->sym
+		do
+			if( sym->class = class_ ) then
 				match = TRUE
 				exit do, do
 			end if
@@ -1124,10 +1124,10 @@ function symbFindByClass _
 			sym = sym->hash.next
 		loop while( sym <> NULL )
 
-    	chain_ = chain_->next
-    loop
-    
-    if( match = FALSE ) then
+		chain_ = chain_->next
+	loop
+
+	if( match = FALSE ) then
 		return NULL
 	end if
 
@@ -1151,45 +1151,45 @@ function symbFindVarBySuffix _
 		byval suffix as integer _
 	) as FBSYMBOL ptr
 
-    dim as FBSYMBOL ptr sym = any
+	dim as FBSYMBOL ptr sym = any
 
-    '' symbol has a suffix: lookup a symbol with the same type, suffixed or not
+	'' symbol has a suffix: lookup a symbol with the same type, suffixed or not
 
-   	'' QB quirk: fixed-len and zstrings referenced using '$' as suffix..
-   	if( suffix = FB_DATATYPE_STRING ) then
-   		do while( chain_ <> NULL )
-    		sym = chain_->sym
-    		do
-    			if( symbIsVar( sym ) ) then
-     				select case symbGetType( sym )
-     				case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, FB_DATATYPE_CHAR
-     					goto check_var
-     				end select
-     			end if
-
-				sym = sym->hash.next
-			loop while( sym <> NULL )
-
-    		chain_ = chain_->next
-    	loop
-
-    '' anything but strings..
-    else
-    	do while( chain_ <> NULL )
-    		sym = chain_->sym
-    		do
-    			if( symbIsVar( sym ) ) then
-    				if( symbGetType( sym ) = suffix ) then
-    					goto check_var
-    				end if
-    			end if
+	'' QB quirk: fixed-len and zstrings referenced using '$' as suffix..
+	if( suffix = FB_DATATYPE_STRING ) then
+		do while( chain_ <> NULL )
+			sym = chain_->sym
+			do
+				if( symbIsVar( sym ) ) then
+					select case symbGetType( sym )
+					case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, FB_DATATYPE_CHAR
+						goto check_var
+					end select
+				end if
 
 				sym = sym->hash.next
 			loop while( sym <> NULL )
 
-    		chain_ = chain_->next
-    	loop
-    end if
+			chain_ = chain_->next
+		loop
+
+	'' anything but strings..
+	else
+		do while( chain_ <> NULL )
+			sym = chain_->sym
+			do
+				if( symbIsVar( sym ) ) then
+					if( symbGetType( sym ) = suffix ) then
+						goto check_var
+					end if
+				end if
+
+				sym = sym->hash.next
+			loop while( sym <> NULL )
+
+			chain_ = chain_->next
+		loop
+	end if
 
 	return NULL
 
@@ -1210,54 +1210,54 @@ function symbFindVarByDefType _
 		byval def_dtype as integer _
 	) as FBSYMBOL ptr
 
-    dim as FBSYMBOL ptr sym = any
+	dim as FBSYMBOL ptr sym = any
 
-    '' symbol has no suffix: lookup a symbol w/o suffix or with the
-    '' same type as default type (last DEF###)
+	'' symbol has no suffix: lookup a symbol w/o suffix or with the
+	'' same type as default type (last DEF###)
 
-    '' QB quirk: see above
-    if( def_dtype = FB_DATATYPE_STRING ) then
-    	do while( chain_ <> NULL )
-    		sym = chain_->sym
-    		do
-    			if( symbIsVar( sym ) ) then
-    				if( symbIsSuffixed( sym ) ) then
-    					select case sym->typ
-    					case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, FB_DATATYPE_CHAR
-    						goto check_var
-    					end select
-    				else
-    					goto check_var
-    				end if
-    			end if
-
-				sym = sym->hash.next
-			loop while( sym <> NULL )
-
-    		chain_ = chain_->next
-    	loop
-
-    '' anything but strings..
-    else
-    	do while( chain_ <> NULL )
-    		sym = chain_->sym
-    		do
-    			if( symbIsVar( sym ) ) then
-    				if( symbIsSuffixed( sym ) ) then
-    					if( symbGetType( sym ) = def_dtype ) then
-    						goto check_var
-    					end if
-    				else
-    					goto check_var
-    				end if
-    			end if
+	'' QB quirk: see above
+	if( def_dtype = FB_DATATYPE_STRING ) then
+		do while( chain_ <> NULL )
+			sym = chain_->sym
+			do
+				if( symbIsVar( sym ) ) then
+					if( symbIsSuffixed( sym ) ) then
+						select case sym->typ
+						case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, FB_DATATYPE_CHAR
+							goto check_var
+						end select
+					else
+						goto check_var
+					end if
+				end if
 
 				sym = sym->hash.next
 			loop while( sym <> NULL )
 
-    		chain_ = chain_->next
-    	loop
-    end if
+			chain_ = chain_->next
+		loop
+
+	'' anything but strings..
+	else
+		do while( chain_ <> NULL )
+			sym = chain_->sym
+			do
+				if( symbIsVar( sym ) ) then
+					if( symbIsSuffixed( sym ) ) then
+						if( symbGetType( sym ) = def_dtype ) then
+							goto check_var
+						end if
+					else
+						goto check_var
+					end if
+				end if
+
+				sym = sym->hash.next
+			loop while( sym <> NULL )
+
+			chain_ = chain_->next
+		loop
+	end if
 
 	return NULL
 
@@ -1313,36 +1313,36 @@ sub symbDelFromChainList _
 		byval s as FBSYMBOL ptr _
 	)
 
-    dim as FBSYMBOL ptr prv = any, nxt = any
+	dim as FBSYMBOL ptr prv = any, nxt = any
 
 	'' note: symbols declared inside namespaces can't be
-    '' removed by #undef or OPTION NOKEYWORD so the import
-    '' chain doesn't have to be updated
+	'' removed by #undef or OPTION NOKEYWORD so the import
+	'' chain doesn't have to be updated
 
-    '' relink
-    prv = s->hash.prev
-    nxt = s->hash.next
-    if( prv <> NULL ) then
-    	prv->hash.next = nxt
+	'' relink
+	prv = s->hash.prev
+	nxt = s->hash.next
+	if( prv <> NULL ) then
+		prv->hash.next = nxt
 
-    	if( nxt <> NULL ) then
-    		nxt->hash.prev = prv
-    	end if
+		if( nxt <> NULL ) then
+			nxt->hash.prev = prv
+		end if
 
-    else
-    	'' symbol was the head node?
-    	if( nxt <> NULL ) then
-    		nxt->hash.prev = NULL
+	else
+		'' symbol was the head node?
+		if( nxt <> NULL ) then
+			nxt->hash.prev = NULL
 
-    		'' update list head
-       		s->hash.item->data = nxt
-       		s->hash.item->name = nxt->id.name
+			'' update list head
+			s->hash.item->data = nxt
+			s->hash.item->name = nxt->id.name
 
-    	'' nothing left? remove from hash table
-    	else
-    		hashDel( @s->hash.tb->tb, s->hash.item, s->hash.index )
-    	end if
-    end if
+		'' nothing left? remove from hash table
+		else
+			hashDel( @s->hash.tb->tb, s->hash.item, s->hash.index )
+		end if
+	end if
 
 end sub
 
@@ -1358,7 +1358,7 @@ sub symbDelFromHash _
 
 	symbDelFromChainList( s )
 
-    s->hash.item = NULL
+	s->hash.item = NULL
 
 end sub
 
@@ -1368,17 +1368,17 @@ sub symbFreeSymbol _
 		byval s as FBSYMBOL ptr _
 	)
 
-    '' Symbol has forward type? That means it was added to the fwdref's list
-    '' of references/users for backpatching later. If the fwdref type is
-    '' still here, that means no backpatching happened yet, so the fwdref node
-    '' still exists and may do backpatching later. 
-    '' This symbol must be removed from the fwdref's user list, otherwise the
-    '' fwdref could backpatch a deleted node and would then corrupt any symbol
-    '' allocated at that address.
-    if( typeGetDtOnly( s->typ ) = FB_DATATYPE_FWDREF ) then
-        assert( s->subtype->class = FB_SYMBCLASS_FWDREF )
-        symbRemoveFromFwdRef( s->subtype, s )
-    end if
+	'' Symbol has forward type? That means it was added to the fwdref's list
+	'' of references/users for backpatching later. If the fwdref type is
+	'' still here, that means no backpatching happened yet, so the fwdref node
+	'' still exists and may do backpatching later.
+	'' This symbol must be removed from the fwdref's user list, otherwise the
+	'' fwdref could backpatch a deleted node and would then corrupt any symbol
+	'' allocated at that address.
+	if( typeGetDtOnly( s->typ ) = FB_DATATYPE_FWDREF ) then
+		assert( s->subtype->class = FB_SYMBCLASS_FWDREF )
+		symbRemoveFromFwdRef( s->subtype, s )
+	end if
 
 	'' revove from hash tb
 	symbDelFromHash( s )
@@ -1478,14 +1478,14 @@ function symbCloneSymbol( byval s as FBSYMBOL ptr ) as FBSYMBOL ptr
 		assert( symbGetIsFuncPtr( s ) )
 		function = symbAddProcPtrFromFunction( s )
 
-    case FB_SYMBCLASS_VAR
-    	function = symbCloneVar( s )
+	case FB_SYMBCLASS_VAR
+		function = symbCloneVar( s )
 
-    case FB_SYMBCLASS_CONST
+	case FB_SYMBCLASS_CONST
 		function = symbCloneConst( s )
 
-    case FB_SYMBCLASS_LABEL
-    	function = symbCloneLabel( s )
+	case FB_SYMBCLASS_LABEL
+		function = symbCloneLabel( s )
 
 	case FB_SYMBCLASS_STRUCT
 
@@ -1493,7 +1493,7 @@ function symbCloneSymbol( byval s as FBSYMBOL ptr ) as FBSYMBOL ptr
 		'' (most other structs would be too complex, especially classes)
 
 		assert( (s->udt.ext = NULL) )
-		
+
 		if( symbIsDescriptor( s ) ) then
 			symbGetDescTypeArrayDtype( s, arraydtype, arraysubtype )
 			function = symbAddArrayDescriptorType( symbGetDescTypeDimensions( s ), arraydtype, arraysubtype )
@@ -1501,26 +1501,26 @@ function symbCloneSymbol( byval s as FBSYMBOL ptr ) as FBSYMBOL ptr
 			function = symbCloneSimpleStruct( s )
 		end if
 
-    case else
+	case else
 		assert( FALSE )
-    	function = NULL
-    end select
+		function = NULL
+	end select
 
 end function
 
 '':::::
 sub symbDelGlobalTb( )
 
-    do
-    	'' starting from last (an USING must be removed before
-    	'' the ns in the same scope it's referencing)
-    	dim as FBSYMBOL ptr s = symbGetGlobalTb( ).tail
-    	if( s = NULL ) then
-    		exit do
-    	end if
+	do
+		'' starting from last (an USING must be removed before
+		'' the ns in the same scope it's referencing)
+		dim as FBSYMBOL ptr s = symbGetGlobalTb( ).tail
+		if( s = NULL ) then
+			exit do
+		end if
 
-    	symbDelSymbol( s, TRUE )
-    loop
+		symbDelSymbol( s, TRUE )
+	loop
 
 end sub
 
@@ -1531,8 +1531,8 @@ sub symbDelSymbolTb _
 		byval hashonly as integer _
 	)
 
-    '' del from hash tb only?
-    if( hashonly ) then
+	'' del from hash tb only?
+	if( hashonly ) then
 		dim as FBSYMBOL ptr s = tb->head
 		while( s )
 			symbDelFromHash( s )
@@ -1543,20 +1543,20 @@ sub symbDelSymbolTb _
 
 			s = s->next
 		wend
-    '' del from hash and symbol tb's
-    else
-    	do
-    	    '' starting from last because USING's can be referencing
-    	    '' namespace symbols in the same scope block
-    	    dim as FBSYMBOL ptr s = tb->tail
-    		if( s = NULL ) then
-    			exit do
-    		end if
+	'' del from hash and symbol tb's
+	else
+		do
+			'' starting from last because USING's can be referencing
+			'' namespace symbols in the same scope block
+			dim as FBSYMBOL ptr s = tb->tail
+			if( s = NULL ) then
+				exit do
+			end if
 
-	    	symbDelSymbol( s, TRUE )
-    	loop
+			symbDelSymbol( s, TRUE )
+		loop
 
-    end if
+	end if
 
 end sub
 
@@ -1626,14 +1626,14 @@ function symbGetValistType _
 	'' have the mangle modifer on the dtype to get recognized.
 	''
 	'' if it's just an ANY PTR without any mangle modifer
-	'' then it might be used for va_list on the target, 
+	'' then it might be used for va_list on the target,
 	'' but we don't know, and it doesn't matter anyway
 	'' so just return FB_CVA_LIST_NONE
 	''
 	'' for va_list structure type, we might be looking at a dtype
 	'' with a UDT subtype, or we might be looking at the UDT
 	'' itself.  Either way, we must look at the UDT itself to
-	'' determine if it is a struct, a struct array type 
+	'' determine if it is a struct, a struct array type
 	'' or std::va_list type using
 	''   - symbGetUdtValistType()
 
@@ -1641,7 +1641,7 @@ function symbGetValistType _
 	''   1) va_list type?  (any target/va_list type)
 	''   2) is a __builtin_va_list type? (gcc)
 	''   3) is a struct type, or an array struct type? (gcc)
-	
+
 	function = FB_CVA_LIST_NONE
 
 	'' mangle modifier?
@@ -1778,7 +1778,7 @@ function symbGetDefType _
 		byval symbol as const zstring ptr _
 	) as integer
 
-    dim as integer c = any
+	dim as integer c = any
 	dim as integer i = any
 
 	c = symbol[0][0]
@@ -1812,7 +1812,7 @@ sub symbSetDefType _
 		byval dtype as integer _
 	)
 
-    dim as integer i = any
+	dim as integer i = any
 
 	if( ichar < asc("A") ) then
 		ichar = asc("A")
@@ -2186,18 +2186,18 @@ function symbCheckConstAssign _
 	) as integer
 
 	'' TODO:
-	'' 1) consider combining 
+	'' 1) consider combining
 	''      - symbCheckConstAssign()
 	''      - hSymbCheckConstAssignFuncPtr()
 	''      - symbCheckConstAssignTopLevel()
-	'' 2) callers of symbCheckConstAssignTopLevel() need to respond to errors 
+	'' 2) callers of symbCheckConstAssignTopLevel() need to respond to errors
 	''    and warnings if calling symbCheckConstAssign() instead
 
 	dim ret as integer = any
 
 	'' check top-level const
 	ret = symbCheckConstAssignTopLevel( ldtype, rdtype, lsubtype, rsubtype, mode, matches )
-	
+
 	if( ret ) then
 		'' both types function pointer?
 		if( ( typeGetDtOnly( ldType ) = FB_DATATYPE_FUNCTION ) and ( typeGetDtOnly( rdType ) = FB_DATATYPE_FUNCTION ) ) then

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -113,9 +113,10 @@ enum FB_SYMBCLASS
 	FB_SYMBCLASS_CLASS
 	FB_SYMBCLASS_FIELD
 	FB_SYMBCLASS_TYPEDEF
-	FB_SYMBCLASS_FWDREF                         '' forward definition
+	FB_SYMBCLASS_FWDREF                     '' forward definition
 	FB_SYMBCLASS_SCOPE
-	FB_SYMBCLASS_NSIMPORT                       '' namespace import (an USING)
+	FB_SYMBCLASS_RESERVED                   '' reserved symbol
+	FB_SYMBCLASS_NSIMPORT                   '' namespace import (an USING)
 end enum
 
 '' symbol state mask


### PR DESCRIPTION
Adds `#pragma reserve  (asm, shared) symbol` statement to reserve words in the global shared namespace and ASM statements.

- `#pragma reserve (asm) symbol` - reserve symbol as ASM keyword
- `#pragma reserve (shared) symbol` - reserve symbol in the global shared namespace
- `#pragma reserve (asm, shared) symbol` - reserve symbol as both ASM keyword and in the global shared namespace
- `#pragma reserve symbol` - reserve symbol in current scope / namespace (not very well tested and is a side-effect of the above).
 
This PR provides a partial solution for backend compilation errors reported:
- sourceforge.net [#515 Reserved variable names (0.21.1) ](https://sourceforge.net/p/fbc/bugs/515/)
- freebasic.net [fbc 0.21.1: Bug or feature, that's the question](https://www.freebasic.net/forum/viewtopic.php?p=145570#145570)
- freebasic.net [Strange behaviour. Maybe a bug?](https://www.freebasic.net/forum/viewtopic.php?t=22305)
- freebasic.net [Re: Wiki improvements](https://www.freebasic.net/forum/viewtopic.php?p=285095#p285095)
- freebasic.net ['dword ptr [K2]' is not a valid base/index expression](https://www.freebasic.net/forum/viewtopic.php?t=27851)

Short version of the problem: some symbol names in fbc are emitted as-is to the backend compilers (gcc, as, etc) where the symbol name is a reserved keyword by the backend compiler.  There are typically two outcomes:
- compilation error in the backend
- bad code generation in the backend - successful compile and unexpected run time crashes

`#pragma reserve` allows user some access to the internal symbol tables.

Before updating the compiler to automatically add reserved words (and potentially breaking user code), this seemed like a good approach for testing the internals.  And in future, users can add reserved words in the event that new reserved words in the backend are discovered.
