### PR TITLE
Gas64 rev

### DIFF
--- a/src/compiler/ir-gas64.bas
+++ b/src/compiler/ir-gas64.bas
@@ -128,7 +128,6 @@ rbp-y -->  local vars
 	end if
 #endmacro
 declare sub cfi_windows_asm_code(byval statement as string)
-declare sub hwriteasm64( byref ln as string,byval opt as integer=KDOALL)
 
 '' Define __GAS64_DEBUG__ if it wasn't explicitly disabled
 '' by '-d DISABLE_GAS64_DEBUG' passed as compiler option when
@@ -147,19 +146,7 @@ declare sub hwriteasm64( byref ln as string,byval opt as integer=KDOALL)
 #endif
 
 #ifdef __GAS64_DEBUG__
-#include once "crt/string.bi"
-
-	private sub asm_info( byval s as string )
-		dim as zstring ptr sdata = strptr( s )
-		dim as const zstring ptr newlines = @!"\r\n"
-		dim as zstring ptr iter =  strpbrk( sdata, newlines )
-		while iter
-			*iter = asc("#")
-			iter = strpbrk( iter + 1, newlines )
-		wend
-		hWriteasm64("# "+s)
-	end sub
-
+	#define asm_info(s) hWriteasm64("# "+s)
 #else
 	#define asm_info(s) rem
 	#ifndef typeDumpToStr
@@ -353,6 +340,7 @@ declare sub _emitdbg(byval op as integer,byval proc as FBSYMBOL ptr,byval lnum a
 declare sub check_optim(byref code as string)
 declare sub _emitconvert( byval v1 as IRVREG ptr, byval v2 as IRVREG ptr )
 declare function hgetdatatype_asm64 (byval sym as FBSYMBOL ptr,byval arraydimensions as integer = 0) as string
+declare sub hwriteasm64( byref ln as string,byval opt as integer=KDOALL)
 declare sub _emitvariniend( byval sym as FBSYMBOL ptr )
 declare sub _emitvarinipad( byval bytes as longint )
 declare sub _emitvariniwstr(byval varlength as longint,byval literal as wstring ptr,byval litlength as longint)
@@ -6363,7 +6351,7 @@ private sub _emitasmline( byval asmtokenhead as ASTASMTOK ptr )
 		select case( n->type )
 			case AST_ASMTOK_TEXT
 				asmline += *n->text
-				asm_info("asm text="+*n->text)
+				'asm_info("asm text="+*n->text)
 			case AST_ASMTOK_SYMB
 
 				Var ofs = symbGetOfs( n->sym )


### PR DESCRIPTION
As asm_info call has been removed from _emitasmline there should be not anymore problem with adeyblue's multilines so asm_info function is also removed