### PR TITLE
Fix bad code generation if asm ast nodes have newlines in them

### DIFF
--- a/src/compiler/ir-gas64.bas
+++ b/src/compiler/ir-gas64.bas
@@ -128,9 +128,22 @@ rbp-y -->  local vars
 	end if
 #endmacro
 declare sub cfi_windows_asm_code(byval statement as string)
+declare sub hwriteasm64( byref ln as string,byval opt as integer=KDOALL)
 
 #if __FB_DEBUG__ <> 0
-	#define asm_info(s) hWriteasm64("# "+s)
+#include once "crt/string.bi"
+
+	private sub asm_info( byval s as string )
+		dim as zstring ptr sdata = strptr( s )
+		dim as const zstring ptr newlines = @!"\r\n"
+		dim as zstring ptr iter =  strpbrk( sdata, newlines )
+		while iter
+			*iter = asc("#")
+			iter = strpbrk( iter + 1, newlines )
+		wend
+		hWriteasm64("# "+s)
+	end sub
+
 #else
 	#define asm_info(s) rem
 	#define typeDumpToStr(a,b) " "+str(a)
@@ -322,7 +335,6 @@ declare sub _emitdbg(byval op as integer,byval proc as FBSYMBOL ptr,byval lnum a
 declare sub check_optim(byref code as string)
 declare sub _emitconvert( byval v1 as IRVREG ptr, byval v2 as IRVREG ptr )
 declare function hgetdatatype_asm64 (byval sym as FBSYMBOL ptr,byval arraydimensions as integer = 0) as string
-declare sub hwriteasm64( byref ln as string,byval opt as integer=KDOALL)
 declare sub _emitvariniend( byval sym as FBSYMBOL ptr )
 declare sub _emitvarinipad( byval bytes as longint )
 declare sub _emitvariniwstr(byval varlength as longint,byval literal as wstring ptr,byval litlength as longint)


### PR DESCRIPTION
asm_info only comments the first line output. If the text to output has newlines in it, further lines are emitted uncommented. This is especially bad in _emitasmline - the asm_info comments the frst line of assembly, while subseqent ones are emitted into the code stream, and then all the lines are emitted into the code stream again by the asm_code.

This switches asm code to use gas' multiline comments rather than the single so subseqent lines remain commented.