### PR TITLE
Fix compiler crash during error recovery for __FB_ARG_EXTRACT__()

### DIFF
--- a/src/compiler/hlp-str.bas
+++ b/src/compiler/hlp-str.bas
@@ -1279,9 +1279,14 @@ function hStr2long( byref txt as string, byref value as long ) as integer
 
 	dim nvalue as long = 0
 	dim nsign as long = 1
+
+	if( len( txt ) = 0 ) then
+		return FALSE
+	end if
+
 	dim s as ubyte ptr = strptr(txt)
 
-	if( *s = CHAR_NULL ) then
+	if( s = NULL orelse *s = CHAR_NULL ) then
 		return FALSE
 	end if
 


### PR DESCRIPTION
If a non-numeric arg-to-extract is specified for __FB_ARG_EXTRACT__'s
first parameter, fbc will show an error, but then it crashed:

```
pp/macro-arg-extract-fail.bas : TEST_MODE=COMPILE_ONLY_FAIL
pp/macro-arg-extract-fail.bas(10) error 42: Variable not declared, jimArg in '' TEST_MODE : COMPILE_ONLY_FAIL'

Aborting due to runtime error 7 (null pointer access) at line 1284 of src/compiler/hlp-str.bas::HSTR2LONG()

pp/macro-arg-extract-fail.bas : RESULT=PASSED
```

Since hMacro_EvalZ() can return an empty string for error recovery,
hStr2long() should handle this case as "invalid" too.

No new unit test needed, pp/macro-arg-extract-fail.bas already triggers
this case.