### PR TITLE
tests: Fix stack corruption in mid() unit tests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -69,6 +69,7 @@ Version 1.10.0
 - The DISABLE_GPM build option for the Unix rtlib now only disables GETMOUSE() for TERM=linux, which is the case that uses GPM, however GETMOUSE() for TERM=xterm now keeps working under DISABLE_GPM, since that case does not use GPM.
 - Unix rtlib: Multi-threaded use of shell()/exec()/dylibload()/dylibfree() can no longer cause input/output terminal configuration cleanup at program exit to fail
 - sf.net #965: fbc: Bad code generation in gcc backend for NOT PTR_EXPR - don't allow unary ops on pointers
+- Internal (unit tests): Stack corruption in mid() tests (regression from 1.07.0)
 
 
 Version 1.09.0

--- a/tests/udt-wstring/midstmt.bas
+++ b/tests/udt-wstring/midstmt.bas
@@ -10,7 +10,7 @@
 '' and the garbage in the buffer will affect the tests
 #macro INIT_FIXED_STRING( s, dtype, size, value )
 	dim s as dtype * size
-	clear @s, 0, sizeof(s)
+	clear s, 0, sizeof(s)
 	s = value
 #endmacro
 

--- a/tests/udt-zstring/midstmt.bas
+++ b/tests/udt-zstring/midstmt.bas
@@ -10,7 +10,7 @@
 '' and the garbage in the buffer will affect the tests
 #macro INIT_FIXED_STRING( s, dtype, size, value )
 	dim s as dtype * size
-	clear @s, 0, sizeof(s)
+	clear s, 0, sizeof(s)
 	s = value
 #endmacro
 

--- a/tests/wstring/midstmt.bas
+++ b/tests/wstring/midstmt.bas
@@ -18,7 +18,7 @@ SUITE( fbc_tests.wstring_.midstmt )
 			INIT_FIXED_STRING( w1, wstring, BUFFERSIZE, left( dst, (length1) ) )
 			INIT_FIXED_STRING( w2, wstring, BUFFERSIZE, left( src, (length2) ) )
 			INIT_FIXED_STRING( e1, wstring, BUFFERSIZE, w1 )
-			dim n1 as integer = 50 '' len(w1)
+			dim n1 as integer = BUFFERSIZE '' len(w1)
 			dim n2 as integer = len(w2)
 			dim idx1 as integer = start
 			dim idx2 as integer = 1
@@ -30,7 +30,7 @@ SUITE( fbc_tests.wstring_.midstmt )
 					idx1 += 1
 					idx2 += 1
 				wend
-				e1[n1] = 0
+				e1[n1-1] = 0
 			end if
 
 			mid( w1, start ) = w2
@@ -58,7 +58,7 @@ SUITE( fbc_tests.wstring_.midstmt )
 					idx2 += 1
 					n += 1
 				wend
-				e1[n1] = 0
+				e1[n1-1] = 0
 			end if
 
 			mid( w1, start, length ) = w2

--- a/tests/wstring/midstmt.bas
+++ b/tests/wstring/midstmt.bas
@@ -7,7 +7,7 @@
 '' and the garbage in the buffer will affect the tests
 #macro INIT_FIXED_STRING( s, dtype, size, value )
 	dim s as dtype * size
-	clear @s, 0, sizeof(s)
+	clear s, 0, sizeof(s)
 	s = value
 #endmacro
 


### PR DESCRIPTION
1. Pass correct object to CLEAR (its first parameter is object BYREF, not address BYVAL)
2. Fix out-of-bounds store when manually setting null terminator

Fixes: 135f364274