### PR TITLE
Fix incorrect handling of initializers (typeini)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -75,6 +75,7 @@ Version 1.10.0
 - Internal (unit tests): Stack corruption in mid() tests (regression from 1.07.0)
 - gfxlib2: LINE statement computing an incorrect line style pattern on any non-X86 (i.e. 64-bit, etc)
 - github #393: rtlib: OPEN fails when opening an encoded file for append.  Check the BOM on existing files for INPUT/APPEND, write the BOM for new files for OUTPUT/APPEND.
+- sf.net #968: fbc: major changes how initializers are handled and pairing of a UDT's (internal) structure and the initializer list given by the user.
 
 
 Version 1.09.0

--- a/src/compiler/ast-node-assign.bas
+++ b/src/compiler/ast-node-assign.bas
@@ -46,7 +46,7 @@ private function hCheckUDTOps _
 		byval ldclass as FB_DATACLASS, _
 		byref r as ASTNODE ptr, _
 		byval rdclass as FB_DATACLASS, _
-		byval checkOnly as integer = TRUE _ 
+		byval checkOnly as integer = TRUE _
 	) as integer
 
 	dim as FBSYMBOL ptr proc = any
@@ -63,18 +63,18 @@ private function hCheckUDTOps _
 		end if
 	end if
 
-    '' is r an UDT?
+	'' is r an UDT?
 	if( astGetDataType( r ) <> FB_DATATYPE_STRUCT ) then
 		exit function
 	end if
 
-   	'' different subtypes?
+	'' different subtypes?
 	if( l->subtype <> r->subtype ) then
 		'' check if lhs is a base type of rhs
 		if( symbGetUDTBaseLevel( r->subtype, l->subtype ) = 0 ) then
 			exit function
 		End If
-		
+
 		'' cast to the base type
 		if( checkOnly = FALSE ) then
 			r = astNewCONV( astGetDataType( l ), l->subtype, r )
@@ -102,7 +102,7 @@ private function hCheckWstringOps _
 	ldtype = typeGet( ldfull )
 	rdtype = typeGet( rdfull )
 
-    '' left?
+	'' left?
 	if( ldtype = FB_DATATYPE_WCHAR ) then
 		'' is right a zstring? (fixed- or
 		'' var-len strings won't reach here)
@@ -179,13 +179,13 @@ private sub hCheckEnumOps _
 		byval rdclass as FB_DATACLASS _
 	)
 
-    '' not the same?
-    if( astGetDataType( l ) <> astGetDataType( r ) ) then
-    	if( (ldclass <> FB_DATACLASS_INTEGER) or _
-    		(rdclass <> FB_DATACLASS_INTEGER) ) then
-    		errReportWarn( FB_WARNINGMSG_IMPLICITCONVERSION )
-    	end if
-    end if
+	'' not the same?
+	if( astGetDataType( l ) <> astGetDataType( r ) ) then
+		if( (ldclass <> FB_DATACLASS_INTEGER) or _
+			(rdclass <> FB_DATACLASS_INTEGER) ) then
+			errReportWarn( FB_WARNINGMSG_IMPLICITCONVERSION )
+		end if
+	end if
 
 end sub
 
@@ -245,9 +245,9 @@ function astCheckASSIGN _
 		byval r as ASTNODE ptr _
 	) as integer
 
-    dim as ASTNODE ptr n = any
-    dim as FB_DATATYPE ldtype = any, rdtype = any, ldfull = any, rdfull = any
-    dim as FB_DATACLASS ldclass = any, rdclass = any
+	dim as ASTNODE ptr n = any
+	dim as FB_DATATYPE ldtype = any, rdtype = any, ldfull = any, rdfull = any
+	dim as FB_DATACLASS ldclass = any, rdclass = any
 
 	function = FALSE
 
@@ -258,9 +258,9 @@ function astCheckASSIGN _
 	ldclass = typeGetClass( ldtype )
 	rdclass = typeGetClass( rdtype )
 
-    '' strings?
-    if( (ldclass = FB_DATACLASS_STRING) or _
-    	(rdclass = FB_DATACLASS_STRING) ) then
+	'' strings?
+	if( (ldclass = FB_DATACLASS_STRING) or _
+		(rdclass = FB_DATACLASS_STRING) ) then
 
 		'' both not strings?
 		if( ldclass <> rdclass ) then
@@ -281,13 +281,13 @@ function astCheckASSIGN _
 
 		return TRUE
 
-    '' wstrings?
-    elseif( (ldtype = FB_DATATYPE_WCHAR) or _
-    		(rdtype = FB_DATATYPE_WCHAR) ) then
+	'' wstrings?
+	elseif( (ldtype = FB_DATATYPE_WCHAR) or _
+			(rdtype = FB_DATATYPE_WCHAR) ) then
 
 		'' both = wstrings?
 		if( ldtype <> rdtype ) then
-    		dim as integer is_zstr
+			dim as integer is_zstr
 			if( hCheckWstringOps( l, ldfull, r, rdfull, is_zstr ) = FALSE ) then
 				exit function
 			end if
@@ -303,9 +303,9 @@ function astCheckASSIGN _
 			rdtype = typeGet( rdfull )
 		end if
 
-    '' zstrings?
-    elseif( (ldtype = FB_DATATYPE_CHAR) or _
-    		(rdtype = FB_DATATYPE_CHAR) ) then
+	'' zstrings?
+	elseif( (ldtype = FB_DATATYPE_CHAR) or _
+			(rdtype = FB_DATATYPE_CHAR) ) then
 
 		'' both zstrings?
 		if( ldtype = rdtype ) then
@@ -322,13 +322,13 @@ function astCheckASSIGN _
 		ldtype = typeGet( ldfull )
 		rdtype = typeGet( rdfull )
 
-    '' enums?
-    elseif( (ldtype = FB_DATATYPE_ENUM) or _
-    		(rdtype = FB_DATATYPE_ENUM) ) then
+	'' enums?
+	elseif( (ldtype = FB_DATATYPE_ENUM) or _
+			(rdtype = FB_DATATYPE_ENUM) ) then
 		hCheckEnumOps( l, ldclass, r, rdclass )
 	end if
 
-    '' check pointers
+	'' check pointers
 	if( hCheckConstAndPointerOps( l, ldfull, r, rdfull ) = FALSE ) then
 		exit function
 	end if
@@ -527,8 +527,8 @@ function astNewASSIGN _
 						result = astBuildCtorCall( l->subtype, astCloneTree( l ) )
 					else
 						result = astNewMEM( AST_OP_MEMCLEAR, _
-						                    astCloneTree( l ), _
-						                    astNewCONSTi( symbGetLen( l->subtype ) ) )
+							astCloneTree( l ), _
+							astNewCONSTi( symbGetLen( l->subtype ) ) )
 					end if
 				else
 					result = NULL
@@ -569,9 +569,9 @@ function astNewASSIGN _
 	rdtype = typeGet( rdfull )
 	rdclass = typeGetClass( rdtype )
 
-    '' strings?
-    if( (ldclass = FB_DATACLASS_STRING) or _
-    	(rdclass = FB_DATACLASS_STRING) ) then
+	'' strings?
+	if( (ldclass = FB_DATACLASS_STRING) or _
+		(rdclass = FB_DATACLASS_STRING) ) then
 
 		'' both not strings?
 		if( ldclass <> rdclass ) then
@@ -585,7 +585,7 @@ function astNewASSIGN _
 		'' otherwise, don't do any assignment by now to allow optimizations..
 		if( (options and AST_OPOPT_ISINI) <> 0 ) then
 			'' unless it's an initialization
-			return rtlStrAssign( l, r, TRUE	)
+			return rtlStrAssign( l, r, TRUE )
 		end if
 
 	'' UDT's?
@@ -641,9 +641,9 @@ function astNewASSIGN _
 		rdclass = ldclass
 		astSetType( r, rdfull, lsubtype )
 
-    '' wstrings?
-    elseif( (ldtype = FB_DATATYPE_WCHAR) or _
-    		(rdtype = FB_DATATYPE_WCHAR) ) then
+	'' wstrings?
+	elseif( (ldtype = FB_DATATYPE_WCHAR) or _
+			(rdtype = FB_DATATYPE_WCHAR) ) then
 
 		'' If both are wstrings, delay assignment until astOptimizeTree(),
 		'' unless it's an initialization, then we can't do optimizations anyways.
@@ -670,9 +670,9 @@ function astNewASSIGN _
 			rdtype = typeGet( rdfull )
 		end if
 
-    '' zstrings?
-    elseif( (ldtype = FB_DATATYPE_CHAR) or _
-    		(rdtype = FB_DATATYPE_CHAR) ) then
+	'' zstrings?
+	elseif( (ldtype = FB_DATATYPE_CHAR) or _
+			(rdtype = FB_DATATYPE_CHAR) ) then
 
 		'' both the same? assign as string..
 		if( ldtype = rdtype ) then
@@ -689,18 +689,18 @@ function astNewASSIGN _
 		ldtype = typeGet( ldfull )
 		rdtype = typeGet( rdfull )
 
-    '' enums?
-    elseif( (ldtype = FB_DATATYPE_ENUM) or _
-    		(rdtype = FB_DATATYPE_ENUM) ) then
+	'' enums?
+	elseif( (ldtype = FB_DATATYPE_ENUM) or _
+			(rdtype = FB_DATATYPE_ENUM) ) then
 		hCheckEnumOps( l, ldclass, r, rdclass )
 	end if
 
-    '' check pointers
-    if( (options and AST_OPOPT_DONTCHKPTR) = 0 ) then
+	'' check pointers
+	if( (options and AST_OPOPT_DONTCHKPTR) = 0 ) then
 		if( hCheckConstAndPointerOps( l, ldfull, r, rdfull ) = FALSE ) then
 			exit function
 		end if
-    end if
+	end if
 
 	'' convert types if needed
 	if( (ldtype <> rdtype) or (l->subtype <> r->subtype) ) then
@@ -747,8 +747,8 @@ function astNewASSIGN _
 end function
 
 function astLoadASSIGN( byval n as ASTNODE ptr ) as IRVREG ptr
-    dim as ASTNODE ptr l = any, r = any
-    dim as IRVREG ptr vs = any, vr = any
+	dim as ASTNODE ptr l = any, r = any
+	dim as IRVREG ptr vs = any, vr = any
 
 	l = n->l
 	r = n->r

--- a/src/compiler/ast-node-assign.bas
+++ b/src/compiler/ast-node-assign.bas
@@ -75,8 +75,16 @@ private function hCheckUDTOps _
 			exit function
 		End If
 
-		'' cast to the base type
-		if( checkOnly = FALSE ) then
+		if( checkOnly ) then
+			'' if checking only, assume we meant checking without conversion
+			'' we need this from astCheckASSIGNToType() -> astCheckASSIGN()
+			'' to fail initializers that cannot be precisely assigned but
+			'' could be assigned with a conversion.  This allows passing
+			'' an initializer that could be assigned to a base by conversion
+			'' to a parent that could be assigned exactly.
+			exit function
+		else
+			'' cast to the base type
 			r = astNewCONV( astGetDataType( l ), l->subtype, r )
 		end if
 	end if

--- a/src/compiler/ast-node-conv.bas
+++ b/src/compiler/ast-node-conv.bas
@@ -451,6 +451,12 @@ function astNewCONV _
 			exit function
 		end if
 
+		'' don't allow cast to base types?
+		if( (options and AST_CONVOPT_NOCONVTOBASE) <> 0 ) then
+			exit function
+		end if
+
+		'' no valid cast to base type?
 		if( symbGetUDTBaseLevel( l->subtype, to_subtype ) = 0 ) then
 			exit function
 		end if

--- a/src/compiler/ast-node-misc.bas
+++ b/src/compiler/ast-node-misc.bas
@@ -962,8 +962,14 @@ private function hAstNodeToStr _
 	case AST_NODECLASS_SCOPEBEGIN
 		return "SCOPEBEGIN: " & hSymbToStr( n->sym )
 
+	case AST_NODECLASS_TYPEINI
+		return "TYPEINI( offset=" & n->typeini.ofs & ", bytes=" & n->typeini.bytes & " ) " & NODE_TYPE
+
 	case AST_NODECLASS_TYPEINI_ASSIGN
-		return "TYPEINI_ASSIGN( offset=" & n->typeini.ofs & " )"
+		return "TYPEINI_ASSIGN( offset=" & n->typeini.ofs & ", bytes=" & n->typeini.bytes & " )"
+
+	case AST_NODECLASS_TYPEINI_PAD
+		return "TYPEINI_PAD( offset=" & n->typeini.ofs & ", bytes=" & n->typeini.bytes & " ) " & NODE_TYPE
 
 	case AST_NODECLASS_MACRO
 		return "MACRO: " & astDumpOpToStr( n->op.op ) & " " & NODE_TYPE

--- a/src/compiler/ast-node-typeini.bas
+++ b/src/compiler/ast-node-typeini.bas
@@ -1,5 +1,5 @@
 '' AST type initializer nodes
-'' tree	    : l = head; r = (when constructing: tail, when updating: base var)
+'' tree     : l = head; r = (when constructing: tail, when updating: base var)
 '' expr node: l = expr; r = next
 '' pad node : l = NULL; r = next
 ''
@@ -21,7 +21,7 @@ function astTypeIniBegin _
 		byval ofs as longint _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr n = any
+	dim as ASTNODE ptr n = any
 
 	'' alloc new node
 	n = astNewNode( AST_NODECLASS_TYPEINI, _
@@ -38,7 +38,7 @@ function astTypeIniBegin _
 			'' (from a parent TYPEINI)
 			add_scope = not astIsTYPEINI( parser.currblock->scp.backnode )
 		else
-		    add_scope = TRUE
+			add_scope = TRUE
 		end if
 	end if
 
@@ -59,7 +59,7 @@ sub astTypeIniEnd _
 		byval is_initializer as integer _
 	)
 
-    dim as ASTNODE ptr n = any, p = any, l = any, r = any
+	dim as ASTNODE ptr n = any, p = any, l = any, r = any
 	dim as longint ofs = any
 	dim as FBSYMBOL ptr sym = any
 
@@ -77,38 +77,38 @@ sub astTypeIniEnd _
 	'' registered for astTypeIniUpdate() later.
 
 	'' merge nested type ini trees
-    p = NULL
-    n = tree->l
-    do while( n <> NULL )
-    	'' expression node?
-    	if( n->class = AST_NODECLASS_TYPEINI_ASSIGN ) then
+	p = NULL
+	n = tree->l
+	do while( n <> NULL )
+		'' expression node?
+		if( n->class = AST_NODECLASS_TYPEINI_ASSIGN ) then
 			l = n->l
 			'' is it an ini tree too?
 			if( astIsTYPEINI( l ) ) then
 				ast.typeinicount -= 1
 
-    			ofs = n->typeini.ofs
+				ofs = n->typeini.ofs
 
-    			r = n->r
-    			astDelNode( n )
-    			n = l->l
-    			astDelNode( l )
+				r = n->r
+				astDelNode( n )
+				n = l->l
+				astDelNode( l )
 
-    			'' relink
-    			if( p <> NULL ) then
-    				p->r = n
-    			else
-    				tree->l = n
-    			end if
+				'' relink
+				if( p <> NULL ) then
+					p->r = n
+				else
+					tree->l = n
+				end if
 
-    			'' update the offset, using the parent's
-    			do while( n->r <> NULL )
-    				n->typeini.ofs += ofs
-    				n = n->r
-    			loop
-    			n->typeini.ofs += ofs
+				'' update the offset, using the parent's
+				do while( n->r <> NULL )
+					n->typeini.ofs += ofs
+					n = n->r
+				loop
+				n->typeini.ofs += ofs
 
-    			n->r = r
+				n->r = r
 			end if
 		end if
 
@@ -420,7 +420,7 @@ function astTypeIniFlush overload _
 
 	assert( astIsTYPEINI( initree ) )
 	assert( astIsVAR( target ) or astIsDEREF( target ) or _
-	        astIsFIELD( target ) or astIsIDX( target ) )
+			astIsFIELD( target ) or astIsIDX( target ) )
 
 	if( update_typeinicount ) then
 		'' Unregister the TYPEINI - we're emitting it right now, no need
@@ -588,13 +588,13 @@ private sub hFlushExprStatic( byval n as ASTNODE ptr, byval basesym as FBSYMBOL 
 			if( edtype <> FB_DATATYPE_WCHAR ) then
 				'' less the null-char
 				irEmitVARINISTR( symbGetStrLen( sym ) - 1, _
-						 	 	 symbGetVarLitText( litsym ), _
-						 	 	 symbGetStrLen( litsym ) - 1 )
+								symbGetVarLitText( litsym ), _
+								symbGetStrLen( litsym ) - 1 )
 			else
 				'' ditto
 				irEmitVARINISTR( symbGetStrLen( sym ) - 1, _
-						 	 	 str( *symbGetVarLitTextW( litsym ) ), _
-						 	 	 symbGetWstrLen( litsym ) - 1 )
+								str( *symbGetVarLitTextW( litsym ) ), _
+								symbGetWstrLen( litsym ) - 1 )
 			end if
 		'' wstring..
 		else
@@ -602,13 +602,13 @@ private sub hFlushExprStatic( byval n as ASTNODE ptr, byval basesym as FBSYMBOL 
 			if( edtype <> FB_DATATYPE_WCHAR ) then
 				'' less the null-char
 				irEmitVARINIWSTR( symbGetWstrLen( sym ) - 1, _
-						 	  	  wstr( *symbGetVarLitText( litsym ) ), _
-						 	  	  symbGetStrLen( litsym ) - 1 )
+								wstr( *symbGetVarLitText( litsym ) ), _
+								symbGetStrLen( litsym ) - 1 )
 			else
 				'' ditto
 				irEmitVARINIWSTR( symbGetWstrLen( sym ) - 1, _
-						 	  	  symbGetVarLitTextW( litsym ), _
-						 	  	  symbGetWstrLen( litsym ) - 1 )
+								symbGetVarLitTextW( litsym ), _
+								symbGetWstrLen( litsym ) - 1 )
 			end if
 		end if
 	end if
@@ -623,31 +623,31 @@ sub astLoadStaticInitializer _
 		byval basesym as FBSYMBOL ptr _
 	)
 
-    dim as ASTNODE ptr n = any, nxt = any
+	dim as ASTNODE ptr n = any, nxt = any
 
 	irEmitVARINIBEGIN( basesym )
 
-    n = tree->l
-    do while( n <> NULL )
-        nxt = n->r
+	n = tree->l
+	do while( n <> NULL )
+		nxt = n->r
 
-    	select case as const n->class
-    	case AST_NODECLASS_TYPEINI_PAD
-    		irEmitVARINIPAD( n->typeini.bytes )
+		select case as const n->class
+		case AST_NODECLASS_TYPEINI_PAD
+			irEmitVARINIPAD( n->typeini.bytes )
 
-    	case AST_NODECLASS_TYPEINI_SCOPEINI
+		case AST_NODECLASS_TYPEINI_SCOPEINI
 			irEmitVARINISCOPEBEGIN( n->sym, n->typeiniscope.is_array )
 
-    	case AST_NODECLASS_TYPEINI_SCOPEEND
+		case AST_NODECLASS_TYPEINI_SCOPEEND
 			irEmitVARINISCOPEEND( )
 
-    	case else
+		case else
 			hFlushExprStatic( n, basesym )
-    	end select
+		end select
 
-        astDelNode( n )
-    	n = nxt
-    loop
+		astDelNode( n )
+		n = nxt
+	loop
 
 	irEmitVARINIEND( basesym )
 
@@ -667,7 +667,7 @@ private function hExprIsConst( byval n as ASTNODE ptr ) as integer
 	var expr = n->l
 
 	'' Expression must be:
-	'' - constant, or 
+	'' - constant, or
 	'' - address-of global, or
 	'' - conversion of address of global
 	'' to be usable in global initializer.
@@ -759,7 +759,7 @@ function astTypeIniUsesLocals _
 		'' a LOCAL here, we only report it back to the caller if it
 		'' has none of these attributes.
 		if( symbIsLocal( n->sym ) and _
-		    ((symbGetAttrib( n->sym ) and ignoreattrib) = 0) ) then
+			((symbGetAttrib( n->sym ) and ignoreattrib) = 0) ) then
 			return TRUE
 		end if
 	end if
@@ -770,7 +770,7 @@ function astTypeIniUsesLocals _
 
 	'' walk
 	function = astTypeIniUsesLocals( n->l, ignoreattrib ) or _
-	           astTypeIniUsesLocals( n->r, ignoreattrib )
+			astTypeIniUsesLocals( n->r, ignoreattrib )
 
 	#if __FB_DEBUG__
 		reclevel -= 1
@@ -909,7 +909,7 @@ function astTypeIniTryRemove( byval tree as ASTNODE ptr ) as ASTNODE ptr
 	'' Not the same type (detects the case when the TYPEINI is for an UDT,
 	'' and the first TYPEINI_ASSIGN is for the first field)
 	if( (astGetDataType( tree ) <> astGetDataType( tree->l )) or _
-	    (tree->subtype <> tree->l->subtype) ) then
+		(tree->subtype <> tree->l->subtype) ) then
 		exit function
 	end if
 

--- a/src/compiler/ast-node-typeini.bas
+++ b/src/compiler/ast-node-typeini.bas
@@ -140,6 +140,14 @@ private function hAddNode _
 		subtype = symbGetSubtype( sym )
 	end if
 
+	''      tree
+	''      / \
+	''     l   r
+	''
+	''  tree    = AST_NODE_TYPEINI AST_NODECLASS_TYPEINI
+	''  tree->l = list of items in TREE
+	''  tree->r = last node of list
+
 	n = astNewNode( class_, dtype, subtype )
 
 	if( tree->r <> NULL ) then

--- a/src/compiler/ast.bi
+++ b/src/compiler/ast.bi
@@ -542,6 +542,7 @@ enum AST_CONVOPT
 	AST_CONVOPT_DONTWARNCONST   = &h10
 	AST_CONVOPT_DONTWARNFUNCPTR = &h20
 	AST_CONVOPT_EXACT_CAST      = &h40
+	AST_CONVOPT_NOCONVTOBASE    = &h80
 end enum
 
 declare function astTryOvlStringCONV( byref expr as ASTNODE ptr ) as integer

--- a/src/compiler/parser-decl-symb-init.bas
+++ b/src/compiler/parser-decl-symb-init.bas
@@ -11,12 +11,12 @@
 #include once "symb.bi"
 
 type FB_INITCTX
-	sym			as FBSYMBOL ptr
-	dtype			as integer
-	subtype			as FBSYMBOL ptr
-	dimension 		as integer
-	tree		as ASTNODE ptr
-	options		as FB_INIOPT
+	sym         as FBSYMBOL ptr
+	dtype       as integer
+	subtype     as FBSYMBOL ptr
+	dimension   as integer
+	tree        as ASTNODE ptr
+	options     as FB_INIOPT
 	init_expr   as ASTNODE ptr
 end type
 
@@ -80,11 +80,11 @@ private function hElmInit _
 		byval no_fake as integer = FALSE _
 	) as integer
 
-    dim as ASTNODE ptr expr = any
-    dim as FBSYMBOL ptr oldsym = any
-    dim as integer old_dtype = any
+	dim as ASTNODE ptr expr = any
+	dim as FBSYMBOL ptr oldsym = any
+	dim as integer old_dtype = any
 
-    function = FALSE
+	function = FALSE
 
 	'' set the context symbol to allow taking the address of overloaded
 	'' procs and also to allow anonymous UDT's
@@ -93,7 +93,7 @@ private function hElmInit _
 	parser.ctxsym    = symbGetSubType( ctx.sym )
 	parser.ctx_dtype = symbGetType( ctx.sym )
 
-    '' parse expression
+	'' parse expression
 	expr = cExpression( )
 
 	'' invalid expression
@@ -109,7 +109,7 @@ private function hElmInit _
 	'' to hand it back if necessary
 	ctx.init_expr = expr
 
-    '' restore context if needed
+	'' restore context if needed
 	parser.ctxsym    = oldsym
 	parser.ctx_dtype = old_dtype
 
@@ -177,8 +177,8 @@ private function hArrayInit _
 		'' too many dimensions?
 		if( ctx.dimension >= symbGetArrayDimensions( ctx.sym ) ) then
 			errReport( iif( symbGetArrayDimensions( ctx.sym ) > 0, _
-			                FB_ERRMSG_TOOMANYEXPRESSIONS, _
-			                FB_ERRMSG_EXPECTEDARRAY ) )
+							FB_ERRMSG_TOOMANYEXPRESSIONS, _
+							FB_ERRMSG_EXPECTEDARRAY ) )
 			'' error recovery: skip until next '}'
 			hSkipUntil( CHAR_RBRACE, TRUE )
 			ctx.dimension -= 1
@@ -334,15 +334,15 @@ private function hUDTInit( byref ctx as FB_INITCTX ) as integer
 	dim as FBSYMBOL ptr fld = any, first = any
 	dim as FBSYMBOL ptr oldsubtype = any
 	dim as integer olddtype = any
-    dim as FB_INITCTX old_ctx = any
+	dim as FB_INITCTX old_ctx = any
 
-    function = FALSE
+	function = FALSE
 
-    rec_cnt += 1
+	rec_cnt += 1
 
-    '' ctor?
-    if( (ctx.options and FB_INIOPT_ISOBJ) <> 0 ) then
-    	dim as ASTNODE ptr expr = any
+	'' ctor?
+	if( (ctx.options and FB_INIOPT_ISOBJ) <> 0 ) then
+		dim as ASTNODE ptr expr = any
 
 		'' Set the context data type, to allow anonymous type()'s to
 		'' work for UDTs with constructors here
@@ -351,18 +351,18 @@ private function hUDTInit( byref ctx as FB_INITCTX ) as integer
 		parser.ctx_dtype = ctx.dtype
 		parser.ctxsym    = ctx.subtype
 
-	    '' Expression
-	    expr = cExpression( )
+		'' Expression
+		expr = cExpression( )
 
 		'' Restore context data type
 		parser.ctx_dtype = olddtype
 		parser.ctxsym    = oldsubtype
 
-	    if( expr = NULL ) then
+		if( expr = NULL ) then
 			errReport( FB_ERRMSG_EXPECTEDEXPRESSION )
 			'' error recovery: fake an expr
 			expr = astNewCONSTi( 0 )
-	    end if
+		end if
 
 		'' When initializing a BYREF parameter, an expression of the
 		'' same type should be used as-is instead of causing a copy
@@ -373,7 +373,7 @@ private function hUDTInit( byref ctx as FB_INITCTX ) as integer
 		if( symbGetClass( ctx.sym ) = FB_SYMBCLASS_PARAM ) then
 			if( symbGetParamMode( ctx.sym ) = FB_PARAMMODE_BYREF ) then
 				if( (astGetDataType( expr ) = typeGetDtAndPtrOnly( ctx.dtype )) and _
-				    (astGetSubtype( expr ) = ctx.subtype) ) then
+					(astGetSubtype( expr ) = ctx.subtype) ) then
 					rec_cnt -= 1
 					return hDoAssign( ctx, expr )
 				end if
@@ -566,7 +566,7 @@ function cInitializer _
 	) as ASTNODE ptr
 
 	dim as integer is_local = any, ok = any
-    dim as FB_INITCTX ctx = any
+	dim as FB_INITCTX ctx = any
 
 	function = NULL
 

--- a/src/compiler/parser-decl-symb-init.bas
+++ b/src/compiler/parser-decl-symb-init.bas
@@ -514,7 +514,7 @@ private function hUDTInit( byref ctx as FB_INITCTX ) as integer
 				if( fld = NULL ) then
 					exit do
 				end if
-				if( baseofs + symbGetOfs( fld ) >= astTypeIniGetOfs( ctx.tree ) ) then
+				if( baseofs + symbGetOfs( fld ) >= ctx.tree->typeini.bytes ) then
 					exit do
 				end if
 			loop

--- a/src/compiler/parser-decl-symb-init.bas
+++ b/src/compiler/parser-decl-symb-init.bas
@@ -497,13 +497,13 @@ private function hUDTInit( byref ctx as FB_INITCTX ) as integer
 		end if
 
 		'' next field to initialize
-		'' if it's a bitfield only add the field size if the bit
-		'' position is zero.  multiple bitfields share the same
-		'' offset so we should only add the size of the field once.
 		if( symbFieldIsBitField( fld ) ) then
-			if( symbGetFieldBitOffset( fld ) = 0 ) then
-				lgt += symbGetRealSize( fld )
-			end if
+			'' !!! TODO !!! - this logic is a carry over from previous
+			'' versions of fbc, but it doesn't seem correct
+			'' multiple bitfields share the same offset so seems like
+			'' we should only add the size of the field once.
+			'' more tests are required for bitfields
+			lgt += symbGetRealSize( fld )
 			fld = symbUdtGetNextInitableField( fld )
 		else
 			'' loop through next initializable fields until we

--- a/src/compiler/parser-decl-symb-init.bas
+++ b/src/compiler/parser-decl-symb-init.bas
@@ -52,7 +52,14 @@ private function hDoAssign _
 
 	if( astCheckASSIGNToType( ctx.dtype, ctx.subtype, expr ) = FALSE ) then
 		'' check if it's a cast
-		expr = astNewCONV( ctx.dtype, ctx.subtype, expr )
+
+		'' pass the initializing expression back to parent if it fails here
+		ctx.init_expr = expr
+
+		'' fail initializers that could be assigned with a cast to a base type.
+		'' This allows passing an initializer back to an exact matched parent.
+
+		expr = astNewCONV( ctx.dtype, ctx.subtype, expr, AST_CONVOPT_NOCONVTOBASE ) '' asdf
 		if( expr = NULL ) then
 			'' hand it back...
 			'' (used with UDTs; if an UDT var is given in an UDT initializer,
@@ -492,7 +499,7 @@ private function hUDTInit( byref ctx as FB_INITCTX ) as integer
 				return astTypeIniAddCtorCall( ctx.tree, ctx.sym, expr, ctx.dtype, ctx.subtype ) <> NULL
 			else
 				'' try to assign it (do a shallow copy)
-				return hDoAssign( ctx, expr )
+				return hDoAssign( ctx, expr, TRUE )
 			end if
 		end if
 

--- a/tests/structs/udt-init-1.bas
+++ b/tests/structs/udt-init-1.bas
@@ -1,0 +1,118 @@
+#include once "fbcunit.bi"
+
+SUITE( fbc_tests.structs.udt_init_1 )
+
+	type udt1
+		dim as integer i11, i12
+	end type
+
+	type udt2 extends udt1
+		dim as integer i21, i22, i23, i24
+	end type
+
+	type udt3 extends udt2
+		dim as integer i31, i32, i33
+	end type
+
+	type udt4 extends udt3
+		dim as integer i41
+	end type
+
+	#include once "udt-init-check.bi"
+
+	TEST( full_init )
+
+		'' UDT1
+		dim as udt1 u1
+		check1_zero( u1 )
+
+		u1 = type<udt1>(1, 2)
+		check1( u1 )
+
+		'' UDT2
+		dim as udt2 u20, u2
+		check2_zero( u20 )
+		check2_zero( u2 )
+
+		u2 = u20 : check2_zero( u2 )
+
+		u2 = type<udt2>(1, 2, 3, 4, 5, 6)
+		check2( u2 )
+
+		u2 = u20 : check2_zero( u2 )
+		u2 = type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6)
+		check2( u2 )
+
+		u2 = u20 : check2_zero( u2 )
+		u2 = type<udt2>(u1, 3, 4, 5, 6)
+		check2( u2 )
+
+		u2 = u20 : check2_zero( u2 )
+		u2 = type<udt2>(1, 2, 3, 4, 5, 6)
+		check2( u2 )
+
+		'' UDT3
+		dim as udt3 u30, u3
+		check3_zero( u30 )
+		check3_zero( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(1, 2, 3, 4, 5, 6, 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(type<udt2>(1, 2, 3, 4, 5, 6), 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6), 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(u2, 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(type<udt2>(u1, 3, 4, 5, 6), 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(1, 2, 3, 4, 5, 6, 7, 8, 9)
+		check3( u3 )
+
+		'' UDT4
+		dim as udt4 u40, u4
+		check4_zero( u40 )
+		check4_zero( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(1, 2, 3, 4, 5, 6, 7, 8, 9), 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(type<udt2>(1, 2, 3, 4, 5, 6), 7, 8, 9), 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6), 7, 8, 9), 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(u3, 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(u2, 7, 8, 9), 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(type<udt2>(u1, 3, 4, 5, 6), 7, 8, 9), 10)
+		check4( u4 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/structs/udt-init-2.bas
+++ b/tests/structs/udt-init-2.bas
@@ -1,0 +1,226 @@
+#include once "fbcunit.bi"
+
+SUITE( fbc_tests.structs.udt_init_2 )
+
+	type udt1
+		dim as integer i11, i12
+	end type
+
+	type udt2 extends udt1
+		dim as integer i21, i22, i23, i24
+	end type
+
+	type udt3 extends udt2
+		dim as integer i31, i32, i33
+		declare constructor()
+		declare constructor _
+			( _
+				byval i11 as integer, _
+				byval i12 as integer, _
+				byval i21 as integer, _
+				byval i22 as integer, _
+				byval i23 as integer, _
+				byval i24 as integer, _
+				byval i31 as integer, _
+				byval i32 as integer, _
+				byval i33 as integer _
+			)
+		declare constructor _
+			( _
+				byref u2 as udt2, _
+				byval i31 as integer, _
+				byval i32 as integer, _
+				byval i33 as integer _
+			)
+	end type
+
+	constructor udt3()
+	end constructor
+
+	constructor udt3 _
+		( _
+			byval i11 as integer, _
+			byval i12 as integer, _
+			byval i21 as integer, _
+			byval i22 as integer, _
+			byval i23 as integer, _
+			byval i24 as integer, _
+			byval i31 as integer, _
+			byval i32 as integer, _
+			byval i33 as integer _
+		)
+		this.i11 = i11
+		this.i12 = i12
+		this.i21 = i21
+		this.i22 = i22
+		this.i23 = i23
+		this.i24 = i24
+		this.i31 = i31
+		this.i32 = i32
+		this.i33 = i33
+	end constructor
+
+	constructor udt3 _
+		( _
+			byref u2 as udt2, _
+			byval i31 as integer, _
+			byval i32 as integer, _
+			byval i33 as integer _
+		)
+		cast(udt2, this) = u2
+		this.i31 = i31
+		this.i32 = i32
+		this.i33 = i33
+	end constructor
+
+	type udt4 extends udt3
+		dim as integer i41
+		declare constructor()
+		declare constructor _
+			( _
+				byval i11 as integer, _
+				byval i12 as integer, _
+				byval i21 as integer, _
+				byval i22 as integer, _
+				byval i23 as integer, _
+				byval i24 as integer, _
+				byval i31 as integer, _
+				byval i32 as integer, _
+				byval i33 as integer, _
+				byval i41 as integer _
+			)
+		declare constructor _
+			( _
+				byref u3 as udt3, _
+				byval i41 as integer _
+			)
+	end type
+
+	constructor udt4()
+	end constructor
+
+	constructor udt4 _
+		( _
+			byval i11 as integer, _
+			byval i12 as integer, _
+			byval i21 as integer, _
+			byval i22 as integer, _
+			byval i23 as integer, _
+			byval i24 as integer, _
+			byval i31 as integer, _
+			byval i32 as integer, _
+			byval i33 as integer, _
+			byval i41 as integer _
+		)
+		this.i11 = i11
+		this.i12 = i12
+		this.i21 = i21
+		this.i22 = i22
+		this.i23 = i23
+		this.i24 = i24
+		this.i31 = i31
+		this.i32 = i32
+		this.i33 = i33
+		this.i41 = i41
+	end constructor
+
+	constructor udt4 _
+		( _
+			byref u3 as udt3, _
+			byval i41 as integer _
+		)
+		cast(udt3, this) = u3
+		this.i41 = i41
+	end constructor
+
+	#include once "udt-init-check.bi"
+
+	TEST( full_init )
+		dim as udt1 u1
+		check1_zero( u1 )
+
+		u1 = type<udt1>(1, 2)
+		check1( u1 )
+
+		dim as udt2 u20, u2
+		check2_zero( u20 )
+		check2_zero( u2 )
+
+		u2 = u20 : check2_zero( u2 )
+		u2 = type<udt2>(1, 2, 3, 4, 5, 6)
+		check2( u2 )
+
+		u2 = u20 : check2_zero( u2 )
+		u2 = type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6)
+		check2( u2 )
+
+		u2 = u20 : check2_zero( u2 )
+		u2 = type<udt2>(u1, 3, 4, 5, 6)
+		check2( u2 )
+
+		u2 = type<udt2>(1, 2, 3, 4, 5, 6)
+		check2( u2 )
+
+		dim as udt3 u30, u3
+		check3_zero( u30 )
+		check3_zero( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(1, 2, 3, 4, 5, 6, 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(type<udt2>(1, 2, 3, 4, 5, 6), 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6), 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(u2, 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(type<udt2>(u1, 3, 4, 5, 6), 7, 8, 9)
+		check3( u3 )
+
+		u3 = u30 : check3_zero( u3 )
+		u3 = type<udt3>(1, 2, 3, 4, 5, 6, 7, 8, 9)
+		check3( u3 )
+
+		dim as udt4 u40, u4
+		check4_zero( u40 )
+		check4_zero( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(1, 2, 3, 4, 5, 6, 7, 8, 9), 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(type<udt2>(1, 2, 3, 4, 5, 6), 7, 8, 9), 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6), 7, 8, 9), 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(u3, 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(u2, 7, 8, 9), 10)
+		check4( u4 )
+
+		u4 = u40 : check4_zero( u4 )
+		u4 = type<udt4>(type<udt3>(type<udt2>(u1, 3, 4, 5, 6), 7, 8, 9), 10)
+		check4( u4 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/structs/udt-init-3.bas
+++ b/tests/structs/udt-init-3.bas
@@ -1,0 +1,56 @@
+#include once "fbcunit.bi"
+
+SUITE( fbc_tests.structs.udt_init_3 )
+
+	type udt1
+		dim as integer i11, i12
+	end type
+
+	type udt2 extends udt1
+		dim as integer i21, i22, i23, i24
+	end type
+
+	type udt3 extends udt2
+		dim as integer i31, i32, i33
+		declare constructor _
+			( _
+				byref u2 as udt2, _
+				byval i31 as integer, _
+				byval i32 as integer, _
+				byval i33 as integer _
+			)
+	end type
+
+	constructor udt3 _
+		( _
+			byref u2 as udt2, _
+			byval i31 as integer, _
+			byval i32 as integer, _
+			byval i33 as integer _
+		)
+		base(u2)
+		'' cast(udt2, this) = u2
+		this.i31 = i31
+		this.i32 = i32
+		this.i33 = i33
+	end constructor
+
+	#include once "udt-init-check.bi"
+
+	TEST( full_init )
+
+		dim as udt2 u21
+		check2_zero( u21 )
+
+		u21.i11 = 1 : u21.i12 = 2 : u21.i21 = 3 : u21.i22 = 4 : u21.i23 = 5 : u21.i24 = 6
+		check2( u21 )
+
+		dim as udt2 u2 = u21
+		check2( u2 )
+
+		dim as udt3 u3 = udt3(u21, 7, 8, 9)
+		check3( u3 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/structs/udt-init-4.bas
+++ b/tests/structs/udt-init-4.bas
@@ -1,0 +1,54 @@
+#include once "fbcunit.bi"
+
+SUITE( fbc_tests.structs.udt_init_4 )
+
+	type udt1
+		dim as integer i11, i12
+	end type
+
+	type udt2 extends udt1
+		dim as integer i21, i22, i23, i24
+	end type
+
+	type udt3 extends udt2
+		dim as integer i31, i32, i33
+	end type
+
+	type udt4 extends udt3
+		dim as integer i41
+		declare constructor _
+			( _
+				byref u3 as udt3, _
+				byval i41 as integer _
+			)
+	end type
+
+	constructor udt4 _
+		( _
+			byref u3 as udt3, _
+			byval i41 as integer _
+		)
+		base(u3)
+		'' cast(udt3, this) = u3
+		this.i41 = i41
+	end constructor
+
+	#include once "udt-init-check.bi"
+
+	TEST( full_init )
+
+		dim as udt3 u31
+		check3_zero( u31 )
+
+		u31.i11 = 1 : u31.i12 = 2 : u31.i21 = 3 : u31.i22 = 4 : u31.i23 = 5 : u31.i24 = 6 : u31.i31 = 7 : u31.i32 = 8 : u31.i33 = 9
+		check3( u31 )
+
+		dim as udt3 u3 = u31
+		check3( u3 )
+
+		dim as udt4 u4 = udt4(u31, 10)
+		check4( u4 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/structs/udt-init-5.bas
+++ b/tests/structs/udt-init-5.bas
@@ -1,0 +1,97 @@
+#include once "fbcunit.bi"
+
+SUITE( fbc_tests.structs.udt_init_5 )
+
+	type udt1
+		dim as integer i11, i12
+	end type
+
+	type udt2 extends udt1
+		dim as integer i21, i22, i23, i24
+	end type
+
+	type udt3 extends udt2
+		dim as integer i31, i32, i33
+	end type
+
+	type udt4 extends udt3
+		dim as integer i41
+		declare constructor()
+		declare constructor(byref u3 as udt3, byval i10 as integer)
+	end type
+
+	constructor udt4()
+	end constructor
+
+	constructor udt4(byref u3 as udt3, byval i10 as integer)
+		base(u3)
+		'' cast(udt3, this) = u3
+		this.i41 = i10
+	end constructor
+
+	#include once "udt-init-check.bi"
+
+	TEST( full_init )
+
+		dim as udt2 u21 = type<udt2>(1, 2, 3, 4, 5, 6)
+		check2( u21 )
+
+		dim as udt3 u31
+		check3_zero( u31 )
+
+		cast(udt2, u31) = u21
+		u31.i31 = 7
+		u31.i32 = 8
+		u31.i33 = 9
+		check3( u31 )
+
+		dim as udt3 u32 = u31
+		check3( u32 )
+
+		dim as udt3 u33 = type<udt3>(u31)
+		check3( u33 )
+
+		dim as udt3 u34
+		check3_zero( u34 )
+
+		u34 = u31
+		check3( u34 )
+
+		dim as udt3 u35
+		u35 = type<udt3>(u31)
+		check3( u35 )
+
+		dim as udt3 u36
+		u36 = type<udt3>(u21)
+		check32( u36 )
+
+		dim as udt3 u37 = type<udt3>(u21)
+		check32( u37 )
+
+		dim as udt3 u38
+		u38 = type<udt3>(u21, 7, 8, 9)
+		check3( u38 )
+
+		dim as udt3 u39 = type<udt3>(u21, 7, 8, 9)
+		check3( u39 )
+
+		dim as udt3 u3a
+		u3a = type<udt3>(type<udt2>(1, 2, 3, 4, 5, 6), 7, 8, 9)
+		check3( u3a )
+
+		dim as udt3 u3b = type<udt3>(type<udt2>(1, 2, 3, 4, 5, 6), 7, 8, 9)
+		check3( u3b )
+
+		dim as udt3 u3c
+		u3c = type<udt3>(type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6), 7, 8, 9)
+		check3( u3c )
+
+		dim as udt3 u3d = type<udt3>(type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6), 7, 8, 9)
+		check3( u3d )
+
+		dim as udt4 u41 =  udt4(u31, 10)
+		check4( u41 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/structs/udt-init-6.bas
+++ b/tests/structs/udt-init-6.bas
@@ -1,0 +1,121 @@
+#include once "fbcunit.bi"
+
+SUITE( fbc_tests.structs.udt_init_6 )
+
+	type udt1
+		dim as integer i11, i12
+	end type
+
+	type udt2 extends udt1
+		dim as integer i21, i22, i23, i24
+	end type
+
+	type udt3 extends udt2
+		dim as integer i31, i32, i33
+		declare constructor()
+		declare constructor(byref u3 as udt3)
+		declare constructor _
+			( _
+				byref u2 as udt2, _
+				byval i7 as integer = 0, _
+				byval i8 as integer = 0, _
+				byval i9 as integer = 0 _
+			)
+	end type
+
+	constructor udt3()
+	end constructor
+
+	constructor udt3(byref u3 as udt3)
+		this = u3
+	end constructor
+
+	constructor udt3 _
+		( _
+			byref u2 as udt2, _
+			byval i7 as integer = 0, _
+			byval i8 as integer = 0, _
+			byval i9 as integer = 0 _
+		)
+		cast(udt2, this) = u2
+		this.i31 = i7
+		this.i32 = i8
+		this.i33 = i9
+	end constructor
+
+	type udt4 extends udt3
+		dim as integer i41
+		declare constructor()
+		declare constructor _
+			( _
+				byref u3 as udt3, _
+				byval i10 as integer _
+			)
+	end type
+
+	constructor udt4()
+	end constructor
+
+	constructor udt4(byref u3 as udt3, byval i10 as integer)
+		base(u3)
+		'' cast(udt3, this) = u3
+		this.i41 = i10
+	end constructor
+
+	#include once "udt-init-check.bi"
+
+	TEST( FULL_INIT )
+
+		dim as udt2 u21 = type<udt2>(1, 2, 3, 4, 5, 6)
+		check2( u21 )
+
+		dim as udt3 u31
+		cast(udt2, u31) = u21 : u31.i31 = 7 : u31.i32 = 8 : u31.i33 = 9
+		check3( u31 )
+
+		dim as udt3 u32 = u31
+		check3( u32 )
+
+		dim as udt3 u33 = type<udt3>(u31)
+		check3( u33 )
+
+		dim as udt3 u34
+		u34 = u31
+		check3( u34 )
+
+		dim as udt3 u35
+		u35 = type<udt3>(u31)
+		check3( u35 )
+
+		dim as udt3 u36
+		u36 = type<udt3>(u21)
+		check32( u36 )
+
+		dim as udt3 u37 = type<udt3>(u21)
+		check32( u37 )
+
+		dim as udt3 u38
+		u38 = type<udt3>(u21, 7, 8, 9)
+		check3( u38 )
+
+		dim as udt3 u39 = type<udt3>(u21, 7, 8, 9)
+		dim as udt3 u3a
+		u3a = type<udt3>(type<udt2>(1, 2, 3, 4, 5, 6), 7, 8, 9)
+		check3( u3a )
+
+		dim as udt3 u3b = type<udt3>(type<udt2>(1, 2, 3, 4, 5, 6), 7, 8, 9)
+		check3( u3b )
+
+		dim as udt3 u3c
+		u3c = type<udt3>(type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6), 7, 8, 9)
+		check3( u3c )
+
+		dim as udt3 u3d = type<udt3>(type<udt2>(type<udt1>(1, 2), 3, 4, 5, 6), 7, 8, 9)
+		check3( u3d )
+
+		dim as udt4 u41 =  udt4(u31, 10)
+		check4( u41 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/structs/udt-init-7.bas
+++ b/tests/structs/udt-init-7.bas
@@ -1,0 +1,75 @@
+#include once "fbcunit.bi"
+
+SUITE( fbc_tests.structs.udt_init_7 )
+
+	type udt1
+		dim as integer i11, i12
+	end type
+
+	type udt2 extends udt1
+		dim as integer i21, i22, i23, i24
+	end type
+
+	type udt3 extends udt2
+		dim as integer i31, i32, i33
+	end type
+
+	type udt4 extends udt3
+		dim as integer i41
+		declare constructor()
+		declare constructor _
+			( _
+				byref u3 as udt3, _
+				byval i10 as integer _
+			)
+	end type
+
+	constructor udt4()
+	end constructor
+
+	constructor udt4 _
+		( _
+			byref u3 as udt3, _
+			byval i10 as integer _
+		)
+		base(u3)
+		''    cast(udt3, this) = u3
+		this.i41 = i10
+	end constructor
+
+	#include once "udt-init-check.bi"
+
+	TEST( full_init )
+
+		dim as udt1 u11
+		u11.i11 = 1 : u11.i12 = 2
+		check1( u11 )
+
+		dim as udt2 u21
+		cast(udt1, u21) = u11 : u21.i21 = 3 : u21.i22 = 4 : u21.i23 = 5 : u21.i24 = 6
+		check2( u21 )
+
+		dim as udt3 u31
+		cast(udt2, u31) = u21 : u31.i31 = 7 : u31.i32 = 8 : u31.i33 = 9
+		check3( u31 )
+
+		dim as udt3 u32 = u31
+		check3( u32 )
+
+		dim as udt3 u33 = type<udt3>(u31)
+		check3( u33 )
+
+		dim as udt3 u34
+		u34 = u31
+		check3( u34 )
+
+		dim as udt3 u35
+		u35 = type<udt3>(u31)
+		check3( u35 )
+
+		dim as udt4 u41 =  udt4(u31, 10)
+		check4( u41 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/structs/udt-init-8.bas
+++ b/tests/structs/udt-init-8.bas
@@ -1,0 +1,79 @@
+#include once "fbcunit.bi"
+
+SUITE( fbc_tests.structs.udt_init_8 )
+
+	type udt1
+		dim as integer i11, i12
+		declare constructor()
+	end type
+
+	constructor udt1()
+	end constructor
+
+	type udt2 extends udt1
+		dim as integer i21, i22, i23, i24
+	end type
+
+	type udt3 extends udt2
+		dim as integer i31, i32, i33
+	end type
+
+	type udt4 extends udt3
+		dim as integer i41
+		declare constructor()
+		declare constructor _
+			( _
+				byref u3 as udt3, _
+				byval i10 as integer _
+			)
+	end type
+
+	constructor udt4()
+	end constructor
+
+	constructor udt4 _
+		( _
+			byref u3 as udt3, _
+			byval i10 as integer _
+		)
+		base(u3)
+		'' cast(udt3, this) = u3
+		this.i41 = i10
+	end constructor
+
+	#include once "udt-init-check.bi"
+
+	TEST( full_init )
+
+		dim as udt1 u11
+		u11.i11 = 1 : u11.i12 = 2
+		check1( u11 )
+
+		dim as udt2 u21
+		cast(udt1, u21) = u11 : u21.i21 = 3 : u21.i22 = 4 : u21.i23 = 5 : u21.i24 = 6
+		check2( u21 )
+
+		dim as udt3 u31
+		cast(udt2, u31) = u21 : u31.i31 = 7 : u31.i32 = 8 : u31.i33 = 9
+		check3( u31 )
+
+		dim as udt3 u32 = u31
+		check3( u32 )
+
+		dim as udt3 u33 = type<udt3>(u31)
+		check3( u33 )
+
+		dim as udt3 u34
+		u34 = u31
+		check3( u34 )
+
+		dim as udt3 u35
+		u35 = type<udt3>(u31)
+		check3( u35 )
+
+		dim as udt4 u41 =  udt4(u31, 10)
+		check4( u41 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/structs/udt-init-check.bi
+++ b/tests/structs/udt-init-check.bi
@@ -1,0 +1,56 @@
+	#macro check1_zero( n )
+		CU_ASSERT( n##.i11 = 0 )
+		CU_ASSERT( n##.i12 = 0 )
+	#endmacro
+
+	#macro check2_zero( n )
+		check1_zero( n )
+		CU_ASSERT( n##.i21 = 0 )
+		CU_ASSERT( n##.i22 = 0 )
+		CU_ASSERT( n##.i23 = 0 )
+		CU_ASSERT( n##.i24 = 0 )
+	#endmacro
+
+	#macro check3_zero( n )
+		check2_zero( n )
+		CU_ASSERT( n##.i31 = 0 )
+		CU_ASSERT( n##.i32 = 0 )
+		CU_ASSERT( n##.i33 = 0 )
+	#endmacro
+
+	#macro check4_zero( n )
+		check3_zero( n )
+		CU_ASSERT( n##.i41 = 0 )
+	#endmacro
+
+	#macro check1( n )
+		CU_ASSERT( n##.i11 = 1 )
+		CU_ASSERT( n##.i12 = 2 )
+	#endmacro
+
+	#macro check2( n )
+		check1( n )
+		CU_ASSERT( n##.i21 = 3 )
+		CU_ASSERT( n##.i22 = 4 )
+		CU_ASSERT( n##.i23 = 5 )
+		CU_ASSERT( n##.i24 = 6 )
+	#endmacro
+
+	#macro check3( n )
+		check2( n )
+		CU_ASSERT( n##.i31 = 7 )
+		CU_ASSERT( n##.i32 = 8 )
+		CU_ASSERT( n##.i33 = 9 )
+	#endmacro
+
+	#macro check32( n )
+		check2( n )
+		CU_ASSERT( n##.i31 = 0 )
+		CU_ASSERT( n##.i32 = 0 )
+		CU_ASSERT( n##.i33 = 0 )
+	#endmacro
+
+	#macro check4( n )
+		check3( n )
+		CU_ASSERT( n##.i41 = 10 )
+	#endmacro


### PR DESCRIPTION
fbc parser's handling of the initializer list elements and pairing of the initializers with UDT fields was not correctly synchronized - resulting in bad implicit copy construction.

As reported:
- [#968 Using TYPE() or BASE() on derived instance, implicit copy/construct only copies data members of topmost base](https://sourceforge.net/p/fbc/bugs/968/)
- related: [#894 Can't initialise a UDT as copy of another if the first element is a UNION](https://sourceforge.net/p/fbc/bugs/894/)
- discussion: [Nesting TYPE (temporary) keyword does not support multi-level inheritance structure](https://www.freebasic.net/forum/viewtopic.php?t=31830)

Changes/Fix:
- fixes/changes how fbc handles pairing of a UDT's (internal) structure and the initializer list given by the user
- new: track the overall initializer size in bytes
- don't allow implicit casting to base types
- pass back the initializer to a parent field for full initialization instead of truncated initialization
- determine next field to initialize based on the overall bytes initialized instead of only the 'next field'
- pair the next initializer (in user source) with the next best matched field (in UDT's symbol structure)
- consider every field of the UDT including fields of hidden base types
- initializer elements for TYPE's should pair with and initialize every member of the TYPE sequentially
- initializer elements for UNION's should pair with only the first member of the UNION and skip the rest
- don't implicitly cast parent types to base types; instead pass the initializer back up the parser and try to pair the initializer with a parent type
- different handling (ideally better) of comma and parentheses initializer list delimeters so that next initializer is paired with correct UDT field.

Background information (under the hood):
- initializers for variables, BASE, NEW, anonymous types, fields, and optional parameters are all handled by a common parser entry point - internally in fbc sources 'cInitializer()
- cInitializer() parsing routine is also the entry point for arrays. Array elements and UDT fields can contain each of the other, so it's a bit of a recursion nightmare to debug.
- the shallow bit-wise copy is generated based on 1) the initializer list given in source by the user, and 2) the UDT's structure as stored in the internal symbol table
- non-trivial types (i.e. having constructor procedures), are handled slightly differently in the parser (i.e. they have a different code path and checks).
