### PR TITLE
sf.net # 645 - namespace and scope resolution on variables

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -68,6 +68,7 @@ Version 1.09.0
 - sf.net #843: Implicit casting of argument to string works for Instr() and Mid() but not for Left() and Right() 
 - sf.net #483 fblite: Can't call LEN with nested WITH block string member 
 - gas64 : fix required size for local variables >2GB
+- sf.net #645: don't access locals if explicit namespace is given on identifier
 
 
 Version 1.08.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -48,6 +48,7 @@ Version 1.09.0
 - fbc: '#pragma reserve symbol' statement will reserve a symbol name in the current scope / namespace
 - fbc: '#pragma reserve (shared) symbol' statement will reserve a symbol name in the shared scope
 - fbc: '#pragma reserve (asm) symbol' statement will reserve an ASM symbol name in all ASM statements and blocks
+- sf.net #645: respect global namespace '.' and '..' prefixes in REDIM
 
 [fixed]
 - github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)

--- a/changelog.txt
+++ b/changelog.txt
@@ -70,6 +70,7 @@ Version 1.09.0
 - gas64 : fix required size for local variables >2GB
 - sf.net #645: don't access locals if explicit namespace is given on identifier
 - sf.net #645: don't access locals if explicit global namespace '.' and '..' prefixes are given on identifier
+- sf.net #645: throw compile time error if scoped REDIM variable shadows a variable of the same name
 
 
 Version 1.08.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -45,8 +45,9 @@ Version 1.09.0
 - github #341: fbc: only process #cmdline in the first pass of the source module (which must be specified on the real command line)
 - github #341: fbc: '-z nocmdline' command line option to ignore #cmdline directives, allows overriding source directives with real fbc command line, show warning if used with '-w all'
 - fbc: #cmdline "-version" will immediately print the fbc version information if it was not already printed.  To get verbose version information '-v' option must appear before '-version'.  fbc command line  option '-v' option behaviour overrides #cmdline "-v"
-- fbc: '#pragma reserve (shared) symbol' statement will reserve a symbol name in the current scope / namespace
-- fbc: '#pragma reserve (asm) symbol' statement will reserve an ASM symbol name in for all ASM statements and blocks
+- fbc: '#pragma reserve symbol' statement will reserve a symbol name in the current scope / namespace
+- fbc: '#pragma reserve (shared) symbol' statement will reserve a symbol name in the shared scope
+- fbc: '#pragma reserve (asm) symbol' statement will reserve an ASM symbol name in all ASM statements and blocks
 
 [fixed]
 - github #315: set parameters when calling SCREENCONTROL (was broken in fbc 1.08.0 due to new LONG/LONGINT SCREENCONTROL API's)

--- a/changelog.txt
+++ b/changelog.txt
@@ -69,6 +69,7 @@ Version 1.09.0
 - sf.net #483 fblite: Can't call LEN with nested WITH block string member 
 - gas64 : fix required size for local variables >2GB
 - sf.net #645: don't access locals if explicit namespace is given on identifier
+- sf.net #645: don't access locals if explicit global namespace '.' and '..' prefixes are given on identifier
 
 
 Version 1.08.0

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -1637,10 +1637,18 @@ function cVarDecl _
 		'' typeless REDIM?
 		if( is_typeless ) then
 			if( sym ) then
-				'' REDIM'ing existing symbol, uses the same dtype
-				dtype = symbGetType( sym )
-				subtype = symbGetSubtype( sym )
-				lgt = symbGetLen( sym )
+				if( symbIsArray( sym ) ) then
+					'' REDIM'ing existing symbol, uses the same dtype
+					dtype = symbGetType( sym )
+					subtype = symbGetSubtype( sym )
+					lgt = symbGetLen( sym )
+					if( symbIsDynamic( sym ) = FALSE ) then
+						errReportEx( FB_ERRMSG_EXPECTEDDYNAMICARRAY, @id )
+					end if
+				else
+					'' -lang fb: typeless REDIM without pre-existing array not allowed
+					hErrorDefTypeNotAllowed( dtype, subtype, lgt )
+				end if
 			elseif( fbLangOptIsSet( FB_LANG_OPT_DEFTYPE ) ) then
 				'' DEF* is allowed, so typeless REDIM defaults to the default type
 				'' (can just keep using the deftype set above)
@@ -1715,7 +1723,7 @@ function cVarDecl _
 		end if
 
 		''
-		'' Declare the new variable or comlain about duplicate
+		'' Declare the new variable or complain about duplicate
 		'' definition, etc.
 		''
 		sym = hAddVar( sym, parent, id, palias, dtype, subtype, lgt, addsuffix, _

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -878,7 +878,7 @@ private function hResolveRefToRefInitializer( byval dtype as integer, byval expr
 	dim n as ASTNODE ptr = any
 
 	'' if initializer expr is a REF VAR, then crawl the INITREE of the var
-	'' it references for a VAR initializer.  If none found just return the 
+	'' it references for a VAR initializer.  If none found just return the
 	'' original expr.
 
 	if( expr andalso astIsDEREF( expr ) ) then
@@ -947,8 +947,8 @@ end function
 '':::::
 private function hVarInit _
 	( _
-        byval sym as FBSYMBOL ptr, _
-        byval isdecl as integer _
+		byval sym as FBSYMBOL ptr, _
+		byval isdecl as integer _
 	) as ASTNODE ptr
 
 	dim as integer attrib = any
@@ -1001,7 +1001,7 @@ private function hVarInit _
 		return hCheckAndBuildByrefInitializer( sym, expr )
 	end if
 
-    '' ANY?
+	'' ANY?
 	if( lexGetToken( ) = FB_TK_ANY ) then
 
 		'' don't allow arrays with ellipsis denoting unknown size at this time
@@ -1197,19 +1197,19 @@ private function hFlushInitializer _
 	'' no initializer?
 	if( initree = NULL ) then
 		'' static or shared?
-        if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
-        						   	   FB_SYMBATTRIB_SHARED or _
-        						   	   FB_SYMBATTRIB_COMMON)) <> 0 ) then
+		if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
+			FB_SYMBATTRIB_SHARED or _
+			FB_SYMBATTRIB_COMMON)) <> 0 ) then
 			'' object?
-        	if( has_dtor ) then
-        		'' local?
-           		if( symbIsLocal( sym ) ) then
-           			var_decl = hCallStaticCtor( sym, var_decl, NULL, TRUE )
+			if( has_dtor ) then
+				'' local?
+				if( symbIsLocal( sym ) ) then
+					var_decl = hCallStaticCtor( sym, var_decl, NULL, TRUE )
 
-           		'' global..
-          		else
-        			var_decl = hCallGlobalCtor( sym, var_decl, NULL, TRUE )
-           		end if
+				'' global..
+				else
+					var_decl = hCallGlobalCtor( sym, var_decl, NULL, TRUE )
+				end if
 			end if
 		end if
 
@@ -1217,9 +1217,9 @@ private function hFlushInitializer _
 	end if
 
 	'' not static or shared?
-    if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
-    							   FB_SYMBATTRIB_SHARED or _
-    							   FB_SYMBATTRIB_COMMON)) = 0 ) then
+	if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
+		FB_SYMBATTRIB_SHARED or _
+		FB_SYMBATTRIB_COMMON)) = 0 ) then
 
 		var_decl = hFlushDecl( var_decl )
 
@@ -1243,15 +1243,15 @@ private function hFlushInitializer _
 
 	'' Need to call constructor and/or destructor
 
-    '' local?
-    if( symbIsLocal( sym ) ) then
-       	'' the only possibility is static, SHARED can't be
-        '' used in -lang fb..
-        function = hCallStaticCtor( sym, var_decl, initree, has_dtor )
+	'' local?
+	if( symbIsLocal( sym ) ) then
+		'' the only possibility is static, SHARED can't be
+		'' used in -lang fb..
+		function = hCallStaticCtor( sym, var_decl, initree, has_dtor )
 
 	'' global.. add to the list, to be emitted later
-    else
-    	function = hCallGlobalCtor( sym, var_decl, initree, has_dtor )
+	else
+		function = hCallGlobalCtor( sym, var_decl, initree, has_dtor )
 	end if
 
 end function
@@ -1342,9 +1342,9 @@ function cVarDecl _
 		byval is_fordecl as integer _
 	) as FBSYMBOL ptr
 
-    static as zstring * FB_MAXNAMELEN+1 id
-    static as ASTNODE ptr exprTB(0 to FB_MAXARRAYDIMS-1, 0 to 1)
-    static as FBARRAYDIM dTB(0 to FB_MAXARRAYDIMS-1)
+	static as zstring * FB_MAXNAMELEN+1 id
+	static as ASTNODE ptr exprTB(0 to FB_MAXARRAYDIMS-1, 0 to 1)
+	static as FBARRAYDIM dTB(0 to FB_MAXARRAYDIMS-1)
 	dim as FBSYMCHAIN ptr chain_ = any
 	dim as FBSYMBOL ptr sym = any, subtype = any, parent = any
 	dim as ASTNODE ptr varexpr = any, initree = any, redimcall = any
@@ -1352,12 +1352,12 @@ function cVarDecl _
 	dim as integer is_typeless = any, is_declared = any, is_redim = any
 	dim as integer dtype = any, maybe_expr = any
 	dim as longint lgt = any
-    dim as integer dimensions = any, suffix = any
-    dim as zstring ptr palias = any
-    dim as ASTNODE ptr assign_initree = any
+	dim as integer dimensions = any, suffix = any
+	dim as zstring ptr palias = any
+	dim as ASTNODE ptr assign_initree = any
 	dim as FB_IDOPT options = any
 
-    function = NULL
+	function = NULL
 
 	'' inside a namespace but outside a proc?
 	if( symbIsGlobalNamespc( ) = FALSE ) then
@@ -1518,8 +1518,8 @@ function cVarDecl _
 					'' No exact bounds allowed, just like they can't have initializers either.
 					'' (but they can have fixed dimensions)
 					if( ((attrib and FB_SYMBATTRIB_COMMON) <> 0) or _
-					    (((attrib and FB_SYMBATTRIB_EXTERN) <> 0) and _
-					     ((attrib and FB_SYMBATTRIB_DYNAMIC) <> 0)) ) then
+						(((attrib and FB_SYMBATTRIB_EXTERN) <> 0) and _
+						((attrib and FB_SYMBATTRIB_DYNAMIC) <> 0)) ) then
 						errReport( FB_ERRMSG_DYNAMICEXTERNCANTHAVEBOUNDS )
 						dimensions = -1
 						have_bounds = FALSE
@@ -1684,7 +1684,7 @@ function cVarDecl _
 			else
 				'' "array too big/huge array on stack" check
 				if( symbCheckArraySize( dimensions, @dTB(0), lgt, _
-				                        ((attrib and (FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_STATIC)) = 0) ) = FALSE ) then
+					((attrib and (FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_STATIC)) = 0) ) = FALSE ) then
 					errReport( FB_ERRMSG_ARRAYTOOBIG )
 					'' error recovery: use small array
 					dimensions = 1
@@ -1755,8 +1755,8 @@ function cVarDecl _
 				if( ( initree <> NULL ) and ( fbLangOptIsSet( FB_LANG_OPT_SCOPE ) = FALSE ) ) then
 					'' local?
 					if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
-												   FB_SYMBATTRIB_SHARED or _
-												   FB_SYMBATTRIB_COMMON)) = 0 ) then
+						FB_SYMBATTRIB_SHARED or _
+						FB_SYMBATTRIB_COMMON)) = 0 ) then
 
 						''
 						'' The variable will be unscoped, i.e. it needs a default initree
@@ -1833,8 +1833,8 @@ function cVarDecl _
 					if( ((attrib and FB_SYMBATTRIB_DYNAMIC) <> 0) or (dimensions > 0) ) then
 						'' local?
 						if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
-												   	   FB_SYMBATTRIB_SHARED or _
-												   	   FB_SYMBATTRIB_COMMON)) = 0 ) then
+							FB_SYMBATTRIB_SHARED or _
+							FB_SYMBATTRIB_COMMON)) = 0 ) then
 
 							'' flush the decl node, safe to do here as it's a non-static
 							'' local var (and because the decl must be flushed first)

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -638,8 +638,8 @@ private function hLookupVarAndCheckParent _
 
 	sym = hLookupVar( chain_, dtype, is_typeless, has_suffix )
 
-	'' Namespace prefix explicitly given?
-	if( parent ) then
+	'' Namespace prefix explicitly given? And is not global
+	if( (parent <> NULL) and (parent <> @symbGetGlobalNamespc()) ) then
 		if( sym ) then
 			'' "DIM Parent.foo" is only allowed if there was an
 			'' "EXTERN foo" in the Parent namespace, or if it's a
@@ -1643,7 +1643,10 @@ function cVarDecl _
 					subtype = symbGetSubtype( sym )
 					lgt = symbGetLen( sym )
 					if( symbIsDynamic( sym ) = FALSE ) then
-						errReportEx( FB_ERRMSG_EXPECTEDDYNAMICARRAY, @id )
+						'' if it's a parameter, we won't know if it's dynamic or not until run-time
+						if( symbIsParamVarByDesc( sym ) = FALSE ) then
+							errReportEx( FB_ERRMSG_EXPECTEDDYNAMICARRAY, @id )
+						end if
 					end if
 				else
 					'' -lang fb: typeless REDIM without pre-existing array not allowed

--- a/src/compiler/parser-identifier.bas
+++ b/src/compiler/parser-identifier.bas
@@ -13,17 +13,17 @@ private sub hSkipSymbol( )
 	do
 		lexSkipToken( LEXCHECK_NOPERIOD )  '' should this have LEXCHECK_POST_SUFFIX?
 
-    	'' '.'?
-    	if( lexGetToken( ) <> CHAR_DOT ) then
-    		exit do
-    	end if
+		'' '.'?
+		if( lexGetToken( ) <> CHAR_DOT ) then
+			exit do
+		end if
 
-    	select case as const lexGetClass()
-    	case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_KEYWORD, FB_TKCLASS_QUIRKWD
+		select case as const lexGetClass()
+		case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_KEYWORD, FB_TKCLASS_QUIRKWD
 
-    	case else
-    		exit do
-    	end select
+		case else
+			exit do
+		end select
 	loop
 
 end sub
@@ -36,38 +36,38 @@ private function hGlobalId _
 
 	function = NULL
 
-    '' another '.'?
-    if( lexGetLookAhead( 1, LEXCHECK_NOPERIOD ) = CHAR_DOT ) then
-    	'' skip the first '.'
-    	lexSkipToken( LEXCHECK_NOPERIOD )
+	'' another '.'?
+	if( lexGetLookAhead( 1, LEXCHECK_NOPERIOD ) = CHAR_DOT ) then
+		'' skip the first '.'
+		lexSkipToken( LEXCHECK_NOPERIOD )
 
-    else
-    	'' inside a WITH block, a single '.' is ambiguous..
+	else
+		'' inside a WITH block, a single '.' is ambiguous..
 		if( parser.stmt.with ) then
 			exit function
 		end if
-    end if
+	end if
 
-    if( (options and FB_IDOPT_ISDECL) <> 0 ) then
-    	'' different name spaces?
-    	if( symbIsGlobalNamespc( ) = FALSE ) then
+	if( (options and FB_IDOPT_ISDECL) <> 0 ) then
+		'' different name spaces?
+		if( symbIsGlobalNamespc( ) = FALSE ) then
 			errReport( FB_ERRMSG_DECLOUTSIDENAMESPC )
-    	end if
-    end if
+		end if
+	end if
 
-    '' skip the '.'
-    lexSkipToken( LEXCHECK_NOPERIOD )
+	'' skip the '.'
+	lexSkipToken( LEXCHECK_NOPERIOD )
 
-    '' not an ID?
-    select case lexGetClass( )
-    case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_QUIRKWD
+	'' not an ID?
+	select case lexGetClass( )
+	case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_QUIRKWD
 
-    case else
-    	if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
-    		errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
-    	end if
-    	exit function
-    end select
+	case else
+		if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
+			errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
+		end if
+		exit function
+	end select
 
 	function = symbLookupAt( @symbGetGlobalNamespc( ), _
 							 lexGetText( ), _
@@ -85,15 +85,15 @@ end function
 		options _
 	)
 
-    if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
-    	'' declaration?
-    	if( (options and FB_IDOPT_ISDECL) <> 0 ) then
-    		if( base_parent <> NULL ) then
-    			'' different parents?
-    			if( symbGetParent( base_parent ) <> symbGetCurrentNamespc( ) ) then
-    				errReport( FB_ERRMSG_DECLOUTSIDENAMESPC )
-    				return NULL
-    			end if
+	if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
+		'' declaration?
+		if( (options and FB_IDOPT_ISDECL) <> 0 ) then
+			if( base_parent <> NULL ) then
+				'' different parents?
+				if( symbGetParent( base_parent ) <> symbGetCurrentNamespc( ) ) then
+					errReport( FB_ERRMSG_DECLOUTSIDENAMESPC )
+					return NULL
+				end if
 			end if
 
 		'' not a decl..
@@ -113,9 +113,9 @@ end function
 						end if
 					end if
 				end if
-    		end if
-    	end if
-    end if
+			end if
+		end if
+	end if
 
 #endmacro
 
@@ -146,8 +146,8 @@ private function hIsStructAllowed _
 end function
 
 '':::::
-'' Identifier	= (ID{namespace|class} '.')* ID
-''				|  ID ('.' ID)* .
+'' Identifier   = (ID{namespace|class} '.')* ID
+''              |  ID ('.' ID)* .
 ''
 function cIdentifier _
 	( _
@@ -157,10 +157,10 @@ function cIdentifier _
 
 	assert((options and FB_IDOPT_DONTCHKPERIOD) = 0)
 
-    dim as FBSYMCHAIN ptr chain_ = any
-    dim as FBSYMBOL ptr parent = any
+	dim as FBSYMCHAIN ptr chain_ = any
+	dim as FBSYMBOL ptr parent = any
 
-    base_parent = NULL
+	base_parent = NULL
 
 	'' use the saved namespace prefix if cTypeOrExpression() saved it.
 	if( parser.nsprefix ) then
@@ -174,39 +174,39 @@ function cIdentifier _
 	    return chain_
 	end if
 
-    if( chain_ = NULL ) then
-    	'' '.'?
+	if( chain_ = NULL ) then
+		'' '.'?
 
-    	if( lexGetToken( ) <> CHAR_DOT ) then
-    		return NULL
-    	end if
+		if( lexGetToken( ) <> CHAR_DOT ) then
+			return NULL
+		end if
 
-    	chain_ = hGlobalId( options )
-    	if( chain_ = NULL ) then
-          	if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
-          		errReportUndef( FB_ERRMSG_UNDEFINEDSYMBOL, lexGetText( ) )
-    		else
-    			hSkipSymbol( )
-           	end if
+		chain_ = hGlobalId( options )
+		if( chain_ = NULL ) then
+			if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
+				errReportUndef( FB_ERRMSG_UNDEFINEDSYMBOL, lexGetText( ) )
+			else
+				hSkipSymbol( )
+			end if
 
-    		return NULL
-    	end if
-    end if
+			return NULL
+		end if
+	end if
 
-    parent = NULL
+	parent = NULL
 
-    do
-    	dim as FBSYMBOL ptr sym = chain_->sym
+	do
+		dim as FBSYMBOL ptr sym = chain_->sym
 
-    	select case as const symbGetClass( sym )
-    	case FB_SYMBCLASS_NAMESPACE, FB_SYMBCLASS_CLASS, FB_SYMBCLASS_ENUM
+		select case as const symbGetClass( sym )
+		case FB_SYMBCLASS_NAMESPACE, FB_SYMBCLASS_CLASS, FB_SYMBCLASS_ENUM
 
-    	case FB_SYMBCLASS_STRUCT
+		case FB_SYMBCLASS_STRUCT
 			if( hIsStructAllowed( sym, options ) = FALSE ) then
 				exit do
 			end if
 
-    	case FB_SYMBCLASS_TYPEDEF
+		case FB_SYMBCLASS_TYPEDEF
 			'' typedef of a TYPE/CLASS?
 			select case( symbGetType( sym ) )
 			case FB_DATATYPE_STRUCT
@@ -223,13 +223,13 @@ function cIdentifier _
 				exit do
 			end select
 
-    	case else
-    		exit do
-    	end select
+		case else
+			exit do
+		end select
 
-    	'' check visibility (of the UDT only, because symbols can be
-    	'' overloaded or the names duplicated, so that check can only
-    	'' be done by specific functions)
+		'' check visibility (of the UDT only, because symbols can be
+		'' overloaded or the names duplicated, so that check can only
+		'' be done by specific functions)
 		if( parent <> NULL ) then
 			if( symbCheckAccess( sym ) = FALSE ) then
 				if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
@@ -238,25 +238,25 @@ function cIdentifier _
 			end if
 		end if
 
-    	'' '.'?
-    	if( lexGetLookAhead( 1, LEXCHECK_NOPERIOD ) <> CHAR_DOT ) then
-    		'' if it's a namespace, the '.' is obligatory, the
-    		'' namespace itself isn't a composite type
+		'' '.'?
+		if( lexGetLookAhead( 1, LEXCHECK_NOPERIOD ) <> CHAR_DOT ) then
+			'' if it's a namespace, the '.' is obligatory, the
+			'' namespace itself isn't a composite type
 			'' The only exception to that is namespaces appearing
 			'' in preprocessor expressions in #ifdef or #undef etc.
 			'' Those don't pass FB_IDOPT_SHOWERROR, and they skip
 			'' this last namespace id manually (like any other id),
 			'' because for them, this is not a syntax error.
-    		if( symbGetClass( sym ) = FB_SYMBCLASS_NAMESPACE ) then
-    			if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
+			if( symbGetClass( sym ) = FB_SYMBCLASS_NAMESPACE ) then
+				if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
 					'' skip id
 					lexSkipToken( LEXCHECK_NOPERIOD or LEXCHECK_POST_SUFFIX )
 					errReport( FB_ERRMSG_EXPECTEDPERIOD )
-    			end if
-    		end if
+				end if
+			end if
 
-    		exit do
-    	end if
+			exit do
+		end if
 
 		if( symbIsEnum( sym ) ) then
 			if( symbEnumHasHashTb( sym ) = FALSE ) then
@@ -267,34 +267,34 @@ function cIdentifier _
 			end if
 		end if
 
-    	'' skip id
-    	lexSkipToken( LEXCHECK_NOPERIOD or LEXCHECK_POST_SUFFIX )
+		'' skip id
+		lexSkipToken( LEXCHECK_NOPERIOD or LEXCHECK_POST_SUFFIX )
 
-    	'' skip '.'
-    	lexSkipToken( LEXCHECK_NOPERIOD )
+		'' skip '.'
+		lexSkipToken( LEXCHECK_NOPERIOD )
 
-    	parent = sym
+		parent = sym
 
-    	if( base_parent = NULL ) then
-    		base_parent = parent
-    	end if
+		if( base_parent = NULL ) then
+			base_parent = parent
+		end if
 
-    	'' ID
-    	select case as const lexGetClass( )
-    	case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_QUIRKWD
+		'' ID
+		select case as const lexGetClass( )
+		case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_QUIRKWD
 
-    	case FB_TKCLASS_OPERATOR, FB_TKCLASS_KEYWORD
-    		if( (options and FB_IDOPT_ISOPERATOR ) <> 0 ) then
-    			exit do
-    		end if
+		case FB_TKCLASS_OPERATOR, FB_TKCLASS_KEYWORD
+			if( (options and FB_IDOPT_ISOPERATOR ) <> 0 ) then
+				exit do
+			end if
 
-    		if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
-    			errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
-    		end if
+			if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
+				errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
+			end if
 
-    		return NULL
+			return NULL
 
-    	case else
+		case else
 			'' Allow '[' for '[]' operator overloads, it's not part
 			'' of FB_TKCLASS_OPERATOR since it's not a real op.
 			if( lexGetToken( ) = CHAR_LBRACKET ) then
@@ -303,49 +303,49 @@ function cIdentifier _
 				end if
 			end if
 
-    		if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
-    			errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
-    		end if
+			if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
+				errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
+			end if
 
-    		return NULL
-    	end select
+			return NULL
+		end select
 
-    	'' look up
-    	chain_ = symbLookupAt( parent, lexGetText( ), FALSE )
-    	if( chain_ = NULL ) then
-          	if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
-          		errReportUndef( FB_ERRMSG_UNDEFINEDSYMBOL, lexGetText( ) )
-    		else
-    			hSkipSymbol( )
-           	end if
+		'' look up
+		chain_ = symbLookupAt( parent, lexGetText( ), FALSE )
+		if( chain_ = NULL ) then
+			if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
+				errReportUndef( FB_ERRMSG_UNDEFINEDSYMBOL, lexGetText( ) )
+			else
+				hSkipSymbol( )
+			end if
 
-    	    return NULL
-    	end if
+		    return NULL
+		end if
 
-    	'' check access to non-static members
-    	if( (options and FB_IDOPT_CHECKSTATIC) <> 0 ) then
-    		'' struct or class?
-    		select case symbGetClass( parent )
-    		case FB_SYMBCLASS_STRUCT, FB_SYMBCLASS_CLASS
-    			'' for each symbol (because dups..)
-    			dim as FBSYMCHAIN ptr iter = chain_
-    			do
-        			dim as FBSYMBOL ptr sym = iter->sym
-        			do
-        				'' field, never static..
-        				if( symbGetClass( sym ) = FB_SYMBCLASS_FIELD ) then
+		'' check access to non-static members
+		if( (options and FB_IDOPT_CHECKSTATIC) <> 0 ) then
+			'' struct or class?
+			select case symbGetClass( parent )
+			case FB_SYMBCLASS_STRUCT, FB_SYMBCLASS_CLASS
+				'' for each symbol (because dups..)
+				dim as FBSYMCHAIN ptr iter = chain_
+				do
+					dim as FBSYMBOL ptr sym = iter->sym
+					do
+						'' field, never static..
+						if( symbGetClass( sym ) = FB_SYMBCLASS_FIELD ) then
 							errReport( FB_ERRMSG_ACCESSTONONSTATICMEMBER )
-        					exit do, do
-        				end if
+							exit do, do
+						end if
 
-        				sym = sym->hash.next
-        			loop while( sym <> NULL )
+						sym = sym->hash.next
+					loop while( sym <> NULL )
 
-    				iter = symbChainGetNext( iter )
-    			loop while( iter <> NULL )
-    		end select
-    	end if
-    loop
+					iter = symbChainGetNext( iter )
+				loop while( iter <> NULL )
+			end select
+		end if
+	loop
 
 	''
 	hCheckDecl( base_parent, parent, chain_, options )
@@ -355,45 +355,45 @@ function cIdentifier _
 end function
 
 '':::::
-'' ParentId		= ID{namespace|class} ('.' ID{namespace|class})* .
+'' ParentId     = ID{namespace|class} ('.' ID{namespace|class})* .
 ''
 function cParentId _
 	( _
 		byval options as FB_IDOPT _
 	) as FBSYMBOL ptr
 
-    dim as FBSYMCHAIN ptr chain_ = any
-    dim as FBSYMBOL ptr sym = any, parent = any, base_parent = any
+	dim as FBSYMCHAIN ptr chain_ = any
+	dim as FBSYMBOL ptr sym = any, parent = any, base_parent = any
 
 	if( fbLangOptIsSet( FB_LANG_OPT_NAMESPC ) = FALSE ) then
 	    return NULL
 	end if
 
-    chain_ = lexGetSymChain( )
-    if( chain_ = NULL ) then
-    	'' '.'?
-    	if( lexGetToken( ) = CHAR_DOT ) then
-    		chain_ = hGlobalId( )
-    	end if
-    end if
+	chain_ = lexGetSymChain( )
+	if( chain_ = NULL ) then
+		'' '.'?
+		if( lexGetToken( ) = CHAR_DOT ) then
+			chain_ = hGlobalId( )
+		end if
+	end if
 
-    sym = NULL
-    parent = NULL
-    base_parent = NULL
+	sym = NULL
+	parent = NULL
+	base_parent = NULL
 
-    do while( chain_ <> NULL )
+	do while( chain_ <> NULL )
 
-    	sym = chain_->sym
-    	select case as const symbGetClass( sym )
-    	case FB_SYMBCLASS_NAMESPACE, FB_SYMBCLASS_CLASS, FB_SYMBCLASS_ENUM
+		sym = chain_->sym
+		select case as const symbGetClass( sym )
+		case FB_SYMBCLASS_NAMESPACE, FB_SYMBCLASS_CLASS, FB_SYMBCLASS_ENUM
 
-    	case FB_SYMBCLASS_STRUCT
+		case FB_SYMBCLASS_STRUCT
 			if( hIsStructAllowed( sym, options ) = FALSE ) then
 				sym = parent
 				exit do
 			end if
 
-    	case FB_SYMBCLASS_TYPEDEF
+		case FB_SYMBCLASS_TYPEDEF
 			'' typedef of a TYPE/CLASS?
 			select case( symbGetType( sym ) )
 			case FB_DATATYPE_STRUCT
@@ -412,10 +412,10 @@ function cParentId _
 				exit do
 			end select
 
-    	case else
-    		sym = parent
-    		exit do
-    	end select
+		case else
+			sym = parent
+			exit do
+		end select
 
 		'' check visibility
 		if( parent <> NULL ) then
@@ -424,18 +424,18 @@ function cParentId _
 			end if
 		end if
 
-    	'' '.'?
-    	if( lexGetLookAhead( 1, LEXCHECK_NOPERIOD ) <> CHAR_DOT ) then
-    		'' skip id
-    		lexSkipToken( LEXCHECK_NOPERIOD )
+		'' '.'?
+		if( lexGetLookAhead( 1, LEXCHECK_NOPERIOD ) <> CHAR_DOT ) then
+			'' skip id
+			lexSkipToken( LEXCHECK_NOPERIOD )
 
-    		if( (options and FB_IDOPT_DONTCHKPERIOD) <> 0 ) then
-    			exit do
-    		end if
+			if( (options and FB_IDOPT_DONTCHKPERIOD) <> 0 ) then
+				exit do
+			end if
 
 			errReport( FB_ERRMSG_EXPECTEDPERIOD )
 			exit do
-    	end if
+		end if
 
 		if( symbIsEnum( sym ) ) then
 			if( symbEnumHasHashTb( sym ) = FALSE ) then
@@ -444,31 +444,31 @@ function cParentId _
 			end if
 		end if
 
-    	'' skip id
-    	lexSkipToken( LEXCHECK_NOPERIOD or LEXCHECK_POST_SUFFIX )
+		'' skip id
+		lexSkipToken( LEXCHECK_NOPERIOD or LEXCHECK_POST_SUFFIX )
 
-    	'' skip '.'
-    	lexSkipToken( LEXCHECK_NOPERIOD )
+		'' skip '.'
+		lexSkipToken( LEXCHECK_NOPERIOD )
 
-    	parent = sym
+		parent = sym
 
-    	if( base_parent = NULL ) then
-    		base_parent = parent
-    	end if
+		if( base_parent = NULL ) then
+			base_parent = parent
+		end if
 
-    	'' ID
-    	select case as const lexGetClass( )
-    	case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_QUIRKWD
+		'' ID
+		select case as const lexGetClass( )
+		case FB_TKCLASS_IDENTIFIER, FB_TKCLASS_QUIRKWD
 
-    	case FB_TKCLASS_OPERATOR, FB_TKCLASS_KEYWORD
-    		if( (options and FB_IDOPT_ISOPERATOR ) <> 0 ) then
-    			exit do
-    		end if
+		case FB_TKCLASS_OPERATOR, FB_TKCLASS_KEYWORD
+			if( (options and FB_IDOPT_ISOPERATOR ) <> 0 ) then
+				exit do
+			end if
 
 			errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
 			exit do
 
-    	case else
+		case else
 			'' Allow '[' for '[]' operator overloads, it's not part
 			'' of FB_TKCLASS_OPERATOR since it's not a real op.
 			if( lexGetToken( ) = CHAR_LBRACKET ) then
@@ -478,11 +478,11 @@ function cParentId _
 			end if
 
 			errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
-    			exit do
-    	end select
+				exit do
+		end select
 
-    	chain_ = symbLookupAt( sym, lexGetText( ), FALSE )
-    loop
+		chain_ = symbLookupAt( sym, lexGetText( ), FALSE )
+	loop
 
 	''
 	hCheckDecl( base_parent, parent, chain_, options )

--- a/src/compiler/symb-comp.bas
+++ b/src/compiler/symb-comp.bas
@@ -9,10 +9,10 @@
 declare function symbGetCompCopyCtor( byval sym as FBSYMBOL ptr ) as FBSYMBOL ptr
 
 type FB_SYMBNEST
-	sym				as FBSYMBOL ptr
-	symtb			as FBSYMBOLTB ptr			'' prev symbol tb
-	hashtb			as FBHASHTB ptr				'' prev hash tb
-	ns				as FBSYMBOL ptr				'' prev namespace
+	sym             as FBSYMBOL ptr
+	symtb           as FBSYMBOLTB ptr           '' prev symbol tb
+	hashtb          as FBHASHTB ptr             '' prev hash tb
+	ns              as FBSYMBOL ptr             '' prev namespace
 end type
 
 sub symbCompInit( )
@@ -379,9 +379,9 @@ private sub hAssignList _
 	subtype = symbGetSubtype( fld )
 
 	cnt = symbAddTempVar( FB_DATATYPE_INTEGER )
-    label = symbAddLabel( NULL )
-    dst = symbAddTempVar( typeAddrOf( symbGetType( fld ) ), subtype )
-    src = symbAddTempVar( typeAddrOf( symbGetType( fld ) ), subtype )
+	label = symbAddLabel( NULL )
+	dst = symbAddTempVar( typeAddrOf( symbGetType( fld ) ), subtype )
+	src = symbAddTempVar( typeAddrOf( symbGetType( fld ) ), subtype )
 
 	'' dst = @this.arrayfield(0)
 	astAdd( astBuildVarAssign( dst, astNewADDROF( astBuildVarField( this_, fld ) ), AST_OPOPT_ISINI ) )
@@ -391,13 +391,13 @@ private sub hAssignList _
 	'' for cnt = 0 to symbGetArrayElements( dst )-1
 	astAdd( astBuildForBegin( NULL, cnt, label, 0 ) )
 
-    '' *dst = *src
-    astAdd( astNewASSIGN( astBuildVarDeref( dst ), astBuildVarDeref( src ) ) )
+	'' *dst = *src
+	astAdd( astNewASSIGN( astBuildVarDeref( dst ), astBuildVarDeref( src ) ) )
 
 	'' dst += 1
-    astAdd( astBuildVarInc( dst, 1 ) )
+	astAdd( astBuildVarInc( dst, 1 ) )
 	'' src += 1
-    astAdd( astBuildVarInc( src, 1 ) )
+	astAdd( astBuildVarInc( src, 1 ) )
 
 	'' next
 	astAdd( astBuildForEnd( NULL, cnt, label, astNewCONSTi( symbGetArrayElements( fld ) ) ) )
@@ -430,7 +430,7 @@ private function hCopyUnionFields _
 		fld = fld->next
 	loop while( fld andalso symbIsField( fld ) andalso symbGetIsUnionField( fld ) )
 
-    '' copy all them at once
+	'' copy all them at once
 	astAdd( astNewMEM( AST_OP_MEMMOVE, _
 				astBuildVarField( this_, base_fld ), _
 				astBuildVarField( rhs, base_fld ), _
@@ -899,28 +899,28 @@ function symbGetCompOpOvlHead _
 		byval op as AST_OP _
 	) as FBSYMBOL ptr
 
-   	'' self?
-   	if( astGetOpIsSelf( op ) ) then
-   		select case symbGetClass( sym )
-   		case FB_SYMBCLASS_STRUCT
-   			if( sym->udt.ext = NULL ) then
-   				return NULL
-   			end if
+	'' self?
+	if( astGetOpIsSelf( op ) ) then
+		select case symbGetClass( sym )
+		case FB_SYMBCLASS_STRUCT
+			if( sym->udt.ext = NULL ) then
+				return NULL
+			end if
 
-   			function = symbGetUDTOpOvlTb(sym)(op - AST_OP_SELFBASE)
+			function = symbGetUDTOpOvlTb(sym)(op - AST_OP_SELFBASE)
 
-   		case FB_SYMBCLASS_ENUM
-   			function = NULL
+		case FB_SYMBCLASS_ENUM
+			function = NULL
 
-   		case FB_SYMBCLASS_CLASS
-   			'' ...
+		case FB_SYMBCLASS_CLASS
+			'' ...
 
-   		end select
+		end select
 
-   	'' not self..
-   	else
-   		function = symb.globOpOvlTb(op).head
-   	end if
+	'' not self..
+	else
+		function = symb.globOpOvlTb(op).head
+	end if
 
 end function
 
@@ -1047,7 +1047,7 @@ private sub hRemoveNested _
 		if( symbGetCompExt( ns )->cnt <> 0 ) then
 			'' add to import hash tb list
 			symbHashListInsertNamespace( ns, _
-										 symbGetCompSymbTb( ns ).head )
+				symbGetCompSymbTb( ns ).head )
 		end if
 
 		ns = symbGetNamespace( ns )
@@ -1074,7 +1074,7 @@ private sub hInsertImported _
 			if( symbGetCompExt( ns )->cnt = 1 ) then
 				'' add to import hash tb list
 				symbHashListInsertNamespace( ns, _
-											 symbGetCompSymbTb( ns ).head )
+					symbGetCompSymbTb( ns ).head )
 			end if
 		end if
 
@@ -1204,7 +1204,7 @@ sub symbNestEnd _
 		if( symbGetCompExt( sym )->cnt <> 0 ) then
 			'' add to import hash tb list
 			symbHashListInsertNamespace( sym, _
-										 symbGetCompSymbTb( sym ).head )
+				symbGetCompSymbTb( sym ).head )
 		end if
 
 		symbSetCurrentHashTb( n->hashtb )
@@ -1361,7 +1361,7 @@ sub symbCompRTTIInit( )
 	'' stdlibvtable as any ptr
 	symbAddField( rttitype, "stdlibvtable", 0, dTB(), typeAddrOf( FB_DATATYPE_VOID ), NULL, 0, 0, 0 )
 
-	'' dim id as zstring ptr 
+	'' dim id as zstring ptr
 	symbAddField( rttitype, "id", 0, dTB(), typeAddrOf( FB_DATATYPE_CHAR ), NULL, 0, 0, 0 )
 
 	'' dim rttibase as fb_RTTI$ ptr

--- a/src/compiler/symb-define.bas
+++ b/src/compiler/symb-define.bas
@@ -255,6 +255,8 @@ private function hMacro_EvalZ( byval arg as zstring ptr ) as string
 		'' - text to expand is to be loaded in LEX.CTX->DEFTEXT[W]
 		'' - use the parser to build an AST for the literal result
 
+		'' !!!FIXME!!! : check if env.includerec is too deep
+		'' if( env.includerec >= FB_MAXINCRECLEVEL ) then
 		lexPushCtx()
 		lexInit( FALSE, TRUE )
 
@@ -337,6 +339,8 @@ private function hMacro_EvalW( byval arg as wstring ptr ) as wstring ptr
 		'' - text to expand is to be loaded in LEX.CTX->DEFTEXT[W]
 		'' - use the parser to build an AST for the literal result
 
+		'' !!!FIXME!!! : check if env.includerec is too deep
+		'' if( env.includerec >= FB_MAXINCRECLEVEL ) then
 		lexPushCtx()
 		lexInit( FALSE, TRUE )
 

--- a/src/compiler/symb-label.bas
+++ b/src/compiler/symb-label.bas
@@ -1,7 +1,7 @@
 '' symbol table module for labels
 ''
 '' chng: sep/2004 written [v1ctor]
-''		 jan/2005 updated to use real linked-lists [v1ctor]
+''       jan/2005 updated to use real linked-lists [v1ctor]
 
 
 #include once "fb.bi"
@@ -18,38 +18,38 @@ function symbAddLabel _
 		byval options as FB_SYMBOPT _
 	) as FBSYMBOL ptr
 
-    dim as zstring ptr id = any, id_alias = any
-    dim as FBSYMBOL ptr l = any
-    dim as FBSYMBOLTB ptr symtb = any
-    dim as FBHASHTB ptr hashtb = any
-    dim as integer isglobal = any
+	dim as zstring ptr id = any, id_alias = any
+	dim as FBSYMBOL ptr l = any
+	dim as FBSYMBOLTB ptr symtb = any
+	dim as FBHASHTB ptr hashtb = any
+	dim as integer isglobal = any
 
-    function = NULL
+	function = NULL
 
-    if( symbol <> NULL ) then
-    	'' check if label already exists
-    	l = symbLookupByNameAndClass( symbGetCurrentNamespc( ), _
-    								  symbol, _
-    								  FB_SYMBCLASS_LABEL, _
-    								  FALSE )
-    	if( l <> NULL ) then
-    		if( (options and FB_SYMBOPT_DECLARING) <> 0 ) then
-    			'' dup definition?
-    			if( l->lbl.declared ) then
-	    			exit function
-    			end if
+	if( symbol <> NULL ) then
+		'' check if label already exists
+		l = symbLookupByNameAndClass( symbGetCurrentNamespc( ), _
+			symbol, _
+			FB_SYMBCLASS_LABEL, _
+			FALSE )
+		if( l <> NULL ) then
+			if( (options and FB_SYMBOPT_DECLARING) <> 0 ) then
+				'' dup definition?
+				if( l->lbl.declared ) then
+					exit function
+				end if
 
-    			'' set the right values
-    			l->lbl.declared = TRUE
-    			l->lbl.parent = parser.currblock
-    			l->lbl.stmtnum = parser.stmt.cnt
-    			l->scope = parser.scope
-    			return l
+				'' set the right values
+				l->lbl.declared = TRUE
+				l->lbl.parent = parser.currblock
+				l->lbl.stmtnum = parser.stmt.cnt
+				l->scope = parser.scope
+				return l
 
-    		else
-    			return l
-    		end if
-    	end if
+			else
+				return l
+			end if
+		end if
 
 		'' add the new label
 		if( (options and FB_SYMBOPT_CREATEALIAS) = 0 ) then
@@ -64,47 +64,47 @@ function symbAddLabel _
 		id_alias = symbUniqueLabel( )
 	end if
 
-    if( (options and FB_SYMBOPT_MOVETOGLOB) <> 0 ) then
-    	isglobal = TRUE
+	if( (options and FB_SYMBOPT_MOVETOGLOB) <> 0 ) then
+		isglobal = TRUE
 
-    	symtb = @symbGetGlobalTb( )
-    	hashtb = @symbGetGlobalHashTb( )
+		symtb = @symbGetGlobalTb( )
+		hashtb = @symbGetGlobalHashTb( )
 
-    else
-    	'' parsing main? add to global tb
-    	if( fbIsModLevel( ) ) then
-    		isglobal = TRUE
+	else
+		'' parsing main? add to global tb
+		if( fbIsModLevel( ) ) then
+			isglobal = TRUE
 
-    		'' unless inside a namespace..
-    		if( symbIsGlobalNamespc() = FALSE ) then
-    			symtb = symb.symtb
-    			hashtb = symb.hashtb
-    		else
-    			symtb = @symbGetGlobalTb( )
-    			hashtb = @symbGetGlobalHashTb( )
-    		end if
+			'' unless inside a namespace..
+			if( symbIsGlobalNamespc() = FALSE ) then
+				symtb = symb.symtb
+				hashtb = symb.hashtb
+			else
+				symtb = @symbGetGlobalTb( )
+				hashtb = @symbGetGlobalHashTb( )
+			end if
 
-    	'' otherside the current proc sym table must be used, not the
-    	'' current scope because labels inside scopes are unique,
-    	'' and branching to them from other scopes must be allowed
-    	else
-    		isglobal = FALSE
+		'' otherwise the current proc sym table must be used, not the
+		'' current scope because labels inside scopes are unique,
+		'' and branching to them from other scopes must be allowed
+		else
+			isglobal = FALSE
 
-    		symtb = @parser.currproc->proc.symtb
-    		hashtb = symb.hashtb
-    	end if
-    end if
+			symtb = @parser.currproc->proc.symtb
+			hashtb = symb.hashtb
+		end if
+	end if
 
-    l = symbNewSymbol( iif( symbol = NULL, FB_SYMBOPT_NONE, FB_SYMBOPT_DOHASH ), _
-    				   NULL, _
-    				   symtb, hashtb, _
-    				   FB_SYMBCLASS_LABEL, _
-    				   id, id_alias, _
-    				   FB_DATATYPE_INVALID, NULL, _
-    				   iif( isglobal, FB_SYMBATTRIB_NONE, FB_SYMBATTRIB_LOCAL ), FB_PROCATTRIB_NONE )
-    if( l = NULL ) then
-    	exit function
-    end if
+	l = symbNewSymbol( iif( symbol = NULL, FB_SYMBOPT_NONE, FB_SYMBOPT_DOHASH ), _
+		NULL, _
+		symtb, hashtb, _
+		FB_SYMBCLASS_LABEL, _
+		id, id_alias, _
+		FB_DATATYPE_INVALID, NULL, _
+		iif( isglobal, FB_SYMBATTRIB_NONE, FB_SYMBATTRIB_LOCAL ), FB_PROCATTRIB_NONE )
+	if( l = NULL ) then
+		exit function
+	end if
 
 	if( (options and FB_SYMBOPT_DECLARING) <> 0 ) then
 		'' label parent won't be the current proc block as
@@ -139,11 +139,11 @@ sub symbDelLabel _
 		byval s as FBSYMBOL ptr _
 	)
 
-    if( s = NULL ) then
-    	exit sub
-    end if
+	if( s = NULL ) then
+		exit sub
+	end if
 
-    symbFreeSymbol( s )
+	symbFreeSymbol( s )
 
 end sub
 

--- a/src/compiler/symb.bas
+++ b/src/compiler/symb.bas
@@ -855,6 +855,22 @@ private function chainpoolNext() as FBSYMCHAIN ptr
 end function
 
 '':::::
+function symbNewChainpool _
+	( _
+		byval sym as FBSYMBOL ptr _
+	) as FBSYMCHAIN ptr
+
+	assert( sym )
+
+	dim as FBSYMCHAIN ptr chain_ = chainpoolNext()
+	chain_->sym = sym
+	chain_->next = NULL
+	chain_->isimport = FALSE
+	return chain_
+
+end function
+
+'':::::
 function symbLookup _
 	( _
 		byval id as zstring ptr, _
@@ -2707,10 +2723,18 @@ function symbDumpToStr _
 end function
 
 sub symbDump( byval sym as FBSYMBOL ptr )
+	print "symbDump [" + hex( sym ) + "]:"
+	if( sym = NULL ) then
+		exit sub
+	end if
 	print symbDumpToStr( sym )
 end sub
 
 sub symbDumpNamespace( byval ns as FBSYMBOL ptr )
+	print "symbDumpNamespace [" + hex( ns ) + "]:"
+	if( ns = NULL ) then
+		exit sub
+	endif
 	select case( ns->class )
 	case FB_SYMBCLASS_STRUCT, FB_SYMBCLASS_ENUM, FB_SYMBCLASS_NAMESPACE
 
@@ -2768,7 +2792,7 @@ sub symbDumpChain( byval chain_ as FBSYMCHAIN ptr )
 		loop while( chain_ )
 	end if
 end sub
-#endif
+#endif '' __FB_DEBUG__
 
 dim shared as zstring ptr classnamesPretty(FB_SYMBCLASS_VAR to FB_SYMBCLASS_NSIMPORT) = _
 { _

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -481,13 +481,13 @@ enum FB_UDTOPT
 	FB_UDTOPT_HASIDXGETPROPERTY = &h0200
 	FB_UDTOPT_HASIDXSETPROPERTY = &h0400
 	FB_UDTOPT_HASKWDFIELD       = &h0800
-	FB_UDTOPT_HASINITEDFIELD        = &h1000
-	FB_UDTOPT_HASANONUNION          = &h2000
-	FB_UDTOPT_HASSTATICVAR          = &h4000
-	FB_UDTOPT_HASBITFIELD           = &h8000
-	FB_UDTOPT_ISWSTRING             = &h10000
-	FB_UDTOPT_ISZSTRING             = &h20000
-	FB_UDTOPT_VALISTTYPEMASK       = &hf00000
+	FB_UDTOPT_HASINITEDFIELD    = &h1000
+	FB_UDTOPT_HASANONUNION      = &h2000
+	FB_UDTOPT_HASSTATICVAR      = &h4000
+	FB_UDTOPT_HASBITFIELD       = &h8000
+	FB_UDTOPT_ISWSTRING         = &h10000
+	FB_UDTOPT_ISZSTRING         = &h20000
+	FB_UDTOPT_VALISTTYPEMASK    = &hf00000
 end enum
 
 type FB_STRUCT_DBG
@@ -900,13 +900,13 @@ type SYMBCTX
 					0 to AST_OPCODES-1 _
 				)   as SYMB_OVLOP               '' global operator overloading
 
-	fbarray_data        as integer          '' offsetof( FBARRAY, data )
-	fbarray_ptr     as integer          '' offsetof( FBARRAY, ptr )
-	fbarray_size        as integer          '' offsetof( FBARRAY, size )
-	fbarray_dimtb       as integer          '' offsetof( FBARRAY, dimTB )
-	fbarraydim      as FBSYMBOL ptr         '' FBARRAYDIM (dimTB element structure)
-	fbarraydim_lbound   as integer          '' offsetof( FBARRAYDIM, lbound )
-	fbarraydim_ubound   as integer          '' offsetof( FBARRAYDIM, ubound )
+	fbarray_data        as integer              '' offsetof( FBARRAY, data )
+	fbarray_ptr         as integer              '' offsetof( FBARRAY, ptr )
+	fbarray_size        as integer              '' offsetof( FBARRAY, size )
+	fbarray_dimtb       as integer              '' offsetof( FBARRAY, dimTB )
+	fbarraydim          as FBSYMBOL ptr         '' FBARRAYDIM (dimTB element structure)
+	fbarraydim_lbound   as integer              '' offsetof( FBARRAYDIM, lbound )
+	fbarraydim_ubound   as integer              '' offsetof( FBARRAYDIM, ubound )
 
 	rtti            as FB_RTTICTX
 end type
@@ -949,6 +949,11 @@ declare sub symbEnd _
 	)
 
 declare sub symbDataInit( )
+
+declare function symbNewChainpool _
+	( _
+		byval sym as FBSYMBOL ptr _
+	) as FBSYMCHAIN ptr
 
 declare function symbLookup _
 	( _

--- a/tests/namespace/global.bas
+++ b/tests/namespace/global.bas
@@ -30,9 +30,20 @@ private sub test2_proc
 	using module.ns.glob
 
 	CU_ASSERT( foo = LOCA_VAL )
-	CU_ASSERT( .foo = LOCA_VAL )
-	CU_ASSERT( ..foo = LOCA_VAL )
-	CU_ASSERT( global.foo = LOCA_VAL )
+	CU_ASSERT( .foo = GLOB_VAL )
+	CU_ASSERT( ..foo = GLOB_VAL )
+	CU_ASSERT( global.foo = GLOB_VAL )
+end sub	
+
+private sub test2a_proc
+	using module.ns.glob
+
+	dim as integer foo = LOCA_VAL
+
+	CU_ASSERT( foo = LOCA_VAL )
+	CU_ASSERT( .foo = GLOB_VAL )
+	CU_ASSERT( ..foo = GLOB_VAL )
+	CU_ASSERT( global.foo = GLOB_VAL )
 end sub	
 
 private sub test3_proc

--- a/tests/namespace/redim-3.bas
+++ b/tests/namespace/redim-3.bas
@@ -18,11 +18,8 @@ namespace ns
 	end sub
 
 	private sub f2( )
-		'' Even with the . global namespace resolution, this will currently
-		'' not redim the COMMON SHARED (which is somewhat weird)
-		dim .array1(2 to 2) as integer
-
-		'' These should REDIM the globals though
+		'' These REDIM the globals
+		redim .array1(2 to 2) as integer
 		redim .array2(2 to 2) as integer
 		redim .array3(2 to 2) as integer
 		redim .array4(2 to 2) as integer
@@ -52,7 +49,7 @@ private sub test_proc
 
 	ns.f2( )
 
-	CU_ASSERT( lbound( array1 ) = 0 ) : CU_ASSERT( ubound( array1 ) = -1 )
+	CU_ASSERT( lbound( array1 ) = 2 ) : CU_ASSERT( ubound( array1 ) = 2 )
 	CU_ASSERT( lbound( array2 ) = 2 ) : CU_ASSERT( ubound( array2 ) = 2 )
 	CU_ASSERT( lbound( array3 ) = 2 ) : CU_ASSERT( ubound( array3 ) = 2 )
 	CU_ASSERT( lbound( array4 ) = 2 ) : CU_ASSERT( ubound( array4 ) = 2 )

--- a/tests/numbers/longints.bas
+++ b/tests/numbers/longints.bas
@@ -42,7 +42,6 @@ SUITE( fbc_tests.numbers.longints )
 		CU_ASSERT( v1 = 1 )
 
 		dim as ulongint v2
-	# print one warning to follow
 		v2 = 2 ^ 34
 		v2 shr= 34
 		CU_ASSERT( v2 = 1 )

--- a/tests/numbers/numbers.bas
+++ b/tests/numbers/numbers.bas
@@ -40,7 +40,6 @@ SUITE( fbc_tests.numbers.numbers_ )
 
 		test_b_lb = -128
 		test_b_ub = 127
-		# print two warnings follow
 		b_lb = -129
 		b_ub = 128
 		cu_assert( b_lb = test_b_ub )
@@ -52,7 +51,6 @@ SUITE( fbc_tests.numbers.numbers_ )
 
 		test_ub_lb = 0
 		test_ub_ub = 255
-		# print two warnings follow
 		ub_lb = -1
 		ub_ub = 256
 		cu_assert( ub_lb = test_ub_ub )
@@ -64,7 +62,6 @@ SUITE( fbc_tests.numbers.numbers_ )
 
 		test_s_lb = -32768
 		test_s_ub = 32767
-		# print two warnings follow
 		s_lb = -32769
 		s_ub = 32768
 		cu_assert( s_lb = test_s_ub )
@@ -76,7 +73,6 @@ SUITE( fbc_tests.numbers.numbers_ )
 
 		test_us_lb = 0
 		test_us_ub = 65535
-		# print two warnings follow
 		us_lb = -1
 		us_ub = 65536
 		cu_assert( us_lb = test_us_ub )
@@ -93,7 +89,6 @@ SUITE( fbc_tests.numbers.numbers_ )
 		test_i_lb = -2147483648
 		test_i_ub = 2147483647
 	#endif
-		# print two warnings follow
 	#ifdef __FB_64BIT__
 		i_lb = -9223372036854775809
 		i_ub = 9223372036854775808
@@ -112,7 +107,6 @@ SUITE( fbc_tests.numbers.numbers_ )
 		test_ui_lb = 0
 		test_ui_ub = 18446744073709551615
 
-		# print two warnings follow
 		ui_lb = -1
 		'' is truncated to 18446744073709551615, not wrapping around
 		ui_ub = 18446744073709551616
@@ -122,7 +116,6 @@ SUITE( fbc_tests.numbers.numbers_ )
 	#else
 		test_ui_lb = 0
 		test_ui_ub = 4294967295
-		# print two warnings follow
 		ui_lb = -1
 		ui_ub = 4294967296
 		cu_assert( ui_lb = test_ui_ub )
@@ -135,7 +128,6 @@ SUITE( fbc_tests.numbers.numbers_ )
 
 		test_l_lb = -9223372036854775808
 		test_l_ub = 9223372036854775807
-		# print two warnings follow
 		l_lb = -9223372036854775809
 		l_ub = 9223372036854775808
 		cu_assert( l_lb = test_l_ub )
@@ -147,7 +139,6 @@ SUITE( fbc_tests.numbers.numbers_ )
 
 		test_ul_lb = 0
 		test_ul_ub = 18446744073709551615
-		# print two warnings follow
 		ul_lb = -1
 		'' is truncated to 18446744073709551615, not wrapping around
 		ul_ub = 18446744073709551616


### PR DESCRIPTION
In response to [#645 Access to global duplicated symbol is captured by local symbol ](https://sourceforge.net/p/fbc/bugs/645/)

This PR makes changes to address issues of namespace and scope resolution for variables (and arrays).
- sf.net # 645: respect global namespace '.' and '..' prefixes in REDIM
- sf.net # 645: don't access locals if explicit namespace is given on identifier
- sf.net # 645: don't access locals if explicit global namespace '.' and '..' prefixes are given on identifier
- sf.net # 645: throw compile time error if scoped REDIM variable shadows a variable of the same name

