### PR TITLE
Unix rtlib: Fix tty state cleanup in case of parallel shell()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -67,6 +67,7 @@ Version 1.10.0
 - rtlib: multikey was missing VK_NUMPAD5 and SC_CLEAR scancodes in the key table, causing NUMPAD-5 to be handled as escape in the windows D2D gfx driver
 - sf.net: #961: rtlib/gfxlib: COLOR() function returns LONG but should be ULONG
 - The DISABLE_GPM build option for the Unix rtlib now only disables GETMOUSE() for TERM=linux, which is the case that uses GPM, however GETMOUSE() for TERM=xterm now keeps working under DISABLE_GPM, since that case does not use GPM.
+- Unix rtlib: Multi-threaded use of shell()/exec()/dylibload()/dylibfree() can no longer cause input/output terminal configuration cleanup at program exit to fail
 
 
 Version 1.09.0

--- a/src/rtlib/unix/fb_private_console.h
+++ b/src/rtlib/unix/fb_private_console.h
@@ -65,9 +65,6 @@ typedef struct FBCONSOLE
 
 extern FBCONSOLE __fb_con;
 
-#ifdef HOST_LINUX
-int fb_hTermQuery( int code, int *val1, int *val2 );
-#endif
 void fb_hRecheckCursorPos( void );
 void fb_hRecheckConsoleSize( int requery_cursorpos );
 int fb_hTermOut(int code, int param1, int param2);

--- a/src/rtlib/unix/fb_private_console.h
+++ b/src/rtlib/unix/fb_private_console.h
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #define INIT_CONSOLE 1
 #define INIT_X11     2
 
@@ -43,6 +45,9 @@ typedef struct FBCONSOLE
 	FILE *f_in;
 	struct termios old_term_out, old_term_in;
 	int old_in_flags;
+	bool saved_old_term_out;
+	bool saved_old_term_in;
+	bool saved_old_in_flags;
 	unsigned int fg_color, bg_color;
 	int cur_x, cur_y;
 	int w, h;

--- a/src/rtlib/unix/hinit.c
+++ b/src/rtlib/unix/hinit.c
@@ -119,7 +119,7 @@ static void signal_handler(int sig)
    read from stdin returns EOF).
    Used with SEQ_QUERY_WINDOW and SEQ_QUERY_CURSOR only (but could easily be
    extended to support more). */
-int fb_hTermQuery( int code, int *val1, int *val2 )
+static int fb_hTermQuery( int code, int *val1, int *val2 )
 {
 	if( fb_hTermOut( code, 0, 0 ) == FALSE )
 		return FALSE;

--- a/src/rtlib/unix/hinit.c
+++ b/src/rtlib/unix/hinit.c
@@ -31,8 +31,25 @@ FBCONSOLE __fb_con;
 typedef void (*SIGHANDLER)(int);
 static SIGHANDLER old_sighandler[NSIG];
 static volatile sig_atomic_t __fb_console_resized;
-static const char *seq[] = { "cm", "ho", "cs", "cl", "ce", "WS", "bl", "AF", "AB",
-							 "me", "md", "SF", "ve", "vi", "dc", "ks", "ke" };
+static const char *seq[] = {
+	"cm", /* SEQ_LOCATE        */
+	"ho", /* SEQ_HOME          */
+	"cs", /* SEQ_SCROLL_REGION */
+	"cl", /* SEQ_CLS           */
+	"ce", /* SEQ_CLEOL         */
+	"WS", /* SEQ_WINDOW_SIZE   */
+	"bl", /* SEQ_BEEP          */
+	"AF", /* SEQ_FG_COLOR      */
+	"AB", /* SEQ_BG_COLOR      */
+	"me", /* SEQ_RESET_COLOR   */
+	"md", /* SEQ_BRIGHT_COLOR  */
+	"SF", /* SEQ_SCROLL        */
+	"ve", /* SEQ_SHOW_CURSOR   */
+	"vi", /* SEQ_HIDE_CURSOR   */
+	"dc", /* SEQ_DEL_CHAR      */
+	"ks", /* SEQ_INIT_KEYPAD   */
+	"ke", /* SEQ_EXIT_KEYPAD   */
+};
 
 static pthread_t __fb_bg_thread;
 static int bgthread_inited = FALSE;
@@ -263,8 +280,15 @@ int fb_hTermOut( int code, int param1, int param2 )
 
 	   Thus, we provide the __fb_enable_vt100_escapes global variable, which
 	   FB programs can set to TRUE or FALSE as needed at runtime. */
-	const char *extra_seq[] = { "\e(U", "\e(B", "\e[6n", "\e[18t",
-		"\e[?1000h\e[?1003h", "\e[?1003l\e[?1000l", "\e[H\e[J\e[0m" };
+	const char *extra_seq[] = {
+		"\e(U",               /* SEQ_INIT_CHARSET */
+		"\e(B",               /* SEQ_EXIT_CHARSET */
+		"\e[6n",              /* SEQ_QUERY_CURSOR */
+		"\e[18t",             /* SEQ_QUERY_WINDOW */
+		"\e[?1000h\e[?1003h", /* SEQ_INIT_XMOUSE */
+		"\e[?1003l\e[?1000l", /* SEQ_EXIT_XMOUSE */
+		"\e[H\e[J\e[0m",      /* SEQ_EXIT_GFX_MODE */
+	};
 
 	char *str;
 

--- a/tests/unix-tty/.gitignore
+++ b/tests/unix-tty/.gitignore
@@ -1,0 +1,5 @@
+/testee-*
+!/testee-*.bas
+/tester
+/examplebin
+/libexamplelib.so

--- a/tests/unix-tty/examplebin.bas
+++ b/tests/unix-tty/examplebin.bas
@@ -1,0 +1,5 @@
+print "hello ";
+var oldcolors = color(1)
+print "hello ";
+color(loword(oldcolors))
+print "hello ";

--- a/tests/unix-tty/examplelib.bas
+++ b/tests/unix-tty/examplelib.bas
@@ -1,0 +1,11 @@
+function get123() as integer
+	return 123
+end function
+
+sub print_hello()
+	print "hello ";
+	var oldcolors = color(1)
+	print "hello ";
+	color(loword(oldcolors))
+	print "hello ";
+end sub

--- a/tests/unix-tty/makefile
+++ b/tests/unix-tty/makefile
@@ -1,0 +1,40 @@
+FBC := fbc
+CXX := g++
+
+FBFLAGS :=
+CXXFLAGS := -O2 -g
+LDFLAGS :=
+
+ALLFBFLAGS := $(FBFLAGS)
+ALLCXXFLAGS := $(CXXFLAGS) -Wall
+ALLLDFLAGS := $(LDFLAGS)
+
+TESTEE_SOURCES := $(sort $(wildcard testee-*.bas))
+TESTEE_BINARIES := $(patsubst %.bas,%,$(TESTEE_SOURCES))
+
+ALL_BINARIES := tester $(TESTEE_BINARIES) libexamplelib.so examplebin
+
+all: $(ALL_BINARIES)
+
+tester: tester.cxx
+	$(CXX) $(ALLCXXFLAGS) $< $(ALLLDFLAGS) -o $@
+
+$(TESTEE_BINARIES): %: %.bas
+	$(FBC) $(ALLFBFLAGS) $<
+
+# #include dependency
+testee-dylibload-dylibfree-examplelib: testee-dylibload-only-examplelib.bas
+
+libexamplelib.so: examplelib.bas
+	$(FBC) $(ALLFBFLAGS) $< -dylib
+
+examplebin: examplebin.bas
+	$(FBC) $(ALLFBFLAGS) $<
+
+.PHONY: clean
+clean:
+	rm -f $(ALL_BINARIES)
+
+.PHONY: tests
+tests: all
+	./tester

--- a/tests/unix-tty/readme.txt
+++ b/tests/unix-tty/readme.txt
@@ -1,0 +1,15 @@
+This directory contains a tester program and various testee programs,
+for testing some of the issues related to tty state handling of FB's unix rtlib.
+
+The tester uses C++ (to avoid the test environment from being contaminated by an FB runtime),
+captures the original TTY state, runs each testee FB program and checks the TTY state afterwards everytime.
+Any changes in TTY state means that the testee FB program did not clean it up properly and is treated as test failure.
+
+What does the FB runtime do that's visible externally (i.e. affecting system
+state outside the FB program/process) and that could be tested this way?
+- For the input/output ttys (if stdin/stdout are ttys): It adjusts tty settings,
+  e.g. disables echoing, and some other settings. See fb_hInitConsole() and fb_hExitConsole().
+  We can check this via tcgetattr().
+- (Re-)Configures the terminal by sending escape codes on stdout (see SEQ_INIT_* and SEQ_EXIT_* in the rtlib).
+  I don't know how we can check this - are there any terminal escape codes/control sequences to query the status
+  of settings used by the FB runtime?

--- a/tests/unix-tty/testee-chain-examplebin.bas
+++ b/tests/unix-tty/testee-chain-examplebin.bas
@@ -1,0 +1,6 @@
+'' chain() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+var cmd = "./examplebin"
+if chain(cmd) = -1 then
+	print "error: chain() failed for " + cmd
+	end 1
+end if

--- a/tests/unix-tty/testee-chain-true.bas
+++ b/tests/unix-tty/testee-chain-true.bas
@@ -1,0 +1,6 @@
+'' chain() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+var cmd = "true"
+if chain(cmd) = -1 then
+	print "error: chain() failed for " + cmd
+	end 1
+end if

--- a/tests/unix-tty/testee-do-nothing.bas
+++ b/tests/unix-tty/testee-do-nothing.bas
@@ -1,0 +1,1 @@
+'' Even an "empty" FB program may result in calls to fb_hInitConsole()/fb_hExitConsole()

--- a/tests/unix-tty/testee-dylibload-dylibfree-examplelib.bas
+++ b/tests/unix-tty/testee-dylibload-dylibfree-examplelib.bas
@@ -1,0 +1,7 @@
+'' dylibload()/dylibfree() call fb_hInitConsole()/fb_hExitConsole(), so we test them.
+
+#include "testee-dylibload-only-examplelib.bas"
+
+'' With explicit dylibfree(): The dynamic library's global dtors (including the FB runtime's one)
+'' will run now, before those of the main program.
+dylibfree(dylib)

--- a/tests/unix-tty/testee-dylibload-only-examplelib.bas
+++ b/tests/unix-tty/testee-dylibload-only-examplelib.bas
@@ -1,0 +1,30 @@
+'' dylibload() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+
+const LIBNAME = "examplelib"
+
+dim dylib as any ptr = dylibload(LIBNAME)
+if dylib = 0 then
+	print "dylibload() failed, dylib " + LIBNAME + " not found"
+	end 1
+end if
+
+scope
+	dim get123 as function() as integer = dylibsymbol(dylib, "GET123")
+	if get123 = 0 then
+		print "dylibsymbol() failed, symbol GET123 not found in dylib " + LIBNAME
+		end 1
+	end if
+	print get123(); " ";
+end scope
+
+scope
+	dim print_hello as sub() = dylibsymbol(dylib, "PRINT_HELLO")
+	if print_hello = 0 then
+		print "dylibsymbol() failed, symbol PRINT_HELLO not found in dylib " + LIBNAME
+		end 1
+	end if
+	print_hello()
+end scope
+
+'' No dylibfree(): The dynamic library's global dtors (including the FB runtime's one)
+'' may run after those of the main program.

--- a/tests/unix-tty/testee-exec-examplebin.bas
+++ b/tests/unix-tty/testee-exec-examplebin.bas
@@ -1,0 +1,6 @@
+'' exec() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+var cmd = "./examplebin"
+if exec(cmd, "") = -1 then
+	print "error: exec() failed for " + cmd
+	end 1
+end if

--- a/tests/unix-tty/testee-exec-true.bas
+++ b/tests/unix-tty/testee-exec-true.bas
@@ -1,0 +1,6 @@
+'' exec() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+var cmd = "true"
+if exec(cmd, "") = -1 then
+	print "error: exec() failed for " + cmd
+	end 1
+end if

--- a/tests/unix-tty/testee-open-pipe-examplebin.bas
+++ b/tests/unix-tty/testee-open-pipe-examplebin.bas
@@ -1,0 +1,10 @@
+'' open pipe() may not call fb_hInitConsole()/fb_hExitConsole() yet, but we can test it anyways.
+var cmd = "./examplebin"
+
+var f = freefile()
+if open pipe(cmd, for input, as #f) <> 0 then
+	print "error: open pipe() failed for " + cmd
+	end 1
+end if
+
+close #f

--- a/tests/unix-tty/testee-open-pipe-true.bas
+++ b/tests/unix-tty/testee-open-pipe-true.bas
@@ -1,0 +1,10 @@
+'' open pipe() may not call fb_hInitConsole()/fb_hExitConsole() yet, but we can test it anyways.
+var cmd = "true"
+
+var f = freefile()
+if open pipe(cmd, for input, as #f) <> 0 then
+	print "error: open pipe() failed for " + cmd
+	end 1
+end if
+
+close #f

--- a/tests/unix-tty/testee-parallel-shell-sleep.bas
+++ b/tests/unix-tty/testee-parallel-shell-sleep.bas
@@ -1,0 +1,36 @@
+'' shell() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+'' This invokes shell() twice in parallel.
+'' "sleep" is used to try to make sure to get
+''    fb_hInitConsole()
+''    fb_hInitConsole()
+''    fb_hExitConsole()
+''    fb_hExitConsole()
+'' instead of
+''    fb_hInitConsole()
+''    fb_hExitConsole()
+''    fb_hInitConsole()
+''    fb_hExitConsole()
+'' but of course strictly speaking this is not guaranteed (we would have to use
+'' a proper synchronisation mechanism to make sure).
+
+sub threadmain(byval arg as any ptr)
+	var cmd = "sleep 1"
+	if shell(cmd) = -1 then
+		print "error: shell() failed for " + cmd
+		end 1
+	end if
+end sub
+
+var thread = threadcreate(@threadmain)
+if thread = 0 then
+	print "error: threadcreate() failed"
+	end 1
+end if
+
+var cmd = "sleep 1"
+if shell(cmd) = -1 then
+	print "error: shell() failed for " + cmd
+	end 1
+end if
+
+threadwait(thread)

--- a/tests/unix-tty/testee-run-examplebin.bas
+++ b/tests/unix-tty/testee-run-examplebin.bas
@@ -1,0 +1,6 @@
+'' run() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+var cmd = "./examplebin"
+if run(cmd) = -1 then
+	print "error: run() failed for " + cmd
+	end 1
+end if

--- a/tests/unix-tty/testee-run-true.bas
+++ b/tests/unix-tty/testee-run-true.bas
@@ -1,0 +1,6 @@
+'' run() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+var cmd = "true"
+if run(cmd) = -1 then
+	print "error: run() failed for " + cmd
+	end 1
+end if

--- a/tests/unix-tty/testee-shell-examplebin.bas
+++ b/tests/unix-tty/testee-shell-examplebin.bas
@@ -1,0 +1,6 @@
+'' shell() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+var cmd = "./examplebin"
+if shell(cmd) = -1 then
+	print "error: shell() failed for " + cmd
+	end 1
+end if

--- a/tests/unix-tty/testee-shell-true.bas
+++ b/tests/unix-tty/testee-shell-true.bas
@@ -1,0 +1,6 @@
+'' shell() calls fb_hInitConsole()/fb_hExitConsole(), so we test it.
+var cmd = "true"
+if shell(cmd) = -1 then
+	print "error: shell() failed for " + cmd
+	end 1
+end if

--- a/tests/unix-tty/tester.cxx
+++ b/tests/unix-tty/tester.cxx
@@ -1,0 +1,361 @@
+// This is the program that will run the tests.
+//
+// Tests mainly consist of capturing the TTY state, running a testee FB program,
+// and checking the TTY state again afterwards. Any change in TTY state
+// probably indicates an issue with the FB runtime's TTY state clean-up code.
+//
+// This should not be written in FB itself, otherwise the test could be contaminated. :/
+
+#include <cstring>
+#include <inttypes.h>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <stdint.h>
+#include <stdio.h>
+#include <string>
+#include <system_error>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+namespace {
+
+#if 0
+class fd_wrapper {
+	std::string m_description;
+	int m_fd;
+public:
+	fd_wrapper(const std::string &path, int flags, int mode = 0)
+		: m_description(path)
+		, m_fd(open(path.c_str(), flags, mode))
+	{
+		if (m_fd < 0) {
+			const int e = errno;
+			throw std::system_error(e, std::system_category(), "Failed to open \"" + path + "\"");
+		}
+	}
+
+	~fd_wrapper() {
+		close(m_fd);
+	}
+
+	// Copying not allowed, due to owned fd (could be implemented with dup(), but not needed)
+	fd_wrapper(const fd_wrapper &) = delete;
+	fd_wrapper &operator =(const fd_wrapper &) = delete;
+};
+#endif
+
+std::string dump_tty_state(const struct termios &state) {
+	std::ostringstream s;
+	s << '\n';
+	s << "  c_iflag=0x" << std::hex << state.c_iflag << '\n';
+	s << "  c_oflag=0x" << std::hex << state.c_oflag << '\n';
+	s << "  c_cflag=0x" << std::hex << state.c_cflag << '\n';
+	s << "  c_lflag=0x" << std::hex << state.c_lflag << '\n';
+	s << "  c_line=0x" << std::hex << static_cast<unsigned int>(state.c_line) << '\n';
+	for (size_t i = 0; i < NCCS; ++i) {
+		s << "  c_cc[" << std::dec << i << "]=0x" << std::hex << static_cast<unsigned int>(state.c_cc[i]) << '\n';
+	}
+	s << "  c_ispeed=0x" << std::hex << state.c_ispeed << '\n';
+	s << "  c_ospeed=0x" << std::hex << state.c_ospeed;
+	return s.str();
+}
+
+void check_tty_state_is_equal(const struct termios &a, const struct termios &b) {
+	#define CHECK(field) \
+		do { \
+			if (a.field != b.field) { \
+				std::ostringstream s; \
+				s << "TTY state mismatch: " << #field << " 0x" << static_cast<unsigned int>(a.field) << " != " << static_cast<unsigned int>(b.field); \
+				throw std::runtime_error(s.str()); \
+			} \
+		} while (0);
+
+	CHECK(c_iflag);
+	CHECK(c_oflag);
+	CHECK(c_cflag);
+	CHECK(c_lflag);
+	CHECK(c_line);
+	for (size_t i = 0; i < NCCS; ++i) {
+		if (a.c_cc[i] != b.c_cc[i]) {
+			std::ostringstream s;
+			s << "TTY state mismatch: c_cc[" << std::dec << i << "] 0x" << static_cast<unsigned int>(a.c_cc[i]) << " != " << static_cast<unsigned int>(b.c_cc[i]);
+			throw std::runtime_error(s.str());
+		}
+	}
+	CHECK(c_ispeed);
+	CHECK(c_ospeed);
+
+	#undef CHECK
+}
+
+struct termios get_tty_attr(int fd, const std::string &description) {
+	struct termios attr;
+	if (tcgetattr(fd, &attr) < 0) {
+		const int e = errno;
+		throw std::system_error(e, std::system_category(), "tcgetattr() failed for " + description);
+	}
+	return attr;
+}
+
+void apply_tty_attr(int fd, const std::string &description, const struct termios &wanted) {
+	if (tcsetattr(fd, TCSANOW, &wanted) < 0) {
+		const int e = errno;
+		throw std::system_error(e, std::system_category(), "tcsetattr() failed for " + description);
+	}
+
+	// tcsetattr() may only apply some settings, instead of all, so we have to re-check the resulting state.
+	const struct termios actual = get_tty_attr(fd, description);
+	try {
+		check_tty_state_is_equal(wanted, actual);
+	} catch (const std::exception &e) {
+		throw std::runtime_error(
+			"tcsetattr() failed to apply all the wanted settings for " + description + "\n" +
+			e.what() + "\n" +
+			"wanted: " + dump_tty_state(wanted) + "\n" +
+			"actual: " + dump_tty_state(wanted)
+		);
+	}
+}
+
+class tty_state_accessor {
+	int m_fd = -1;
+	std::string m_description;
+public:
+	tty_state_accessor(int fd, const std::string &description)
+		: m_fd(fd)
+		, m_description(description)
+	{
+		if (!is_a_tty()) {
+			throw std::runtime_error(m_description + " is not a tty. This test requires a TTY though, to test the FB runtime's TTY handling.");
+		}
+	}
+
+	const std::string &get_description() const {
+		return m_description;
+	}
+
+	bool is_a_tty() const {
+		return isatty(m_fd);
+	}
+
+	struct termios get_live_state() const {
+		return get_tty_attr(m_fd, m_description);
+	}
+
+	void apply_state(const struct termios &state) const {
+		apply_tty_attr(m_fd, m_description, state);
+	}
+
+	bool is_echoing_enabled() const {
+		const struct termios live = get_live_state();
+		return ((live.c_lflag & ECHO) != 0);
+	}
+
+	void set_echoing(bool enable) const {
+		struct termios state = get_live_state();
+		if (enable) {
+			state.c_lflag |= ECHO;
+		} else {
+			state.c_lflag &= ~ECHO;
+		}
+		apply_state(state);
+	}
+};
+
+class tty_state_tracker {
+	tty_state_accessor m_accessor;
+	std::optional<struct termios> m_saved_state;
+
+	void ensure_captured() const {
+		if (!m_saved_state) {
+			throw std::logic_error("restore() without capture()");
+		}
+	}
+
+public:
+	explicit tty_state_tracker(tty_state_accessor accessor)
+		: m_accessor(accessor)
+	{
+	}
+
+	void capture() {
+		m_saved_state = m_accessor.get_live_state();
+	}
+
+	void restore() const {
+		ensure_captured();
+		m_accessor.apply_state(*m_saved_state);
+	}
+
+	struct unexpected_state_error : public std::runtime_error {
+		using std::runtime_error::runtime_error;
+	};
+
+	void check_live_equals_captured() const {
+		ensure_captured();
+		const auto live = m_accessor.get_live_state();
+		try {
+			check_tty_state_is_equal(live, *m_saved_state);
+		} catch (const std::exception &e) {
+			throw unexpected_state_error("Unexpected TTY state for " + m_accessor.get_description() + ". " + e.what());
+		}
+	}
+
+	void sanity_check() const {
+		ensure_captured();
+
+		const bool echoing = m_accessor.is_echoing_enabled();
+		if (!echoing) {
+			throw std::runtime_error("Echoing was initially disabled for " + m_accessor.get_description());
+		}
+
+		m_accessor.set_echoing(false);
+		try {
+			check_live_equals_captured();
+			throw std::runtime_error("Sanity check failed: Did not detect disabled echoing");
+		} catch (const unexpected_state_error &e) {
+		}
+
+		m_accessor.set_echoing(true);
+		try {
+			check_live_equals_captured();
+		} catch (...) {
+			throw std::runtime_error("Sanity check failed: Unexpectedly reported a state mismatch after re-enabling echoing");
+		}
+	}
+};
+
+class system_state_tracker {
+	tty_state_tracker m_in{tty_state_accessor{STDIN_FILENO, "input tty"}};
+	tty_state_tracker m_out{tty_state_accessor{STDOUT_FILENO, "output tty"}};
+public:
+	system_state_tracker() {
+		capture();
+	}
+
+	void capture() {
+		m_in.capture();
+		m_out.capture();
+	}
+
+	void restore() const {
+		m_in.restore();
+		m_out.restore();
+	}
+
+	void check_live_equals_captured() const {
+		m_in.check_live_equals_captured();
+		m_out.check_live_equals_captured();
+	}
+
+	void sanity_check() const {
+		m_in.sanity_check();
+		m_out.sanity_check();
+	}
+};
+
+void run_child_program(const std::string &path) {
+	const pid_t childpid = fork();
+	if (childpid < 0) {
+		const int e = errno;
+		throw std::system_error(e, std::system_category(), "fork() failed");
+	}
+
+	if (childpid == 0) {
+		// In child
+		const char *const argv[] = {
+			path.c_str(),
+			nullptr,
+		};
+		execv(path.c_str(), const_cast<char *const *>(argv));
+		const int e = errno;
+		throw std::system_error(e, std::system_category(), "Failed to execute program \"" + path + "\"");
+	}
+
+	// In parent
+	int status = 0;
+	if (waitpid(childpid, &status, 0) < 0) {
+		const int e = errno;
+		throw std::system_error(e, std::system_category(), "waitpid() failed");
+	}
+	if (WIFEXITED(status)) {
+		const int exitcode = WEXITSTATUS(status);
+		if (exitcode != 0) {
+			throw std::runtime_error("Unexpected exit code " + std::to_string(exitcode) + " from child program " + path);
+		}
+	} else if (WIFSIGNALED(status)) {
+		throw std::runtime_error("Unexpected exit due to signal " + std::to_string(WTERMSIG(status)) + " from child program " + path);
+	} else {
+		throw std::runtime_error("Unexpected exit from child program " + path);
+	}
+}
+
+class test_context {
+	system_state_tracker m_tracker;
+	uint32_t m_oks = 0;
+	uint32_t m_fails = 0;
+
+	void test_child_process(const std::string &testee_name) {
+		printf("test: %s... ", testee_name.c_str());
+		fflush(stdout);
+		run_child_program("./" + testee_name);
+		try {
+			m_tracker.check_live_equals_captured();
+			m_oks++;
+			printf("OK\n");
+		} catch (const tty_state_tracker::unexpected_state_error &e) {
+			m_fails++;
+			m_tracker.restore();
+			m_tracker.check_live_equals_captured();
+			printf("FAIL: %s\n", e.what());
+		}
+	}
+
+public:
+	test_context() {
+		m_tracker.sanity_check();
+		printf("sanity check: OK\n");
+	}
+
+	void run() {
+		test_child_process("testee-chain-examplebin");
+		test_child_process("testee-chain-true");
+		test_child_process("testee-do-nothing");
+		test_child_process("testee-dylibload-dylibfree-examplelib");
+		test_child_process("testee-dylibload-only-examplelib");
+		test_child_process("testee-exec-examplebin");
+		test_child_process("testee-exec-true");
+		test_child_process("testee-open-pipe-examplebin");
+		test_child_process("testee-open-pipe-true");
+		test_child_process("testee-parallel-shell-sleep");
+		test_child_process("testee-run-examplebin");
+		test_child_process("testee-run-true");
+		test_child_process("testee-shell-examplebin");
+		test_child_process("testee-shell-true");
+
+		printf("done: %" PRIu32 " OKs, %" PRIu32 " FAILs\n", m_oks, m_fails);
+	}
+
+	bool succeeded() const {
+		return (m_fails == 0);
+	}
+};
+
+} // namespace
+
+int main() {
+	try {
+		test_context test;
+		test.run();
+		return test.succeeded() ? 0 : 1;
+	} catch (const std::exception &e) {
+		fprintf(stderr, "error: %s\n", e.what());
+		return 1;
+	}
+}


### PR DESCRIPTION
This fixes a bug with `fb_hInitConsole()/fb_hExitConsole()`. `fb_hInitConsole()` can be called repeatedly, without `fb_hExitConsole()` in between. An example for this is a multi-threaded FB program with parallel SHELL calls. But this affects other functions/keywords too, such as EXEC, DYLIBLOAD, etc. In a case like that, `fb_hInitConsole()` should only capture the original tty state (for restoring it on exit) once. It should not re-capture again and again, because then it would only capture the state it set itself before, causing the wrong state to be restored on exit.

See the commit messages for some more details. I'm relatively (but not 100%) confident that this shouldn't break anything. I've been using this locally for a couple of days, and I've added a test program which runs several tests and fails before the patch but not anymore afterwards. Thus I think this should be safe to merge.