### PR TITLE
Enable unwind tables on 64 bit targets

### DIFF
--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -1118,6 +1118,24 @@ private function hLinkFiles( ) as integer
 		ldcline += " -macosx_version_min 10.4"
 	end if
 
+	'' This is required for 64-bit modules on *nix-y platforms
+	'' for the unwind tables to have any effect
+	'' Windows doesn't need this option
+	select case as const fbGetOption( FB_COMPOPT_TARGET )
+	case FB_COMPTARGET_LINUX, FB_COMPTARGET_FREEBSD, _
+	     FB_COMPTARGET_OPENBSD, FB_COMPTARGET_NETBSD, _
+	     FB_COMPTARGET_DRAGONFLY, FB_COMPTARGET_SOLARIS, _
+	     FB_COMPTARGET_DARWIN
+		dim as long outtype = fbGetOption( FB_COMPOPT_OUTTYPE )
+		if outtype = FB_OUTTYPE_EXECUTABLE OrElse outtype = FB_OUTTYPE_DYNAMICLIB Then
+			dim as long cpufamily = fbGetCpuFamily( )
+			if cpufamily = FB_CPUFAMILY_X86_64 OrElse cpufamily = FB_CPUFAMILY_AARCH64 OrElse _
+			   cpuFamily = FB_CPUFAMILY_PPC64 OrElse cpufamily = FB_CPUFAMILY_PPC64LE Then
+				ldcline += " --eh-frame-hdr"
+			end if
+		end if
+	end select
+
 	'' extra options
 	ldcline += " " + fbc.extopt.ld
 

--- a/src/compiler/ir-gas64.bas
+++ b/src/compiler/ir-gas64.bas
@@ -122,6 +122,8 @@ rbp-y -->  local vars
 #define KNOOPTIM 3
 
 #define asm_code(s,opt...) hWriteasm64(s,opt)
+#define cfi_asm_code(s, opt...) hWriteasm64(s,opt)
+declare sub cfi_windows_asm_code(byval statement as string)
 
 #if __FB_DEBUG__ <> 0
 	#define asm_info(s) hWriteasm64("# "+s)
@@ -2132,6 +2134,7 @@ private function _emitbegin( ) as integer
 	if( env.clopt.debuginfo = true ) then edbgemitheader_asm64( env.inf.name )
 
 	asm_code( ".intel_syntax noprefix")
+	cfi_asm_code( ".cfi_sections .debug_frame")
 	asm_section(".text")
 	ctx.indent-=1
 	function = TRUE
@@ -6335,6 +6338,8 @@ private sub _emitprocbegin(byval proc as FBSYMBOL ptr,byval initlabel as FBSYMBO
 	if symbisprivate(proc)=FALSE then
 		asm_code(".globl "+*symbGetMangledName( proc ))
 	end if
+	cfi_asm_code(".cfi_startproc")
+	cfi_windows_asm_code(".seh_proc "+*symbGetMangledName( proc ))
 	ctx.indent-=1
 	asm_code(*symbGetMangledName( proc )+":")
 	ctx.indent+=1
@@ -6374,13 +6379,22 @@ private sub _emitprocend _
 	if symbIsNaked(proc)=false then
 
 		asm_code("push rbp")
+		'' the locations of the cfi/seh statements are important
+		'' so they do have to split the two prologue instructions
+		cfi_windows_asm_code(".seh_pushreg rbp")
+		cfi_asm_code(".cfi_def_cfa_offset 16") '' 16 = return address + this push
+		cfi_asm_code(".cfi_offset 6, -16") '' register 6 = rbp
 		asm_code("mov  rbp,rsp")
+		cfi_windows_asm_code(".seh_setframe rbp, 0") '' 0 = offset into this function's stack alloocation
+		cfi_asm_code(".cfi_def_cfa_register 6")
 			if ctx.stk>=2147483648 then
 			asm_code("mov rax, "+Str(ctx.stk))
 			asm_code("sub rsp, rax")
 		else
 			asm_code("sub rsp, "+Str(ctx.stk))
 		end if
+		cfi_windows_asm_code(".seh_stackalloc " + Str(ctx.stk))
+		cfi_windows_asm_code(".seh_endprologue")
 
 		'inside prolog/epilog
 		'--------------------
@@ -6440,8 +6454,12 @@ private sub _emitprocend _
 		''not usefull Asm_code("add rsp,XXXXX") as moving rbp to rsp restore the value just after the call and the push rbp
 		asm_code("mov rsp,rbp")
 		asm_code("pop rbp")
+		cfi_asm_code(".cfi_restore 6") '' rbp now back to what it was
+		cfi_asm_code(".cfi_def_cfa 7, 8") '' and the stack frame is back to rsp+8
 	end if
 	asm_code("ret")
+	cfi_asm_code(".cfi_endproc")
+	cfi_windows_asm_code(".seh_endproc")
 
 	if( env.clopt.debuginfo = true ) then
 		dim as string lname = *symbUniqueLabel( )
@@ -6823,4 +6841,9 @@ end sub
 private sub _emitlabelnf(byval label as FBSYMBOL Ptr)
 	'_emit( AST_OP_LABEL, NULL, NULL, NULL, label )
 	asm_error("emitlabelINF used ???? = "+ *symbGetMangledName( label ) )
+end sub
+private sub cfi_windows_asm_code(byval statement as string)
+	if ctx.target = FB_COMPTARGET_WIN32 then
+		cfi_asm_code(statement)
+	end if
 end sub


### PR DESCRIPTION
RE: https://www.freebasic.net/forum/viewtopic.php?f=3&t=31371#p289056
Intentionally disabling these makes debugging the resulting object much harder than it really needs to be, and then requires manual code to get right rather being able to leverage standard OS tools.  It's not gated by comopt_debug because non-debug output arguably needs it more.

The overhead mentioned in the comment is pretty negligable. FBC x64 Windows goes from 2.3MB to 2.39MB when -Wc -funwind-tables is added.