### PR TITLE
Fix mangling involving toplevel CONST and abbreviations

### DIFF
--- a/tests/cpp/mangle-cpp.cpp
+++ b/tests/cpp/mangle-cpp.cpp
@@ -271,4 +271,26 @@ namespace cpp_mangle
 	{
 		return n;
 	}
+
+	// multiple non-trivial parameters, triggering the use of abbreviations
+
+	// These 2 functions should have the same mangling (for parameters, not the name of course),
+	// the CONST on the BYVAL parameter "a" should not make a difference.
+	int cpp__byval_int__byref_int__byref_int(int a, int &b, int &c)
+	{
+		return a;
+	}
+	int cpp__byval_const_int__byref_int__byref_int(const int a, int &b, int &c)
+	{
+		return a;
+	}
+
+	int cpp__byval_const_int_ptr__byref_int__byref_int(const int *a, int &b, int &c)
+	{
+		return *a;
+	}
+	int cpp__byval_const_int_const_ptr__byref_int__byref_int(const int *const a, int &b, int &c)
+	{
+		return *a;
+	}
 }

--- a/tests/cpp/mangle-fbc.bas
+++ b/tests/cpp/mangle-fbc.bas
@@ -86,6 +86,11 @@ namespace cpp_mangle
 	declare function cpp_variadic_list_ptr( byval n as long, byval args as cva_list ptr ) as long
 	declare function cpp_variadic_list_ptr_ptr( byval n as long, byval args as cva_list ptr ptr ) as long
 
+	declare function cpp__byval_int__byref_int__byref_int(byval a as long, byref b as long, byref c as long) as long
+	declare function cpp__byval_const_int__byref_int__byref_int(byval a as const long, byref b as long, byref c as long) as long
+	declare function cpp__byval_const_int_ptr__byref_int__byref_int(byval a as const long ptr, byref b as long, byref c as long) as long
+	declare function cpp__byval_const_int_const_ptr__byref_int__byref_int(byval a as const long const ptr, byref b as long, byref c as long) as long
+
 end namespace
 
 end extern
@@ -316,3 +321,10 @@ scope
 	variadic_list_ptr_ptr( 3, 1, 2, 3 )
 end scope
 
+scope
+	dim i as long = 123
+	ASSERT( cpp__byval_int__byref_int__byref_int( 123, 0, 0 ) = 123 )
+	ASSERT( cpp__byval_const_int__byref_int__byref_int( 123, 0, 0 ) = 123 )
+	ASSERT( cpp__byval_const_int_ptr__byref_int__byref_int( @i, 0, 0 ) = 123 )
+	ASSERT( cpp__byval_const_int_const_ptr__byref_int__byref_int( @i, 0, 0 ) = 123 )
+end scope


### PR DESCRIPTION
This attempts to fix a mangling problem with `BYVAL x AS CONST TYPE` parameters. This toplevel CONST should be ignored in the mangling, just like it's ignored in a C++ function signature. fbc already correctly skipped the `K`, but it should also not add an abbreviation for this.

Checking gcc (on x86_64 linux):
```
void f(      int, int &, int &) { } // _Z1fiRiS_
void g(const int, int &, int &) { } // _Z1giRiS_
```
No `K` is added, and the abbreviation used for the 3rd parameter is `S_`, which is the first abbreviation, meaning that none was added for the first parameter. Also, note that C++ considers both signatures equal.