### PR TITLE
name mangling for 'char' type using [u]byte alias "char"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ Version 1.10.0
 - makefile: 'DISABLE_GAS64_DEBUG=1' makefile configuration option to disable debugging comments in gas64 asm files
 - gfxlib2: add FB.GET_SCANLINE_SIZE to fbgfx.bi and ScreenControl() to get current internal scan line size multiplier
 - gfxlib2: SCREENCONTROL: add getters for GL parameters - new GET_GL_* constants in fbgfx.bi
+- Name mangling for c++ 'char' through BYTE/UBYTE parameters using the form "[unsigned] byte alias "char".  Data type size is still 8 byte signed/unsigned from fbc side, but will mangled as 'char'; neither signed nor unsigned for the c++ side.
 
 [fixed]
 - gas64: missing restoring of use of one virtual register on sqr for float (SARG)

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -464,6 +464,8 @@ private function cMangleModifier _
 				select case dtype
 				case FB_DATATYPE_VOID
 					dtype = typeSetMangleDt( dtype, FB_DATATYPE_CHAR )
+				case FB_DATATYPE_BYTE, FB_DATATYPE_UBYTE
+					dtype = typeSetMangleDt( dtype, FB_DATATYPE_CHAR )
 				case else
 					errReport( FB_ERRMSG_SYNTAXERROR )	
 				end select
@@ -581,10 +583,12 @@ function cSymbolType _
 		case FB_TK_BYTE
 			lexSkipToken( LEXCHECK_POST_SUFFIX )
 			dtype = FB_DATATYPE_BYTE
+			cMangleModifier( dtype, subtype )
 
 		case FB_TK_UBYTE
 			lexSkipToken( LEXCHECK_POST_SUFFIX )
 			dtype = FB_DATATYPE_UBYTE
+			cMangleModifier( dtype, subtype )
 
 		case FB_TK_SHORT
 			lexSkipToken( LEXCHECK_POST_SUFFIX )
@@ -794,7 +798,11 @@ function cSymbolType _
 			'' remap type, if valid
 			select case as const typeGet( dtype )
 			case FB_DATATYPE_BYTE
-				dtype = FB_DATATYPE_UBYTE
+				if( typeHasMangleDt( dtype ) ) then
+					dtype = typeSetMangleDt( FB_DATATYPE_UBYTE, FB_DATATYPE_CHAR )
+				else
+					dtype = FB_DATATYPE_UBYTE
+				end if
 
 			case FB_DATATYPE_SHORT
 				dtype = FB_DATATYPE_USHORT

--- a/tests/cpp/mangle-cpp.cpp
+++ b/tests/cpp/mangle-cpp.cpp
@@ -12,7 +12,7 @@ namespace cpp_mangle
 		return a;
 	} 
 
-    // float
+	// float
 
 	float cpp_byval_float( float a )
 	{
@@ -24,7 +24,7 @@ namespace cpp_mangle
 		return a;
 	} 
 
-   	// double
+	// double
 
 	double cpp_byval_double( double a )
 	{
@@ -38,6 +38,38 @@ namespace cpp_mangle
 
 	// char = 8 bit
 
+	char cpp_byval_char_b( char a )
+	{
+		return a;
+	}
+
+	char cpp_byval_char_u( char a )
+	{
+		return a;
+	}
+
+	char cpp_byval_char_ub( char a )
+	{
+		return a;
+	}
+
+	char cpp_byref_char_b( char &a )
+	{
+		return a;
+	} 
+
+	char cpp_byref_char_u( char &a )
+	{
+		return a;
+	} 
+
+	char cpp_byref_char_ub( char &a )
+	{
+		return a;
+	} 
+
+	// signed | unsigned char = 8 bit
+
 	unsigned char cpp_byval_uchar( unsigned char a )
 	{
 		return a;
@@ -47,13 +79,13 @@ namespace cpp_mangle
 	{
 		return a;
 	}
-	
+
 	unsigned char cpp_byref_uchar( unsigned char &a )
 	{
 		return a;
 	} 
 
-   	signed char cpp_byref_schar( signed char &a )
+	signed char cpp_byref_schar( signed char &a )
 	{
 		return a;
 	} 

--- a/tests/cpp/mangle-fbc.bas
+++ b/tests/cpp/mangle-fbc.bas
@@ -33,7 +33,15 @@ namespace cpp_mangle
 
 	declare function cpp_byval_double( byval a as double ) as double
 	declare function cpp_byref_double( byref a as double ) as double
-	
+
+	declare function cpp_byval_char_b( byval a as byte alias "char" ) as byte alias "char"
+	declare function cpp_byval_char_u( byval a as ubyte alias "char" ) as ubyte alias "char"
+	declare function cpp_byval_char_ub( byval a as unsigned byte alias "char" ) as unsigned byte alias "char"
+
+	declare function cpp_byref_char_b( byref a as byte alias "char" ) as byte alias "char"
+	declare function cpp_byref_char_u( byref a as ubyte alias "char" ) as ubyte alias "char"
+	declare function cpp_byref_char_ub( byref a as unsigned byte alias "char" ) as unsigned byte alias "char"
+
 	declare function cpp_byval_uchar( byval a as unsigned byte ) as unsigned byte
 	declare function cpp_byval_schar( byval a as byte ) as byte
 	declare function cpp_byref_uchar( byref a as unsigned byte ) as unsigned byte
@@ -138,20 +146,32 @@ end scope
 
 scope
 				 
-	''  c = signed|unsigned char
+	''  c = [signed|unsigned] char
 	'' fb = [unsigned] byte
 
+	ASSERT( cpp_byval_char_b(0) = 0 )
+	ASSERT( cpp_byval_char_u(0) = 0 )
+	ASSERT( cpp_byval_char_ub(0) = 0 )
 	ASSERT( cpp_byval_uchar(0) = 0 )
 	ASSERT( cpp_byval_schar(0) = 0 )
+	ASSERT( cpp_byval_char_b(&h7f) = &h7f )
+	ASSERT( cpp_byval_char_u(&h7f) = &h7f )
+	ASSERT( cpp_byval_char_ub(&h7f) = &h7f )
 	ASSERT( cpp_byval_uchar(&h7f) = &h7f )
 	ASSERT( cpp_byval_schar(&h7f) = &h7f )
 
 	dim ub as unsigned byte = 0
 	dim sb as byte = 0
+	ASSERT( cpp_byref_char_b(ub) = 0 )
+	ASSERT( cpp_byref_char_u(ub) = 0 )
+	ASSERT( cpp_byref_char_ub(ub) = 0 )
 	ASSERT( cpp_byref_uchar(ub) = 0 )
 	ASSERT( cpp_byref_schar(sb) = 0 )
 	ub = &h7f
 	sb = &h7f
+	ASSERT( cpp_byref_char_b(ub) = &h7f )
+	ASSERT( cpp_byref_char_u(ub) = &h7f )
+	ASSERT( cpp_byref_char_ub(ub) = &h7f )
 	ASSERT( cpp_byref_uchar(ub) = &h7f )
 	ASSERT( cpp_byref_schar(sb) = &h7f )
 


### PR DESCRIPTION
name mangling for 'char' type using `[u]byte alias "char"`

- Name mangling for c++ 'char' through BYTE/UBYTE parameters using the form "[unsigned] byte alias "char".
- Data type size is still 8 byte signed/unsigned from fbc side, but will be mangled as 'char'; neither signed nor unsigned for the c++ side.

fbc does not directly support the c++ 'char' type; only char* through zstring ptr.

This addition allows procedure parameters to be declared with the the built-in datatype  `ubyte` or `byte` but have the mangled (decorated) name generated as if the type was a `char`.

Should also work with `const`, `ptr`, etc, but not tested.  Documentation to be updated later on freebasic wiki at [Alias (Modified)](https://www.freebasic.net/wiki/KeyPgAliasModifier)