### PR TITLE
rtlib: OPEN fails opening an encoded file for APPEND

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -74,7 +74,7 @@ Version 1.10.0
 - sf.net #965: fbc: Bad code generation in gcc backend for NOT PTR_EXPR - don't allow unary ops on pointers
 - Internal (unit tests): Stack corruption in mid() tests (regression from 1.07.0)
 - gfxlib2: LINE statement computing an incorrect line style pattern on any non-X86 (i.e. 64-bit, etc)
-- github #393: rtlib: OPEN fails when opening an encoded file for append.
+- github #393: rtlib: OPEN fails when opening an encoded file for append.  Check the BOM on existing files for INPUT/APPEND, write the BOM for new files for OUTPUT/APPEND.
 
 
 Version 1.09.0

--- a/src/rtlib/dev_file_encod_open.c
+++ b/src/rtlib/dev_file_encod_open.c
@@ -151,6 +151,8 @@ int fb_DevFileOpenEncod
 		}
 		else
 		{
+			fb_hSetFileBufSize( fp );
+
 			if( !hCheckBOM( fp, handle->encod ) )
 			{
 				fclose( fp );
@@ -180,17 +182,27 @@ int fb_DevFileOpenEncod
 	if ( handle->access == FB_FILE_ACCESS_ANY)
 		handle->access = FB_FILE_ACCESS_READWRITE;
 
-	/*
-	write the BOM if file was just newly created
-	*/
-	if( effective_mode == FB_FILE_MODE_OUTPUT )
+	switch( effective_mode )
 	{
+	case FB_FILE_MODE_INPUT:
+		/* check the BOM if reading only */
+		if( !hCheckBOM( fp, handle->encod ) )
+		{
+			fclose( fp );
+			FB_UNLOCK();
+			return fb_ErrorSetNum( FB_RTERROR_FILEIO );
+		}
+		break;
+
+	case FB_FILE_MODE_OUTPUT:
+		/* write the BOM if file was just newly created */
 		if( !hWriteBOM( fp, handle->encod ) )
 		{
 			fclose( fp );
 			FB_UNLOCK();
 			return fb_ErrorSetNum( FB_RTERROR_FILENOTFOUND );
 		}
+		break;
 	}
 
 	/* calc file size */

--- a/tests/file/encod-check.bas
+++ b/tests/file/encod-check.bas
@@ -1,0 +1,170 @@
+# include "fbcunit.bi"
+
+SUITE( fbc_tests.file_.encod_check )
+
+	const testFile = "./file/test_encod_check.txt"
+
+	const FILE_MODE_INPUT = 0
+	const FILE_MODE_OUTPUT = 1
+	const FILE_MODE_APPEND = 2
+
+	private function createTestFile( byref encod as string ) as boolean
+		dim ret as boolean
+		ret = (open( testFile, for output, encoding encod, as #1 ) = 0)
+		if( ret = false ) then
+			CU_FAIL_FATAL("couldn't create test file.")
+			return false
+		end if
+
+		print #1, "hello"
+		close #1
+		return true
+	end function
+
+	private function openTestFile( byval file_mode as integer, byref encod as string ) as boolean
+		dim ret as boolean
+		select case file_mode
+		case FILE_MODE_INPUT
+			ret = (open( testFile, for input, encoding encod, as #1 ) = 0)
+		case FILE_MODE_OUTPUT
+			ret = (open( testFile, for output, encoding encod, as #1 ) = 0)
+		case FILE_MODE_APPEND
+			ret = (open( testFile, for append, encoding encod, as #1 ) = 0)
+		case else
+			ret = false
+		end select
+		return ret
+	end function
+
+	private sub closeTestFile( )
+		close #1
+	end sub
+
+	private sub killTestFile( )
+		kill testFile
+	end sub
+
+	TEST( create_new )
+
+		'' check creating a new file with various encodings
+
+		#macro do_check( expected_ret, file_mode, encod )
+			scope
+				dim ret as boolean
+				ret = openTestFile( file_mode, encod )
+				CU_ASSERT( ret = expected_ret )
+
+				if( ret ) then
+					closeTestFile( )
+				end if
+
+				killTestFile( )
+			end scope
+		#endmacro
+
+		#macro do_mode_check( expected_ret, file_mode )
+			do_check( expected_ret, file_mode, "ascii" )
+			do_check( expected_ret, file_mode, "utf8" )
+			do_check( expected_ret, file_mode, "utf16" )
+			do_check( expected_ret, file_mode, "utf32" )
+		#endmacro
+
+		do_mode_check( false, FILE_MODE_INPUT )
+		do_mode_check( true, FILE_MODE_OUTPUT )
+		do_mode_check( true, FILE_MODE_APPEND )
+		
+	END_TEST
+
+	TEST( open_existing )
+
+		'' check open an existing file with same & different encodings
+
+		#macro do_check( expected_ret, file_mode, encod1, encod2 )
+			scope
+				killTestFile()
+				createTestFile( encod1 )
+
+				dim ret as boolean
+				ret = openTestFile( file_mode, encod2 )
+				CU_ASSERT( ret = expected_ret )
+
+				if( ret ) then
+					closeTestFile( )
+				end if
+
+				killTestFile( )
+			end scope
+		#endmacro
+
+		'' ASCII
+		do_check( true , FILE_MODE_INPUT, "ascii", "ascii" )
+		do_check( false, FILE_MODE_INPUT, "ascii", "utf8" )
+		do_check( false, FILE_MODE_INPUT, "ascii", "utf16" )
+		do_check( false, FILE_MODE_INPUT, "ascii", "utf32" )
+
+		do_check( true , FILE_MODE_OUTPUT, "ascii", "ascii" )
+		do_check( true , FILE_MODE_OUTPUT, "ascii", "utf8" )
+		do_check( true , FILE_MODE_OUTPUT, "ascii", "utf16" )
+		do_check( true , FILE_MODE_OUTPUT, "ascii", "utf32" )
+
+		do_check( true , FILE_MODE_APPEND, "ascii", "ascii" )
+		do_check( false, FILE_MODE_APPEND, "ascii", "utf8" )
+		do_check( false, FILE_MODE_APPEND, "ascii", "utf16" )
+		do_check( false, FILE_MODE_APPEND, "ascii", "utf32" )
+
+		'' UTF-8
+		do_check( true , FILE_MODE_INPUT, "utf8", "ascii" )
+		do_check( true , FILE_MODE_INPUT, "utf8", "utf8" )
+		do_check( false, FILE_MODE_INPUT, "utf8", "utf16" )
+		do_check( false, FILE_MODE_INPUT, "utf8", "utf32" )
+
+		do_check( true , FILE_MODE_OUTPUT, "utf8", "ascii" )
+		do_check( true , FILE_MODE_OUTPUT, "utf8", "utf8" )
+		do_check( true , FILE_MODE_OUTPUT, "utf8", "utf16" )
+		do_check( true , FILE_MODE_OUTPUT, "utf8", "utf32" )
+
+		do_check( true , FILE_MODE_APPEND, "utf8", "ascii" )
+		do_check( true , FILE_MODE_APPEND, "utf8", "utf8" )
+		do_check( false, FILE_MODE_APPEND, "utf8", "utf16" )
+		do_check( false, FILE_MODE_APPEND, "utf8", "utf32" )
+
+		'' UTF-16
+		do_check( true , FILE_MODE_INPUT, "utf16", "ascii" )
+		do_check( false, FILE_MODE_INPUT, "utf16", "utf8" )
+		do_check( true , FILE_MODE_INPUT, "utf16", "utf16" )
+		do_check( false, FILE_MODE_INPUT, "utf16", "utf32" )
+
+		do_check( true , FILE_MODE_OUTPUT, "utf16", "ascii" )
+		do_check( true , FILE_MODE_OUTPUT, "utf16", "utf8" )
+		do_check( true , FILE_MODE_OUTPUT, "utf16", "utf16" )
+		do_check( true , FILE_MODE_OUTPUT, "utf16", "utf32" )
+
+		do_check( true , FILE_MODE_APPEND, "utf16", "ascii" )
+		do_check( false, FILE_MODE_APPEND, "utf16", "utf8" )
+		do_check( true , FILE_MODE_APPEND, "utf16", "utf16" )
+		do_check( false, FILE_MODE_APPEND, "utf16", "utf32" )
+	
+		'' UTF-32
+		'' ** checking for utf16le when file was encoded in utf32le
+		'' maybe gives false positives .. something for users to watch for
+		'' utf32le & utf16le have same start bytes and so the check
+		'' passes when maybe user would expect it to fail
+
+		do_check( true , FILE_MODE_INPUT, "utf32", "ascii" )
+		do_check( false, FILE_MODE_INPUT, "utf32", "utf8" )
+		do_check( true , FILE_MODE_INPUT, "utf32", "utf16" )
+		do_check( true , FILE_MODE_INPUT, "utf32", "utf32" )
+
+		do_check( true , FILE_MODE_OUTPUT, "utf32", "ascii" )
+		do_check( true , FILE_MODE_OUTPUT, "utf32", "utf8" )
+		do_check( true , FILE_MODE_OUTPUT, "utf32", "utf16" ) '' **
+		do_check( true , FILE_MODE_OUTPUT, "utf32", "utf32" )
+
+		do_check( true , FILE_MODE_APPEND, "utf32", "ascii" )
+		do_check( false, FILE_MODE_APPEND, "utf32", "utf8" )
+		do_check( true , FILE_MODE_APPEND, "utf32", "utf16" ) '' **
+		do_check( true , FILE_MODE_APPEND, "utf32", "utf32" )
+
+	END_TEST
+
+END_SUITE


### PR DESCRIPTION
Amends #394 to fix #393 due to introducing a new bug on files opened for INPUT.

- check BOM on existing files
- write BOM on new files
- set buffer size before reading BOM
- add tests to test BOM logic
