### PR TITLE
rtlib: OPEN fails opening an encoded file for APPEND

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -74,6 +74,7 @@ Version 1.10.0
 - sf.net #965: fbc: Bad code generation in gcc backend for NOT PTR_EXPR - don't allow unary ops on pointers
 - Internal (unit tests): Stack corruption in mid() tests (regression from 1.07.0)
 - gfxlib2: LINE statement computing an incorrect line style pattern on any non-X86 (i.e. 64-bit, etc)
+- github #393: rtlib: OPEN fails when opening an encoded file for append.
 
 
 Version 1.09.0

--- a/src/rtlib/dev_file_encod_open.c
+++ b/src/rtlib/dev_file_encod_open.c
@@ -3,96 +3,88 @@
 #include "fb.h"
 
 static FB_FILE_HOOKS hooks_dev_file = {
-    fb_DevFileEof,
-    fb_DevFileClose,
-    fb_DevFileSeek,
-    fb_DevFileTell,
-    fb_DevFileReadEncod,
-    fb_DevFileReadEncodWstr,
-    fb_DevFileWriteEncod,
-    fb_DevFileWriteEncodWstr,
-    fb_DevFileLock,
-    fb_DevFileUnlock,
-    fb_DevFileReadLineEncod,
-    fb_DevFileReadLineEncodWstr,
-    NULL,
-    fb_DevFileFlush
+	fb_DevFileEof,
+	fb_DevFileClose,
+	fb_DevFileSeek,
+	fb_DevFileTell,
+	fb_DevFileReadEncod,
+	fb_DevFileReadEncodWstr,
+	fb_DevFileWriteEncod,
+	fb_DevFileWriteEncodWstr,
+	fb_DevFileLock,
+	fb_DevFileUnlock,
+	fb_DevFileReadLineEncod,
+	fb_DevFileReadLineEncodWstr,
+	NULL,
+	fb_DevFileFlush
 };
 
-static int hCheckBOM( FB_FILE *handle )
+static int hCheckBOM( FILE *fp, FB_FILE_ENCOD encod )
 {
-    int res, bom = 0;
-    FILE *fp = (FILE *)handle->opaque;
+	int res, bom = 0;
 
-    if( handle->mode == FB_FILE_MODE_APPEND )
-    	fseek( fp, 0, SEEK_SET );
+	switch( encod )
+	{
+	case FB_FILE_ENCOD_UTF8:
+		if( fread( &bom, 3, 1, fp ) != 1 )
+			return 0;
 
-    switch( handle->encod )
-    {
-    case FB_FILE_ENCOD_UTF8:
-        if( fread( &bom, 3, 1, fp ) != 1 )
-        	return 0;
-
-    	res = (bom == 0x00BFBBEF);
-    	break;
-
-	case FB_FILE_ENCOD_UTF16:
-        if( fread( &bom, sizeof( UTF_16 ), 1, fp ) != 1 )
-        	return 0;
-
-    	/* !!!FIXME!!! only litle-endian supported */
-    	res = (bom == 0x0000FEFF);
-    	break;
-
-	case FB_FILE_ENCOD_UTF32:
-
-        if( fread( &bom, sizeof( UTF_32 ), 1, fp ) != 1 )
-        	return 0;
-
-    	/* !!!FIXME!!! only litle-endian supported */
-    	res = (bom == 0x0000FEFF);
+		res = (bom == 0x00BFBBEF);
 		break;
 
-    default:
-        res = 0;
-    }
-
-    if( handle->mode == FB_FILE_MODE_APPEND )
-        fseek( fp, 0, SEEK_END );
-
-    return res;
-}
-
-static int hWriteBOM( FB_FILE *handle )
-{
-    int bom;
-    FILE *fp = (FILE *)handle->opaque;
-
-    switch( handle->encod )
-    {
-    case FB_FILE_ENCOD_UTF8:
-        bom = 0x00BFBBEF;
-        if( fwrite( &bom, 3, 1, fp ) != 1 )
-        	return 0;
-    	break;
-
 	case FB_FILE_ENCOD_UTF16:
-        /* !!!FIXME!!! only litle-endian supported */
-        bom = 0x0000FEFF;
-        if( fwrite( &bom, sizeof( UTF_16 ), 1, fp ) != 1 )
-        	return 0;
-    	break;
+		if( fread( &bom, sizeof( UTF_16 ), 1, fp ) != 1 )
+			return 0;
+
+		/* !!!FIXME!!! only litle-endian supported */
+		res = (bom == 0x0000FEFF);
+		break;
 
 	case FB_FILE_ENCOD_UTF32:
-        /* !!!FIXME!!! only litle-endian supported */
-        bom = 0x0000FEFF;
-        if( fwrite( &bom, sizeof( UTF_32 ), 1, fp ) != 1 )
-            return 0;
-        break;
 
-    default:
-        return 0;
-    }
+		if( fread( &bom, sizeof( UTF_32 ), 1, fp ) != 1 )
+			return 0;
+
+		/* !!!FIXME!!! only litle-endian supported */
+		res = (bom == 0x0000FEFF);
+		break;
+
+	default:
+		res = 0;
+	}
+
+	return res;
+}
+
+static int hWriteBOM( FILE *fp, FB_FILE_ENCOD encod )
+{
+	int bom;
+
+	switch( encod )
+	{
+	case FB_FILE_ENCOD_UTF8:
+		bom = 0x00BFBBEF;
+		if( fwrite( &bom, 3, 1, fp ) != 1 )
+			return 0;
+		break;
+
+	case FB_FILE_ENCOD_UTF16:
+		/* !!!FIXME!!! only litle-endian supported */
+		bom = 0x0000FEFF;
+		if( fwrite( &bom, sizeof( UTF_16 ), 1, fp ) != 1 )
+			return 0;
+		break;
+
+	case FB_FILE_ENCOD_UTF32:
+		/* !!!FIXME!!! only litle-endian supported */
+		bom = 0x0000FEFF;
+		if( fwrite( &bom, sizeof( UTF_32 ), 1, fp ) != 1 )
+			return 0;
+		break;
+
+	default:
+		return 0;
+	}
 
 	return 1;
 }
@@ -104,91 +96,113 @@ int fb_DevFileOpenEncod
 		size_t fname_len
 	)
 {
-    FILE *fp = NULL;
-    char *openmask;
-    char *fname;
+	FILE *fp = NULL;
+	char *openmask;
+	char *fname;
+	int effective_mode;
 
-    FB_LOCK();
+	FB_LOCK();
 
-    fname = (char*) alloca(fname_len + 1);
-    memcpy(fname, filename, fname_len);
-    fname[fname_len] = 0;
+	fname = (char*) alloca(fname_len + 1);
+	memcpy(fname, filename, fname_len);
+	fname[fname_len] = 0;
 
-    /* Convert directory separators to whatever the current platform supports */
-    fb_hConvertPath( fname );
+	/* Convert directory separators to whatever the current platform supports */
+	fb_hConvertPath( fname );
 
-    handle->hooks = &hooks_dev_file;
+	handle->hooks = &hooks_dev_file;
+	effective_mode = handle->mode;
 
-    openmask = NULL;
-    switch( handle->mode )
-    {
-    case FB_FILE_MODE_APPEND:
-        /* will create the file if it doesn't exist */
-        openmask = "ab";
-        break;
+	openmask = NULL;
 
-    case FB_FILE_MODE_INPUT:
-        /* will fail if file doesn't exist */
-        openmask = "rb";
-        break;
+	switch( handle->mode )
+	{
+	case FB_FILE_MODE_INPUT:
+	case FB_FILE_MODE_APPEND:
+		/*	Even in append mode, try and open for reading first 
+			because trying to read the BOM in "ab" mode will fail 
+		*/
+		openmask = "rb";
+		break;
 
-    case FB_FILE_MODE_OUTPUT:
-        /* will create the file if it doesn't exist */
-        openmask = "wb";
-        break;
+	case FB_FILE_MODE_OUTPUT:
+		openmask = "wb";
+		break;
 
-    default:
-        FB_UNLOCK();
-        return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
-    }
+	default:
+		FB_UNLOCK();
+		return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
+	}
 
-    /* try opening */
-    if( (fp = fopen( fname, openmask )) == NULL )
-    {
-    	FB_UNLOCK();
-        return fb_ErrorSetNum( FB_RTERROR_FILENOTFOUND );
-    }
+	/* try opening */
+	fp = fopen( fname, openmask );
 
-    fb_hSetFileBufSize( fp );
+	if( handle->mode == FB_FILE_MODE_APPEND )
+	{
+		/*	if we weren't able to open an existing file for
+			append, then try writing instead 
+		*/
+		if( fp == NULL )
+		{
+			/* not found? handle mode as if output was specified */
+			effective_mode = FB_FILE_MODE_OUTPUT;
+			openmask = "ab";
+			fp = fopen( fname, openmask );
+		}
+		else
+		{
+			if( !hCheckBOM( fp, handle->encod ) )
+			{
+				fclose( fp );
+				FB_UNLOCK();
+				return fb_ErrorSetNum( FB_RTERROR_FILEIO );
+			}
+			else
+			{
+				/* if we have the correct BOM, then reopen the file for append */
+				openmask = "ab";
+				fp = freopen( fname, openmask, fp );
+			}
+		}
+	}
 
-    handle->opaque = fp;
+	/* not opened? */
+	if( fp == NULL )
+	{
+		FB_UNLOCK();
+		return fb_ErrorSetNum( FB_RTERROR_FILENOTFOUND );
+	}
 
-    if ( handle->access == FB_FILE_ACCESS_ANY)
-        handle->access = FB_FILE_ACCESS_READWRITE;
+	fb_hSetFileBufSize( fp );
 
-    /* handle BOM */
-    switch( handle->mode )
-    {
-    case FB_FILE_MODE_APPEND:
-    case FB_FILE_MODE_INPUT:
-        if( !hCheckBOM( handle ) )
-        {
-    		fclose( fp );
-    		FB_UNLOCK();
-        	return fb_ErrorSetNum( FB_RTERROR_FILENOTFOUND );
-        }
+	handle->opaque = fp;
 
-        break;
+	if ( handle->access == FB_FILE_ACCESS_ANY)
+		handle->access = FB_FILE_ACCESS_READWRITE;
 
-    case FB_FILE_MODE_OUTPUT:
-        if( !hWriteBOM( handle ) )
-        {
-    		fclose( fp );
-    		FB_UNLOCK();
-        	return fb_ErrorSetNum( FB_RTERROR_FILENOTFOUND );
-        }
+	/*
+	write the BOM if file was just newly created
+	*/
+	if( effective_mode == FB_FILE_MODE_OUTPUT )
+	{
+		if( !hWriteBOM( fp, handle->encod ) )
+		{
+			fclose( fp );
+			FB_UNLOCK();
+			return fb_ErrorSetNum( FB_RTERROR_FILENOTFOUND );
+		}
 	}
 
 	/* calc file size */
-    handle->size = fb_DevFileGetSize( fp, handle->mode, handle->encod, TRUE );
-    if( handle->size == -1 )
-    {
-    	fclose( fp );
-        FB_UNLOCK();
-        return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
+	handle->size = fb_DevFileGetSize( fp, handle->mode, handle->encod, TRUE );
+	if( handle->size == -1 )
+	{
+		fclose( fp );
+		FB_UNLOCK();
+		return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
 	}
 
-    FB_UNLOCK();
+	FB_UNLOCK();
 
 	return fb_ErrorSetNum( FB_RTERROR_OK );
 }

--- a/tests/file/encod.bas
+++ b/tests/file/encod.bas
@@ -7,9 +7,24 @@
 
 SUITE( fbc_tests.file_.encod )
 
-	private sub WriteToFile (byref encod as string)
+	private function getTESTFILE( byref encod as string ) as string
+		return "./file/test_" + encod + ".txt"
+	end function
 
-		if( open( "test_" + encod + ".txt", for output, encoding encod, as #1 ) <> 0 ) then
+	private sub KillTestFile( byref encod as string )
+
+		dim TESTFILE as string
+		TESTFILE = getTESTFILE( encod )
+
+		kill TESTFILE
+	end sub
+
+	private sub WriteToFile( byref encod as string )
+
+		dim TESTFILE as string
+		TESTFILE = getTESTFILE( encod )
+
+		if( open( TESTFILE, for output, encoding encod, as #1 ) <> 0 ) then
 			CU_FAIL_FATAL("couldn't open test file.")
 		end if
 
@@ -18,64 +33,134 @@ SUITE( fbc_tests.file_.encod )
 		print #1, TEST_1
 		print #1, TEST_2
 		print #1, TEST_3; TEST_4
-		
+
 		close #1
 
 	end sub
 
-	private sub ReadFromFile (byref encod as string)
-
+	private sub ReadFromFile1( )
 		dim s as string
 		dim ws as wstring * 100
 		dim i as integer
 		dim d as double
-		
-		if( open( "test_" + encod + ".txt", for input, encoding encod, as #1 ) <> 0 ) then
+
+		input #1, s, ws, i, d
+
+		CU_ASSERT_EQUAL( s, TEST_1 )
+		CU_ASSERT_EQUAL( ws, TEST_2 )
+		CU_ASSERT_EQUAL( i, TEST_3 )
+		CU_ASSERT_EQUAL( d, TEST_4 )
+
+		input #1, s, ws, i, d
+
+		CU_ASSERT_EQUAL( s, TEST_1 )
+		CU_ASSERT_EQUAL( ws, TEST_2 )
+		CU_ASSERT_EQUAL( i, TEST_3 )
+		CU_ASSERT_EQUAL( d, TEST_4 )
+	end sub
+
+	private sub ReadFromFile2( )
+		dim s as string
+		dim ws as wstring * 100
+		dim i as integer
+		dim d as double
+
+		input #1, d, i, ws, s
+
+		CU_ASSERT_EQUAL( s, TEST_1 )
+		CU_ASSERT_EQUAL( ws, TEST_2 )
+		CU_ASSERT_EQUAL( i, TEST_3 )
+		CU_ASSERT_EQUAL( d, TEST_4 )
+
+		input #1, d, i, ws, s
+
+		CU_ASSERT_EQUAL( s, TEST_1 )
+		CU_ASSERT_EQUAL( ws, TEST_2 )
+		CU_ASSERT_EQUAL( i, TEST_3 )
+		CU_ASSERT_EQUAL( d, TEST_4 )
+	end sub
+
+	private sub ReadFromFile( byref encod as string, byval sections as integer )
+
+		dim TESTFILE as string
+		TESTFILE = getTESTFILE( encod )
+
+		if( open( TESTFILE, for input, encoding encod, as #1 ) <> 0 ) then
 			CU_FAIL_FATAL("couldn't open test file.")
 		end if
-		
-		input #1, s, ws, i, d
-		
-		CU_ASSERT_EQUAL( s, TEST_1 )
-		CU_ASSERT_EQUAL( ws, TEST_2 )
-		CU_ASSERT_EQUAL( i, TEST_3 )
-		CU_ASSERT_EQUAL( d, TEST_4 )
-		
-		input #1, s, ws, i, d
-		
-		CU_ASSERT_EQUAL( s, TEST_1 )
-		CU_ASSERT_EQUAL( ws, TEST_2 )
-		CU_ASSERT_EQUAL( i, TEST_3 )
-		CU_ASSERT_EQUAL( d, TEST_4 )
-		
+
+		if( sections >= 1 ) then
+			ReadFromFile1()
+		end if
+
+		if( sections >= 2 ) then
+			ReadFromFile2()
+		end if
+
 		close #1
 
 	end sub
 
-	private sub performTest (byref encod as string)
+	private sub AppendToNewFile( byref encod as string )
 
-		'//
-		'// write
-		'//
+		dim TESTFILE as string
+		TESTFILE = getTESTFILE( encod )
 
-		WriteToFile(encod)
-		
-		'//
-		'// read
-		'//
+		if( open( TESTFILE, for append, encoding encod, as #1 ) <> 0 ) then
+			CU_FAIL_FATAL("couldn't open test file.")
+		end if
 
-		ReadFromFile(encod)
+		write #1, TEST_1, TEST_2, TEST_3, TEST_4
 
-		kill "test_" + encod + ".txt"
+		print #1, TEST_1
+		print #1, TEST_2
+		print #1, TEST_3; TEST_4
+
+		close #1
+
+	end sub
+
+	private sub AppendToExistingFile( byref encod as string )
+
+		dim TESTFILE as string
+		TESTFILE = getTESTFILE( encod )
+
+		if( open( TESTFILE, for append, encoding encod, as #1 ) <> 0 ) then
+			CU_FAIL_FATAL("couldn't open test file.")
+		end if
+
+		write #1, TEST_4, TEST_3, TEST_2, TEST_1
+
+		print #1, TEST_4; TEST_3
+		print #1, TEST_2
+		print #1, TEST_1
+
+		close #1
+
+	end sub
+
+	private sub performTest( byref encod as string )
+
+		WriteToFile( encod )
+		ReadFromFile( encod, 1 )
+
+		KillTestFile( encod )
+
+		AppendToNewFile( encod )
+		ReadFromFile( encod, 1 )
+		AppendToExistingFile( encod )
+		ReadFromFile( encod, 2 )
+
+		KillTestFile( encod )
 
 	end sub
 
 	TEST( encoding )
 
-		performTest("utf8")
-		performTest("utf16")
-		performTest("utf32")
-		performTest("ascii")
+		performTest( "utf8" )
+		performTest( "utf16" )
+		performTest( "utf32" )
+		performTest( "ascii" )
 
 	END_TEST
 


### PR DESCRIPTION
rtlib: OPEN always fails when opening an encoded file for APPEND

fixes #393 

BUG:
- fixes bugs when opening encoded files
- opening a non-existent file for append always failed because of an incorrect check for not yet written BOM
- opening an existing file for append always failed because the file mode didn't support reading the existing BOM

FIX:
- opening an encoded file for append initially opens the file for read mode
- if the file exists, the BOM is read and checked and if it matches the specified encoding, and the file is reopened for append mode
- if the file does not exist, the file is reopened for append mode and the BOM written