### PR TITLE
Fix GPM support for GETMOUSE under TERM=linux

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -66,6 +66,7 @@ Version 1.10.0
 - fbc: remove double path separator characters '/', '\' when setting the fbc path prefix
 - rtlib: multikey was missing VK_NUMPAD5 and SC_CLEAR scancodes in the key table, causing NUMPAD-5 to be handled as escape in the windows D2D gfx driver
 - sf.net: #961: rtlib/gfxlib: COLOR() function returns LONG but should be ULONG
+- The DISABLE_GPM build option for the Unix rtlib now only disables GETMOUSE() for TERM=linux, which is the case that uses GPM, however GETMOUSE() for TERM=xterm now keeps working under DISABLE_GPM, since that case does not use GPM.
 
 
 Version 1.09.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@ Version 1.10.0
 - makefile: internal rename (TARGET_PRFEX => BUILD_PREFIX) and conditionally set the library and object directories (default is still based on TARGET)
 - fbc: dos: set DXE_LD_LIBRARY_PATH environment variable when calling DXE3GEN
 - release: target DOS gcc 9.3.0 and bin utils 2.30 for next release
+- Unix GETMOUSE() under TERM=linux now requires libgpm 1.20.4 or higher (libgpm.so.2), instead of the older libgpm.so.1 versions. (for compatibility with modern Debian/Ubuntu versions, and probably other distros, since 2008)
 
 [added]
 - gas/gas64: '.cif_sections' and '.cif_' directives for stack unwinding (adeyblue)
@@ -65,7 +66,6 @@ Version 1.10.0
 - fbc: remove double path separator characters '/', '\' when setting the fbc path prefix
 - rtlib: multikey was missing VK_NUMPAD5 and SC_CLEAR scancodes in the key table, causing NUMPAD-5 to be handled as escape in the windows D2D gfx driver
 - sf.net: #961: rtlib/gfxlib: COLOR() function returns LONG but should be ULONG
-- Unix GETMOUSE() now works with libgpm.so.2 too, not only libgpm.so.1, for mouse support in the TERM=linux case (for compatibility with Debian/Ubuntu versions, and probably other distros, since 2008)
 
 
 Version 1.09.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -65,6 +65,7 @@ Version 1.10.0
 - fbc: remove double path separator characters '/', '\' when setting the fbc path prefix
 - rtlib: multikey was missing VK_NUMPAD5 and SC_CLEAR scancodes in the key table, causing NUMPAD-5 to be handled as escape in the windows D2D gfx driver
 - sf.net: #961: rtlib/gfxlib: COLOR() function returns LONG but should be ULONG
+- Unix GETMOUSE() now works with libgpm.so.2 too, not only libgpm.so.1, for mouse support in the TERM=linux case (for compatibility with Debian/Ubuntu versions, and probably other distros, since 2008)
 
 
 Version 1.09.0

--- a/makefile
+++ b/makefile
@@ -123,7 +123,8 @@
 #
 # rtlib/gfxlib2 source code configuration (CFLAGS):
 #   -DDISABLE_X11    build without X11 headers (disables X11 gfx driver)
-#   -DDISABLE_GPM    build without gpm.h (disables Linux GetMouse)
+#   -DDISABLE_GPM    build without gpm.h (disables GetMouse in the Linux terminal (TERM=linux),
+#                    although the TERM=xterm variant keeps working)
 #   -DDISABLE_FFI    build without ffi.h (disables ThreadCall)
 #   -DDISABLE_OPENGL build without OpenGL headers (disables OpenGL gfx drivers)
 #   -DDISABLE_FBDEV  build without Linux framebuffer device headers (disables Linux fbdev gfx driver)

--- a/src/gfxlib2/gfx_opengl.c
+++ b/src/gfxlib2/gfx_opengl.c
@@ -212,7 +212,7 @@ void fb_hGL_NormalizeParameters(int gl_options)
 
 int fb_hGL_Init(FB_DYLIB lib, char *os_extensions)
 {
-	const char *gl_funcs[] = { "glEnable", "glDisable", "glEnableClientState", "glDisableClientState",
+	const char *const gl_funcs[] = { "glEnable", "glDisable", "glEnableClientState", "glDisableClientState",
 							   "glGetString", "glViewport", "glMatrixMode",
 							   "glLoadIdentity", "glOrtho", "glShadeModel", "glDepthMask", "glClearColor",
 							   "glClear", "glGenTextures", "glDeleteTextures", "glBindTexture", 
@@ -227,7 +227,7 @@ int fb_hGL_Init(FB_DYLIB lib, char *os_extensions)
 
 	fb_hMemSet(&__fb_gl, 0, sizeof(FB_GL));
 
-	if (fb_hDynLoadAlso(lib, gl_funcs, funcs_ptr, sizeof(gl_funcs) / sizeof(const char *)))
+	if (fb_hDynLoadAlso(lib, gl_funcs, funcs_ptr, ARRAY_SIZE(gl_funcs)))
 		return -1;
 
 	strncpy(__fb_gl.extensions, (char *)__fb_gl.GetString(GL_EXTENSIONS), size);

--- a/src/gfxlib2/unix/gfx_driver_opengl_x11.c
+++ b/src/gfxlib2/unix/gfx_driver_opengl_x11.c
@@ -139,7 +139,7 @@ static void opengl_window_update(void)
 
 static int driver_init(char *title, int w, int h, int depth, int refresh_rate, int flags)
 {
-	const char *glx_funcs[] = {
+	const char *const glx_funcs[] = {
 		"glXChooseVisual", "glXCreateContext", "glXDestroyContext",
 		"glXMakeCurrent", "glXSwapBuffers", NULL
 	};

--- a/src/gfxlib2/win32/gfx_driver_opengl.c
+++ b/src/gfxlib2/win32/gfx_driver_opengl.c
@@ -410,7 +410,7 @@ static DWORD WINAPI opengl_thread( LPVOID param )
 
 static int driver_init(char *title, int w, int h, int depth_arg, int refresh_rate, int flags)
 {
-	const char *wgl_funcs[] = { "wglCreateContext", "wglMakeCurrent", "wglDeleteContext", NULL };
+	const char *const wgl_funcs[] = { "wglCreateContext", "wglMakeCurrent", "wglDeleteContext", NULL };
 	int depth = MAX(8, depth_arg);
 
 	fb_hMemSet(&fb_win32, 0, sizeof(fb_win32));

--- a/src/rtlib/fb.h
+++ b/src/rtlib/fb.h
@@ -89,6 +89,26 @@
 
 #define ARRAY_SIZE(a) ((sizeof (a)) / sizeof ((a)[0]))
 
+/* Use C11/C++11 static assertion keyword if possible (safer and better error messages) */
+#if defined __cplusplus
+	#if __cplusplus >= 201103L
+		#define STATIC_ASSERT(predicate) static_assert(predicate, #predicate)
+	#endif
+#elif defined __STDC_VERSION__
+	#if __STDC_VERSION__ >= 201112L
+		#define STATIC_ASSERT(predicate) _Static_assert(predicate, #predicate)
+	#endif
+#endif
+
+/* Fall back for older compilers */
+#define STATIC_ASSERT_LEGACY_LINE2(predicate, line) typedef char static_assertion_on_line_##line[(predicate) ? 1 : -1] __attribute__((unused));
+#define STATIC_ASSERT_LEGACY_LINE1(predicate, line) STATIC_ASSERT_LEGACY_LINE2(predicate, line)
+#define STATIC_ASSERT_LEGACY(predicate) STATIC_ASSERT_LEGACY_LINE1(predicate, __LINE__)
+
+#ifndef STATIC_ASSERT
+#define STATIC_ASSERT(predicate) STATIC_ASSERT_LEGACY(predicate)
+#endif
+
 #if defined HOST_DOS
 	#include "dos/fb_dos.h"
 #elif defined HOST_UNIX

--- a/src/rtlib/fb.h
+++ b/src/rtlib/fb.h
@@ -87,6 +87,8 @@
 
 #define SWAP(a,b)		((a) ^= (b), (b) ^= (a), (a) ^= (b))
 
+#define ARRAY_SIZE(a) ((sizeof (a)) / sizeof ((a)[0]))
+
 #if defined HOST_DOS
 	#include "dos/fb_dos.h"
 #elif defined HOST_UNIX

--- a/src/rtlib/fb_private_hdynload.h
+++ b/src/rtlib/fb_private_hdynload.h
@@ -7,8 +7,8 @@
 	typedef void *FB_DYLIB;
 #endif
 
-FB_DYLIB fb_hDynLoad    (const char *libname, const char **funcname, void **funcptr);
-int      fb_hDynLoadAlso(FB_DYLIB lib, const char **funcname, void **funcptr, ssize_t count);
+FB_DYLIB fb_hDynLoad    (const char *libname, const char *const *funcname, void **funcptr);
+int      fb_hDynLoadAlso(FB_DYLIB lib, const char *const *funcname, void **funcptr, ssize_t count);
 void     fb_hDynUnload  (FB_DYLIB *lib);
 
 #endif

--- a/src/rtlib/linux/io_mouse.c
+++ b/src/rtlib/linux/io_mouse.c
@@ -109,7 +109,7 @@ static void mouse_handler(void)
 
 static int mouse_init(void)
 {
-	const char *funcs[] = { "Gpm_Open", "Gpm_Close", "Gpm_GetEvent", "gpm_fd", NULL };
+	const char *const funcs[] = { "Gpm_Open", "Gpm_Close", "Gpm_GetEvent", "gpm_fd", NULL };
 
 	if (__fb_con.inited == INIT_CONSOLE) {
 		gpm_lib = fb_hDynLoad("libgpm.so.1", funcs, (void **)&gpm);

--- a/src/rtlib/linux/io_multikey.c
+++ b/src/rtlib/linux/io_multikey.c
@@ -235,11 +235,6 @@ static void keyboard_x11_handler(void)
 
 static int keyboard_init(void)
 {
-#ifndef DISABLE_X11
-	const char *funcs[] = {
-		"XOpenDisplay", "XCloseDisplay", "XQueryKeymap", "XDisplayKeycodes", "XGetKeyboardMapping", "XFree", NULL
-	};
-#endif
 	struct termios term;
 	memset( &term, 0, sizeof( term ) );
 
@@ -269,6 +264,10 @@ static int keyboard_init(void)
 
 #ifndef DISABLE_X11
 	else {
+		const char *const funcs[] = {
+			"XOpenDisplay", "XCloseDisplay", "XQueryKeymap", "XDisplayKeycodes", "XGetKeyboardMapping", "XFree", NULL
+		};
+
 		xlib = fb_hDynLoad("libX11.so", funcs, (void **)&X);
 		if (!xlib)
 			return -1;

--- a/src/rtlib/unix/hdynload.c
+++ b/src/rtlib/unix/hdynload.c
@@ -7,7 +7,7 @@
 #define hDylibFree( lib ) dlclose( lib )
 #define hDylibSymbol( lib, sym ) dlsym( lib, sym )
 
-FB_DYLIB fb_hDynLoad(const char *libname, const char **funcname, void **funcptr)
+FB_DYLIB fb_hDynLoad(const char *libname, const char *const *funcname, void **funcptr)
 {
 	FB_DYLIB lib;
 	ssize_t i;
@@ -33,7 +33,7 @@ FB_DYLIB fb_hDynLoad(const char *libname, const char **funcname, void **funcptr)
 	return lib;
 }
 
-int fb_hDynLoadAlso( FB_DYLIB lib, const char **funcname, void **funcptr, ssize_t count )
+int fb_hDynLoadAlso( FB_DYLIB lib, const char *const *funcname, void **funcptr, ssize_t count )
 {
 	ssize_t i;
 

--- a/src/rtlib/unix/io_xfocus.c
+++ b/src/rtlib/unix/io_xfocus.c
@@ -26,7 +26,7 @@ static Window xterm_window;
 int fb_hXTermInitFocus(void)
 {
 #ifndef DISABLE_X11
-	const char *funcs[] = { "XOpenDisplay", "XCloseDisplay", "XGetInputFocus", NULL };
+	const char *const funcs[] = { "XOpenDisplay", "XCloseDisplay", "XGetInputFocus", NULL };
 	int dummy;
 
 	ref_count++;

--- a/src/rtlib/win32/hdynload.c
+++ b/src/rtlib/win32/hdynload.c
@@ -6,7 +6,7 @@
 #define hDylibFree( lib ) FreeLibrary( lib )
 #define hDylibSymbol( lib, sym ) GetProcAddress( lib, sym )
 
-FB_DYLIB fb_hDynLoad(const char *libname, const char **funcname, void **funcptr)
+FB_DYLIB fb_hDynLoad(const char *libname, const char *const *funcname, void **funcptr)
 {
 	FB_DYLIB lib;
 	ssize_t i;
@@ -26,7 +26,7 @@ FB_DYLIB fb_hDynLoad(const char *libname, const char **funcname, void **funcptr)
 	return lib;
 }
 
-int fb_hDynLoadAlso( FB_DYLIB lib, const char **funcname, void **funcptr, ssize_t count )
+int fb_hDynLoadAlso( FB_DYLIB lib, const char *const *funcname, void **funcptr, ssize_t count )
 {
 	ssize_t i;
 


### PR DESCRIPTION
The GPM support didn't work at all, because it looked for `libgpm.so.1`, while a current Debian/Ubuntu has `libgpm.so.2`. It looks like that was changed around 2008, so apparently it has been broken for quite a while.

Due to an ABI compatibility issue (see comments in the code) with different versions of `libgpm.so.1`, it seems best to drop support for that completely. For `libgpm.so.2` I didn't find any ABI issues.