### PR TITLE
fbc: allow inner (scoped) types and unions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -42,9 +42,9 @@ Version 1.10.0
 - makefile: 'DISABLE_GAS64_DEBUG=1' makefile configuration option to disable debugging comments in gas64 asm files
 - gfxlib2: add FB.GET_SCANLINE_SIZE to fbgfx.bi and ScreenControl() to get current internal scan line size multiplier
 - gfxlib2: SCREENCONTROL: add getters for GL parameters - new GET_GL_* constants in fbgfx.bi
+- fbc: allow a TYPE or UNION to be declared inside another TYPE or UNION to allow declaration of inner named types.  Support c++ name mangling parameters of inner types.
 - Name mangling for c++ 'char' through BYTE/UBYTE parameters using the form "[unsigned] byte alias "char".  Data type size is still 8 byte signed/unsigned from fbc side, but will mangled as 'char'; neither signed nor unsigned for the c++ side.
 - Support 'SOURCE_DATE_EPOCH' environment variable for controlling the instrinsic __DATE__, __DATE_ISO__, __TIME__ macros.  This in turn controls __FB_BUILD_DATE__ and __FB_BUILD_DATE_ISO__ macros when building the compiler.  Report error message on malformed values.
-- fbc: allow a TYPE or UNION to be declared inside another TYPE or UNION to allow declaration of inner named types.  Support c++ name mangling parameters of inner types.
 
 [fixed]
 - gas64: missing restoring of use of one virtual register on sqr for float (SARG)

--- a/changelog.txt
+++ b/changelog.txt
@@ -44,6 +44,7 @@ Version 1.10.0
 - gfxlib2: SCREENCONTROL: add getters for GL parameters - new GET_GL_* constants in fbgfx.bi
 - Name mangling for c++ 'char' through BYTE/UBYTE parameters using the form "[unsigned] byte alias "char".  Data type size is still 8 byte signed/unsigned from fbc side, but will mangled as 'char'; neither signed nor unsigned for the c++ side.
 - Support 'SOURCE_DATE_EPOCH' environment variable for controlling the instrinsic __DATE__, __DATE_ISO__, __TIME__ macros.  This in turn controls __FB_BUILD_DATE__ and __FB_BUILD_DATE_ISO__ macros when building the compiler.  Report error message on malformed values.
+- fbc: allow a TYPE or UNION to be declared inside another TYPE or UNION to allow declaration of inner named types.  Support c++ name mangling parameters of inner types.
 
 [fixed]
 - gas64: missing restoring of use of one virtual register on sqr for float (SARG)

--- a/src/compiler/ast-helper.bas
+++ b/src/compiler/ast-helper.bas
@@ -153,6 +153,7 @@ function astBuildVarDtorCall overload _
 			'' UDT var with dtor?
 			if( symbHasDtor( s ) ) then
 				if( check_access ) then
+					'' Check visibility of the destructor
 					if( symbCheckAccess( symbGetCompDtor1( symbGetSubtype( s ) ) ) = FALSE ) then
 						errReport( FB_ERRMSG_NOACCESSTODTOR )
 					end if
@@ -638,7 +639,7 @@ function astBuildImplicitCtorCall _
         return expr
 	end if
 
-	'' check visibility
+	'' Check visibility of the constructor
 	if( symbCheckAccess( proc ) = FALSE ) then
 		errReport( FB_ERRMSG_NOACCESSTOCTOR )
 	end if

--- a/src/compiler/ast-helper.bas
+++ b/src/compiler/ast-helper.bas
@@ -191,17 +191,17 @@ function astBuildDerefAddrOf overload _
 		n = astNewBOP( AST_OP_ADD, n, offsetexpr )
 	end if
 
-	'' Don't warn on CONST qualifier changes, astBuildDerefAddrOf() is only 
+	'' Don't warn on CONST qualifier changes, astBuildDerefAddrOf() is only
 	'' called for internal expressions in:
-	''		- astBuildVarField(), 
-	''		- hShallowCopy()
-	''		- hCallCtorList()
-	''		- cDynamicArrayIndex()
-	''		- cVariableEx()
-	''		- hAssignDynamicArray()
+	''      - astBuildVarField(),
+	''      - hShallowCopy()
+	''      - hCallCtorList()
+	''      - cDynamicArrayIndex()
+	''      - cVariableEx()
+	''      - hAssignDynamicArray()
 	'' Except:
-	''		- astTypeIniFlush(), HOWEVER, astNewASSIGN() does it's own 
-	''		  checks and calls astNewCONV()
+	''      - astTypeIniFlush(), HOWEVER, astNewASSIGN() does it's own
+	''        checks and calls astNewCONV()
 
 	n = astNewCONV( typeAddrOf( dtype ), subtype, n, AST_CONVOPT_DONTCHKPTR or AST_CONVOPT_DONTWARNCONST )
 	n = astNewDEREF( n )
@@ -341,7 +341,7 @@ function astBuildWhileCounterEnd _
 	function = tree
 end function
 
-'' For: 
+'' For:
 ''
 ''     CNT = INIVALUE
 ''     DO
@@ -509,27 +509,27 @@ function astBuildCtorCall _
 		byval thisexpr as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as FBSYMBOL ptr ctor = any
-    dim as ASTNODE ptr proc = any
-    dim as integer params = any
+	dim as FBSYMBOL ptr ctor = any
+	dim as ASTNODE ptr proc = any
+	dim as integer params = any
 
-    ctor = symbGetCompDefCtor( sym )
-    if( ctor = NULL ) then
-    	return NULL
-    end if
+	ctor = symbGetCompDefCtor( sym )
+	if( ctor = NULL ) then
+		return NULL
+	end if
 
-    proc = astNewCALL( ctor )
+	proc = astNewCALL( ctor )
 
-    astNewARG( proc, thisexpr )
+	astNewARG( proc, thisexpr )
 
-    '' add the optional params, if any
-    params = symbGetProcParams( ctor ) - 1
-    do while( params > 0 )
-    	astNewARG( proc, NULL )
-    	params -= 1
-    loop
+	'' add the optional params, if any
+	params = symbGetProcParams( ctor ) - 1
+	do while( params > 0 )
+		astNewARG( proc, NULL )
+		params -= 1
+	loop
 
-    function = proc
+	function = proc
 
 end function
 
@@ -623,8 +623,8 @@ function astBuildImplicitCtorCall _
 		byref is_ctorcall as integer _
 	) as ASTNODE ptr
 
- 	dim as integer err_num = any
-    dim as FBSYMBOL ptr proc = any
+	dim as integer err_num = any
+	dim as FBSYMBOL ptr proc = any
 
 	proc = symbFindCtorOvlProc( subtype, expr, arg_mode, @err_num )
 	if( proc = NULL ) then
@@ -636,7 +636,7 @@ function astBuildImplicitCtorCall _
 		end if
 
 		'' could be a shallow copy..
-        return expr
+		return expr
 	end if
 
 	'' Check visibility of the constructor
@@ -644,24 +644,24 @@ function astBuildImplicitCtorCall _
 		errReport( FB_ERRMSG_NOACCESSTOCTOR )
 	end if
 
-    '' build a ctor call
-    dim as ASTNODE ptr procexpr = astNewCALL( proc )
+	'' build a ctor call
+	dim as ASTNODE ptr procexpr = astNewCALL( proc )
 
 	'' Use a fake THIS ptr for now,
 	'' a NULL ptr given BYVAL to the BYREF THIS param
 	astNewARG( procexpr, astFakeInstPtr( subtype ), , FB_PARAMMODE_BYVAL )
 
-    astNewARG( procexpr, expr, , arg_mode )
+	astNewARG( procexpr, expr, , arg_mode )
 
-    '' add the optional params, if any
-    dim as integer params = symbGetProcParams( proc ) - 2
-    do while( params > 0 )
-    	astNewARG( procexpr, NULL )
-    	params -= 1
-    loop
+	'' add the optional params, if any
+	dim as integer params = symbGetProcParams( proc ) - 2
+	do while( params > 0 )
+		astNewARG( procexpr, NULL )
+		params -= 1
+	loop
 
-    is_ctorcall = TRUE
-    function = procexpr
+	is_ctorcall = TRUE
+	function = procexpr
 
 end function
 
@@ -674,21 +674,21 @@ function astBuildImplicitCtorCallEx _
 		byref is_ctorcall as integer _
 	) as ASTNODE ptr
 
-    dim as FBSYMBOL ptr subtype = any
+	dim as FBSYMBOL ptr subtype = any
 
 	subtype = symbGetSubType( sym )
 
-    '' check ctor call
-    if( astIsCALLCTOR( expr ) ) then
-    	if( symbGetSubtype( expr ) = subtype ) then
-    		is_ctorcall = TRUE
-    		'' remove the the anon/temp instance
-    		return astCALLCTORToCALL( expr )
-    	end if
-    end if
+	'' check ctor call
+	if( astIsCALLCTOR( expr ) ) then
+		if( symbGetSubtype( expr ) = subtype ) then
+			is_ctorcall = TRUE
+			'' remove the the anon/temp instance
+			return astCALLCTORToCALL( expr )
+		end if
+	end if
 
-    '' try calling any ctor with the expression
-    function = astBuildImplicitCtorCall( subtype, expr, arg_mode, is_ctorcall )
+	'' try calling any ctor with the expression
+	function = astBuildImplicitCtorCall( subtype, expr, arg_mode, is_ctorcall )
 
 end function
 
@@ -820,9 +820,9 @@ function astBuildArrayDescIniTree _
 		byval array_expr as ASTNODE ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr tree = any
+	dim as ASTNODE ptr tree = any
 	dim as integer dtype = any, dimensions = any, max_dimensions = any, flags = 0
-    dim as FBSYMBOL ptr elm = any, dimtb = any, subtype = any
+	dim as FBSYMBOL ptr elm = any, dimtb = any, subtype = any
 
 	'' COMMON or EXTERN? Cannot be initialized
 	if( symbIsCommon( array ) or symbIsExtern( array ) ) then
@@ -837,8 +837,8 @@ function astBuildArrayDescIniTree _
 
 	tree = astTypeIniBegin( symbGetFullType( desc ), symbGetSubtype( desc ), not symbIsField( desc ), symbGetOfs( desc ) )
 
-    dtype = symbGetFullType( array )
-    subtype = symbGetSubType( array )
+	dtype = symbGetFullType( array )
+	subtype = symbGetSubType( array )
 
 	elm = symbGetUDTSymbTbHead( symbGetSubtype( desc ) )
 	assert( symbIsField( elm ) )
@@ -865,7 +865,7 @@ function astBuildArrayDescIniTree _
 
 	astTypeIniScopeBegin( tree, desc, FALSE )
 
-    '' .data = @array(0) + diff
+	'' .data = @array(0) + diff
 	astTypeIniAddAssign( tree, _
 		astNewBOP( AST_OP_ADD, astCloneTree( array_expr ), _
 			astNewCONSTi( _
@@ -876,22 +876,22 @@ function astBuildArrayDescIniTree _
 
 	elm = symbGetNext( elm )
 
-	'' .ptr	= @array(0)
+	'' .ptr = @array(0)
 	astTypeIniAddAssign( tree, array_expr, elm )
 
-    elm = symbGetNext( elm )
+	elm = symbGetNext( elm )
 
-    '' .size = len( array ) * elements( array )
+	'' .size = len( array ) * elements( array )
 	astTypeIniAddAssign( tree, _
 	                     astNewCONSTi( iif( symbIsDynamic( array ), 0ll, symbGetRealSize( array ) ) ), _
 	                     elm )
 
-    elm = symbGetNext( elm )
+	elm = symbGetNext( elm )
 
-    '' .element_len	= len( array )
+	'' .element_len = len( array )
 	astTypeIniAddAssign( tree, astNewCONSTi( symbGetLen( array ) ), elm )
 
-    elm = symbGetNext( elm )
+	elm = symbGetNext( elm )
 
 	'' .dimensions = dims( array )
 	dimensions = symbGetArrayDimensions( array )
@@ -911,22 +911,22 @@ function astBuildArrayDescIniTree _
 	assert( dimensions >= 0 )
 	astTypeIniAddAssign( tree, astNewCONSTi( dimensions ), elm )
 
-    elm = symbGetNext( elm )
+	elm = symbGetNext( elm )
 
 	'' .flags = flags
 	flags or= ( max_dimensions and FBARRAY_FLAGS_DIMENSIONS )
 	astTypeIniAddAssign( tree, astNewCONSTi( flags ), elm )
 
-    elm = symbGetNext( elm )
+	elm = symbGetNext( elm )
 
-    '' setup dimTB
+	'' setup dimTB
 	var dimtbfield = elm
-    dimtb = symbGetUDTSymbTbHead( symbGetSubtype( elm ) )
+	dimtb = symbGetUDTSymbTbHead( symbGetSubtype( elm ) )
 
 	astTypeIniScopeBegin( tree, dimtbfield, TRUE )
 
-    '' static array?
-    if( symbGetIsDynamic( array ) = FALSE ) then
+	'' static array?
+	if( symbGetIsDynamic( array ) = FALSE ) then
 		for i as integer = 0 to symbGetArrayDimensions( array ) - 1
 			elm = dimtb
 
@@ -960,11 +960,11 @@ function astBuildArrayDescIniTree _
 		astTypeIniAddPad( tree, dimensions * symbGetLen( symb.fbarraydim ) )
 	end if
 
-    astTypeIniScopeEnd( tree, dimtbfield )
-    astTypeIniScopeEnd( tree, desc )
-    astTypeIniEnd( tree, TRUE )
+	astTypeIniScopeEnd( tree, dimtbfield )
+	astTypeIniScopeEnd( tree, desc )
+	astTypeIniEnd( tree, TRUE )
 
-    function = tree
+	function = tree
 end function
 
 private function hConstBound _

--- a/src/compiler/ast-helper.bas
+++ b/src/compiler/ast-helper.bas
@@ -62,13 +62,13 @@ function astBuildFakeWstringAssign _
 
 	'' wcharptr = WstrAlloc( WstrLen( expr ) )
 	t = astNewLINK( t, _
-		astBuildVarAssign( sym, rtlWstrAlloc( rtlWstrLen( astCloneTree( expr ) ) ), options ), _
-		AST_LINK_RETURN_NONE )
+	                astBuildVarAssign( sym, rtlWstrAlloc( rtlWstrLen( astCloneTree( expr ) ) ), options ), _
+	                AST_LINK_RETURN_NONE )
 
 	'' *wcharptr = expr
 	t = astNewLINK( t, _
-		astNewASSIGN( astBuildFakeWstringAccess( sym ), expr, options ), _
-		AST_LINK_RETURN_RIGHT )
+	                astNewASSIGN( astBuildFakeWstringAccess( sym ), expr, options ), _
+	                AST_LINK_RETURN_RIGHT )
 
 	function = t
 end function
@@ -96,7 +96,7 @@ function astBuildVarInc _
 	end if
 
 	function = astNewSelfBOP( op, astNewVAR( lhs ), _
-		astNewCONSTi( rhs ), NULL, options )
+	                          astNewCONSTi( rhs ), NULL, options )
 
 end function
 
@@ -278,7 +278,7 @@ function astBuildTempVarClear( byval sym as FBSYMBOL ptr ) as ASTNODE ptr
 
 	'' Clear variable's memory
 	function = astNewMEM( AST_OP_MEMCLEAR, astNewVAR( sym ), _
-			astNewCONSTi( symbGetLen( sym ) ) )
+	                      astNewCONSTi( symbGetLen( sym ) ) )
 end function
 
 ''
@@ -883,8 +883,8 @@ function astBuildArrayDescIniTree _
 
     '' .size = len( array ) * elements( array )
 	astTypeIniAddAssign( tree, _
-		astNewCONSTi( iif( symbIsDynamic( array ), 0ll, symbGetRealSize( array ) ) ), _
-		elm )
+	                     astNewCONSTi( iif( symbIsDynamic( array ), 0ll, symbGetRealSize( array ) ) ), _
+	                     elm )
 
     elm = symbGetNext( elm )
 

--- a/src/compiler/ast-node-proc.bas
+++ b/src/compiler/ast-node-proc.bas
@@ -1154,6 +1154,7 @@ private function hCallBaseCtor _
 	if( defctor ) then
 		'' Check access here, because (unlike fields) it's not done
 		'' during the TYPE compound parsing
+		'' Check visibility of the default construtor
 		if( symbCheckAccess( defctor ) = FALSE ) then
 			errReport( FB_ERRMSG_NOACCESSTOBASEDEFCTOR )
 		end if
@@ -1329,6 +1330,7 @@ private sub hCallBaseDtor _
 
 	'' Check access here, because (unlike fields) it's not done
 	'' during the TYPE compound parsing
+	'' Check visibility of the default destructor
 	if( symbCheckAccess( dtor ) = FALSE ) then
 		errReport( FB_ERRMSG_NOACCESSTOBASEDTOR )
 	end if

--- a/src/compiler/ast-node-proc.bas
+++ b/src/compiler/ast-node-proc.bas
@@ -3,8 +3,8 @@
 '' l = head node; r = tail node
 ''
 '' note: an implicit scope block isn't created, because the
-''		 implicit main() function (inside scope blocks only
-''		 non-decl statements are allowed)
+''       implicit main() function (inside scope blocks only
+''       non-decl statements are allowed)
 ''
 
 
@@ -18,9 +18,9 @@
 #include once "ast.bi"
 
 type FB_GLOBINSTANCE
-	sym				as FBSYMBOL_ ptr			'' for symbol
-	initree			as ASTNODE ptr				'' can't store in sym, or emit will use it
-	call_dtor		as integer
+	sym             as FBSYMBOL_ ptr            '' for symbol
+	initree         as ASTNODE ptr              '' can't store in sym, or emit will use it
+	call_dtor       as integer
 end type
 
 declare function hModLevelIsEmpty( byval p as ASTNODE ptr ) as integer
@@ -666,14 +666,14 @@ function astProcEnd( byval callrtexit as integer ) as integer
 		astScopeDestroyVars(symbGetProcSymbTb(sym).tail)
 	end if
 
-   	''
-   	astAdd( astNewLABEL( n->block.exitlabel ) )
+	''
+	astAdd( astNewLABEL( n->block.exitlabel ) )
 
 	'' Check for any undefined labels (labels can be forward references)
 	res = (symbCheckLabels(symbGetProcSymbTbHead(parser.currproc)) = 0)
 
 	if( res ) then
-		'' Complete Destructor? (D1) 
+		'' Complete Destructor? (D1)
 		if( symbIsDestructor1( sym ) and enable_implicit_code ) then
 			'' Call destructors, behind the exit label, so they'll
 			'' always be called, even with early returns.
@@ -1185,7 +1185,7 @@ private function hInitVptr _
 
 	'' this.vptr = cast( any ptr, (cast(byte ptr, @vtable) + sizeof(void *) * 2) )
 	'' assuming that everything with a vptr extends fb_Object
-	function = astNewASSIGN( _ 
+	function = astNewASSIGN( _
 		astBuildVarField( this_, symbUdtGetFirstField( symb.rtti.fb_object ) ), _
 		                  astNewCONV( typeAddrOf( FB_DATATYPE_VOID ), NULL, _
 		                  astNewADDROF( astNewVAR( parent->udt.ext->vtable, env.pointersize * 2 ) ) ), _

--- a/src/compiler/ast-node-proc.bas
+++ b/src/compiler/ast-node-proc.bas
@@ -538,10 +538,10 @@ private function hCheckErrHnd _
 	'' or constructor's field would be initialized and break ctor chaining)
 	if( env.clopt.errlocation ) then
 		head_node = astAddAfter( rtlErrorSetModName( sym, _
-			astNewCONSTstr( @env.inf.name ) ), head_node )
+		                         astNewCONSTstr( @env.inf.name ) ), head_node )
 
 		head_node = astAddAfter( rtlErrorSetFuncName( sym, _
-			astNewCONSTstr( symbGetName( sym ) ) ), head_node )
+		                         astNewCONSTstr( symbGetName( sym ) ) ), head_node )
 	end if
 
 	with sym->proc.ext->err
@@ -843,8 +843,8 @@ private sub hLoadProcResult( byval proc as FBSYMBOL ptr )
 	else
 		'' Use the real type, in case it's BYREF return or a UDT result
 		n = astNewLOAD( astNewVAR( s, 0, symbGetProcRealType( proc ), _
-					symbGetProcRealSubtype( proc ) ), _
-				symbGetProcRealType( proc ), TRUE )
+		                symbGetProcRealSubtype( proc ) ), _
+		                symbGetProcRealType( proc ), TRUE )
 	end if
 
 	astAdd( n )
@@ -1108,9 +1108,9 @@ private function hCallFieldCtors _
 						'' Note: flushing the field's TYPEINI against the whole "THIS" instance,
 						'' not against "THIS.thefield", because the TYPEINI contains absolute offsets.
 						tree = astNewLINK( tree, _
-							astTypeIniFlush( astBuildVarField( this_ ), _
-								astTypeIniClone( symbGetTypeIniTree( fld ) ), _
-								FALSE, AST_OPOPT_ISINI ), AST_LINK_RETURN_NONE )
+						                   astTypeIniFlush( astBuildVarField( this_ ), _
+						                   astTypeIniClone( symbGetTypeIniTree( fld ) ), _
+						                   FALSE, AST_OPOPT_ISINI ), AST_LINK_RETURN_NONE )
 					end if
 				end if
 			end if
@@ -1187,8 +1187,8 @@ private function hInitVptr _
 	'' assuming that everything with a vptr extends fb_Object
 	function = astNewASSIGN( _ 
 		astBuildVarField( this_, symbUdtGetFirstField( symb.rtti.fb_object ) ), _
-		astNewCONV( typeAddrOf( FB_DATATYPE_VOID ), NULL, _
-			astNewADDROF( astNewVAR( parent->udt.ext->vtable, env.pointersize * 2 ) ) ), _
+		                  astNewCONV( typeAddrOf( FB_DATATYPE_VOID ), NULL, _
+		                  astNewADDROF( astNewVAR( parent->udt.ext->vtable, env.pointersize * 2 ) ) ), _
 		AST_OPOPT_ISINI )
 end function
 
@@ -1343,8 +1343,8 @@ private sub hCallBaseDtor _
 
 	this_ = symbGetParamVar( symbGetProcHeadParam( proc ) )
 	astAdd( astBuildDtorCall( symbGetSubtype( base_ ), _
-				astBuildVarField( this_, base_ ), _
-				TRUE ) )
+	        astBuildVarField( this_, base_ ), _
+	        TRUE ) )
 end sub
 
 private sub hCallDtors( byval proc as FBSYMBOL ptr )

--- a/src/compiler/parser-assignment.bas
+++ b/src/compiler/parser-assignment.bas
@@ -278,7 +278,7 @@ private function hAssignFromField _
 		return astNewNOP( )
 	end if
 
-	'' check visibility
+	'' Check visibility of the field
 	if( symbCheckAccess( fld ) = FALSE ) then
 		hReportLetError( FB_ERRMSG_ILLEGALMEMBERACCESS, num )
 		'' error recovery

--- a/src/compiler/parser-assignment.bas
+++ b/src/compiler/parser-assignment.bas
@@ -18,7 +18,7 @@ end sub
 '':::::
 sub parserLetEnd
 
-    listEnd( @parser.stmt.let.list )
+	listEnd( @parser.stmt.let.list )
 
 end sub
 
@@ -217,12 +217,12 @@ sub cAssignment( byval l as ASTNODE ptr )
 end sub
 
 function cAssignmentOrPtrCallEx( byval expr as ASTNODE ptr ) as integer
-    function = FALSE
+	function = FALSE
 
-    if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_CODE ) = FALSE ) then
+	if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_CODE ) = FALSE ) then
 		hSkipStmt( )
-    	exit function
-    end if
+		exit function
+	end if
 
 	'' Not just calling a SUB?
 	if( expr ) then
@@ -233,7 +233,7 @@ function cAssignmentOrPtrCallEx( byval expr as ASTNODE ptr ) as integer
 		end if
 	end if
 
-    function = TRUE
+	function = TRUE
 end function
 
 '':::::
@@ -313,7 +313,7 @@ end function
 
 '':::::
 ''Assignment      =   LET? Variable BOP? '=' Expression
-''				  |	  Variable{function ptr} '(' ProcParamList ')' .
+''                |   Variable{function ptr} '(' ProcParamList ')' .
 ''
 function cAssignmentOrPtrCall _
 	( _
@@ -353,21 +353,21 @@ function cAssignmentOrPtrCall _
 		return cAssignmentOrPtrCallEx( expr )
 	end if
 
-    '' LET..
-    if( fbLangOptIsSet( FB_LANG_OPT_LET ) = FALSE ) then
-    	if( lexGetLookAhead( 1 ) <> CHAR_LPRNT ) then
+	'' LET..
+	if( fbLangOptIsSet( FB_LANG_OPT_LET ) = FALSE ) then
+		if( lexGetLookAhead( 1 ) <> CHAR_LPRNT ) then
 			errReportNotAllowed( FB_LANG_OPT_LET )
-    	else
-    		ismult = TRUE
+		else
+			ismult = TRUE
 			'' 'LET'
-    		lexSkipToken( LEXCHECK_POST_SUFFIX )
-    	end if
-    end if
+			lexSkipToken( LEXCHECK_POST_SUFFIX )
+		end if
+	end if
 
-    if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_CODE ) = FALSE ) then
+	if( cCompStmtIsAllowed( FB_CMPSTMT_MASK_CODE ) = FALSE ) then
 		hSkipStmt( )
-    	exit function
-    end if
+		exit function
+	end if
 
 	'' LET | '('
 	lexSkipToken( LEXCHECK_POST_SUFFIX )
@@ -386,28 +386,28 @@ function cAssignmentOrPtrCall _
 	end if
 
 	'' multiple..
-    dim as integer exprcnt = 0
+	dim as integer exprcnt = 0
 
-   	do
-    	'' null expressions are allowed ('let(foo, , bar)')
-        dim as FB_LETSTMT_NODE ptr node = listNewNode( @parser.stmt.let.list )
+	do
+		'' null expressions are allowed ('let(foo, , bar)')
+		dim as FB_LETSTMT_NODE ptr node = listNewNode( @parser.stmt.let.list )
 
-        node->expr = cVarOrDeref( )
-        if( node->expr <> NULL ) then
+		node->expr = cVarOrDeref( )
+		if( node->expr <> NULL ) then
 			'' const?
 			if( astIsConstant( node->expr ) ) then
 				errReport( FB_ERRMSG_CONSTANTCANTBECHANGED, TRUE )
 			end if
 
-        	exprcnt += 1
-        end if
+			exprcnt += 1
+		end if
 
-        '' ','?
-        if( lexGetToken( ) <> CHAR_COMMA ) then
-        	exit do
-        end if
+		'' ','?
+		if( lexGetToken( ) <> CHAR_COMMA ) then
+			exit do
+		end if
 
-        lexSkipToken( )
+		lexSkipToken( )
 	loop
 
 	if( exprcnt = 0 ) then
@@ -461,16 +461,16 @@ function cAssignmentOrPtrCall _
 	end if
 
 	if( expr = NULL ) then
-        do
-        	dim as FB_LETSTMT_NODE ptr node = listGetHead( @parser.stmt.let.list )
-        	if( node = NULL ) then
-        		exit do
-        	end if
+		do
+			dim as FB_LETSTMT_NODE ptr node = listGetHead( @parser.stmt.let.list )
+			if( node = NULL ) then
+				exit do
+			end if
 
-        	listDelNode( @parser.stmt.let.list, node )
-        loop
+			listDelNode( @parser.stmt.let.list, node )
+		loop
 
-        exit function
+		exit function
 	end if
 
 	'' proc call?
@@ -488,32 +488,32 @@ function cAssignmentOrPtrCall _
 	end if
 
 	fld = symbUdtGetFirstField( astGetSubtype( expr ) )
-    exprcnt = 0
-    do
-    	dim as FB_LETSTMT_NODE ptr node = listGetHead( @parser.stmt.let.list )
-    	if( node = NULL ) then
-        	exit do
-        end if
+	exprcnt = 0
+	do
+		dim as FB_LETSTMT_NODE ptr node = listGetHead( @parser.stmt.let.list )
+		if( node = NULL ) then
+			exit do
+		end if
 
-        '' EOL?
-        if( fld = NULL ) then
+		'' EOL?
+		if( fld = NULL ) then
 			errReport( FB_ERRMSG_TOOMANYELEMENTS )
-       	else
-    		exprcnt += 1
+		else
+			exprcnt += 1
 
-    		if( node->expr <> NULL ) then
-        		expr = hAssignFromField( fld, node->expr, tmp, exprcnt )
-        		if( expr = NULL ) then
-        			exit function
-        		end if
+			if( node->expr <> NULL ) then
+				expr = hAssignFromField( fld, node->expr, tmp, exprcnt )
+				if( expr = NULL ) then
+					exit function
+				end if
 
-        		tree = astNewLINK( tree, expr, AST_LINK_RETURN_NONE )
-        	end if
+				tree = astNewLINK( tree, expr, AST_LINK_RETURN_NONE )
+			end if
 
 			fld = symbUdtGetNextField( fld )
-        end if
+		end if
 
-        listDelNode( @parser.stmt.let.list, node )
+		listDelNode( @parser.stmt.let.list, node )
 	loop
 
 	'' must add the tree at once because the temporary results

--- a/src/compiler/parser-compound-for.bas
+++ b/src/compiler/parser-compound-for.bas
@@ -10,9 +10,9 @@
 #include once "symb.bi"
 
 enum FOR_FLAGS
-	FOR_ISUDT			= &h0001
-	FOR_HASCTOR			= &h0002
-	FOR_ISLOCAL			= &h0004
+	FOR_ISUDT           = &h0001
+	FOR_HASCTOR         = &h0002
+	FOR_ISLOCAL         = &h0004
 end enum
 
 #define CREATEFAKEID( ) _
@@ -38,14 +38,14 @@ declare sub hFlushBOP _
 declare sub hFlushSelfBOP _
 	( _
 		byval op as integer, _
-	 	byval lhs as FB_CMPSTMT_FORELM ptr, _
+		byval lhs as FB_CMPSTMT_FORELM ptr, _
 		byval rhs as FB_CMPSTMT_FORELM ptr _
 	)
 
 ''::::
 private function hElmToExpr _
 	( _
-	 	byval v as FB_CMPSTMT_FORELM ptr _
+		byval v as FB_CMPSTMT_FORELM ptr _
 	) as ASTNODE ptr
 
 	'' This function creates an AST node using the value
@@ -281,7 +281,7 @@ end function
 private sub hFlushBOP _
 	( _
 		byval op as integer, _
-	 	byval lhs as FB_CMPSTMT_FORELM ptr, _
+		byval lhs as FB_CMPSTMT_FORELM ptr, _
 		byval rhs as FB_CMPSTMT_FORELM ptr, _
 		byval ex as FBSYMBOL ptr _
 	)
@@ -328,7 +328,7 @@ end sub
 private function hStepExpression _
 	( _
 		byval lhs_dtype as integer, _
-	 	byval lhs_subtype as FBSYMBOL ptr, _
+		byval lhs_subtype as FBSYMBOL ptr, _
 		byval rhs as FB_CMPSTMT_FORELM ptr _
 	) as ASTNODE ptr
 
@@ -377,7 +377,7 @@ end function
 private sub hFlushSelfBOP _
 	( _
 		byval op as integer, _
-	 	byval lhs as FB_CMPSTMT_FORELM ptr, _
+		byval lhs as FB_CMPSTMT_FORELM ptr, _
 		byval rhs as FB_CMPSTMT_FORELM ptr _
 	)
 
@@ -1006,8 +1006,8 @@ private sub hForStmtClose(byval stk as FB_CMPSTMTSTK ptr)
 		'' emit test label
 		astAdd( astNewLABEL( stk->for.testlabel ) )
 
-        '' check
-        hUdtNext( stk )
+		'' check
+		hUdtNext( stk )
 
 	case else
 		'' update

--- a/src/compiler/parser-compound-for.bas
+++ b/src/compiler/parser-compound-for.bas
@@ -80,9 +80,9 @@ private sub hUdtFor _
 	end if
 
 	proc = hUdtCallOpOvl( symbGetSubtype( stk->for.cnt.sym ), _
-						  AST_OP_FOR, _
-					  	  hElmToExpr( @stk->for.cnt ), _
-					  	  step_expr )
+	                      AST_OP_FOR, _
+	                      hElmToExpr( @stk->for.cnt ), _
+	                      step_expr )
 
 	if( proc <> NULL ) then
 		astAdd( proc )
@@ -104,9 +104,9 @@ private sub hUdtStep _
 	end if
 
 	proc = hUdtCallOpOvl( symbGetSubtype( stk->for.cnt.sym ), _
-						  AST_OP_STEP, _
-						  hElmToExpr( @stk->for.cnt ), _
-						  step_expr )
+	                      AST_OP_STEP, _
+	                      hElmToExpr( @stk->for.cnt ), _
+	                      step_expr )
 
 	if( proc <> NULL ) then
 		astAdd( proc )
@@ -128,18 +128,18 @@ private sub hUdtNext _
 	end if
 
 	proc = hUdtCallOpOvl( symbGetSubtype( stk->for.cnt.sym ), _
-						  AST_OP_NEXT, _
-						  hElmToExpr( @stk->for.cnt ), _
-						  hElmToExpr( @stk->for.end ), _
-						  step_expr )
+	                      AST_OP_NEXT, _
+	                      hElmToExpr( @stk->for.cnt ), _
+	                      hElmToExpr( @stk->for.end ), _
+	                      step_expr )
 
 	if( proc <> NULL ) then
 		'' if proc(...) <> 0 then goto init
 		astAdd( astNewBOP( AST_OP_NE, _
-						proc, _
-						astNewCONSTi( 0 ), _
-						stk->for.inilabel, _
-						AST_OPOPT_NONE ) )
+		                   proc, _
+		                   astNewCONSTi( 0 ), _
+		                   stk->for.inilabel, _
+		                   AST_OPOPT_NONE ) )
 	end if
 
 end sub
@@ -172,11 +172,11 @@ private sub hScalarNext _
 		dim as FBSYMBOL ptr cl = symbAddLabel( NULL )
 
 		'' if ispositive = FALSE then
-		astAdd( astNewBOP( AST_OP_NE, _
-					   	   hElmToExpr( @stk->for.ispos ), _
-					   	   astNewCONSTi( 0 ), _
-					   	   cl, _
-					   	   AST_OPOPT_NONE ) )
+				astAdd( astNewBOP( AST_OP_NE, _
+				        hElmToExpr( @stk->for.ispos ), _
+				        astNewCONSTi( 0 ), _
+				        cl, _
+				        AST_OPOPT_NONE ) )
 
 			'' if counter >= end_condition then
 				'' goto top_of_FOR
@@ -880,8 +880,8 @@ sub cForStmtBegin( )
 	'' check if this branch is needed
 	if( isconst = 3 ) then
 		expr = astNewBOP( iif( stk->for.ispos.value.i, AST_OP_LE, AST_OP_GE ), _
-					astNewCONST( @stk->for.cnt.value, stk->for.cnt.dtype ), _
-					astNewCONST( @stk->for.end.value, stk->for.end.dtype ) )
+		                  astNewCONST( @stk->for.cnt.value, stk->for.cnt.dtype ), _
+		                  astNewCONST( @stk->for.end.value, stk->for.end.dtype ) )
 
 		if( astConstFlushToInt( expr ) = 0 ) then
 			astAdd( astNewBRANCH( AST_OP_JMP, el ) )
@@ -919,8 +919,8 @@ private function hUdtCallOpOvl _
 
 	if( sym = NULL ) then
 		errReport( FB_ERRMSG_UDTINFORNEEDSOPERATORS, _
-				   TRUE, _
-				   astGetOpId( op ) )
+		           TRUE, _
+		           astGetOpId( op ) )
 		return NULL
 	end if
 

--- a/src/compiler/parser-compound-for.bas
+++ b/src/compiler/parser-compound-for.bas
@@ -978,7 +978,7 @@ private function hUdtCallOpOvl _
 		end if
 		return NULL
 	else
-		'' check visibility / access
+		'' Check visibility of the operator
 		if( symbCheckAccess( sym ) = FALSE ) then
 			errReportEx( FB_ERRMSG_ILLEGALMEMBERACCESS , *symbGetFullProcName( sym ) )
 			return NULL

--- a/src/compiler/parser-decl-struct.bas
+++ b/src/compiler/parser-decl-struct.bas
@@ -86,8 +86,8 @@ private sub hTypeProtoDecl _
 
 	select case( tk )
 	case FB_TK_SUB, FB_TK_FUNCTION, _
-	     FB_TK_CONSTRUCTOR, FB_TK_DESTRUCTOR, _
-	     FB_TK_OPERATOR, FB_TK_PROPERTY
+		FB_TK_CONSTRUCTOR, FB_TK_DESTRUCTOR, _
+		FB_TK_OPERATOR, FB_TK_PROPERTY
 		lexSkipToken( LEXCHECK_POST_SUFFIX )
 
 		cProcHeader( attrib, pattrib, is_nested, _
@@ -233,7 +233,7 @@ private sub hFieldInit _
 	'' constructor, if no constructor was specified.
 	symbSetUDTHasInitedField( parent )
 
-    '' ANY?
+	'' ANY?
 	if( lexGetToken( ) = FB_TK_ANY ) then
 		'' don't allow var-len strings
 		if( symbGetType( sym ) = FB_DATATYPE_STRING ) then
@@ -500,7 +500,7 @@ private sub hTypeMultElementDecl _
 		byval attrib as FB_SYMBATTRIB _
 	)
 
-    static as FBARRAYDIM dTB(0 to FB_MAXARRAYDIMS-1)
+	static as FBARRAYDIM dTB(0 to FB_MAXARRAYDIMS-1)
 	dim as zstring ptr id = any
 	dim as FBSYMBOL ptr subtype = any
 	dim as integer dtype = any, bits = any, dims = any, fieldattrib = any
@@ -540,7 +540,7 @@ private sub hTypeElementDecl _
 		byval attrib as FB_SYMBATTRIB _
 	)
 
-    static as FBARRAYDIM dTB(0 to FB_MAXARRAYDIMS-1)
+	static as FBARRAYDIM dTB(0 to FB_MAXARRAYDIMS-1)
 	dim as zstring ptr id = any
 	dim as FBSYMBOL ptr subtype = any
 	dim as integer dtype = any, bits = any, dims = any
@@ -750,7 +750,7 @@ private sub hTypeBody( byval s as FBSYMBOL ptr )
 
 	do
 		select case as const lexGetToken( )
-        '' visibility?
+		'' visibility?
 		case FB_TK_PRIVATE, FB_TK_PUBLIC, FB_TK_PROTECTED
 			if( symbGetUDTIsUnion( s ) ) then
 				errReport( FB_ERRMSG_SYNTAXERROR )
@@ -776,7 +776,7 @@ private sub hTypeBody( byval s as FBSYMBOL ptr )
 
 		'' single-line comment?
 		case FB_TK_COMMENT, FB_TK_REM
-		    cComment( )
+			cComment( )
 
 		'' newline?
 		case FB_TK_EOL
@@ -805,9 +805,10 @@ private sub hTypeBody( byval s as FBSYMBOL ptr )
 			'' isn't it a field called TYPE|UNION?
 			select case as const lexGetLookAhead( 1 )
 			case FB_TK_EOL, FB_TK_EOF, FB_TK_COMMENT, FB_TK_REM, _
-			     FB_TK_FIELD
+				FB_TK_FIELD
 
-decl_inner:		'' it's an anonymous inner UDT
+decl_inner:
+				'' it's an anonymous inner UDT
 				isunion = lexGetToken( ) = FB_TK_UNION
 				if( symbGetUDTIsUnion( s ) = isunion ) then
 					errReport( FB_ERRMSG_SYNTAXERROR )
@@ -966,11 +967,11 @@ sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 
 	case FB_TKCLASS_QUIRKWD
 
-    case else
+	case else
 		errReport( FB_ERRMSG_EXPECTEDIDENTIFIER )
 		'' error recovery: fake an ID
 		checkid = FALSE
-    end select
+	end select
 
 	if( checkid ) then
 		'' Namespace identifier if it matches the current namespace
@@ -979,8 +980,8 @@ sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 		if( fbLangOptIsSet( FB_LANG_OPT_PERIODS ) ) then
 			'' if inside a namespace, symbols can't contain periods (.)'s
 			if( symbIsGlobalNamespc( ) = FALSE ) then
-  				if( lexGetPeriodPos( ) > 0 ) then
-  					errReport( FB_ERRMSG_CANTINCLUDEPERIODS )
+				if( lexGetPeriodPos( ) > 0 ) then
+					errReport( FB_ERRMSG_CANTINCLUDEPERIODS )
 				end if
 			end if
 		end if
@@ -1022,7 +1023,7 @@ sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 
 		'' is the base type a struct?
 		if( baseDType <> FB_DATATYPE_STRUCT ) then
-			
+
 			'' allow extending WSTRING and ZSTRING, the UDT
 			'' will use different rules for conversions,
 			if (baseDType = FB_DATATYPE_WCHAR) or (baseDType = FB_DATATYPE_CHAR) then
@@ -1089,8 +1090,8 @@ sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 	'' start a new compound, or any EXTERN..END EXTERN used around this struct
 	'' would turn-off function mangling depending on the mode passed
 	cCompStmtPush( FB_TK_TYPE, _
-	 		   	   FB_CMPSTMT_MASK_ALL and (not FB_CMPSTMT_MASK_CODE) _
-	 					 			        and (not FB_CMPSTMT_MASK_DATA) )
+		FB_CMPSTMT_MASK_ALL and (not FB_CMPSTMT_MASK_CODE) _
+		and (not FB_CMPSTMT_MASK_DATA) )
 
 	'' we have to store some contextual information,
 	'' while there's no proper scope stack
@@ -1121,9 +1122,9 @@ sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 	if( symbGetIsUnique( sym ) ) then
 		'' any preview declaration than itself?
 		dim as FBSYMCHAIN ptr chain_ = symbLookupAt( symbGetCurrentNamespc( ), _
-													 id, _
-													 FALSE, _
-													 FALSE )
+			id, _
+			FALSE, _
+			FALSE )
 		'' could be NULL, because error recovery
 		if( chain_ <> NULL ) then
 			if( chain_->sym <> sym ) then
@@ -1162,7 +1163,8 @@ private sub hPatchByvalParamsToSelf( byval parent as FBSYMBOL ptr )
 			while( param )
 				'' BYVAL AS ParentUDT?
 				if( (symbGetType( param ) = FB_DATATYPE_STRUCT) and _
-				    (symbGetSubtype( param ) = parent)                ) then
+					(symbGetSubtype( param ) = parent) ) then
+
 					if( symbGetParamMode( param ) = FB_PARAMMODE_BYVAL ) then
 						symbRecalcLen( param )
 					end if
@@ -1183,8 +1185,9 @@ private sub hPatchByvalResultToSelf( byval parent as FBSYMBOL ptr )
 
 		'' Function or static variable? Using parent UDT as Byval (result) data type?
 		if( (symbGetType( sym ) = FB_DATATYPE_STRUCT) and _
-		    (symbGetSubtype( sym ) = parent) and _
-		    (not symbIsRef( sym )) ) then
+			(symbGetSubtype( sym ) = parent) and _
+			(not symbIsRef( sym )) ) then
+
 			if( symbIsProc( sym ) ) then
 				symbProcRecalcRealType( sym )
 				'' (FBSYMBOL->lgt is 0 for procedures anyways, no need to update)

--- a/src/compiler/parser-decl-struct.bas
+++ b/src/compiler/parser-decl-struct.bas
@@ -86,12 +86,13 @@ private sub hTypeProtoDecl _
 
 	select case( tk )
 	case FB_TK_SUB, FB_TK_FUNCTION, _
-		FB_TK_CONSTRUCTOR, FB_TK_DESTRUCTOR, _
-		FB_TK_OPERATOR, FB_TK_PROPERTY
+	     FB_TK_CONSTRUCTOR, FB_TK_DESTRUCTOR, _
+	     FB_TK_OPERATOR, FB_TK_PROPERTY
+
 		lexSkipToken( LEXCHECK_POST_SUFFIX )
 
 		cProcHeader( attrib, pattrib, is_nested, _
-				FB_PROCOPT_ISPROTO or FB_PROCOPT_HASPARENT, tk )
+		             FB_PROCOPT_ISPROTO or FB_PROCOPT_HASPARENT, tk )
 
 	case else
 		errReport( FB_ERRMSG_SYNTAXERROR )
@@ -624,8 +625,8 @@ sub hTypeStaticVarDecl _
 	'' at its declaration in the TYPE compound, only at the DIM later.
 
 	attrib or= FB_SYMBATTRIB_EXTERN or _
-			FB_SYMBATTRIB_SHARED or _
-			FB_SYMBATTRIB_STATIC
+	           FB_SYMBATTRIB_SHARED or _
+	           FB_SYMBATTRIB_STATIC
 
 	cVarDecl( attrib, FALSE, FB_TK_EXTERN, FALSE )
 
@@ -814,7 +815,7 @@ private sub hTypeBody( byval s as FBSYMBOL ptr )
 			'' isn't it a field called TYPE|UNION?
 			select case as const lexGetLookAhead( 1 )
 			case FB_TK_EOL, FB_TK_EOF, FB_TK_COMMENT, FB_TK_REM, _
-				FB_TK_FIELD
+			     FB_TK_FIELD
 
 decl_inner:
 				'' it's an anonymous inner UDT
@@ -1116,8 +1117,8 @@ sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 	'' start a new compound, or any EXTERN..END EXTERN used around this struct
 	'' would turn-off function mangling depending on the mode passed
 	cCompStmtPush( FB_TK_TYPE, _
-		FB_CMPSTMT_MASK_ALL and (not FB_CMPSTMT_MASK_CODE) _
-		and (not FB_CMPSTMT_MASK_DATA) )
+	               FB_CMPSTMT_MASK_ALL and (not FB_CMPSTMT_MASK_CODE) _
+	               and (not FB_CMPSTMT_MASK_DATA) )
 
 	'' we have to store some contextual information,
 	'' while there's no proper scope stack
@@ -1151,10 +1152,13 @@ sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 	'' has methods? must be unique..
 	if( symbGetIsUnique( sym ) ) then
 		'' any preview declaration than itself?
-		dim as FBSYMCHAIN ptr chain_ = symbLookupAt( symbGetCurrentNamespc( ), _
-			id, _
-			FALSE, _
-			FALSE )
+		dim as FBSYMCHAIN ptr chain_ = _
+			symbLookupAt( _
+				symbGetCurrentNamespc( ), _
+				id, _
+				FALSE, _
+				FALSE _
+			)
 		'' could be NULL, because error recovery
 		if( chain_ <> NULL ) then
 			if( chain_->sym <> sym ) then

--- a/src/compiler/parser-decl-struct.bas
+++ b/src/compiler/parser-decl-struct.bas
@@ -870,11 +870,18 @@ decl_inner:
 			case FB_TK_AS
 				hTypeElementDecl( FB_TK_DIM, s, attrib )
 
-			'' Otherwise TYPE|UNION starts an inner declaration
+			'' Otherwise TYPE|UNION maybe starts an inner declaration
 			case else
+				'' Inside an anonymous type|union?  Don't allow named types
+				if( symbIsStruct( s ) andalso symbGetUDTIsAnon( s ) ) then
+					hTypeElementDecl( FB_TK_DIM, s, attrib )
+
 				'' allow named UNION|TYPE to be nested in another UNION|TYPE
-				hBeginNesting( s )
-				cTypeDecl( attrib )
+				else
+					hBeginNesting( s )
+					cTypeDecl( attrib )
+
+				end if
 
 			end select
 

--- a/src/compiler/parser-decl-struct.bas
+++ b/src/compiler/parser-decl-struct.bas
@@ -173,7 +173,7 @@ private sub hFieldInit _
 					'' Does it have a default constructor?
 					defctor = symbGetCompDefCtor( subtype )
 					if( defctor ) then
-						'' Check whether we have access
+						'' Check visibility of the default constructor
 						if( symbCheckAccess( defctor ) = FALSE ) then
 							errReport( FB_ERRMSG_NOACCESSTODEFAULTCTOR )
 						end if
@@ -186,7 +186,7 @@ private sub hFieldInit _
 				'' Does it have a destructor?
 				defctor = symbGetCompDtor1( subtype )
 				if( defctor ) then
-					'' Check whether we have access
+					'' Check visibility of the default constructor
 					if( symbCheckAccess( defctor ) = FALSE ) then
 						errReport( FB_ERRMSG_NOACCESSTODTOR )
 					end if

--- a/src/compiler/parser-decl-struct.bas
+++ b/src/compiler/parser-decl-struct.bas
@@ -945,7 +945,7 @@ end sub
 ''  END (TYPE|UNION) .
 sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 
-	static as zstring * FB_MAXNAMELEN+1 id
+	dim as zstring * FB_MAXNAMELEN+1 id
 	dim as integer isunion = any, checkid = any
 	dim as FBSYMBOL ptr sym = any
 	dim as FB_CMPSTMTSTK ptr stk = any

--- a/src/compiler/parser-decl-struct.bas
+++ b/src/compiler/parser-decl-struct.bas
@@ -1027,7 +1027,7 @@ sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 	if( lexGetToken( ) = FB_TK_EXTENDS ) then
 		lexSkipToken( LEXCHECK_POST_SUFFIX )
 
-		'' SymbolType 
+		'' SymbolType
 		'' - on error hSymbolType() will return [integer] in baseDType
 		hSymbolType( baseDType, baseSubtype, 0, FALSE, TRUE )
 
@@ -1076,6 +1076,7 @@ sub cTypeDecl( byval attrib as FB_SYMBATTRIB )
 			while( context <> @symbGetGlobalNamespc( ) )
 				if( symbGetClass( context ) = FB_SYMBCLASS_STRUCT ) then
 					if( context = baseSubtype ) then
+						baseDType = 0
 						baseSubtype = NULL
 						errReport( FB_ERRMSG_INVALIDDATATYPES )
 						exit while

--- a/src/compiler/parser-decl-symb-init.bas
+++ b/src/compiler/parser-decl-symb-init.bas
@@ -185,8 +185,8 @@ private function hArrayInit _
 		'' too many dimensions?
 		if( ctx.dimension >= symbGetArrayDimensions( ctx.sym ) ) then
 			errReport( iif( symbGetArrayDimensions( ctx.sym ) > 0, _
-							FB_ERRMSG_TOOMANYEXPRESSIONS, _
-							FB_ERRMSG_EXPECTEDARRAY ) )
+			                FB_ERRMSG_TOOMANYEXPRESSIONS, _
+			                FB_ERRMSG_EXPECTEDARRAY ) )
 			'' error recovery: skip until next '}'
 			hSkipUntil( CHAR_RBRACE, TRUE )
 			ctx.dimension -= 1
@@ -266,7 +266,7 @@ private function hArrayInit _
 		'' symbCheckArraySize() handles this special case. (The check will be incomplete,
 		'' but ultimately
 		if( symbCheckArraySize( symbGetArrayDimensions( ctx.sym ), @symbGetArrayDim( ctx.sym, 0 ), ctx.sym->lgt, _
-					((ctx.sym->attrib and (FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_STATIC)) = 0) ) = FALSE ) then
+		                        ((ctx.sym->attrib and (FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_STATIC)) = 0) ) = FALSE ) then
 			errReport( FB_ERRMSG_ARRAYTOOBIG )
 			'' error recovery: set this dimension to 1 element
 			symbSetFixedSizeArrayDimensionElements( ctx.sym, ctx.dimension, 1 )
@@ -379,7 +379,7 @@ private function hUDTInit( byref ctx as FB_INITCTX ) as integer
 		if( symbGetClass( ctx.sym ) = FB_SYMBCLASS_PARAM ) then
 			if( symbGetParamMode( ctx.sym ) = FB_PARAMMODE_BYREF ) then
 				if( (astGetDataType( expr ) = typeGetDtAndPtrOnly( ctx.dtype )) and _
-					(astGetSubtype( expr ) = ctx.subtype) ) then
+				    (astGetSubtype( expr ) = ctx.subtype) ) then
 					return hDoAssign( ctx, expr )
 				end if
 			end if

--- a/src/compiler/parser-decl-symb-init.bas
+++ b/src/compiler/parser-decl-symb-init.bas
@@ -59,7 +59,7 @@ private function hDoAssign _
 		'' fail initializers that could be assigned with a cast to a base type.
 		'' This allows passing an initializer back to an exact matched parent.
 
-		expr = astNewCONV( ctx.dtype, ctx.subtype, expr, AST_CONVOPT_NOCONVTOBASE ) '' asdf
+		expr = astNewCONV( ctx.dtype, ctx.subtype, expr, AST_CONVOPT_NOCONVTOBASE )
 		if( expr = NULL ) then
 			'' hand it back...
 			'' (used with UDTs; if an UDT var is given in an UDT initializer,

--- a/src/compiler/parser-decl-symb-init.bas
+++ b/src/compiler/parser-decl-symb-init.bas
@@ -287,7 +287,7 @@ private function hArrayInit _
 			if( ctor = NULL ) then
 				errReport( FB_ERRMSG_NODEFAULTCTORDEFINED )
 			else
-				'' check visibility
+				'' Check visibility of the default ctor
 				if( symbCheckAccess( ctor ) = FALSE ) then
 					errReport( FB_ERRMSG_NOACCESSTODEFAULTCTOR )
 				end if
@@ -448,6 +448,7 @@ private function hUDTInit( byref ctx as FB_INITCTX ) as integer
 
 		astTypeIniGetOfs( ctx.tree ) = baseofs + fld->ofs
 
+		'' Check visibility of the field
 		if( symbCheckAccess( fld ) = FALSE ) then
 			errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
 		end if

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -28,7 +28,7 @@ function cConstIntExpr _
 		expr = astNewCONSTi( 0, dtype )
 	end if
 
-	'' flush the expr to the specified dtype.  
+	'' flush the expr to the specified dtype.
 	'' default is FB_DATATYPE_INTEGER, if not specified in call to cConstIntExpr()
 	function = astConstFlushToInt( expr, dtype )
 end function
@@ -232,8 +232,8 @@ sub AmbigiousSizeofInfo.maybeWarn( byval tk as integer, byval refers_to_type as 
 	'' Don't warn if it's a type and a var of that type, because then the
 	'' len() or sizeof() would return the same value in either case.
 	if( symbIsVar( nontype ) and _
-	    (symbGetType( nontype ) = FB_DATATYPE_STRUCT) and _
-	    (nontype->subtype = typ) ) then
+		(symbGetType( nontype ) = FB_DATATYPE_STRUCT) and _
+		(nontype->subtype = typ) ) then
 		exit sub
 	end if
 
@@ -294,8 +294,8 @@ function cTypeOrExpression _
 
 	'' Token followed by an operator except '*' / '<'?
 	if( (lexGetLookAheadClass( 1 ) = FB_TKCLASS_OPERATOR) andalso _
-	    (lexGetLookAhead( 1 ) <> CHAR_TIMES) andalso _
-	    (lexGetLookAhead( 1 ) <> FB_TK_LT) ) then
+		(lexGetLookAhead( 1 ) <> CHAR_TIMES) andalso _
+		(lexGetLookAhead( 1 ) <> FB_TK_LT) ) then
 		maybe_type = FALSE
 	else
 		'' Check for some non-operator tokens
@@ -449,17 +449,17 @@ private function cMangleModifier _
 						dtype = typeSetMangleDt( dtype, FB_DATATYPE_UINT )
 						function = TRUE
 					case else
-						errReport( FB_ERRMSG_SYNTAXERROR )	
+						errReport( FB_ERRMSG_SYNTAXERROR )
 					end select
 				else
 					select case dtype
 					case FB_DATATYPE_LONG
 					case FB_DATATYPE_ULONG
 					case else
-						errReport( FB_ERRMSG_SYNTAXERROR )	
+						errReport( FB_ERRMSG_SYNTAXERROR )
 					end select
 				end if
-				
+
 			case "char"
 				select case dtype
 				case FB_DATATYPE_VOID
@@ -467,7 +467,7 @@ private function cMangleModifier _
 				case FB_DATATYPE_BYTE, FB_DATATYPE_UBYTE
 					dtype = typeSetMangleDt( dtype, FB_DATATYPE_CHAR )
 				case else
-					errReport( FB_ERRMSG_SYNTAXERROR )	
+					errReport( FB_ERRMSG_SYNTAXERROR )
 				end select
 
 			case "__builtin_va_list", "__builtin_va_list[]"
@@ -484,14 +484,14 @@ private function cMangleModifier _
 					'' subtype = symbCloneSymbol( subtype )
 					symbSetUdtValistType( subtype, fbGetBackendValistType() )
 				case else
-					errReport( FB_ERRMSG_SYNTAXERROR )	
+					errReport( FB_ERRMSG_SYNTAXERROR )
 				end select
 
 			case ""
 				errReport( FB_ERRMSG_EMPTYALIASSTRING )
 
 			case else
-				errReport( FB_ERRMSG_SYNTAXERROR )	
+				errReport( FB_ERRMSG_SYNTAXERROR )
 			end select
 
 			'' "literal"
@@ -506,17 +506,17 @@ end function
 
 '':::::
 ''SymbolType      =   CONST? UNSIGNED? (
-''				      ANY
-''				  |   BOOLEAN (BYTE|INTEGER)?
-''				  |   CHAR|BYTE
-''				  |	  SHORT|WORD
-''				  |	  INTEGER|LONG|DWORD
-''				  |   SINGLE
-''				  |   DOUBLE
+''                    ANY
+''                |   BOOLEAN (BYTE|INTEGER)?
+''                |   CHAR|BYTE
+''                |   SHORT|WORD
+''                |   INTEGER|LONG|DWORD
+''                |   SINGLE
+''                |   DOUBLE
 ''                |   STRING ('*' NUM_LIT)?
 ''                |   USERDEFTYPE
-''				  |   (FUNCTION|SUB) ('(' args ')') (AS SymbolType)?
-''				      (CONST? (PTR|POINTER))* .
+''                |   (FUNCTION|SUB) ('(' args ')') (AS SymbolType)?
+''                    (CONST? (PTR|POINTER))* .
 ''
 function cSymbolType _
 	( _
@@ -858,9 +858,9 @@ function cSymbolType _
 			end if
 
 			'' note: len of "wstring * expr" symbols will be actually
-			''		 the number of chars times sizeof(wstring), so
-			''		 always use symbGetWstrLen( ) to retrieve the
-			''		 len in characters, not the bytes
+			''       the number of chars times sizeof(wstring), so
+			''       always use symbGetWstrLen( ) to retrieve the
+			''       len in characters, not the bytes
 			if( typeGet( dtype ) = FB_DATATYPE_WCHAR ) then
 				lgt *= typeGetSize( FB_DATATYPE_WCHAR )
 			end if

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -727,7 +727,7 @@ function cSymbolType _
 			if( chain_ ) then
 				'' cTypeOrExpression() will expect that the namespace prefix
 				'' will be preserved if we abort and retry as an expression.
-				'' Eventually namespace prefix it gets used in cIdentifier()
+				'' Eventually namespace prefix gets used in cIdentifier()
 				if( options and FB_SYMBTYPEOPT_SAVENSPREFIX ) then
 					assert( parser.nsprefix = NULL )
 					select case symbGetClass( chain_->sym )

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -232,8 +232,8 @@ sub AmbigiousSizeofInfo.maybeWarn( byval tk as integer, byval refers_to_type as 
 	'' Don't warn if it's a type and a var of that type, because then the
 	'' len() or sizeof() would return the same value in either case.
 	if( symbIsVar( nontype ) and _
-		(symbGetType( nontype ) = FB_DATATYPE_STRUCT) and _
-		(nontype->subtype = typ) ) then
+	    (symbGetType( nontype ) = FB_DATATYPE_STRUCT) and _
+	    (nontype->subtype = typ) ) then
 		exit sub
 	end if
 
@@ -294,8 +294,8 @@ function cTypeOrExpression _
 
 	'' Token followed by an operator except '*' / '<'?
 	if( (lexGetLookAheadClass( 1 ) = FB_TKCLASS_OPERATOR) andalso _
-		(lexGetLookAhead( 1 ) <> CHAR_TIMES) andalso _
-		(lexGetLookAhead( 1 ) <> FB_TK_LT) ) then
+	    (lexGetLookAhead( 1 ) <> CHAR_TIMES) andalso _
+	    (lexGetLookAhead( 1 ) <> FB_TK_LT) ) then
 		maybe_type = FALSE
 	else
 		'' Check for some non-operator tokens
@@ -720,8 +720,8 @@ function cSymbolType _
 
 			if( check_id ) then
 				chain_ = cIdentifier( base_parent, _
-					iif( options and FB_SYMBTYPEOPT_SAVENSPREFIX, FB_IDOPT_NONE, FB_IDOPT_DEFAULT or FB_IDOPT_ALLOWSTRUCT ) _
-					)
+				                      iif( options and FB_SYMBTYPEOPT_SAVENSPREFIX, FB_IDOPT_NONE, FB_IDOPT_DEFAULT or FB_IDOPT_ALLOWSTRUCT ) _
+				                    )
 			end if
 
 			if( chain_ ) then

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -794,7 +794,7 @@ private function hVarInitDefault _
 	if( has_defctor ) then
 		'' not already declared nor dynamic array?
 		if( (not is_declared) and ((symbGetAttrib( sym ) and (FB_SYMBATTRIB_DYNAMIC or FB_SYMBATTRIB_COMMON)) = 0) ) then
-			'' Check visibility
+			'' Check visibility to the default constructor
 			if( symbCheckAccess( symbGetCompDefCtor( symbGetSubtype( sym ) ) ) = FALSE ) then
 				errReport( FB_ERRMSG_NOACCESSTODEFAULTCTOR )
 			end if
@@ -1203,7 +1203,7 @@ private function hFlushInitializer _
 
 	'' object?
 	if( has_dtor and (not symbIsRef( sym )) ) then
-		'' check visibility
+		'' Check visibility of the destructor
 		if( symbCheckAccess( symbGetCompDtor1( symbGetSubtype( sym ) ) ) = FALSE ) then
 			errReport( FB_ERRMSG_NOACCESSTODTOR )
 		end if

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -219,7 +219,7 @@ function cVariableDecl( byval attrib as FB_SYMBATTRIB ) as integer
 				attrib or= FB_SYMBATTRIB_STATIC
 			else
 				attrib or= FB_SYMBATTRIB_SHARED or _
-						   FB_SYMBATTRIB_STATIC
+				           FB_SYMBATTRIB_STATIC
 			end if
 			lexSkipToken( LEXCHECK_POST_SUFFIX )
 		end if
@@ -441,9 +441,9 @@ private function hAddVar _
 		'' Note: If the existing array is a COMMON, then not only REDIM is allowed,
 		'' but also DIM etc.
 		elseif( ((attrib and FB_SYMBATTRIB_DYNAMIC) <> 0) and _
-			have_bounds and _
-			symbGetIsDynamic( sym ) and _
-			((token = FB_TK_REDIM) or symbIsCommon( sym )) ) then
+		        have_bounds and _
+		        symbGetIsDynamic( sym ) and _
+		        ((token = FB_TK_REDIM) or symbIsCommon( sym )) ) then
 
 			'' nothing to do here (besides not declaring a new variable),
 			'' rtlArrayRedim() will be called below
@@ -504,12 +504,12 @@ private function hAddVar _
 		end if
 
 		sym = symbAddVar( id, idalias, dtype, subtype, lgt, dimensions, dTB(), attrib, _
-				iif( fbLangOptIsSet( FB_LANG_OPT_SCOPE ), 0, FB_SYMBOPT_UNSCOPE ) )
+		                  iif( fbLangOptIsSet( FB_LANG_OPT_SCOPE ), 0, FB_SYMBOPT_UNSCOPE ) )
 
 		if( sym ) then
 			var is_global = (symbGetAttrib( sym ) and _
-				(FB_SYMBATTRIB_COMMON or FB_SYMBATTRIB_PUBLIC or _
-				FB_SYMBATTRIB_EXTERN or FB_SYMBATTRIB_SHARED )) <> 0
+			                (FB_SYMBATTRIB_COMMON or FB_SYMBATTRIB_PUBLIC or _
+			                FB_SYMBATTRIB_EXTERN or FB_SYMBATTRIB_SHARED )) <> 0
 
 			'' only warn if the symbol is global and in the global namespace
 			if( is_global ) then
@@ -663,7 +663,7 @@ private function hLookupVarAndCheckParent _
 			'' No EXTERN, or different parent, and not REDIM?
 			if( ((symbIsExtern( sym ) = FALSE) or _
 			     (symbGetNamespace( sym ) <> parent)) and _
-			    (not is_redim) ) then
+			     (not is_redim) ) then
 				errReport( FB_ERRMSG_DECLOUTSIDECLASS )
 			end if
 		else
@@ -978,7 +978,7 @@ private function hVarInit _
 
 	'' already declared, extern or common?
 	if( isdecl or _
-		((attrib and (FB_SYMBATTRIB_EXTERN or FB_SYMBATTRIB_COMMON)) <> 0) ) then
+	    ((attrib and (FB_SYMBATTRIB_EXTERN or FB_SYMBATTRIB_COMMON)) <> 0) ) then
 		errReport( FB_ERRMSG_CANNOTINITEXTERNORCOMMON )
 		'' error recovery: skip
 		hSkipUntil( FB_TK_EOL )
@@ -1109,9 +1109,9 @@ private function hWrapInStaticFlag( byval code as ASTNODE ptr ) as ASTNODE ptr
 	'' condition expression is trivial and won't have temp vars itself.
 	label = symbAddLabel( NULL )
 	t = astNewLINK( t, _
-		astBuildBranch( _
-			astNewBOP( AST_OP_EQ, astNewVAR( flag ), astNewCONSTi( 0 ) ), _
-			label, FALSE, TRUE ), AST_LINK_RETURN_NONE )
+	        astBuildBranch( _
+	        astNewBOP( AST_OP_EQ, astNewVAR( flag ), astNewCONSTi( 0 ) ), _
+	        label, FALSE, TRUE ), AST_LINK_RETURN_NONE )
 
 	'' flag = 1
 	t = astNewLINK( t, astBuildVarAssign( flag, 1 ), AST_LINK_RETURN_NONE )
@@ -1213,8 +1213,8 @@ private function hFlushInitializer _
 	if( initree = NULL ) then
 		'' static or shared?
 		if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
-			FB_SYMBATTRIB_SHARED or _
-			FB_SYMBATTRIB_COMMON)) <> 0 ) then
+		                               FB_SYMBATTRIB_SHARED or _
+		                               FB_SYMBATTRIB_COMMON)) <> 0 ) then
 			'' object?
 			if( has_dtor ) then
 				'' local?
@@ -1233,8 +1233,8 @@ private function hFlushInitializer _
 
 	'' not static or shared?
 	if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
-		FB_SYMBATTRIB_SHARED or _
-		FB_SYMBATTRIB_COMMON)) = 0 ) then
+	                               FB_SYMBATTRIB_SHARED or _
+	                               FB_SYMBATTRIB_COMMON)) = 0 ) then
 
 		var_decl = hFlushDecl( var_decl )
 
@@ -1427,7 +1427,7 @@ function cVarDecl _
 		is_redim = (token = FB_TK_REDIM) and ((attrib and FB_SYMBATTRIB_SHARED) = 0)
 
 		parent = cParentId( FB_IDOPT_DEFAULT or FB_IDOPT_ALLOWSTRUCT or FB_IDOPT_ISVAR or _
-				iif( is_redim, 0, FB_IDOPT_ISDECL ) )
+		                    iif( is_redim, 0, FB_IDOPT_ISDECL ) )
 
 		''
 		'' Ambiguity: If this is a REDIM, it can either redim an existing
@@ -1533,8 +1533,8 @@ function cVarDecl _
 					'' No exact bounds allowed, just like they can't have initializers either.
 					'' (but they can have fixed dimensions)
 					if( ((attrib and FB_SYMBATTRIB_COMMON) <> 0) or _
-						(((attrib and FB_SYMBATTRIB_EXTERN) <> 0) and _
-						((attrib and FB_SYMBATTRIB_DYNAMIC) <> 0)) ) then
+					    (((attrib and FB_SYMBATTRIB_EXTERN) <> 0) and _
+					    ((attrib and FB_SYMBATTRIB_DYNAMIC) <> 0)) ) then
 						errReport( FB_ERRMSG_DYNAMICEXTERNCANTHAVEBOUNDS )
 						dimensions = -1
 						have_bounds = FALSE
@@ -1629,8 +1629,8 @@ function cVarDecl _
 			sym = varexpr->sym
 		else
 			sym = hLookupVarAndCheckParent( parent, chain_, dtype, is_typeless, _
-						(suffix <> FB_DATATYPE_INVALID), _
-						is_redim )
+			                                (suffix <> FB_DATATYPE_INVALID), _
+			                                is_redim )
 
 			if( sym ) then
 				'' If it's an existing field, then we must be inside a method,
@@ -1702,7 +1702,7 @@ function cVarDecl _
 			else
 				'' "array too big/huge array on stack" check
 				if( symbCheckArraySize( dimensions, @dTB(0), lgt, _
-					((attrib and (FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_STATIC)) = 0) ) = FALSE ) then
+				    ((attrib and (FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_STATIC)) = 0) ) = FALSE ) then
 					errReport( FB_ERRMSG_ARRAYTOOBIG )
 					'' error recovery: use small array
 					dimensions = 1
@@ -1745,7 +1745,7 @@ function cVarDecl _
 		'' definition, etc.
 		''
 		sym = hAddVar( sym, parent, id, palias, dtype, subtype, lgt, addsuffix, _
-				attrib, dimensions, have_bounds, dTB(), token )
+		               attrib, dimensions, have_bounds, dTB(), token )
 
 		dim as integer has_defctor = FALSE, has_dtor = FALSE
 		if( sym <> NULL ) then
@@ -1773,8 +1773,8 @@ function cVarDecl _
 				if( ( initree <> NULL ) and ( fbLangOptIsSet( FB_LANG_OPT_SCOPE ) = FALSE ) ) then
 					'' local?
 					if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
-						FB_SYMBATTRIB_SHARED or _
-						FB_SYMBATTRIB_COMMON)) = 0 ) then
+					                               FB_SYMBATTRIB_SHARED or _
+					                               FB_SYMBATTRIB_COMMON)) = 0 ) then
 
 						''
 						'' The variable will be unscoped, i.e. it needs a default initree
@@ -1851,8 +1851,8 @@ function cVarDecl _
 					if( ((attrib and FB_SYMBATTRIB_DYNAMIC) <> 0) or (dimensions > 0) ) then
 						'' local?
 						if( (symbGetAttrib( sym ) and (FB_SYMBATTRIB_STATIC or _
-							FB_SYMBATTRIB_SHARED or _
-							FB_SYMBATTRIB_COMMON)) = 0 ) then
+						                               FB_SYMBATTRIB_SHARED or _
+						                               FB_SYMBATTRIB_COMMON)) = 0 ) then
 
 							'' flush the decl node, safe to do here as it's a non-static
 							'' local var (and because the decl must be flushed first)
@@ -1902,7 +1902,7 @@ function cVarDecl _
 						varexpr = astNewVAR( sym )
 					end if
 					redimcall = rtlArrayRedim( varexpr, dimensions, exprTB(), _
-								dopreserve, (not symbGetDontInit( sym )) )
+					                           dopreserve, (not symbGetDontInit( sym )) )
 
 					'' If this is a local STATIC (not SHARED/COMMON) array declaration (and not
 					'' a typeless REDIM), then the redim call should be executed only once, not
@@ -2173,7 +2173,7 @@ private sub cAutoVarDecl( byval baseattrib as FB_SYMBATTRIB )
 
 		'' id.id? if not, NULL
 		parent = cParentId( FB_IDOPT_DEFAULT or FB_IDOPT_ISDECL or _
-					FB_IDOPT_ALLOWSTRUCT or FB_IDOPT_ISVAR )
+		                    FB_IDOPT_ALLOWSTRUCT or FB_IDOPT_ISVAR )
 
 		'' get id
 		dim as integer suffix = any
@@ -2191,7 +2191,7 @@ private sub cAutoVarDecl( byval baseattrib as FB_SYMBATTRIB )
 		end if
 
 		sym = hLookupVarAndCheckParent( parent, chain_, FB_DATATYPE_INVALID, _
-						TRUE, FALSE, FALSE )
+		                                TRUE, FALSE, FALSE )
 
 		'' '=' | '=>' ?
 		if( cAssignToken( ) = FALSE ) then
@@ -2254,7 +2254,7 @@ private sub cAutoVarDecl( byval baseattrib as FB_SYMBATTRIB )
 
 		'' add var after parsing the expression, or the the var itself could be used
 		sym = hAddVar( sym, parent, id, NULL, dtype, subtype, _
-			symbCalcLen( dtype, subtype ), FALSE, attrib, 0, FALSE, dTB(), FB_TK_VAR )
+		               symbCalcLen( dtype, subtype ), FALSE, attrib, 0, FALSE, dTB(), FB_TK_VAR )
 
 		if( sym <> NULL ) then
 			if( symbIsRef( sym ) ) then

--- a/src/compiler/parser-expr-constant.bas
+++ b/src/compiler/parser-expr-constant.bas
@@ -46,8 +46,8 @@ function cStrLiteral( byval skiptoken as integer ) as ASTNODE ptr
 						if( lexGetToken( ) <> FB_TK_STRLIT_NOESC ) then
 							if( hHasEscape( zs ) ) then
 								errReportWarn( FB_WARNINGMSG_POSSIBLEESCSEQ, _
-										   	   zs, _
-										   	   FB_ERRMSGOPT_ADDCOLON or FB_ERRMSGOPT_ADDQUOTES )
+								               zs, _
+								               FB_ERRMSGOPT_ADDCOLON or FB_ERRMSGOPT_ADDQUOTES )
 							end if
 						end if
 					end if

--- a/src/compiler/parser-expr-constant.bas
+++ b/src/compiler/parser-expr-constant.bas
@@ -8,7 +8,7 @@
 #include once "ast.bi"
 
 function cConstant( byval sym as FBSYMBOL ptr ) as ASTNODE ptr
-	'' check visibility
+	'' Check visibility of constant
 	if( symbCheckAccess( sym ) = FALSE ) then
 		errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
 	end if

--- a/src/compiler/parser-expr-constant.bas
+++ b/src/compiler/parser-expr-constant.bas
@@ -13,27 +13,27 @@ function cConstant( byval sym as FBSYMBOL ptr ) as ASTNODE ptr
 		errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
 	end if
 
-  	'' ID
-  	lexSkipToken( LEXCHECK_POST_LANG_SUFFIX )
+	'' ID
+	lexSkipToken( LEXCHECK_POST_LANG_SUFFIX )
 
 	function = astBuildConst( sym )
 end function
 
 '':::::
-'' LitString	= 	STR_LITERAL STR_LITERAL* .
+'' LitString    =   STR_LITERAL STR_LITERAL* .
 ''
 function cStrLiteral( byval skiptoken as integer ) as ASTNODE ptr
 	dim as FBSYMBOL ptr sym = any
-    dim as integer lgt = any, isunicode = any
-    dim as zstring ptr zs = any
+	dim as integer lgt = any, isunicode = any
+	dim as zstring ptr zs = any
 	dim as wstring ptr ws = any
 
-    dim as ASTNODE ptr expr = NULL
+	dim as ASTNODE ptr expr = NULL
 
 	do
 		lgt = lexGetTextLen( )
 
-  		if( lexGetType( ) <> FB_DATATYPE_WCHAR ) then
+		if( lexGetType( ) <> FB_DATATYPE_WCHAR ) then
 			'' escaped? convert to internal format..
 			if( lexGetToken( ) = FB_TK_STRLIT_ESC ) then
 				zs = hReEscape( lexGetText( ), lgt, isunicode )
@@ -57,13 +57,13 @@ function cStrLiteral( byval skiptoken as integer ) as ASTNODE ptr
 			end if
 
 			if( isunicode = FALSE ) then
-               	sym = symbAllocStrConst( zs, lgt )
+				sym = symbAllocStrConst( zs, lgt )
 			'' convert to unicode..
 			else
 				sym = symbAllocWstrConst( wstr( *zs ), lgt )
 			end if
 
-  		else
+		else
 			'' escaped? convert to internal format..
 			if( lexGetToken( ) = FB_TK_STRLIT_ESC ) then
 				ws = hReEscapeW( lexGetTextW( ), lgt )
@@ -94,8 +94,8 @@ function cStrLiteral( byval skiptoken as integer ) as ASTNODE ptr
 		if( skiptoken ) then
 			lexSkipToken( )
 
-  			'' not another literal string?
-  			if( lexGetClass( ) <> FB_TKCLASS_STRLITERAL ) then
+			'' not another literal string?
+			if( lexGetClass( ) <> FB_TKCLASS_STRLITERAL ) then
 				exit do
 			end if
 

--- a/src/compiler/parser-expr-unary.bas
+++ b/src/compiler/parser-expr-unary.bas
@@ -326,9 +326,9 @@ private function hCast( byval options as AST_CONVOPT ) as ASTNODE ptr
 		subtype = NULL
 
 	case FB_DATATYPE_INTEGER, FB_DATATYPE_UINT, _
-		FB_DATATYPE_LONG, FB_DATATYPE_ULONG, _
-		FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT, _
-		FB_DATATYPE_ENUM
+	     FB_DATATYPE_LONG, FB_DATATYPE_ULONG, _
+	     FB_DATATYPE_LONGINT, FB_DATATYPE_ULONGINT, _
+	     FB_DATATYPE_ENUM
 
 		if( options and AST_CONVOPT_PTRONLY ) then
 			if( fbPdCheckIsSet( FB_PDCHECK_CASTTONONPTR ) ) then
@@ -365,7 +365,7 @@ private function hCast( byval options as AST_CONVOPT ) as ASTNODE ptr
 
 	'' -w constness implies -w funcptr
 	if( (fbPdCheckIsSet( FB_PDCHECK_CASTFUNCPTR ) = FALSE) _
-		and (fbPdCheckIsSet( FB_PDCHECK_CONSTNESS ) = FALSE) ) then
+	    and (fbPdCheckIsSet( FB_PDCHECK_CONSTNESS ) = FALSE) ) then
 		options or= AST_CONVOPT_DONTWARNFUNCPTR
 	end if
 
@@ -503,7 +503,7 @@ private function hVarPtrBody _
 
 	select case as const astGetClass( t )
 	case AST_NODECLASS_VAR, AST_NODECLASS_IDX, AST_NODECLASS_DEREF, _
-		AST_NODECLASS_TYPEINI, AST_NODECLASS_CALLCTOR
+	     AST_NODECLASS_TYPEINI, AST_NODECLASS_CALLCTOR
 
 	case AST_NODECLASS_FIELD
 		'' can't take address of bitfields..
@@ -624,7 +624,7 @@ function cAddrOfExpression( ) as ASTNODE ptr
 		dim as FBSYMBOL ptr sym = any, base_parent = any
 
 		chain_ = cIdentifier( base_parent, _
-			FB_IDOPT_DEFAULT or FB_IDOPT_ALLOWSTRUCT )
+		                      FB_IDOPT_DEFAULT or FB_IDOPT_ALLOWSTRUCT )
 		sym = symbFindByClass( chain_, FB_SYMBCLASS_PROC )
 		if( sym = NULL ) then
 			errReport( FB_ERRMSG_UNDEFINEDSYMBOL )
@@ -718,8 +718,8 @@ function cAddrOfExpression( ) as ASTNODE ptr
 
 		select case as const astGetClass( t )
 		case AST_NODECLASS_VAR, AST_NODECLASS_IDX, _
-			AST_NODECLASS_DEREF, AST_NODECLASS_TYPEINI, _
-			AST_NODECLASS_FIELD
+		     AST_NODECLASS_DEREF, AST_NODECLASS_TYPEINI, _
+		     AST_NODECLASS_FIELD
 
 		case else
 			errReportEx( FB_ERRMSG_INVALIDDATATYPES, "for STRPTR" )
@@ -732,14 +732,14 @@ function cAddrOfExpression( ) as ASTNODE ptr
 
 		case FB_DATATYPE_WCHAR
 			expr = astNewCONV( typeAddrOf( FB_DATATYPE_WCHAR ), _
-				NULL, _
-				astNewADDROF( expr ) )
+			                   NULL, _
+			                   astNewADDROF( expr ) )
 
 		'' anything else: do cast( zstring ptr, @expr )
 		case else
 			expr = astNewCONV( typeAddrOf( FB_DATATYPE_CHAR ), _
-				NULL, _
-				astNewADDROF( expr ) )
+			                   NULL, _
+			                   astNewADDROF( expr ) )
 		end select
 
 		'' ')'

--- a/src/compiler/parser-expr-unary.bas
+++ b/src/compiler/parser-expr-unary.bas
@@ -465,6 +465,7 @@ private function hProcPtrBody _
 		return astNewCONSTi( 0 )
 	end if
 
+	'' Check visibility of the proc
 	if( symbCheckAccess( proc ) = FALSE ) then
 		errReportEx( FB_ERRMSG_ILLEGALMEMBERACCESS, symbGetFullProcName( proc ) )
 	end if

--- a/src/compiler/parser-expr-variable.bas
+++ b/src/compiler/parser-expr-variable.bas
@@ -270,7 +270,7 @@ private function hMemberId( byval parent as FBSYMBOL ptr ) as FBSYMBOL ptr
 				select case as const symbGetClass( sym )
 				'' field or static members?
 				case FB_SYMBCLASS_FIELD, FB_SYMBCLASS_VAR, _
-				     FB_SYMBCLASS_CONST, FB_SYMBCLASS_ENUM
+					FB_SYMBCLASS_CONST, FB_SYMBCLASS_ENUM
 					'' check visibility
 					if( symbCheckAccess( sym ) = FALSE ) then
 						errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
@@ -359,8 +359,8 @@ function cUdtMember _
 
 			'' Only continue if the field was an UDT and there's a '.' following
 			if( (typeGetDtAndPtrOnly( dtype ) <> FB_DATATYPE_STRUCT) or _
-			    (lexGetToken( ) <> CHAR_DOT) or _
-			    astIsNIDXARRAY( varexpr ) ) then
+				(lexGetToken( ) <> CHAR_DOT) or _
+				astIsNIDXARRAY( varexpr ) ) then
 				return varexpr
 			end if
 
@@ -664,7 +664,7 @@ function cMemberDeref _
 			select case( typeGetDtAndPtrOnly( dtype ) )
 			'' string, fixstr, w|zstring? In that case '[]' means string indexing, not MemberDeref.
 			case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, _
-				 FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
+				FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
 				varexpr = hStrIndexing( dtype, varexpr, hCheckIntegerIndex( idxexpr ) )
 				idxexpr = NULL
 
@@ -920,9 +920,10 @@ private function hVarAddUndecl _
 		if( symbIsGlobalNamespc( ) = FALSE ) then
 			if( fbIsModLevel( ) ) then
 				if( (attrib and (FB_SYMBATTRIB_SHARED or _
-								 FB_SYMBATTRIB_COMMON or _
-								 FB_SYMBATTRIB_PUBLIC or _
-								 FB_SYMBATTRIB_EXTERN)) = 0 ) then
+					FB_SYMBATTRIB_COMMON or _
+					FB_SYMBATTRIB_PUBLIC or _
+					FB_SYMBATTRIB_EXTERN)) = 0 ) then
+
 					'' they are never allocated on stack..
 					attrib or= FB_SYMBATTRIB_STATIC
 				end if
@@ -1409,7 +1410,7 @@ function cVarOrDeref _
 
 		select case as const astGetClass( t )
 		case AST_NODECLASS_VAR, AST_NODECLASS_IDX, _
-		     AST_NODECLASS_FIELD, AST_NODECLASS_DEREF
+			AST_NODECLASS_FIELD, AST_NODECLASS_DEREF
 			complain = FALSE
 
 		case AST_NODECLASS_CALL, AST_NODECLASS_NIDXARRAY

--- a/src/compiler/parser-expr-variable.bas
+++ b/src/compiler/parser-expr-variable.bas
@@ -272,7 +272,7 @@ private function hMemberId( byval parent as FBSYMBOL ptr, byval allow_inner as i
 				case FB_SYMBCLASS_FIELD, FB_SYMBCLASS_VAR, _
 				     FB_SYMBCLASS_CONST, FB_SYMBCLASS_ENUM
 
-					'' check visibility
+					'' Check visibility of member
 					if( symbCheckAccess( sym ) = FALSE ) then
 						errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
 					end if
@@ -1022,7 +1022,7 @@ function cVariableEx overload _
 
 	assert( symbIsVar( sym ) )
 
-	'' check visibility
+	'' Check visibility of the variable
 	if( symbCheckAccess( sym ) = FALSE ) then
 		errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
 	end if

--- a/src/compiler/parser-expr-variable.bas
+++ b/src/compiler/parser-expr-variable.bas
@@ -271,7 +271,7 @@ private function hMemberId( byval parent as FBSYMBOL ptr, byval allow_inner as i
 				'' field, static members, or inner types?
 				case FB_SYMBCLASS_FIELD, FB_SYMBCLASS_VAR, _
 				     FB_SYMBCLASS_CONST, FB_SYMBCLASS_ENUM
-					
+
 					'' check visibility
 					if( symbCheckAccess( sym ) = FALSE ) then
 						errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
@@ -365,8 +365,8 @@ function cUdtMember _
 
 			'' Only continue if the field was an UDT and there's a '.' following
 			if( (typeGetDtAndPtrOnly( dtype ) <> FB_DATATYPE_STRUCT) or _
-				(lexGetToken( ) <> CHAR_DOT) or _
-				astIsNIDXARRAY( varexpr ) ) then
+			    (lexGetToken( ) <> CHAR_DOT) or _
+			    astIsNIDXARRAY( varexpr ) ) then
 				return varexpr
 			end if
 
@@ -513,7 +513,7 @@ private function hStrIndexing _
 	if( typeGet( dtype ) = FB_DATATYPE_WCHAR ) then
 		'' times sizeof( wchar ) if it's wstring
 		idxexpr = astNewBOP( AST_OP_MUL, idxexpr, _
-			astNewCONSTi( typeGetSize( FB_DATATYPE_WCHAR ) ) )
+		                     astNewCONSTi( typeGetSize( FB_DATATYPE_WCHAR ) ) )
 	end if
 
 	'' null pointer checking
@@ -629,7 +629,7 @@ function cMemberDeref _
 
 				'' MemberAccess
 				varexpr = cMemberAccess( astGetFullType( varexpr ), _
-						astGetSubType( varexpr ), varexpr )
+				                         astGetSubType( varexpr ), varexpr )
 			end if
 
 			if( varexpr = NULL ) then
@@ -677,7 +677,7 @@ function cMemberDeref _
 			select case( typeGetDtAndPtrOnly( dtype ) )
 			'' string, fixstr, w|zstring? In that case '[]' means string indexing, not MemberDeref.
 			case FB_DATATYPE_STRING, FB_DATATYPE_FIXSTR, _
-				FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
+			     FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
 				varexpr = hStrIndexing( dtype, varexpr, hCheckIntegerIndex( idxexpr ) )
 				idxexpr = NULL
 
@@ -702,7 +702,7 @@ function cMemberDeref _
 
 					'' MemberAccess
 					varexpr = cMemberAccess( astGetFullType( varexpr ), _
-							astGetSubType( varexpr ), varexpr )
+					                         astGetSubType( varexpr ), varexpr )
 					if( varexpr = NULL ) then
 						exit function
 					end if
@@ -752,7 +752,7 @@ function cMemberDeref _
 				'' ptr[index]  =>  ptr + (index * sizeof(*ptr))
 				'' (DEREF added later below, so we can pass the pointer to cUdtMember() first if needed)
 				varexpr = astNewBOP( AST_OP_ADD, varexpr, _
-					astNewBOP( AST_OP_MUL, idxexpr, astNewCONSTi( lgt ) ) )
+				                     astNewBOP( AST_OP_MUL, idxexpr, astNewCONSTi( lgt ) ) )
 
 				'' '.'?
 				if( lexGetToken( ) = CHAR_DOT ) then
@@ -881,8 +881,8 @@ private function cDynamicArrayIndex _
 		'' bounds checking
 		if( env.clopt.arrayboundchk ) then
 			dimexpr = astBuildBOUNDCHK( dimexpr, _
-					astBuildDerefAddrOf( astCloneTree( descexpr ), dimoffset + symb.fbarraydim_lbound, FB_DATATYPE_INTEGER, NULL ), _
-					astBuildDerefAddrOf( astCloneTree( descexpr ), dimoffset + symb.fbarraydim_ubound, FB_DATATYPE_INTEGER, NULL ) )
+			                            astBuildDerefAddrOf( astCloneTree( descexpr ), dimoffset + symb.fbarraydim_lbound, FB_DATATYPE_INTEGER, NULL ), _
+			                            astBuildDerefAddrOf( astCloneTree( descexpr ), dimoffset + symb.fbarraydim_ubound, FB_DATATYPE_INTEGER, NULL ) )
 			assert( dimexpr )
 		end if
 
@@ -933,9 +933,9 @@ private function hVarAddUndecl _
 		if( symbIsGlobalNamespc( ) = FALSE ) then
 			if( fbIsModLevel( ) ) then
 				if( (attrib and (FB_SYMBATTRIB_SHARED or _
-					FB_SYMBATTRIB_COMMON or _
-					FB_SYMBATTRIB_PUBLIC or _
-					FB_SYMBATTRIB_EXTERN)) = 0 ) then
+				                 FB_SYMBATTRIB_COMMON or _
+				                 FB_SYMBATTRIB_PUBLIC or _
+				                 FB_SYMBATTRIB_EXTERN)) = 0 ) then
 
 					'' they are never allocated on stack..
 					attrib or= FB_SYMBATTRIB_STATIC
@@ -991,14 +991,14 @@ private function hMakeArrayIdx( byval sym as FBSYMBOL ptr ) as ASTNODE ptr
 	if( symbIsParamVarByDesc( sym ) ) then
 		'' return descriptor->data
 		return astNewDEREF( astNewVAR( sym, 0, FB_DATATYPE_INTEGER ), _
-				FB_DATATYPE_INTEGER, NULL, symb.fbarray_data )
+		                    FB_DATATYPE_INTEGER, NULL, symb.fbarray_data )
 	end if
 
 	'' dynamic array? (this will handle common's too)
 	if( symbIsDynamic( sym ) ) then
 		'' return descriptor.data
 		return astNewVAR( symbGetArrayDescriptor( sym ), _
-				symb.fbarray_data, FB_DATATYPE_INTEGER )
+		                  symb.fbarray_data, FB_DATATYPE_INTEGER )
 	end if
 
 	'' static array, return lbound( array )
@@ -1065,7 +1065,7 @@ function cVariableEx overload _
 
 					'' plus desc.data (= ptr + diff)
 					idxexpr = astNewBOP( AST_OP_ADD, idxexpr, _
-						astBuildDerefAddrOf( descexpr, symb.fbarray_data, FB_DATATYPE_INTEGER, NULL ) )
+					                     astBuildDerefAddrOf( descexpr, symb.fbarray_data, FB_DATATYPE_INTEGER, NULL ) )
 				else
 					idxexpr = cFixedSizeArrayIndex( sym )
 				end if
@@ -1301,11 +1301,8 @@ private function hImpField _
 	end if
 
 	'' FuncPtrOrMemberDeref?
-	function = cFuncPtrOrMemberDeref( dtype, _
-		subtype, _
-		varexpr, _
-		is_funcptr, _
-		check_array )
+	function = cFuncPtrOrMemberDeref( dtype, subtype, varexpr, is_funcptr, check_array )
+
 end function
 
 ''  WithVariable  = '.' UdtMember FuncPtrOrMemberDeref? .
@@ -1323,7 +1320,7 @@ function cWithVariable( byval check_array as integer ) as ASTNODE ptr
 	end if
 
 	function = hImpField( sym, dtype, symbGetSubtype( sym ), check_array, _
-				parser.stmt.with->with.is_ptr, 0 )
+	                      parser.stmt.with->with.is_ptr, 0 )
 end function
 
 '':::::
@@ -1383,7 +1380,7 @@ function cImplicitDataMember _
 	End If
 
 	function = hImpField( this_, symbGetFullType( this_ ), base_parent, _
-				check_array, TRUE, options )
+	                      check_array, TRUE, options )
 
 end function
 
@@ -1423,7 +1420,7 @@ function cVarOrDeref _
 
 		select case as const astGetClass( t )
 		case AST_NODECLASS_VAR, AST_NODECLASS_IDX, _
-			AST_NODECLASS_FIELD, AST_NODECLASS_DEREF
+		     AST_NODECLASS_FIELD, AST_NODECLASS_DEREF
 			complain = FALSE
 
 		case AST_NODECLASS_CALL, AST_NODECLASS_NIDXARRAY

--- a/src/compiler/parser-expr-variable.bas
+++ b/src/compiler/parser-expr-variable.bas
@@ -268,9 +268,10 @@ private function hMemberId( byval parent as FBSYMBOL ptr ) as FBSYMBOL ptr
 		do
 			if( symbGetScope( sym ) = symbGetScope( parent ) ) then
 				select case as const symbGetClass( sym )
-				'' field or static members?
+				'' field, static members, or inner types?
 				case FB_SYMBCLASS_FIELD, FB_SYMBCLASS_VAR, _
-					FB_SYMBCLASS_CONST, FB_SYMBCLASS_ENUM
+					FB_SYMBCLASS_CONST, FB_SYMBCLASS_ENUM, _
+					FB_SYMBCLASS_STRUCT
 					'' check visibility
 					if( symbCheckAccess( sym ) = FALSE ) then
 						errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
@@ -433,7 +434,7 @@ sub cUdtTypeMember _
 			'' ID
 			lexSkipToken( LEXCHECK_POST_SUFFIX )
 			dtype = symbGetFullType( sym )
-			subtype = symbGetSubType( sym )
+			subtype = sym
 			lgt = symbGetLen( sym )
 			is_fixlenstr = symbGetIsFixLenStr( sym )
 

--- a/src/compiler/parser-identifier.bas
+++ b/src/compiler/parser-identifier.bas
@@ -505,8 +505,8 @@ function cParentId _
 
 		'' check visibility
 		if( parent <> NULL ) then
-			if( symbCheckAccess( sym ) = FALSE ) then
-				if( (options and FB_IDOPT_ISDEFN) = 0 ) then
+			if( (options and FB_IDOPT_ISDEFN) = 0 ) then
+				if( symbCheckAccess( sym ) = FALSE ) then
 					errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
 				end if
 			end if

--- a/src/compiler/parser-identifier.bas
+++ b/src/compiler/parser-identifier.bas
@@ -304,12 +304,12 @@ function cIdentifier _
 			exit do
 		end select
 
-		'' check visibility (of the UDT only, because symbols can be
+		'' Check visibility of the UDT only, because symbols can be
 		'' overloaded or the names duplicated, so that check can only
 		'' be done by specific functions)
 		if( parent <> NULL ) then
-			if( symbCheckAccess( sym ) = FALSE ) then
-				if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
+			if( (options and FB_IDOPT_SHOWERROR) <> 0 ) then
+				if( symbCheckAccess( sym ) = FALSE ) then
 					errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
 				end if
 			end if
@@ -503,7 +503,9 @@ function cParentId _
 			exit do
 		end select
 
-		'' check visibility
+		'' Check visibility of the UDT only, because symbols can be
+		'' overloaded or the names duplicated, so that check can only
+		'' be done by specific functions)
 		if( parent <> NULL ) then
 			if( (options and FB_IDOPT_ISDEFN) = 0 ) then
 				if( symbCheckAccess( sym ) = FALSE ) then

--- a/src/compiler/parser-identifier.bas
+++ b/src/compiler/parser-identifier.bas
@@ -73,9 +73,9 @@ private function hGlobalId _
 	base_parent = @symbGetGlobalNamespc( )
 
 	function = symbLookupAt( base_parent, _
-							 lexGetText( ), _
-							 FALSE, _
-							 TRUE )
+	                         lexGetText( ), _
+	                         FALSE, _
+	                         TRUE )
 
 end function
 

--- a/src/compiler/parser-identifier.bas
+++ b/src/compiler/parser-identifier.bas
@@ -506,7 +506,9 @@ function cParentId _
 		'' check visibility
 		if( parent <> NULL ) then
 			if( symbCheckAccess( sym ) = FALSE ) then
-				errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
+				if( (options and FB_IDOPT_ISDEFN) = 0 ) then
+					errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
+				end if
 			end if
 		end if
 

--- a/src/compiler/parser-proc.bas
+++ b/src/compiler/parser-proc.bas
@@ -1096,6 +1096,11 @@ function cProcHeader _
 		case FB_TK_CONSTRUCTOR, FB_TK_DESTRUCTOR
 			idopt or= FB_IDOPT_DONTCHKPERIOD
 		end select
+		'' don't check access if we are defining the procedure
+		'' (which must be done outside of the TYPE declaration)
+		if( (options and FB_PROCOPT_ISPROTO) = 0 ) then
+			idopt or= idopt or FB_IDOPT_ISDEFN
+		end if
 		parent = cParentId( idopt )
 	end if
 

--- a/src/compiler/parser-proccall-args.bas
+++ b/src/compiler/parser-proccall-args.bas
@@ -279,10 +279,10 @@ private function hOvlProcArgList _
 	) as ASTNODE ptr
 
 	dim as integer i = any, params = any, args = any, have_eq_outside_parens = any
-    dim as ASTNODE ptr procexpr = any
-    dim as FBSYMBOL ptr param = any, ovlproc = any
-    dim as FB_CALL_ARG ptr arg = any, nxt = any
-    dim as FB_ERRMSG err_num = any
+	dim as ASTNODE ptr procexpr = any
+	dim as FBSYMBOL ptr param = any, ovlproc = any
+	dim as FB_CALL_ARG ptr arg = any, nxt = any
+	dim as FB_ERRMSG err_num = any
 
 	function = NULL
 	have_eq_outside_parens = FALSE
@@ -377,7 +377,7 @@ private function hOvlProcArgList _
 		return astBuildFakeCall( proc )
 	end if
 
-    '' method?
+	'' method?
 	if( symbIsMethod( proc ) ) then
 		'' calling a method without the instance ptr?
 		if( (options and FB_PARSEROPT_HASINSTPTR) = 0 ) then
@@ -412,11 +412,11 @@ private function hOvlProcArgList _
 
 	procexpr = astNewCALL( proc, procexpr )
 
-    '' add to tree
+	'' add to tree
 	param = symbGetProcHeadParam( proc )
 	arg = arg_list->head
 	for i = 0 to args-1
-        nxt = arg->next
+		nxt = arg->next
 
 		if( astNewARG( procexpr, arg->expr, , arg->mode ) = NULL ) then
 			errReport( FB_ERRMSG_PARAMTYPEMISMATCH )
@@ -435,7 +435,7 @@ private function hOvlProcArgList _
 
 	'' add the end-of-list optional args, if any
 	params = symbGetProcParams( proc )
-    do while( args < params )
+	do while( args < params )
 		astNewARG( procexpr, NULL )
 
 		'' next
@@ -462,9 +462,9 @@ function cProcArgList _
 	) as ASTNODE ptr
 
 	dim as integer args = any, params = any, mode = any, have_eq_outside_parens = any
-    dim as FBSYMBOL ptr param = any
-    dim as ASTNODE ptr procexpr = any, expr = any
-    dim as FB_CALL_ARG ptr arg = any
+	dim as FBSYMBOL ptr param = any
+	dim as ASTNODE ptr procexpr = any, expr = any
+	dim as FB_CALL_ARG ptr arg = any
 
 	'' overloaded?
 	if( symbGetProcIsOverloaded( proc ) ) then
@@ -487,7 +487,7 @@ function cProcArgList _
 		return astBuildFakeCall( proc )
 	end if
 
-    '' method?
+	'' method?
 	if( symbIsMethod( proc ) ) then
 		'' calling a method without the instance ptr?
 		if( (options and FB_PARSEROPT_HASINSTPTR) = 0 ) then

--- a/src/compiler/parser-proccall-args.bas
+++ b/src/compiler/parser-proccall-args.bas
@@ -346,12 +346,12 @@ private function hOvlProcArgList _
 	end if
 
 	ovlproc = symbFindClosestOvlProc( proc, _
-									  args, _
-									  iif( (options and FB_PARSEROPT_HASINSTPTR) <> 0, _
-									  	   arg_list->head->next, _
-									  	   arg_list->head ), _
-									  @err_num, _
-									  lkup_options )
+	                                  args, _
+	                                  iif( (options and FB_PARSEROPT_HASINSTPTR) <> 0, _
+	                                       arg_list->head->next, _
+	                                       arg_list->head ), _
+	                                  @err_num, _
+	                                  lkup_options )
 
 	if( ovlproc = NULL ) then
 		symbFreeOvlCallArgs( @parser.ovlarglist, arg_list )

--- a/src/compiler/parser-proccall-args.bas
+++ b/src/compiler/parser-proccall-args.bas
@@ -367,7 +367,7 @@ private function hOvlProcArgList _
 
 	proc = ovlproc
 
-	'' check visibility
+	'' Check visibility of the procedure (to be called)
 	if( symbCheckAccess( proc ) = FALSE ) then
 		errReportEx( iif( symbIsConstructor( proc ), _
 		                  FB_ERRMSG_NOACCESSTOCTOR, _
@@ -477,7 +477,7 @@ function cProcArgList _
 	function = NULL
 	have_eq_outside_parens = FALSE
 
-	'' check visibility
+	'' Check visibility of the procedure (to be called)
 	if( symbCheckAccess( proc ) = FALSE ) then
 		errReportEx( iif( symbIsConstructor( proc ), _
 		                  FB_ERRMSG_NOACCESSTOCTOR, _

--- a/src/compiler/parser-quirk-mem.bas
+++ b/src/compiler/parser-quirk-mem.bas
@@ -151,7 +151,7 @@ function cOperatorNew( ) as ASTNODE ptr
 				if( op <> AST_OP_NEW_VEC ) then
 					initexpr = cCtorCall( subtype )
 				else
-					'' check visibility
+					'' Check visibility of the default constructor
 					if( symbCheckAccess( ctor ) = FALSE ) then
 						errReport( FB_ERRMSG_NOACCESSTODEFAULTCTOR )
 					end if
@@ -258,8 +258,9 @@ sub cOperatorDelete( )
 		errReport( FB_ERRMSG_INCOMPLETETYPE, TRUE )
 	end select
 
-	'' check visibility
+	'' Check visibility
 	if( typeHasDtor( typeDeref( dtype ), subtype ) ) then
+		'' Check visibility of the destructor
 		if( symbCheckAccess( symbGetCompDtor1( subtype ) ) = FALSE ) then
 			errReport( FB_ERRMSG_NOACCESSTODTOR )
 		end if

--- a/src/compiler/parser-quirk-mem.bas
+++ b/src/compiler/parser-quirk-mem.bas
@@ -10,7 +10,7 @@
 
 '':::::
 ''cOperatorNew =     NEW DataType|Constructor()
-''			   |	 NEW DataType[Expr] .
+''             |     NEW DataType[Expr] .
 ''
 function cOperatorNew( ) as ASTNODE ptr
 	dim as integer dtype = any
@@ -59,8 +59,8 @@ function cOperatorNew( ) as ASTNODE ptr
 	has_defctor = typeHasDefCtor( dtype, subtype )
 
 	'' '['?
-    if( lexGetToken( ) = CHAR_LBRACKET ) then
-        lexSkipToken( )
+	if( lexGetToken( ) = CHAR_LBRACKET ) then
+		lexSkipToken( )
 
 		elementsexpr = cExpression(  )
 		if( elementsexpr = NULL ) then
@@ -69,13 +69,13 @@ function cOperatorNew( ) as ASTNODE ptr
 			op = AST_OP_NEW_VEC
 		end if
 
-        '' ']'
-        if( lexGetToken( ) <> CHAR_RBRACKET ) then
+		'' ']'
+		if( lexGetToken( ) <> CHAR_RBRACKET ) then
 			errReport( FB_ERRMSG_EXPECTEDRBRACKET )
 			hSkipUntil( CHAR_RBRACKET )
-        else
-        	lexSkipToken( )
-        end if
+		else
+			lexSkipToken( )
+		end if
 
 		'' '{'?
 		if( lexGetToken( ) = CHAR_LBRACE ) then

--- a/src/compiler/parser-quirk-mem.bas
+++ b/src/compiler/parser-quirk-mem.bas
@@ -199,7 +199,7 @@ function cOperatorNew( ) as ASTNODE ptr
 	end if
 
 	expr = astBuildNewOp( op, tmp, elementsexpr, initexpr, _
-			dtype, subtype, do_clear, placementexpr )
+	                      dtype, subtype, do_clear, placementexpr )
 
 	if( expr = NULL ) then
 		errReport( FB_ERRMSG_INVALIDDATATYPES )

--- a/src/compiler/parser.bi
+++ b/src/compiler/parser.bi
@@ -216,6 +216,7 @@ enum FB_IDOPT
 	FB_IDOPT_CHECKSTATIC        = &h00000020
 	FB_IDOPT_ISVAR              = &h00000040  '' parsing namespace prefix for variable declaration?
 	FB_IDOPT_NOSKIP             = &h00000080  '' don't skip unused token, caller will do it
+	FB_IDOPT_ISDEFN             = &h00000100  '' is definition (i,e, procedure definition), ignore some access checks
 
 	FB_IDOPT_DEFAULT            = FB_IDOPT_SHOWERROR or FB_IDOPT_CHECKSTATIC
 end enum

--- a/src/compiler/rtl-array.bas
+++ b/src/compiler/rtl-array.bas
@@ -303,6 +303,7 @@ private sub hCheckDefCtor _
 	assert( symbIsConstructor( ctor ) )
 
 	if( check_access ) then
+		'' Check visibility of the default constructor
 		if( symbCheckAccess( ctor ) = FALSE ) then
 			errReport( FB_ERRMSG_NOACCESSTODEFAULTCTOR )
 		end if
@@ -334,6 +335,7 @@ private sub hCheckDtor _
 	assert( symbIsDestructor1( dtor ) )
 
 	if( check_access ) then
+		'' Check visibility of the default destructor
 		if( symbCheckAccess( dtor ) = FALSE ) then
 			errReport( FB_ERRMSG_NOACCESSTODTOR )
 		end if

--- a/src/compiler/rtl-array.bas
+++ b/src/compiler/rtl-array.bas
@@ -727,8 +727,8 @@ function rtlArrayBound _
 	function = NULL
 
 	proc = astNewCALL( iif( islbound, _
-				PROCLOOKUP( ARRAYLBOUND ), _
-				PROCLOOKUP( ARRAYUBOUND ) ) )
+	                   PROCLOOKUP( ARRAYLBOUND ), _
+	                   PROCLOOKUP( ARRAYUBOUND ) ) )
 
 	'' array() as ANY
 	if( astNewARG( proc, arrayexpr ) = NULL ) then

--- a/src/compiler/rtl-array.bas
+++ b/src/compiler/rtl-array.bas
@@ -351,7 +351,7 @@ private sub hCheckDtor _
 
 end sub
 
-'' fb_ArrayClear* 
+'' fb_ArrayClear*
 '' destruct elements if needed and then re-initialize
 ''
 '' fb_ArrayClear* rtlib functions are called when it is known at
@@ -407,7 +407,7 @@ function rtlArrayClear( byval arrayexpr as ASTNODE ptr ) as ASTNODE ptr
 		end if
 
 	elseif( dtype = FB_DATATYPE_STRING ) then
-		'' fb_ArrayDestructStr() to clear the string array 
+		'' fb_ArrayDestructStr() to clear the string array
 		'' - there is no fb_ArrayClearStr() in rtlib
 		proc = astNewCALL( PROCLOOKUP( ARRAYDESTRUCTSTR ) )
 
@@ -557,13 +557,13 @@ function rtlArrayRedim _
 		byval dopreserve as integer, _
 		byval doclear as integer _
 	) as ASTNODE ptr
-	
+
 	'' no const filtering needed... dynamic arrays can't be const
-	
-    dim as ASTNODE ptr proc = any, expr = any
+
+	dim as ASTNODE ptr proc = any, expr = any
 	dim as FBSYMBOL ptr f = any, sym = any, subtype = any
 	dim as FBSYMBOL ptr ctor = any, dtor = any
-    dim as integer dtype = any
+	dim as integer dtype = any
 	dim as longint elementlen = any
 
 	sym = astGetSymbol( arrayexpr )
@@ -572,7 +572,7 @@ function rtlArrayRedim _
 
 	hGetCtorDtorForRedim( dtype, symbGetSubtype( sym ), ctor, dtor )
 
-    if( (ctor = NULL) and (dtor = NULL) ) then
+	if( (ctor = NULL) and (dtor = NULL) ) then
 		if( dopreserve = FALSE ) then
 			f = PROCLOOKUP( ARRAYREDIM )
 		else
@@ -586,7 +586,7 @@ function rtlArrayRedim _
 		end if
 	end if
 
-    proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
 	'' array() as ANY
 	if( astNewARG( proc, arrayexpr ) = NULL ) then
@@ -753,19 +753,19 @@ function rtlArrayBoundsCheck _
 		byval module as zstring ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
-    dim as FBSYMBOL ptr f = any
+	dim as ASTNODE ptr proc = any
+	dim as FBSYMBOL ptr f = any
 
-   	function = NULL
+	function = NULL
 
-   	'' lbound 0? do a single check
-   	if( lb = NULL ) then
+	'' lbound 0? do a single check
+	if( lb = NULL ) then
 		f = PROCLOOKUP( ARRAYSNGBOUNDCHK )
 	else
-    	f = PROCLOOKUP( ARRAYBOUNDCHK )
+		f = PROCLOOKUP( ARRAYBOUNDCHK )
 	end if
 
-   	proc = astNewCALL( f )
+	proc = astNewCALL( f )
 
 	'' idx
 	if( astNewARG( proc, astNewCONV( FB_DATATYPE_INTEGER, NULL, idx, AST_CONVOPT_DONTWARNCONST ) ) = NULL ) then
@@ -789,11 +789,11 @@ function rtlArrayBoundsCheck _
 		exit function
 	end if
 
-    '' module
+	'' module
 	if( astNewARG( proc, astNewCONSTstr( module ) ) = NULL ) then
-    	exit function
-    end if
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function

--- a/src/compiler/rtl-mem.bas
+++ b/src/compiler/rtl-mem.bas
@@ -309,6 +309,7 @@ function rtlMemNewOp _
 		assert( (astGetOpSelfVer( op ) = AST_OP_NEW_SELF) or (astGetOpSelfVer( op ) = AST_OP_NEW_VEC_SELF) )
 		sym = symbGetCompOpOvlHead( subtype, astGetOpSelfVer( op ) )
 		if( sym ) then
+			'' Check visibility of the new operator
 			if( symbCheckAccess( sym ) = FALSE ) then
 				errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
 			end if
@@ -355,6 +356,7 @@ function rtlMemDeleteOp _
 		assert( (astGetOpSelfVer( op ) = AST_OP_DEL_SELF) or (astGetOpSelfVer( op ) = AST_OP_DEL_VEC_SELF) )
 		sym = symbGetCompOpOvlHead( subtype, astGetOpSelfVer( op ) )
 		if( sym ) then
+			'' Check visibility of the delete operator
 			if( symbCheckAccess( sym ) = FALSE ) then
 				errReport( FB_ERRMSG_ILLEGALMEMBERACCESS )
 			end if

--- a/src/compiler/rtl-mem.bas
+++ b/src/compiler/rtl-mem.bas
@@ -81,7 +81,7 @@
 		( _
 			@"callocate", @"calloc", _
 			typeAddrOf( FB_DATATYPE_VOID ), FB_FUNCMODE_CDECL, _
- 			NULL, FB_RTL_OPT_NOQB, _
+			NULL, FB_RTL_OPT_NOQB, _
 			2, _
 			{ _
 				( typeSetIsConst( FB_DATATYPE_UINT ), FB_PARAMMODE_BYVAL, FALSE ), _
@@ -188,11 +188,11 @@ function rtlNullPtrCheck _
 		byval module as zstring ptr _
 	) as ASTNODE ptr
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
-   	function = NULL
+	function = NULL
 
-   	proc = astNewCALL( PROCLOOKUP( NULLPTRCHK ) )
+	proc = astNewCALL( PROCLOOKUP( NULLPTRCHK ) )
 
 	'' ptr
 	'' we are forcing a CAST to any ptr, so quiet the const checks with AST_CONVOPT_DONTWARNCONST
@@ -207,12 +207,12 @@ function rtlNullPtrCheck _
 		exit function
 	end if
 
-    '' module
+	'' module
 	if( astNewARG( proc, astNewCONSTstr( module ) ) = NULL ) then
-    	exit function
-    end if
+		exit function
+	end if
 
-    function = proc
+	function = proc
 
 end function
 
@@ -259,37 +259,37 @@ function rtlMemCopyClear _
 		byval srclen as longint _
 	) as integer
 
-    dim as ASTNODE ptr proc = any
+	dim as ASTNODE ptr proc = any
 
 	function = FALSE
 
 	''
-    proc = astNewCALL( PROCLOOKUP( MEMCOPYCLEAR ) )
+	proc = astNewCALL( PROCLOOKUP( MEMCOPYCLEAR ) )
 
-    '' dst as any
-    if( astNewARG( proc, dstexpr ) = NULL ) then
-    	exit function
-    end if
+	'' dst as any
+	if( astNewARG( proc, dstexpr ) = NULL ) then
+		exit function
+	end if
 
 	'' byval dstlen as integer
 	if( astNewARG( proc, astNewCONSTi( dstlen ) ) = NULL ) then
 		exit function
 	end if
 
-    '' src as any
-    if( astNewARG( proc, srcexpr ) = NULL ) then
-    	exit function
-    end if
+	'' src as any
+	if( astNewARG( proc, srcexpr ) = NULL ) then
+		exit function
+	end if
 
 	'' byval srclen as integer
 	if( astNewARG( proc, astNewCONSTi( srclen ) ) = NULL ) then
 		exit function
 	end if
 
-    ''
-    astAdd( proc )
+	''
+	astAdd( proc )
 
-    function = TRUE
+	function = TRUE
 
 end function
 
@@ -322,8 +322,8 @@ function rtlMemNewOp _
 	if( sym = NULL ) then
 
 		sym = rtlProcLookup( @"allocate", FB_RTL_IDX_ALLOCATE )
-		
-		'' maybe had '#undef allocate'? 
+
+		'' maybe had '#undef allocate'?
 		if( sym = NULL ) then
 			'' rtlProcLookup() already reported the error
 			return NULL
@@ -369,7 +369,7 @@ function rtlMemDeleteOp _
 	if( sym = NULL ) then
 		sym = rtlProcLookup( @"deallocate", FB_RTL_IDX_DEALLOCATE )
 
-		'' maybe had '#undef deallocate'? 
+		'' maybe had '#undef deallocate'?
 		if( sym = NULL ) then
 			'' rtlProcLookup() already reported the error
 			return NULL

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -550,10 +550,14 @@ sub symbMangleType _
 		if( ns = @symbGetGlobalNamespc( ) ) then
 			hMangleUdtId( mangled, subtype )
 		else
-			mangled += "N"
-			symbMangleType( mangled, symbGetFullType( ns ), ns )
+			if( (options and FB_MANGLEOPT_NESTED) = 0 ) then
+				mangled += "N"
+			end if
+			symbMangleType( mangled, symbGetFullType( ns ), ns, FB_MANGLEOPT_NESTED )
 			hMangleUdtId( mangled, subtype )
-			mangled += "E"
+			if( (options and FB_MANGLEOPT_NESTED) = 0 ) then
+				mangled += "E"
+			end if
 		end if
 
 		hAbbrevAdd( dtype, subtype )

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -106,7 +106,7 @@ function symbGetDBGName( byval sym as FBSYMBOL ptr ) as zstring ptr
 		select case as const symbGetClass( sym )
 		'' but UDT's, they shouldn't include any mangling at all..
 		case FB_SYMBCLASS_ENUM, FB_SYMBCLASS_STRUCT, _
-			 FB_SYMBCLASS_CLASS, FB_SYMBCLASS_NAMESPACE
+			FB_SYMBCLASS_CLASS, FB_SYMBCLASS_NAMESPACE
 
 			'' check if an alias wasn't given
 			dim as zstring ptr res = sym->id.alias
@@ -204,7 +204,7 @@ function symbGetMangledName( byval sym as FBSYMBOL ptr ) as zstring ptr
 	case FB_SYMBCLASS_PROC
 		hMangleProc( sym )
 	case FB_SYMBCLASS_ENUM, FB_SYMBCLASS_STRUCT, FB_SYMBCLASS_FWDREF, _
-	     FB_SYMBCLASS_CLASS, FB_SYMBCLASS_NAMESPACE
+		FB_SYMBCLASS_CLASS, FB_SYMBCLASS_NAMESPACE
 		dim as string mangled
 		hMangleNamespace( mangled, symbGetNamespace( sym ), TRUE, FALSE )
 		hMangleUdtId( mangled, sym )
@@ -741,8 +741,9 @@ private sub hMangleVariable( byval sym as FBSYMBOL ptr )
 	'' prefix
 	'' public global/static?
 	if( sym->attrib and (FB_SYMBATTRIB_PUBLIC or FB_SYMBATTRIB_EXTERN or _
-	                     FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_COMMON or _
-	                     FB_SYMBATTRIB_STATIC) ) then
+		FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_COMMON or _
+		FB_SYMBATTRIB_STATIC) ) then
+
 		'' LLVM: @ prefix for global symbols
 		if( env.clopt.backend = FB_BACKEND_LLVM ) then
 			mangled += "@"
@@ -798,7 +799,7 @@ private sub hMangleVariable( byval sym as FBSYMBOL ptr )
 	else
 		'' shared, public, extern or inside a ns?
 		isglobal = ((sym->attrib and (FB_SYMBATTRIB_PUBLIC or FB_SYMBATTRIB_EXTERN or _
-		                              FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_COMMON)) <> 0)
+			FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_COMMON)) <> 0)
 
 		if( isglobal or docpp ) then
 			'' BASIC? use the upper-cased name

--- a/src/compiler/symb-mangling.bas
+++ b/src/compiler/symb-mangling.bas
@@ -106,7 +106,7 @@ function symbGetDBGName( byval sym as FBSYMBOL ptr ) as zstring ptr
 		select case as const symbGetClass( sym )
 		'' but UDT's, they shouldn't include any mangling at all..
 		case FB_SYMBCLASS_ENUM, FB_SYMBCLASS_STRUCT, _
-			FB_SYMBCLASS_CLASS, FB_SYMBCLASS_NAMESPACE
+		     FB_SYMBCLASS_CLASS, FB_SYMBCLASS_NAMESPACE
 
 			'' check if an alias wasn't given
 			dim as zstring ptr res = sym->id.alias
@@ -204,7 +204,7 @@ function symbGetMangledName( byval sym as FBSYMBOL ptr ) as zstring ptr
 	case FB_SYMBCLASS_PROC
 		hMangleProc( sym )
 	case FB_SYMBCLASS_ENUM, FB_SYMBCLASS_STRUCT, FB_SYMBCLASS_FWDREF, _
-		FB_SYMBCLASS_CLASS, FB_SYMBCLASS_NAMESPACE
+	     FB_SYMBCLASS_CLASS, FB_SYMBCLASS_NAMESPACE
 		dim as string mangled
 		hMangleNamespace( mangled, symbGetNamespace( sym ), TRUE, FALSE )
 		hMangleUdtId( mangled, sym )
@@ -467,7 +467,7 @@ sub symbMangleType _
 		mangled += "R"
 
 		symbMangleType( mangled, typeUnsetIsRef( dtype ), subtype, _
-			options or FB_MANGLEOPT_HASREF or FB_MANGLEOPT_KEEPTOPCONST)
+		                options or FB_MANGLEOPT_HASREF or FB_MANGLEOPT_KEEPTOPCONST)
 
 		hAbbrevAdd( dtype, subtype )
 		exit sub
@@ -500,7 +500,7 @@ sub symbMangleType _
 		mangled += "P"
 
 		symbMangleType( mangled, typeDeref( dtype ), subtype, _
-			options or FB_MANGLEOPT_HASPTR or FB_MANGLEOPT_KEEPTOPCONST )
+		                options or FB_MANGLEOPT_HASPTR or FB_MANGLEOPT_KEEPTOPCONST )
 
 		hAbbrevAdd( dtype, subtype )
 		exit sub
@@ -745,8 +745,8 @@ private sub hMangleVariable( byval sym as FBSYMBOL ptr )
 	'' prefix
 	'' public global/static?
 	if( sym->attrib and (FB_SYMBATTRIB_PUBLIC or FB_SYMBATTRIB_EXTERN or _
-		FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_COMMON or _
-		FB_SYMBATTRIB_STATIC) ) then
+	                     FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_COMMON or _
+	                     FB_SYMBATTRIB_STATIC) ) then
 
 		'' LLVM: @ prefix for global symbols
 		if( env.clopt.backend = FB_BACKEND_LLVM ) then
@@ -803,7 +803,7 @@ private sub hMangleVariable( byval sym as FBSYMBOL ptr )
 	else
 		'' shared, public, extern or inside a ns?
 		isglobal = ((sym->attrib and (FB_SYMBATTRIB_PUBLIC or FB_SYMBATTRIB_EXTERN or _
-			FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_COMMON)) <> 0)
+		                              FB_SYMBATTRIB_SHARED or FB_SYMBATTRIB_COMMON)) <> 0)
 
 		if( isglobal or docpp ) then
 			'' BASIC? use the upper-cased name
@@ -1231,8 +1231,8 @@ private sub hMangleProc( byval sym as FBSYMBOL ptr )
 	'' * only for ASM/LLVM backends, but not for the C backend, because gcc
 	''   will do it already
 	add_stdcall_suffix = (sym->proc.mode = FB_FUNCMODE_STDCALL) and _
-				(fbGetCpuFamily( ) = FB_CPUFAMILY_X86) and _
-				(env.clopt.backend <> FB_BACKEND_GCC)
+	                     (fbGetCpuFamily( ) = FB_CPUFAMILY_X86) and _
+	                     (env.clopt.backend <> FB_BACKEND_GCC)
 
 	'' LLVM: @ prefix for global symbols
 	if( env.clopt.backend = FB_BACKEND_LLVM ) then

--- a/src/compiler/symb-proc.bas
+++ b/src/compiler/symb-proc.bas
@@ -2395,7 +2395,7 @@ function symbFindSelfBopOvlProc _
 			errReport( *err_num, TRUE )
 		end if
 	else
-		'' check visibility
+		'' Check visibility of the operator
 		if( symbCheckAccess( proc ) = FALSE ) then
 			*err_num = FB_ERRMSG_ILLEGALMEMBERACCESS
 			errReportEx( FB_ERRMSG_ILLEGALMEMBERACCESS, _
@@ -2490,7 +2490,7 @@ function symbFindSelfUopOvlProc _
 		end if
 
 	else
-		'' check visibility
+		'' Check visibility of the operator
 		if( symbCheckAccess( proc ) = FALSE ) then
 			*err_num = FB_ERRMSG_ILLEGALMEMBERACCESS
 			errReportEx( FB_ERRMSG_ILLEGALMEMBERACCESS, _
@@ -2665,7 +2665,7 @@ function symbFindCastOvlProc _
 		closest_proc = NULL
 	else
 		if( closest_proc <> NULL ) then
-			'' check visibility
+			'' Check visibility of cast operator
 			if( symbCheckAccess( closest_proc ) = FALSE ) then
 				*err_num = FB_ERRMSG_ILLEGALMEMBERACCESS
 				errReportEx( FB_ERRMSG_ILLEGALMEMBERACCESS, _

--- a/src/compiler/symb-proc.bas
+++ b/src/compiler/symb-proc.bas
@@ -535,14 +535,14 @@ private function hAddOvlProc _
 
 				'' check the const qualifier
 				if( (typeGetConstMask( pdtype ) or _
-					typeGetConstMask( odtype )) <> 0 ) then
+				     typeGetConstMask( odtype )) <> 0 ) then
 
 					'' both byref?
 					if( (param->param.mode = FB_PARAMMODE_BYREF ) _
-						and (ovl_param->param.mode = FB_PARAMMODE_BYREF )) then
+					    and (ovl_param->param.mode = FB_PARAMMODE_BYREF )) then
 
 						if( typeGetConstMask( pdtype ) <> _
-							typeGetConstMask( odtype ) ) then
+						    typeGetConstMask( odtype ) ) then
 							exit do
 						end if
 
@@ -550,7 +550,7 @@ private function hAddOvlProc _
 
 					'' else only matters if it's a 'const ptr' (as in C++)
 					if( typeGetPtrConstMask( pdtype ) <> _
-						typeGetPtrConstMask( odtype ) ) then
+					    typeGetPtrConstMask( odtype ) ) then
 						exit do
 					end if
 
@@ -719,7 +719,7 @@ private function hSetupProc _
 
 	'' ctor/dtor?
 	if( (pattrib and (FB_PROCATTRIB_CONSTRUCTOR or _
-					 FB_PROCATTRIB_DESTRUCTOR1 or FB_PROCATTRIB_DESTRUCTOR0)) <> 0 ) then
+	                  FB_PROCATTRIB_DESTRUCTOR1 or FB_PROCATTRIB_DESTRUCTOR0)) <> 0 ) then
 
 		assert( pattrib and FB_PROCATTRIB_METHOD )
 
@@ -1277,7 +1277,7 @@ function symbAddProcPtrFromFunction _
 	var param = symbGetProcHeadParam( base_proc )
 	do while( param <> NULL )
 		var p = symbAddProcParam( proc, NULL, param->typ, param->subtype, _
-				param->param.bydescdimensions, param->param.mode, param->attrib, param->pattrib )
+		                          param->param.bydescdimensions, param->param.mode, param->attrib, param->pattrib )
 
 		if( symbGetDontInit( param ) ) then
 			symbSetDontInit( p )
@@ -1296,7 +1296,8 @@ function symbAddProcPtrFromFunction _
 	var pattribmask = FB_PROCATTRIB_RETURNBYREF '' return byref
 	pattribmask or = FB_PROCATTRIB_NOTHISCONSTNESS '' method call THIS CONSTness checking
 
-	function = symbAddProcPtr( proc, _
+	function = _
+		symbAddProcPtr( proc, _
 			symbGetFullType( base_proc ), symbGetSubtype( base_proc ), _
 			base_proc->attrib and attribmask, base_proc->pattrib and pattribmask, _
 			symbGetProcMode( base_proc ) )
@@ -1549,7 +1550,7 @@ function symbFindOverloadProc _
 
 	'' procs?
 	if( (symbGetClass( ovl_head_proc ) <> FB_SYMBCLASS_PROC) or _
-		(symbGetClass( proc ) <> FB_SYMBCLASS_PROC) ) then
+	    (symbGetClass( proc ) <> FB_SYMBCLASS_PROC) ) then
 		return NULL
 	end if
 
@@ -2398,7 +2399,7 @@ function symbFindSelfBopOvlProc _
 		if( symbCheckAccess( proc ) = FALSE ) then
 			*err_num = FB_ERRMSG_ILLEGALMEMBERACCESS
 			errReportEx( FB_ERRMSG_ILLEGALMEMBERACCESS, _
-						 symbGetFullProcName( proc ) )
+			             symbGetFullProcName( proc ) )
 
 			proc = NULL
 		end if
@@ -2493,7 +2494,7 @@ function symbFindSelfUopOvlProc _
 		if( symbCheckAccess( proc ) = FALSE ) then
 			*err_num = FB_ERRMSG_ILLEGALMEMBERACCESS
 			errReportEx( FB_ERRMSG_ILLEGALMEMBERACCESS, _
-						 symbGetFullProcName( proc ) )
+			             symbGetFullProcName( proc ) )
 
 			proc = NULL
 		end if
@@ -2668,7 +2669,7 @@ function symbFindCastOvlProc _
 			if( symbCheckAccess( closest_proc ) = FALSE ) then
 				*err_num = FB_ERRMSG_ILLEGALMEMBERACCESS
 				errReportEx( FB_ERRMSG_ILLEGALMEMBERACCESS, _
-							 symbGetFullProcName( closest_proc ) )
+				             symbGetFullProcName( closest_proc ) )
 				closest_proc = NULL
 			end if
 		end if
@@ -2866,8 +2867,8 @@ function symbCalcProcMatch _
 	''   which doesn't take result type into account.
 	'' - SUBs have VOID result type and will be handled here too
 	var match = typeCalcMatch( l->typ, l->subtype, _
-			iif( symbIsReturnByRef( l ), FB_PARAMMODE_BYREF, FB_PARAMMODE_BYVAL ), _
-			r->typ, r->subtype )
+	                           iif( symbIsReturnByRef( l ), FB_PARAMMODE_BYREF, FB_PARAMMODE_BYVAL ), _
+	                           r->typ, r->subtype )
 	if( match = FB_OVLPROC_NO_MATCH ) then
 		errmsg = FB_ERRMSG_OVERRIDERETTYPEDIFFERS
 		return FB_OVLPROC_NO_MATCH

--- a/src/compiler/symb-proc.bas
+++ b/src/compiler/symb-proc.bas
@@ -246,7 +246,7 @@ function symbAddProcParam _
 	'' for UDTs, check if not including a byval param to self
 	if( typeGet( dtype ) = FB_DATATYPE_STRUCT ) then
 		if( mode = FB_PARAMMODE_BYVAL ) then
-			if( subtype = symbGetCurrentNamespc( ) ) then
+			if( symbIsParentNamespace( dtype, subtype ) ) then
 				symbSetUdtHasRecByvalParam( subtype )
 			end if
 		end if
@@ -335,8 +335,8 @@ sub symbProcRecalcRealType( byval proc as FBSYMBOL ptr )
 
 	'' UDT? follow GCC 3.x's ABI
 	case FB_DATATYPE_STRUCT
-		'' still parsing the struct? patch it later..
-		if( subtype = symbGetCurrentNamespc( ) ) then
+		'' still parsing the struct or any inner type? patch it later..
+		if( symbIsParentNamespace( dtype, subtype ) ) then
 			symbSetUdtHasRecByvalRes( subtype )
 		else
 			dtype = symbGetUDTRetType( subtype )

--- a/src/compiler/symb-var.bas
+++ b/src/compiler/symb-var.bas
@@ -623,8 +623,7 @@ function symbAddVar _
 
 	'' Static member var using parent UDT as dtype? Length must be
 	'' recalculated later, when UDT was fully parsed...
-	if( (symbGetType( s ) = FB_DATATYPE_STRUCT) and _
-	    (s->subtype = symbGetCurrentNamespc( )) ) then
+	if( symbIsParentNamespace( symbGetType( s ), s->subtype ) ) then
 		symbSetUdtHasRecByvalRes( subtype )
 	end if
 

--- a/src/compiler/symb-var.bas
+++ b/src/compiler/symb-var.bas
@@ -547,9 +547,9 @@ function symbAddVar _
 
 	''
 	isglobal = (attrib and (FB_SYMBATTRIB_PUBLIC or _
-		FB_SYMBATTRIB_EXTERN or _
-		FB_SYMBATTRIB_SHARED or _
-		FB_SYMBATTRIB_COMMON)) <> 0
+	                        FB_SYMBATTRIB_EXTERN or _
+	                        FB_SYMBATTRIB_SHARED or _
+	                        FB_SYMBATTRIB_COMMON)) <> 0
 
 	''
 	if( lgt <= 0 ) then
@@ -913,8 +913,8 @@ function symbCloneVar( byval sym as FBSYMBOL ptr ) as FBSYMBOL ptr
 		end if
 
 		function = symbAddVar( symbGetName( sym ), NULL, _
-				symbGetType( sym ), symbGetSubType( sym ), 0, _
-				symbGetArrayDimensions( sym ), dTB(), symbGetAttrib( sym ), 0 )
+		                       symbGetType( sym ), symbGetSubType( sym ), 0, _
+		                       symbGetArrayDimensions( sym ), dTB(), symbGetAttrib( sym ), 0 )
 	end if
 end function
 

--- a/src/compiler/symb.bas
+++ b/src/compiler/symb.bas
@@ -2314,7 +2314,7 @@ function symbIsParentNamespace _
 	( _
 		byval dtype as FB_DATATYPE, _
 		byval subtype as FBSYMBOL ptr,  _
-		byval ns as FBSYMBOL ptr = NULL _
+		byval start_ns as FBSYMBOL ptr = NULL _
 	) as integer
 
 	'' Check if dtype/subtype is a parent of namespace (ns)
@@ -2331,8 +2331,8 @@ function symbIsParentNamespace _
 		return FALSE
 	end if
 
-	if( ns ) then
-		context = ns
+	if( start_ns ) then
+		context = start_ns
 	else
 		context = symbGetCurrentNamespc( )
 	end if
@@ -2349,7 +2349,11 @@ function symbIsParentNamespace _
 
 end function
 
-function symbCheckAccess( byval sym as FBSYMBOL ptr ) as integer
+function symbCheckAccess _
+	( _
+		byval sym as FBSYMBOL ptr _
+	) as integer
+
 	dim as FBSYMBOL ptr parent = any, context = any
 
 	'' Neither private nor protected? Always ok.

--- a/src/compiler/symb.bas
+++ b/src/compiler/symb.bas
@@ -254,15 +254,15 @@ function symbCanDuplicate _
 	select case as const s->class
 	'' adding a define, keyword, namespace, class or field?
 	case FB_SYMBCLASS_DEFINE, FB_SYMBCLASS_KEYWORD, _
-		FB_SYMBCLASS_NAMESPACE, FB_SYMBCLASS_CLASS, _
-		FB_SYMBCLASS_FIELD
+	     FB_SYMBCLASS_NAMESPACE, FB_SYMBCLASS_CLASS, _
+	     FB_SYMBCLASS_FIELD
 
 		'' no dups allowed
 		exit function
 
 	'' struct, enum or typedef?
 	case FB_SYMBCLASS_STRUCT, FB_SYMBCLASS_ENUM, _
-		FB_SYMBCLASS_TYPEDEF
+	     FB_SYMBCLASS_TYPEDEF
 
 		'' note: if it's a struct, we don't have to check if it's unique,
 		'' because that will be only set after the symbol is added
@@ -272,9 +272,9 @@ function symbCanDuplicate _
 			'' anything but a define or themselves is allowed (keywords
 			'' (but quirk-keywords) are refused when parsing)
 			case FB_SYMBCLASS_DEFINE, FB_SYMBCLASS_NAMESPACE, _
-				FB_SYMBCLASS_STRUCT, FB_SYMBCLASS_ENUM, _
-				FB_SYMBCLASS_TYPEDEF, FB_SYMBCLASS_CLASS, _
-				FB_SYMBCLASS_FIELD
+			     FB_SYMBCLASS_STRUCT, FB_SYMBCLASS_ENUM, _
+			     FB_SYMBCLASS_TYPEDEF, FB_SYMBCLASS_CLASS, _
+			     FB_SYMBCLASS_FIELD
 
 				exit function
 			end select
@@ -290,7 +290,7 @@ function symbCanDuplicate _
 			'' anything but a define or another forward ref is allowed (keywords
 			'' (but quirk-keywords) are refused when parsing)
 			case FB_SYMBCLASS_DEFINE, FB_SYMBCLASS_NAMESPACE, _
-				FB_SYMBCLASS_FWDREF, FB_SYMBCLASS_CLASS
+			     FB_SYMBCLASS_FWDREF, FB_SYMBCLASS_CLASS
 
 				exit function
 
@@ -311,7 +311,7 @@ function symbCanDuplicate _
 			select case as const head_sym->class
 			'' only dup allowed are labels and UDTs
 			case FB_SYMBCLASS_LABEL, FB_SYMBCLASS_ENUM, _
-				FB_SYMBCLASS_TYPEDEF, FB_SYMBCLASS_FWDREF
+			     FB_SYMBCLASS_TYPEDEF, FB_SYMBCLASS_FWDREF
 
 			'' struct? only it's not unique
 			case FB_SYMBCLASS_STRUCT
@@ -363,7 +363,7 @@ function symbCanDuplicate _
 			select case as const head_sym->class
 			'' allow labels or UDTs as dups
 			case FB_SYMBCLASS_LABEL, FB_SYMBCLASS_ENUM, _
-				FB_SYMBCLASS_TYPEDEF, FB_SYMBCLASS_FWDREF
+			     FB_SYMBCLASS_TYPEDEF, FB_SYMBCLASS_FWDREF
 
 			'' struct? only it's not unique
 			case FB_SYMBCLASS_STRUCT
@@ -437,8 +437,8 @@ function symbCanDuplicate _
 			select case as const head_sym->class
 			'' anything but a define, keyword or another label is allowed
 			case FB_SYMBCLASS_DEFINE, FB_SYMBCLASS_NAMESPACE, _
-				FB_SYMBCLASS_KEYWORD, FB_SYMBCLASS_LABEL, _
-				FB_SYMBCLASS_CLASS
+			     FB_SYMBCLASS_KEYWORD, FB_SYMBCLASS_LABEL, _
+			     FB_SYMBCLASS_CLASS
 
 				exit function
 
@@ -464,8 +464,8 @@ function symbCanDuplicate _
 			select case as const head_sym->class
 			'' only allow if it's in a different scope or namespace
 			case FB_SYMBCLASS_DEFINE, FB_SYMBCLASS_NAMESPACE, _
-				FB_SYMBCLASS_VAR, FB_SYMBCLASS_CONST, _
-				FB_SYMBCLASS_RESERVED
+			     FB_SYMBCLASS_VAR, FB_SYMBCLASS_CONST, _
+			     FB_SYMBCLASS_RESERVED
 				if( (s->scope = head_sym->scope) and (symbGetNamespace(s) = symbGetNamespace(head_sym)) ) then
 					exit function
 				end if
@@ -552,7 +552,7 @@ function symbNewSymbol _
 	'' QB quirks
 	if( (options and FB_SYMBOPT_UNSCOPE) <> 0 ) then
 		if( (parser.currproc->stats and (FB_SYMBSTATS_MAINPROC or _
-										FB_SYMBSTATS_MODLEVELPROC)) <> 0 ) then
+		                                 FB_SYMBSTATS_MODLEVELPROC)) <> 0 ) then
 			s->scope = FB_MAINSCOPE
 		else
 			s->scope = parser.currproc->scope + 1
@@ -778,15 +778,16 @@ sub symbHashListInsertNamespace _
 				chain_->prev = NULL
 				chain_->isimport = TRUE
 
-				dim as FBSYMCHAIN ptr head = hashLookupEx( @symb.imphashtb, _
-														s->id.name, _
-														s->hash.index )
+				dim as FBSYMCHAIN ptr head = _
+					hashLookupEx( @symb.imphashtb, _
+					              s->id.name, _
+					              s->hash.index )
 				'' not defined yet? create a new hash node
 				if( head = NULL ) then
 					chain_->item = hashAdd( @symb.imphashtb, _
-											s->id.name, _
-											chain_, _
-											s->hash.index )
+					                        s->id.name, _
+					                        chain_, _
+					                        s->hash.index )
 					chain_->next = NULL
 
 				'' already defined..
@@ -1482,7 +1483,7 @@ function symbLookupAt _
 		'' Are we in a type's namespace?  Only search for inherited members
 		select case symbGetClass( ns )
 		case FB_SYMBCLASS_STRUCT, FB_SYMBCLASS_CLASS
-			return hLookupImportListByParents( ns, id, index )	
+			return hLookupImportListByParents( ns, id, index )
 		end select
 	end if
 
@@ -2554,8 +2555,8 @@ private function hSymbCheckConstAssignFuncPtr _
 
 	'' check for identical return type
 	var match = typeCalcMatch( lsubtype->typ, lsubtype->subtype, _
-			iif( symbIsReturnByRef( lsubtype ), FB_PARAMMODE_BYREF, FB_PARAMMODE_BYVAL ), _
-			rsubtype->typ, rsubtype->subtype )
+	                           iif( symbIsReturnByRef( lsubtype ), FB_PARAMMODE_BYREF, FB_PARAMMODE_BYVAL ), _
+	                           rsubtype->typ, rsubtype->subtype )
 	if( match = FB_OVLPROC_NO_MATCH ) then
 		wrnmsg = FB_WARNINGMSG_RETURNTYPEMISMATCH
 		exit function
@@ -2832,8 +2833,8 @@ function typeDumpToStr _
 		else
 			select case( typeGetDtOnly( dtype ) )
 			case FB_DATATYPE_STRUCT, FB_DATATYPE_ENUM, _
-				FB_DATATYPE_NAMESPC, _
-				FB_DATATYPE_FUNCTION, FB_DATATYPE_FWDREF
+			     FB_DATATYPE_NAMESPC, _
+			     FB_DATATYPE_FUNCTION, FB_DATATYPE_FWDREF
 				ok = FALSE
 			case else
 				ok = TRUE
@@ -2845,7 +2846,7 @@ function typeDumpToStr _
 		dump += ", "
 		if( subtype ) then
 			if( (subtype->class >= FB_SYMBCLASS_VAR) and _
-				(subtype->class <  FB_SYMBCLASS_NSIMPORT) ) then
+			    (subtype->class <  FB_SYMBCLASS_NSIMPORT) ) then
 				dump += *classnames(subtype->class)
 			else
 				dump += str( subtype->class )

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -1962,6 +1962,11 @@ declare function symbCheckAccess _
 		byval sym as FBSYMBOL ptr _
 	) as integer
 
+declare function symbCheckAccessStruct _
+	( _
+		byval sym as FBSYMBOL ptr _
+	) as integer
+
 declare function symbGetFullProcName _
 	( _
 		byval proc as FBSYMBOL ptr _

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -273,10 +273,11 @@ end enum
 
 ''
 enum FB_MANGLEOPT
-	FB_MANGLEOPT_NONE         = 0  '' no special options
-	FB_MANGLEOPT_KEEPTOPCONST = 1  '' keep the top-level const when mangling
-	FB_MANGLEOPT_HASPTR       = 2  '' mangled type has is a pointer type
-	FB_MANGLEOPT_HASREF       = 4  '' mangled type has is reference type
+	FB_MANGLEOPT_NONE         =   0  '' no special options
+	FB_MANGLEOPT_KEEPTOPCONST =   1  '' keep the top-level const when mangling
+	FB_MANGLEOPT_HASPTR       =   2  '' mangled type has is a pointer type
+	FB_MANGLEOPT_HASREF       =   4  '' mangled type has is reference type
+	FB_MANGLEOPT_NESTED       =   8  '' mangled type is nested in another type
 end enum
 
 enum FB_STRUCT_INREG

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -1954,10 +1954,13 @@ declare function symbIsParentNamespace _
 	( _
 		byval dtype as FB_DATATYPE, _
 		byval subtype as FBSYMBOL ptr,  _
-		byval ns as FBSYMBOL ptr = NULL _
+		byval start_ns as FBSYMBOL ptr = NULL _
 	) as integer
 
-declare function symbCheckAccess( byval sym as FBSYMBOL ptr ) as integer
+declare function symbCheckAccess _
+	( _
+		byval sym as FBSYMBOL ptr _
+	) as integer
 
 declare function symbGetFullProcName _
 	( _

--- a/src/compiler/symb.bi
+++ b/src/compiler/symb.bi
@@ -1950,6 +1950,13 @@ declare function symbCloneLabel _
 		byval sym as FBSYMBOL ptr _
 	) as FBSYMBOL ptr
 
+declare function symbIsParentNamespace _
+	( _
+		byval dtype as FB_DATATYPE, _
+		byval subtype as FBSYMBOL ptr,  _
+		byval ns as FBSYMBOL ptr = NULL _
+	) as integer
+
 declare function symbCheckAccess( byval sym as FBSYMBOL ptr ) as integer
 
 declare function symbGetFullProcName _

--- a/tests/cpp/bop-cpp.cpp
+++ b/tests/cpp/bop-cpp.cpp
@@ -25,11 +25,11 @@ void resetChecks() {
 	setMsg( "" );
 }
 
-const void* getPtr1() { 
+const void* getPtr1() {
 	return ptr1;
 }
 
-const void* getPtr2() { 
+const void* getPtr2() {
 	return ptr2;
 }
 
@@ -41,11 +41,11 @@ int getVal1() {
 	return val1;
 }
 
-int getVal2() { 
+int getVal2() {
 	return val2;
 }
 
-int getVal3() { 
+int getVal3() {
 	return val3;
 }
 

--- a/tests/cpp/bop-fbc.bas
+++ b/tests/cpp/bop-fbc.bas
@@ -1,7 +1,7 @@
 ' TEST_MODE : MULTI_MODULE_TEST
 
 '' test mapping of mangling and calling convention
-'' of global overloaded operators 
+'' of global overloaded operators
 '' between c/c++ and fbc
 
 '' helper macro to track progress

--- a/tests/cpp/call-cpp.cpp
+++ b/tests/cpp/call-cpp.cpp
@@ -24,15 +24,15 @@ void resetChecks() {
 	setMsg( "" );
 }
 
-const void* getPtr1() { 
+const void* getPtr1() {
 	return ptr1;
 }
 
-const void* getPtr2() { 
+const void* getPtr2() {
 	return ptr2;
 }
 
-const void* getPtr3() { 
+const void* getPtr3() {
 	return ptr3;
 }
 

--- a/tests/cpp/call-fbc.bas
+++ b/tests/cpp/call-fbc.bas
@@ -1,6 +1,6 @@
 ' TEST_MODE : MULTI_MODULE_TEST
 
-'' test mapping of mangling and calling convention 
+'' test mapping of mangling and calling convention
 '' between fbc and c/c++ class procedures
 
 '' helper macro to track progress

--- a/tests/cpp/call2-cpp.cpp
+++ b/tests/cpp/call2-cpp.cpp
@@ -24,15 +24,15 @@ void resetChecks() {
 	setMsg( "" );
 }
 
-const void* getPtr1() { 
+const void* getPtr1() {
 	return ptr1;
 }
 
-const void* getPtr2() { 
+const void* getPtr2() {
 	return ptr2;
 }
 
-const void* getPtr3() { 
+const void* getPtr3() {
 	return ptr3;
 }
 

--- a/tests/cpp/call2-fbc.bas
+++ b/tests/cpp/call2-fbc.bas
@@ -1,6 +1,6 @@
 ' TEST_MODE : MULTI_MODULE_TEST
 
-'' test mapping of mangling and calling convention 
+'' test mapping of mangling and calling convention
 '' between fbc and c/c++ class procedures
 
 '' helper macro to track progress

--- a/tests/cpp/class-cpp.cpp
+++ b/tests/cpp/class-cpp.cpp
@@ -33,11 +33,11 @@ void resetChecks() {
 	val3 = 0;
 }
 
-const void* getPtr1() { 
+const void* getPtr1() {
 	return ptr1;
 }
 
-const void* getPtr2() { 
+const void* getPtr2() {
 	return ptr2;
 }
 
@@ -49,11 +49,11 @@ int getVal1() {
 	return val1;
 }
 
-int getVal2() { 
+int getVal2() {
 	return val2;
 }
 
-int getVal3() { 
+int getVal3() {
 	return val3;
 }
 
@@ -70,7 +70,7 @@ class UDT
 	UDT( UDT const& rhs );
 	UDT( int const& rhs );
 	~UDT();
-	void method( int const& rhs );	
+	void method( int const& rhs );
 
 	// assignment
 	UDT& operator=( UDT const& rhs );
@@ -88,7 +88,7 @@ UDT operator-( int const& lhs, UDT const& rhs );
 
 // constructor UDT()
 UDT::UDT()
-{ 
+{
 	if( initial ) {
 		ptr1 = this;
 		ptr2 = NULL;
@@ -102,7 +102,7 @@ UDT::UDT()
 
 // constructor UDT( byref rhs as const UDT )
 UDT::UDT( UDT const& rhs )
-{ 
+{
 	if( initial ) {
 		ptr1 = this;
 		ptr2 = &rhs;
@@ -111,7 +111,7 @@ UDT::UDT( UDT const& rhs )
 		val2 = rhs.value;
 		val3 = rhs.value;
 	}
-	value = rhs.value; 
+	value = rhs.value;
 }
 
 // constructor UDT( byref rhs as const long )
@@ -165,7 +165,7 @@ UDT& UDT::operator=( UDT const& rhs )
 		val1 = value;
 		val2 = rhs.value;
 		val3 = rhs.value;
-	}	
+	}
 	value = rhs.value;
 	return *this;
 }
@@ -180,7 +180,7 @@ UDT& UDT::operator+( int const& rhs )
 	val1 = value;
 	val2 = rhs;
 	val3 = value + rhs;
-	
+
 	value += rhs;
 	return *this;
 }
@@ -194,7 +194,7 @@ UDT& UDT::operator-( int const& rhs )
 	val1 = value;
 	val2 = rhs;
 	val3 = value - rhs;
-	
+
 	value -= rhs;
 	return *this;
 }
@@ -209,7 +209,7 @@ UDT operator+( UDT const& lhs, UDT const& rhs )
 	val1 = lhs.value;
 	val2 = rhs.value;
 	val3 = lhs.value + rhs.value;
-	
+
 	return UDT(lhs.value + rhs.value);
 }
 
@@ -222,7 +222,7 @@ UDT operator-( UDT const& lhs, UDT const& rhs )
 	val1 = lhs.value;
 	val2 = rhs.value;
 	val3 = lhs.value - rhs.value;
-	
+
 	return UDT(lhs.value - rhs.value);
 }
 
@@ -235,7 +235,7 @@ UDT operator+( int const& lhs, UDT const& rhs )
 	val1 = lhs;
 	val2 = rhs.value;
 	val3 = lhs + rhs.value;
-	
+
 	return UDT(lhs + rhs.value);
 }
 
@@ -248,6 +248,6 @@ UDT operator-( int const& lhs, UDT const& rhs )
 	val1 = lhs;
 	val2 = rhs.value;
 	val3 = lhs - rhs.value;
-	
+
 	return UDT(lhs - rhs.value);
 }

--- a/tests/cpp/derived-cpp.cpp
+++ b/tests/cpp/derived-cpp.cpp
@@ -33,11 +33,11 @@ void resetChecks() {
 	val3 = 0;
 }
 
-const void* getPtr1() { 
+const void* getPtr1() {
 	return ptr1;
 }
 
-const void* getPtr2() { 
+const void* getPtr2() {
 	return ptr2;
 }
 
@@ -49,11 +49,11 @@ int getVal1() {
 	return val1;
 }
 
-int getVal2() { 
+int getVal2() {
 	return val2;
 }
 
-int getVal3() { 
+int getVal3() {
 	return val3;
 }
 
@@ -67,7 +67,7 @@ class UDT_BASE
 	UDT_BASE();
 	UDT_BASE( UDT_BASE const& rhs );
 	UDT_BASE( int const& rhs );
-	virtual ~UDT_BASE();	
+	virtual ~UDT_BASE();
 	virtual void method( int const& rhs );
 
 	// assignment
@@ -85,7 +85,7 @@ class UDT_DERIVED : public UDT_BASE
 	UDT_DERIVED();
 	UDT_DERIVED( UDT_DERIVED const& rhs );
 	UDT_DERIVED( int const& rhs );
-	virtual ~UDT_DERIVED();	
+	virtual ~UDT_DERIVED();
 	virtual void method( int const& rhs );
 
 	// assignment
@@ -110,7 +110,7 @@ UDT_DERIVED operator-( int const& lhs, UDT_DERIVED const& rhs );
 
 // constructor UDT_BASE()
 UDT_BASE::UDT_BASE()
-{ 
+{
 	if( initial ) {
 		ptr1 = this;
 		ptr2 = NULL;
@@ -124,7 +124,7 @@ UDT_BASE::UDT_BASE()
 
 // constructor UDT_BASE( byref rhs as const UDT_BASE )
 UDT_BASE::UDT_BASE( UDT_BASE const& rhs )
-{ 
+{
 	if( initial ) {
 		ptr1 = this;
 		ptr2 = &rhs;
@@ -133,7 +133,7 @@ UDT_BASE::UDT_BASE( UDT_BASE const& rhs )
 		val2 = rhs.value;
 		val3 = rhs.value;
 	}
-	value = rhs.value; 
+	value = rhs.value;
 }
 
 // constructor UDT_BASE( byref rhs as const long )
@@ -187,7 +187,7 @@ UDT_BASE& UDT_BASE::operator=( UDT_BASE const& rhs )
 		val1 = value;
 		val2 = rhs.value;
 		val3 = rhs.value;
-	}	
+	}
 	value = rhs.value;
 	return *this;
 }
@@ -200,7 +200,7 @@ UDT_BASE& UDT_BASE::operator+( int const& rhs )
 	val1 = value;
 	val2 = rhs;
 	val3 = value + rhs;
-	
+
 	value += rhs;
 	return *this;
 }
@@ -214,7 +214,7 @@ UDT_BASE& UDT_BASE::operator-( int const& rhs )
 	val1 = value;
 	val2 = rhs;
 	val3 = value - rhs;
-	
+
 	value -= rhs;
 	return *this;
 }
@@ -228,7 +228,7 @@ UDT_BASE operator+( UDT_BASE const& lhs, UDT_BASE const& rhs )
 	val1 = lhs.value;
 	val2 = rhs.value;
 	val3 = lhs.value + rhs.value;
-	
+
 	return UDT_BASE(lhs.value + rhs.value);
 }
 
@@ -241,7 +241,7 @@ UDT_BASE operator-( UDT_BASE const& lhs, UDT_BASE const& rhs )
 	val1 = lhs.value;
 	val2 = rhs.value;
 	val3 = lhs.value - rhs.value;
-	
+
 	return UDT_BASE(lhs.value - rhs.value);
 }
 
@@ -254,7 +254,7 @@ UDT_BASE operator+( int const& lhs, UDT_BASE const& rhs )
 	val1 = lhs;
 	val2 = rhs.value;
 	val3 = lhs + rhs.value;
-	
+
 	return UDT_BASE(lhs + rhs.value);
 }
 
@@ -267,13 +267,13 @@ UDT_BASE operator-( int const& lhs, UDT_BASE const& rhs )
 	val1 = lhs;
 	val2 = rhs.value;
 	val3 = lhs - rhs.value;
-	
+
 	return UDT_BASE(lhs - rhs.value);
 }
 
 // constructor UDT_DERIVED()
 UDT_DERIVED::UDT_DERIVED()
-{ 
+{
 	if( initial ) {
 		ptr1 = this;
 		ptr2 = NULL;
@@ -287,7 +287,7 @@ UDT_DERIVED::UDT_DERIVED()
 
 // constructor UDT_DERIVED( byref rhs as const UDT_DERIVED )
 UDT_DERIVED::UDT_DERIVED( UDT_DERIVED const& rhs )
-{ 
+{
 	if( initial ) {
 		ptr1 = this;
 		ptr2 = &rhs;
@@ -296,7 +296,7 @@ UDT_DERIVED::UDT_DERIVED( UDT_DERIVED const& rhs )
 		val2 = rhs.value;
 		val3 = rhs.value;
 	}
-	value = rhs.value; 
+	value = rhs.value;
 }
 
 // constructor UDT_DERIVED( byref rhs as const long )
@@ -350,7 +350,7 @@ UDT_DERIVED& UDT_DERIVED::operator=( UDT_DERIVED const& rhs )
 		val1 = value;
 		val2 = rhs.value;
 		val3 = rhs.value;
-	}	
+	}
 	value = rhs.value;
 	return *this;
 }
@@ -365,7 +365,7 @@ UDT_DERIVED& UDT_DERIVED::operator+( int const& rhs )
 	val1 = value;
 	val2 = rhs;
 	val3 = value + rhs;
-	
+
 	value += rhs;
 	return *this;
 }
@@ -379,7 +379,7 @@ UDT_DERIVED& UDT_DERIVED::operator-( int const& rhs )
 	val1 = value;
 	val2 = rhs;
 	val3 = value - rhs;
-	
+
 	value -= rhs;
 	return *this;
 }
@@ -394,7 +394,7 @@ UDT_DERIVED operator+( UDT_DERIVED const& lhs, UDT_DERIVED const& rhs )
 	val1 = lhs.value;
 	val2 = rhs.value;
 	val3 = lhs.value + rhs.value;
-	
+
 	return UDT_DERIVED(lhs.value + rhs.value);
 }
 
@@ -407,7 +407,7 @@ UDT_DERIVED operator-( UDT_DERIVED const& lhs, UDT_DERIVED const& rhs )
 	val1 = lhs.value;
 	val2 = rhs.value;
 	val3 = lhs.value - rhs.value;
-	
+
 	return UDT_DERIVED(lhs.value - rhs.value);
 }
 
@@ -420,7 +420,7 @@ UDT_DERIVED operator+( int const& lhs, UDT_DERIVED const& rhs )
 	val1 = lhs;
 	val2 = rhs.value;
 	val3 = lhs + rhs.value;
-	
+
 	return UDT_DERIVED(lhs + rhs.value);
 }
 
@@ -433,6 +433,6 @@ UDT_DERIVED operator-( int const& lhs, UDT_DERIVED const& rhs )
 	val1 = lhs;
 	val2 = rhs.value;
 	val3 = lhs - rhs.value;
-	
+
 	return UDT_DERIVED(lhs - rhs.value);
 }

--- a/tests/cpp/fbcall-cpp.cpp
+++ b/tests/cpp/fbcall-cpp.cpp
@@ -24,15 +24,15 @@ void resetChecks() {
 	setMsg( "" );
 }
 
-const void* getPtr1() { 
+const void* getPtr1() {
 	return ptr1;
 }
 
-const void* getPtr2() { 
+const void* getPtr2() {
 	return ptr2;
 }
 
-const void* getPtr3() { 
+const void* getPtr3() {
 	return ptr3;
 }
 

--- a/tests/cpp/fbcall-fbc.bas
+++ b/tests/cpp/fbcall-fbc.bas
@@ -1,6 +1,6 @@
 ' TEST_MODE : MULTI_MODULE_TEST
 
-'' test mapping of mangling and calling convention 
+'' test mapping of mangling and calling convention
 '' between fbc extern "rtlib" and c
 
 '' helper macro to track progress

--- a/tests/cpp/mangle-cpp.cpp
+++ b/tests/cpp/mangle-cpp.cpp
@@ -1,4 +1,4 @@
-namespace cpp_mangle 
+namespace cpp_mangle
 {
 	// bool
 
@@ -6,11 +6,11 @@ namespace cpp_mangle
 	{
 		return a;
 	}
-	
+
 	bool cpp_byref_bool( bool &a )
 	{
 		return a;
-	} 
+	}
 
 	// float
 
@@ -18,11 +18,11 @@ namespace cpp_mangle
 	{
 		return a;
 	}
-	
+
 	float cpp_byref_float( float &a )
 	{
 		return a;
-	} 
+	}
 
 	// double
 
@@ -30,11 +30,11 @@ namespace cpp_mangle
 	{
 		return a;
 	}
-	
+
 	double cpp_byref_double( double &a )
 	{
 		return a;
-	} 
+	}
 
 	// char = 8 bit
 
@@ -56,17 +56,17 @@ namespace cpp_mangle
 	char cpp_byref_char_b( char &a )
 	{
 		return a;
-	} 
+	}
 
 	char cpp_byref_char_u( char &a )
 	{
 		return a;
-	} 
+	}
 
 	char cpp_byref_char_ub( char &a )
 	{
 		return a;
-	} 
+	}
 
 	// signed | unsigned char = 8 bit
 
@@ -83,12 +83,12 @@ namespace cpp_mangle
 	unsigned char cpp_byref_uchar( unsigned char &a )
 	{
 		return a;
-	} 
+	}
 
 	signed char cpp_byref_schar( signed char &a )
 	{
 		return a;
-	} 
+	}
 
 	// short int = 16 bit
 
@@ -96,21 +96,21 @@ namespace cpp_mangle
 	{
 		return a;
 	}
-	
+
 	signed short cpp_byval_sshort( signed short int a )
 	{
 		return a;
 	}
-	
+
 	unsigned short cpp_byref_ushort( unsigned short int &a )
 	{
 		return a;
-	} 
+	}
 
 	signed short cpp_byref_sshort( signed short int &a )
 	{
 		return a;
-	} 
+	}
 
 	// int
 
@@ -118,21 +118,21 @@ namespace cpp_mangle
 	{
 		return a;
 	}
-	
+
 	signed int cpp_byval_sint( signed int a )
 	{
 		return a;
 	}
-	
+
 	unsigned int cpp_byref_uint( unsigned int &a )
 	{
 		return a;
-	} 
+	}
 
 	signed int cpp_byref_sint( signed int &a )
 	{
 		return a;
-	} 
+	}
 
 	// long int
 
@@ -140,21 +140,21 @@ namespace cpp_mangle
 	{
 		return a;
 	}
-	
+
 	signed long int cpp_byval_slongint( signed long int a )
 	{
 		return a;
 	}
-	
+
 	unsigned long int cpp_byref_ulongint( unsigned long int &a )
 	{
 		return a;
-	} 
+	}
 
 	signed long int cpp_byref_slongint( signed long int &a )
 	{
 		return a;
-	} 
+	}
 
 	// long long int = 64 bit
 
@@ -162,21 +162,21 @@ namespace cpp_mangle
 	{
 		return a;
 	}
-	
+
 	signed long long int cpp_byval_slonglongint( signed long long int a )
 	{
 		return a;
 	}
-	
+
 	unsigned long long int cpp_byref_ulonglongint( unsigned long long int &a )
 	{
 		return a;
-	} 
+	}
 
 	signed long long int cpp_byref_slonglongint( signed long long int &a )
 	{
 		return a;
-	} 
+	}
 
 	/* byval const, pointer, reference */
 

--- a/tests/cpp/mangle-enum-cpp.cpp
+++ b/tests/cpp/mangle-enum-cpp.cpp
@@ -1,0 +1,37 @@
+namespace cpp_mangle_enum
+{
+	enum E1
+	{
+		A, B
+	};
+
+	struct T1
+	{
+		enum E2
+		{
+			A, B
+		};
+		int a;
+	};
+
+	int cpp_enum_byval_1( enum E1 e )
+	{
+		return 1;
+	}
+
+	int cpp_enum_byref_2( enum E1 &e )
+	{
+		return 2;
+	}
+
+	int cpp_enum_byval_3( enum T1::E2 e )
+	{
+		return 3;
+	}
+
+	int cpp_enum_byref_4( enum T1::E2 &e )
+	{
+		return 4;
+	}
+
+}

--- a/tests/cpp/mangle-enum-fbc.bas
+++ b/tests/cpp/mangle-enum-fbc.bas
@@ -1,0 +1,58 @@
+' TEST_MODE : MULTI_MODULE_TEST
+
+'' test mapping of enums between fbc and g++
+'' with c++ name mangling
+
+extern "c++"
+
+namespace cpp_mangle_enum
+
+	enum E1 explicit
+		A
+		B
+	end enum
+
+	type T1
+		enum E2 explicit
+			A
+			B
+		end enum
+		a as long
+	end type
+
+	declare function cpp_enum_byval_1( byval e as E1 ) as long
+	declare function cpp_enum_byref_2( byref e as E1 ) as long
+
+	declare function cpp_enum_byval_3( byval e as T1.E2 ) as long
+	declare function cpp_enum_byref_4( byref e as T1.E2 ) as long
+
+end namespace
+
+end extern
+
+using cpp_mangle_enum
+
+'' ------------------------------------
+'' Tests
+'' ------------------------------------
+
+scope
+	dim z as E1
+	ASSERT( 1 = cpp_enum_byval_1( z ) )
+end scope
+
+scope
+	dim z as E1
+	ASSERT( 2 = cpp_enum_byref_2( z ) )
+end scope
+
+scope
+	dim z as T1.E2
+	ASSERT( 3 = cpp_enum_byval_3( z ) )
+end scope
+
+scope
+	dim z as T1.E2
+	ASSERT( 4 = cpp_enum_byref_4( z ) )
+end scope
+

--- a/tests/cpp/mangle-enum.bmk
+++ b/tests/cpp/mangle-enum.bmk
@@ -1,0 +1,10 @@
+# TEST_MODE : MULTI_MODULE_OK
+
+MAIN := mangle-enum-fbc.bas
+SRCS := 
+
+EXTRA_OBJS := mangle-enum-cpp.o
+
+$(SRCDIR)mangle-enum-cpp.o : $(SRCDIR)mangle-enum-cpp.cpp
+	# Pass $(CFLAGS) to get -m32 or -m64 as required
+	$(CXX) -c $(CFLAGS) -o $@ $^

--- a/tests/cpp/mangle-fbc.bas
+++ b/tests/cpp/mangle-fbc.bas
@@ -3,13 +3,13 @@
 '' test mapping of basic data types between fbc and g++
 '' with c++ name mangling
 
-'' by default, fbc's Long/ULong data type maps to c's int type, and since 
+'' by default, fbc's Long/ULong data type maps to c's int type, and since
 '' Integer/Uinteger are meant to be (consistently) 64bits in fbc-64bit,
-'' there is no other type that (by default) that can map to c's long int, 
+'' there is no other type that (by default) that can map to c's long int,
 '' which is 32bit even on Win64.
 
-'' So, in Win64, to allow calling an external library that needs a 'long int' 
-'' parameter there is the following, non-portable mangling modifier.  It is 
+'' So, in Win64, to allow calling an external library that needs a 'long int'
+'' parameter there is the following, non-portable mangling modifier.  It is
 '' ignored for all targets except for Win64
 
 #if defined(__FB_64BIT__) and not defined(__FB_UNIX__)
@@ -19,12 +19,12 @@
 	'' otherwise, integer is used on 32bit and Unix-64bit consistently to map
 	'' fbc's 32/64bit 'INTEGER' type to the target 32/64bit 'long int' type
 	type cxxlongint as integer
-#endif 
+#endif
 
 extern "c++"
 
 namespace cpp_mangle
-	
+
 	declare function cpp_byval_bool( byval a as boolean ) as boolean
 	declare function cpp_byref_bool( byref a as boolean ) as boolean
 
@@ -47,24 +47,24 @@ namespace cpp_mangle
 	declare function cpp_byref_uchar( byref a as unsigned byte ) as unsigned byte
 	declare function cpp_byref_schar( byref a as byte ) as byte
 
-   	declare function cpp_byval_ushort( byval a as unsigned short ) as unsigned short
+	declare function cpp_byval_ushort( byval a as unsigned short ) as unsigned short
 	declare function cpp_byval_sshort( byval a as short ) as short
 	declare function cpp_byref_ushort( byref a as unsigned short ) as unsigned short
 	declare function cpp_byref_sshort( byref a as short ) as short
 
-   	declare function cpp_byval_uint( byval a as unsigned long ) as unsigned long
+	declare function cpp_byval_uint( byval a as unsigned long ) as unsigned long
 	declare function cpp_byval_sint( byval a as long ) as long
 	declare function cpp_byref_uint( byref a as unsigned long ) as unsigned long
 	declare function cpp_byref_sint( byref a as long ) as long
 
-   	declare function cpp_byval_ulongint( byval a as unsigned cxxlongint ) as unsigned cxxlongint
+	declare function cpp_byval_ulongint( byval a as unsigned cxxlongint ) as unsigned cxxlongint
 	declare function cpp_byval_slongint( byval a as cxxlongint ) as cxxlongint
 	declare function cpp_byref_ulongint( byref a as unsigned cxxlongint ) as unsigned cxxlongint
 	declare function cpp_byref_slongint( byref a as cxxlongint ) as cxxlongint
 
-   	declare function cpp_byval_ulonglongint( byval a as unsigned longint ) as unsigned longint
+	declare function cpp_byval_ulonglongint( byval a as unsigned longint ) as unsigned longint
 	declare function cpp_byval_slonglongint( byval a as longint ) as longint
-	declare function cpp_byref_ulonglongint( byref a as unsigned longint ) as unsigned longint 
+	declare function cpp_byref_ulonglongint( byref a as unsigned longint ) as unsigned longint
 	declare function cpp_byref_slonglongint( byref a as longint ) as longint
 
 	declare function cpp_byval_const_double( byval a as const double ) as double
@@ -145,7 +145,7 @@ scope
 end scope
 
 scope
-				 
+
 	''  c = [signed|unsigned] char
 	'' fb = [unsigned] byte
 

--- a/tests/cpp/mangle-struct-cpp.cpp
+++ b/tests/cpp/mangle-struct-cpp.cpp
@@ -1,0 +1,208 @@
+namespace cpp_mangle_struct
+{
+
+	/* ***********************************
+	** Simple
+	*********************************** */
+	struct Simple
+	{
+		int a;
+	};
+
+	int cpp_struct0_byval_1( int size, struct Simple udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 01;
+		}
+		return 0;
+	}
+
+	int cpp_struct0_byref_2( int size, struct Simple &udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 02;
+		}
+		return 0;
+	}
+
+	/* ***********************************
+	** Outer1 + Outer1::Inner
+	*********************************** */
+
+	struct Outer1
+	{
+		int a;
+		int b;
+		struct Inner
+		{
+			int c;
+		};
+		struct Inner z;
+	};
+
+	int cpp_struct1_byval_1( int size, struct Outer1 udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 11;
+		}
+		return 0;
+	}
+
+	int cpp_struct1_byref_2( int size, struct Outer1 &udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 12;
+		}
+		return 0;
+	}
+
+	int cpp_struct1_byval_3( int size, struct Outer1::Inner udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 13;
+		}
+		return 0;
+	}
+
+	int cpp_struct1_byref_4( int size, struct Outer1::Inner &udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 14;
+		}
+		return 0;
+	}
+
+	/* ***********************************
+	** Outer2 + Outer2::Inner
+	*********************************** */
+
+	struct Outer2
+	{
+		int a;
+		int b;
+		int c;
+		struct Inner
+		{
+			int c;
+			int d;
+		};
+		struct Inner z;
+	};
+
+	int cpp_struct2_byval_1( int size, struct Outer2 udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 21;
+		}
+		return 0;
+	}
+
+	int cpp_struct2_byref_2( int size, struct Outer2 &udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 22;
+		}
+		return 0;
+	}
+
+	int cpp_struct2_byval_3( int size, struct Outer2::Inner udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 23;
+		}
+		return 0;
+	}
+
+	int cpp_struct2_byref_4( int size, struct Outer2::Inner &udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 24;
+		}
+		return 0;
+	}
+
+	/* ***********************************
+	** Outer3 + Outer3::Inner2 + Outer3::Inner2::Inner1
+	*********************************** */
+
+	struct Outer3
+	{
+		int a;
+		int b;
+		int c;
+		struct Inner2
+		{
+			int d;
+			int e;
+			struct Inner1
+			{
+				int f;
+			} g;
+		} h;
+	};
+
+	int cpp_struct3_byval_1( int size, struct Outer3 udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 31;
+		}
+		return 0;
+	}
+
+	int cpp_struct3_byref_2( int size, struct Outer3 &udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 32;
+		}
+		return 0;
+	}
+
+	int cpp_struct3_byval_3( int size, struct Outer3::Inner2 udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 33;
+		}
+		return 0;
+	}
+
+	int cpp_struct3_byref_4( int size, struct Outer3::Inner2 &udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 34;
+		}
+		return 0;
+	}
+
+	int cpp_struct3_byval_5( int size, struct Outer3::Inner2::Inner1 udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 35;
+		}
+		return 0;
+	}
+
+	int cpp_struct3_byref_6( int size, struct Outer3::Inner2::Inner1 &udt )
+	{
+		if( size == sizeof( udt ) )
+		{
+			return 36;
+		}
+		return 0;
+	}
+
+}

--- a/tests/cpp/mangle-struct-fbc.bas
+++ b/tests/cpp/mangle-struct-fbc.bas
@@ -1,0 +1,169 @@
+' TEST_MODE : MULTI_MODULE_TEST
+
+'' test mapping of structs between fbc and g++
+'' with c++ name mangling
+
+extern "c++"
+
+namespace cpp_mangle_struct
+
+	type Simple
+		a as long
+	end type
+
+	declare function cpp_struct0_byval_1( byval size as long, byval udt as Simple ) as long
+	declare function cpp_struct0_byref_2( byval size as long, byref udt as Simple ) as long
+
+	type Outer1
+		a as long
+		b as long
+		type Inner
+			c as long
+		end type
+		d as Inner
+	end type
+
+	declare function cpp_struct1_byval_1( byval size as long, byval udt as Outer1 ) as long
+	declare function cpp_struct1_byref_2( byval size as long, byref udt as Outer1 ) as long
+	declare function cpp_struct1_byval_3( byval size as long, byval udt as Outer1.Inner ) as long
+	declare function cpp_struct1_byref_4( byval size as long, byref udt as Outer1.Inner ) as long
+
+	type Outer2
+		a as long
+		b as long
+		c as long
+		type Inner
+			c as long
+			d as long
+		end type
+		d as Inner
+	end type
+
+	declare function cpp_struct2_byval_1( byval size as long, byval udt as Outer2 ) as long
+	declare function cpp_struct2_byref_2( byval size as long, byref udt as Outer2 ) as long
+	declare function cpp_struct2_byval_3( byval size as long, byval udt as Outer2.Inner ) as long
+	declare function cpp_struct2_byref_4( byval size as long, byref udt as Outer2.Inner ) as long
+
+	type Outer3
+		a as long
+		b as long
+		c as long
+		type Inner2
+			d as long
+			e as long
+			type Inner1
+				f as long
+			end type
+			g as Inner1
+		end type
+		h as Inner2
+	end type
+
+	declare function cpp_struct3_byval_1( byval size as long, byval udt as Outer3 ) as long
+	declare function cpp_struct3_byref_2( byval size as long, byref udt as Outer3 ) as long
+	declare function cpp_struct3_byval_3( byval size as long, byval udt as Outer3.Inner2 ) as long
+	declare function cpp_struct3_byref_4( byval size as long, byref udt as Outer3.Inner2 ) as long
+	declare function cpp_struct3_byval_5( byval size as long, byval udt as Outer3.Inner2.Inner1 ) as long
+	declare function cpp_struct3_byref_6( byval size as long, byref udt as Outer3.Inner2.Inner1 ) as long
+
+end namespace
+
+end extern
+
+using cpp_mangle_struct
+
+'' ------------------------------------
+'' Simple
+'' ------------------------------------
+
+scope
+	dim z as Simple
+	ASSERT( 01 = cpp_struct0_byval_1( sizeof( Simple ), z ) )
+end scope
+
+scope
+	dim z as Simple
+	ASSERT( 02 = cpp_struct0_byref_2( sizeof( Simple ), z ) )
+end scope
+
+'' ------------------------------------
+'' Outer1 + Outer1.Inner
+'' ------------------------------------
+
+scope
+	dim z as Outer1
+	ASSERT( 11 = cpp_struct1_byval_1( sizeof( Outer1 ), z ) )
+end scope
+
+scope
+	dim z as Outer1
+	ASSERT( 12 = cpp_struct1_byref_2( sizeof( Outer1 ), z ) )
+end scope
+
+scope
+	dim z as Outer1.Inner
+	ASSERT( 13 = cpp_struct1_byval_3( sizeof( Outer1.Inner ), z ) )
+end scope
+
+scope
+	dim z as Outer1.Inner
+	ASSERT( 14 = cpp_struct1_byref_4( sizeof( Outer1.Inner ), z ) )
+end scope
+
+'' ------------------------------------
+'' Outer2 + Outer2.Inner
+'' ------------------------------------
+
+scope
+	dim z as Outer2
+	ASSERT( 21 = cpp_struct2_byval_1( sizeof( Outer2 ), z ) )
+end scope
+
+scope
+	dim z as Outer2
+	ASSERT( 22 = cpp_struct2_byref_2( sizeof( Outer2 ), z ) )
+end scope
+
+scope
+	dim z as Outer2.Inner
+	ASSERT( 23 = cpp_struct2_byval_3( sizeof( Outer2.Inner ), z ) )
+end scope
+
+scope
+	dim z as Outer2.Inner
+	ASSERT( 24 = cpp_struct2_byref_4( sizeof( Outer2.Inner ), z ) )
+end scope
+
+'' ------------------------------------
+'' Outer3 + Outer3.Inner1 + Outer3.Inner1.Inner2
+'' ------------------------------------
+
+scope
+	dim z as Outer3
+	ASSERT( 31 = cpp_struct3_byval_1( sizeof( Outer3 ), z ) )
+end scope
+
+scope
+	dim z as Outer3
+	ASSERT( 32 = cpp_struct3_byref_2( sizeof( Outer3 ), z ) )
+end scope
+
+scope
+	dim z as Outer3.Inner2
+	ASSERT( 33 = cpp_struct3_byval_3( sizeof( Outer3.Inner2 ), z ) )
+end scope
+
+scope
+	dim z as Outer3.Inner2
+	ASSERT( 34 = cpp_struct3_byref_4( sizeof( Outer3.Inner2 ), z ) )
+end scope
+
+scope
+	dim z as Outer3.Inner2.Inner1
+	ASSERT( 35 = cpp_struct3_byval_5( sizeof( Outer3.Inner2.Inner1 ), z ) )
+end scope
+
+scope
+	dim z as Outer3.Inner2.Inner1
+	ASSERT( 36 = cpp_struct3_byref_6( sizeof( Outer3.Inner2.Inner1 ), z ) )
+end scope

--- a/tests/cpp/mangle-struct.bmk
+++ b/tests/cpp/mangle-struct.bmk
@@ -1,0 +1,10 @@
+# TEST_MODE : MULTI_MODULE_OK
+
+MAIN := mangle-struct-fbc.bas
+SRCS := 
+
+EXTRA_OBJS := mangle-struct-cpp.o
+
+$(SRCDIR)mangle-struct-cpp.o : $(SRCDIR)mangle-struct-cpp.cpp
+	# Pass $(CFLAGS) to get -m32 or -m64 as required
+	$(CXX) -c $(CFLAGS) -o $@ $^

--- a/tests/cpp/this-cpp.cpp
+++ b/tests/cpp/this-cpp.cpp
@@ -12,15 +12,15 @@ void resetChecks() {
 	ptr1 = ptr2 = ptr3 = 0;
 }
 
-void* getPtr1() { 
+void* getPtr1() {
 	return ptr1;
 }
 
-void* getPtr2() { 
+void* getPtr2() {
 	return ptr2;
 }
 
-void* getPtr3() { 
+void* getPtr3() {
 	return ptr3;
 }
 
@@ -30,7 +30,7 @@ class UDT_DEFAULT {
 	public:
 	int value;
 	UDT_DEFAULT();
-	~UDT_DEFAULT();	
+	~UDT_DEFAULT();
 	void loadpointer1 ( void );
 	void loadpointer2 ( void* arg );
 	void loadpointer3 ( void* arg1, void* arg2 );
@@ -77,7 +77,7 @@ class UDT_THISCALL {
 	public:
 	int value;
 	UDT_THISCALL() __attribute__((thiscall));
-	~UDT_THISCALL() __attribute__((thiscall));	
+	~UDT_THISCALL() __attribute__((thiscall));
 	void loadpointer1 ( void ) __attribute__((thiscall));
 	void loadpointer2 ( void* arg ) __attribute__((thiscall));
 	void loadpointer3 ( void* arg1, void* arg2 ) __attribute__((thiscall));
@@ -120,7 +120,7 @@ class UDT_CDECL {
 	public:
 	int value;
 	UDT_CDECL() __attribute__((cdecl));
-	~UDT_CDECL() __attribute__((cdecl));	
+	~UDT_CDECL() __attribute__((cdecl));
 	void loadpointer1 ( void ) __attribute__((cdecl));
 	void loadpointer2 ( void* arg ) __attribute__((cdecl));
 	void loadpointer3 ( void* arg1, void* arg2 ) __attribute__((cdecl));
@@ -167,7 +167,7 @@ class UDT_STDCALL {
 	// mingw/gcc appears to have a bug that generates wrong
 	// mangling "__ZN11UDT_STDCALLD1Ev@8" so just use cdecl
 	// here instead
-	~UDT_STDCALL() __attribute__((cdecl));	
+	~UDT_STDCALL() __attribute__((cdecl));
 
 	void loadpointer1 ( void ) __attribute__((stdcall));
 	void loadpointer2 ( void* arg ) __attribute__((stdcall));

--- a/tests/cpp/this-fbc.bas
+++ b/tests/cpp/this-fbc.bas
@@ -28,7 +28,7 @@ end extern
 extern "c++"
 
 type UDT_DEFAULT
-	
+
 	value as long
 
 	declare constructor thiscall ()
@@ -44,7 +44,7 @@ end type
 '' on the cpp side, we are explicitly specifying __atribute__((thiscall))
 '' for all member procs.  We do the same here with __thiscall
 type UDT_THISCALL
-	
+
 	value as long
 
 	declare constructor __thiscall ()
@@ -60,7 +60,7 @@ end type
 '' on the cpp side, we are explicitly specifying __atribute__((cdecl))
 '' for all member procs.  We do the same here with cdecl
 type UDT_CDECL
-	
+
 	value as long
 
 	declare constructor cdecl ()
@@ -76,7 +76,7 @@ end type
 '' on the cpp side, we are explicitly specifying __atribute__((stdcall))
 '' for all member procs.  We do the same here with stdcall
 type UDT_STDCALL
-	
+
 	value as long
 
 	declare constructor stdcall ()

--- a/tests/quirk/len-sizeof-udt-member.bas
+++ b/tests/quirk/len-sizeof-udt-member.bas
@@ -95,4 +95,219 @@ SUITE( fbc_tests.quirk.len_sizeof_udt_member )
 
 	END_TEST
 
+	type T3
+		m1 as T
+		m2 as T2
+	end type
+
+	TEST( members_of_member )
+
+		CU_ASSERT( sizeof( T3.m1.sb ) = sizeof( byte ) )
+		CU_ASSERT( sizeof( T3.m1.ub ) = sizeof( ubyte ) )
+		CU_ASSERT( sizeof( T3.m1.ss ) = sizeof( short ) )
+		CU_ASSERT( sizeof( T3.m1.us ) = sizeof( ushort ) )
+		CU_ASSERT( sizeof( T3.m1.sl ) = sizeof( long ) )
+		CU_ASSERT( sizeof( T3.m1.ul ) = sizeof( ulong ) )
+		CU_ASSERT( sizeof( T3.m1.si ) = sizeof( integer ) )
+		CU_ASSERT( sizeof( T3.m1.ui ) = sizeof( uinteger ) )
+		CU_ASSERT( sizeof( T3.m1.sli ) = sizeof( longint ) )
+		CU_ASSERT( sizeof( T3.m1.uli ) = sizeof( ulongint ) )
+		CU_ASSERT( sizeof( T3.m1.zs ) = sizeof( STRCONST ) )
+		CU_ASSERT( sizeof( T3.m1.ws ) = sizeof( wstr( STRCONST ) ) )
+		CU_ASSERT( sizeof( T3.m1.z ) = sizeof( zstring * 10 ) )
+		CU_ASSERT( sizeof( T3.m1.w ) = sizeof( wstring * 10 ) )
+		CU_ASSERT( sizeof( T3.m1.s ) = sizeof( string ) )
+		CU_ASSERT( sizeof( T3.m1.p ) = sizeof( any ptr ) )
+		CU_ASSERT( sizeof( T3.m1.udt ) = sizeof( U ) )
+
+		CU_ASSERT( len( T3.m1.sb ) = len( byte ) )
+		CU_ASSERT( len( T3.m1.ub ) = len( ubyte ) )
+		CU_ASSERT( len( T3.m1.ss ) = len( short ) )
+		CU_ASSERT( len( T3.m1.us ) = len( ushort ) )
+		CU_ASSERT( len( T3.m1.sl ) = len( long ) )
+		CU_ASSERT( len( T3.m1.ul ) = len( ulong ) )
+		CU_ASSERT( len( T3.m1.si ) = len( integer ) )
+		CU_ASSERT( len( T3.m1.ui ) = len( uinteger ) )
+		CU_ASSERT( len( T3.m1.sli ) = len( longint ) )
+		CU_ASSERT( len( T3.m1.uli ) = len( ulongint ) )
+		CU_ASSERT( len( T3.m1.zs ) = len( STRCONST ) )
+		CU_ASSERT( len( T3.m1.ws ) = len( wstr( STRCONST ) ) )
+		CU_ASSERT( len( T3.m1.z ) = len( zstring * 10 ) )
+		CU_ASSERT( len( T3.m1.w ) = len( wstring * 10 ) )
+		CU_ASSERT( len( T3.m1.s ) = len( string ) )
+		CU_ASSERT( len( T3.m1.p ) = len( any ptr ) )
+		CU_ASSERT( len( T3.m1.udt ) = len( U ) )
+
+		CU_ASSERT( len( T3.m2.s ) = sizeof( string ) )
+		CU_ASSERT( sizeof( T3.m2.s ) = sizeof( string ) )
+
+	END_TEST
+
+	type TOuter
+		sb as byte
+		ub as ubyte
+		ss as short
+		us as ushort
+		sl as long
+		ul as ulong
+		si as integer
+		ui as uinteger
+		sli as longint
+		uli as ulongint
+		const zs = STRCONST
+		const ws = wstr( STRCONST )
+		z as zstring * 10
+		w as wstring * 10
+		s as string
+		p as any ptr
+		udt as U
+		type TInner
+			sb as byte
+			ub as ubyte
+			ss as short
+			us as ushort
+			sl as long
+			ul as ulong
+			si as integer
+			ui as uinteger
+			sli as longint
+			uli as ulongint
+			const zs = STRCONST
+			const ws = wstr( STRCONST )
+			z as zstring * 10
+			w as wstring * 10
+			s as string
+			p as any ptr
+			udt as U
+		end type
+	end type
+
+	TEST( inner_type )
+
+		CU_ASSERT( sizeof( TOuter.sb ) = sizeof( byte ) )
+		CU_ASSERT( sizeof( TOuter.ub ) = sizeof( ubyte ) )
+		CU_ASSERT( sizeof( TOuter.ss ) = sizeof( short ) )
+		CU_ASSERT( sizeof( TOuter.us ) = sizeof( ushort ) )
+		CU_ASSERT( sizeof( TOuter.sl ) = sizeof( long ) )
+		CU_ASSERT( sizeof( TOuter.ul ) = sizeof( ulong ) )
+		CU_ASSERT( sizeof( TOuter.si ) = sizeof( integer ) )
+		CU_ASSERT( sizeof( TOuter.ui ) = sizeof( uinteger ) )
+		CU_ASSERT( sizeof( TOuter.sli ) = sizeof( longint ) )
+		CU_ASSERT( sizeof( TOuter.uli ) = sizeof( ulongint ) )
+		CU_ASSERT( sizeof( TOuter.zs ) = sizeof( STRCONST ) )
+		CU_ASSERT( sizeof( TOuter.ws ) = sizeof( wstr( STRCONST ) ) )
+		CU_ASSERT( sizeof( TOuter.z ) = sizeof( zstring * 10 ) )
+		CU_ASSERT( sizeof( TOuter.w ) = sizeof( wstring * 10 ) )
+		CU_ASSERT( sizeof( TOuter.s ) = sizeof( string ) )
+		CU_ASSERT( sizeof( TOuter.p ) = sizeof( any ptr ) )
+		CU_ASSERT( sizeof( TOuter.udt ) = sizeof( U ) )
+
+		CU_ASSERT( len( TOuter.sb ) = len( byte ) )
+		CU_ASSERT( len( TOuter.ub ) = len( ubyte ) )
+		CU_ASSERT( len( TOuter.ss ) = len( short ) )
+		CU_ASSERT( len( TOuter.us ) = len( ushort ) )
+		CU_ASSERT( len( TOuter.sl ) = len( long ) )
+		CU_ASSERT( len( TOuter.ul ) = len( ulong ) )
+		CU_ASSERT( len( TOuter.si ) = len( integer ) )
+		CU_ASSERT( len( TOuter.ui ) = len( uinteger ) )
+		CU_ASSERT( len( TOuter.sli ) = len( longint ) )
+		CU_ASSERT( len( TOuter.uli ) = len( ulongint ) )
+		CU_ASSERT( len( TOuter.zs ) = len( STRCONST ) )
+		CU_ASSERT( len( TOuter.ws ) = len( wstr( STRCONST ) ) )
+		CU_ASSERT( len( TOuter.z ) = len( zstring * 10 ) )
+		CU_ASSERT( len( TOuter.w ) = len( wstring * 10 ) )
+		CU_ASSERT( len( TOuter.s ) = len( string ) )
+		CU_ASSERT( len( TOuter.p ) = len( any ptr ) )
+		CU_ASSERT( len( TOuter.udt ) = len( U ) )
+
+		CU_ASSERT( sizeof( TOuter.TInner.sb ) = sizeof( byte ) )
+		CU_ASSERT( sizeof( TOuter.TInner.ub ) = sizeof( ubyte ) )
+		CU_ASSERT( sizeof( TOuter.TInner.ss ) = sizeof( short ) )
+		CU_ASSERT( sizeof( TOuter.TInner.us ) = sizeof( ushort ) )
+		CU_ASSERT( sizeof( TOuter.TInner.sl ) = sizeof( long ) )
+		CU_ASSERT( sizeof( TOuter.TInner.ul ) = sizeof( ulong ) )
+		CU_ASSERT( sizeof( TOuter.TInner.si ) = sizeof( integer ) )
+		CU_ASSERT( sizeof( TOuter.TInner.ui ) = sizeof( uinteger ) )
+		CU_ASSERT( sizeof( TOuter.TInner.sli ) = sizeof( longint ) )
+		CU_ASSERT( sizeof( TOuter.TInner.uli ) = sizeof( ulongint ) )
+		CU_ASSERT( sizeof( TOuter.TInner.zs ) = sizeof( STRCONST ) )
+		CU_ASSERT( sizeof( TOuter.TInner.ws ) = sizeof( wstr( STRCONST ) ) )
+		CU_ASSERT( sizeof( TOuter.TInner.z ) = sizeof( zstring * 10 ) )
+		CU_ASSERT( sizeof( TOuter.TInner.w ) = sizeof( wstring * 10 ) )
+		CU_ASSERT( sizeof( TOuter.TInner.s ) = sizeof( string ) )
+		CU_ASSERT( sizeof( TOuter.TInner.p ) = sizeof( any ptr ) )
+		CU_ASSERT( sizeof( TOuter.TInner.udt ) = sizeof( U ) )
+
+		CU_ASSERT( len( TOuter.TInner.sb ) = len( byte ) )
+		CU_ASSERT( len( TOuter.TInner.ub ) = len( ubyte ) )
+		CU_ASSERT( len( TOuter.TInner.ss ) = len( short ) )
+		CU_ASSERT( len( TOuter.TInner.us ) = len( ushort ) )
+		CU_ASSERT( len( TOuter.TInner.sl ) = len( long ) )
+		CU_ASSERT( len( TOuter.TInner.ul ) = len( ulong ) )
+		CU_ASSERT( len( TOuter.TInner.si ) = len( integer ) )
+		CU_ASSERT( len( TOuter.TInner.ui ) = len( uinteger ) )
+		CU_ASSERT( len( TOuter.TInner.sli ) = len( longint ) )
+		CU_ASSERT( len( TOuter.TInner.uli ) = len( ulongint ) )
+		CU_ASSERT( len( TOuter.TInner.zs ) = len( STRCONST ) )
+		CU_ASSERT( len( TOuter.TInner.ws ) = len( wstr( STRCONST ) ) )
+		CU_ASSERT( len( TOuter.TInner.z ) = len( zstring * 10 ) )
+		CU_ASSERT( len( TOuter.TInner.w ) = len( wstring * 10 ) )
+		CU_ASSERT( len( TOuter.TInner.s ) = len( string ) )
+		CU_ASSERT( len( TOuter.TInner.p ) = len( any ptr ) )
+		CU_ASSERT( len( TOuter.TInner.udt ) = len( U ) )
+
+	END_TEST
+
+	TEST( inner_member )
+
+		type inner1
+			a as short
+			b as byte
+		end type
+
+		type outer1
+			a as byte
+			b as short
+			m as inner1
+		end type
+
+		type outer
+			a as byte
+			b as short
+			type inner
+				a as short
+				b as byte
+			end type
+			m as inner
+		end type
+
+		CU_ASSERT( sizeof( outer ) = sizeof( outer1 ) )
+		CU_ASSERT( sizeof( outer.inner ) = sizeof( inner1 ) ) 
+
+		CU_ASSERT( sizeof( outer.a ) = sizeof( byte ) )
+		CU_ASSERT( sizeof( outer.b ) = sizeof( short ) )
+		CU_ASSERT( sizeof( outer.inner.a ) = sizeof( short ) )
+		CU_ASSERT( sizeof( outer.inner.b ) = sizeof( byte ) )
+
+		CU_ASSERT( len( outer.a ) = sizeof( byte ) )
+		CU_ASSERT( len( outer.b ) = sizeof( short ) )
+		CU_ASSERT( len( outer.inner.a ) = sizeof( short ) )
+		CU_ASSERT( len( outer.inner.b ) = sizeof( byte ) )
+
+		dim x as outer
+		CU_ASSERT( sizeof( x.a ) = sizeof( byte ) )
+		CU_ASSERT( sizeof( x.b ) = sizeof( short ) )
+
+		CU_ASSERT( len( x.a ) = sizeof( byte ) )
+		CU_ASSERT( len( x.b ) = sizeof( short ) )
+
+		dim y as outer.inner ptr
+		CU_ASSERT( sizeof( y->a ) = sizeof( short ) )
+		CU_ASSERT( sizeof( y->b ) = sizeof( byte ) )
+
+		CU_ASSERT( len( y->a ) = sizeof( short ) )
+		CU_ASSERT( len( y->b ) = sizeof( byte ) )
+
+	END_TEST
+
 END_SUITE

--- a/tests/structs/udt-nested-1.bas
+++ b/tests/structs/udt-nested-1.bas
@@ -1,0 +1,198 @@
+#include once "fbcunit.bi"
+
+SUITE( fbc_tests.structs.udt_nested_1 )
+
+	type T1
+		a as long
+		b as long
+		c as short
+		d as longint
+
+		declare sub p1( byval arg as T1 )
+		declare function f1() as T1
+
+		type T2
+			a as short
+			b as short
+			c as long
+			e as longint
+
+			declare sub p1( byval arg as T1 )
+			declare sub p2( byval arg as T2 )
+			declare function f1() as T1
+			declare function f2() as T2
+		end type
+
+		declare sub p2( byval arg as T2 )
+		declare function f2() as T2
+
+	end type
+
+	#macro chk_t1( o, x, y, z )
+		CU_ASSERT_EQUAL( o.a, x )
+		CU_ASSERT_EQUAL( o.b, y )
+		CU_ASSERT_EQUAL( o.c, z )
+		CU_ASSERT( sizeof(o.a) = sizeof(long) )
+		CU_ASSERT( sizeof(o.b) = sizeof(long) )
+		CU_ASSERT( sizeof(o.c) = sizeof(short) )
+	#endmacro
+
+	#macro set_t1( o, x, y, z )
+		o.a = x
+		o.b = y
+		o.c = z
+		o.d = 1
+	#endmacro
+
+	#macro chk_t2( o, x, y, z )
+		CU_ASSERT_EQUAL( o.a, x )
+		CU_ASSERT_EQUAL( o.b, y )
+		CU_ASSERT_EQUAL( o.c, z )
+		CU_ASSERT( sizeof(o.a) = sizeof(short) )
+		CU_ASSERT( sizeof(o.b) = sizeof(short) )
+		CU_ASSERT( sizeof(o.c) = sizeof(long) )
+	#endmacro
+
+	#macro set_t2( o, x, y, z )
+		o.a = x
+		o.b = y
+		o.c = z
+		o.e = 1
+	#endmacro
+
+	sub T1.p1( byval arg as T1 )
+		CU_ASSERT( sizeof(this) = sizeof(T1) )
+		CU_ASSERT( sizeof(arg) = sizeof(T1) )
+		chk_t1( this, 101, 102, 103 )
+		chk_t1( arg , 111, 112, 113 )
+		set_t1( this, 121, 122, 123 )
+		set_t1( arg , 131, 132, 133 )
+	end sub
+
+	sub T1.p2( byval arg as T2 )
+		CU_ASSERT( sizeof(this) = sizeof(T1) )
+		CU_ASSERT( sizeof(arg) = sizeof(T2) )
+		chk_t1( this, 201, 202, 203 )
+		chk_t2( arg , 211, 212, 213 )
+		set_t1( this, 221, 222, 223 )
+		set_t2( arg , 231, 232, 233 )
+	end sub
+
+	sub T1.T2.p1( byval arg as T1 )
+		CU_ASSERT( sizeof(this) = sizeof(T2) )
+		CU_ASSERT( sizeof(arg) = sizeof(T1) )
+		chk_t2( this, 301, 302, 303 )
+		chk_t1( arg , 311, 312, 313 )
+		set_t2( this, 321, 322, 323 )
+		set_t1( arg , 331, 332, 333 )
+	end sub
+
+	sub T1.T2.p2( byval arg as T2 )
+		CU_ASSERT( sizeof(this) = sizeof(T2) )
+		CU_ASSERT( sizeof(arg) = sizeof(T2) )
+		chk_t2( this, 401, 402, 403 )
+		chk_t2( arg , 411, 412, 413 )
+		set_t2( this, 421, 422, 423 )
+		set_t2( arg , 431, 432, 433 )
+	end sub
+
+	function T1.f1() as T1
+		CU_ASSERT( sizeof(this) = sizeof(T1) )
+		dim ret as T1
+		chk_t1( this, 501, 502, 503 )
+		set_t1( this, 521, 522, 523 )
+		set_t1( ret , 531, 532, 533 )
+		function = ret
+	end function
+
+	function T1.f2() as T2
+		CU_ASSERT( sizeof(this) = sizeof(T1) )
+		dim ret as T2
+		chk_t1( this, 601, 602, 603 )
+		set_t1( this, 621, 622, 623 )
+		set_t2( ret , 631, 632, 633 )
+		function = ret
+	end function
+
+	function T1.T2.f1() as T1
+		CU_ASSERT( sizeof(this) = sizeof(T2) )
+		dim ret as T1
+		chk_t2( this, 701, 702, 703 )
+		set_t2( this, 721, 722, 723 )
+		set_t1( ret , 731, 732, 733 )
+		function = ret
+	end function
+
+	function T1.T2.f2() as T2
+		CU_ASSERT( sizeof(this) = sizeof(T2) )
+		dim ret as T2
+		chk_t2( this, 801, 802, 803 )
+		set_t2( this, 821, 822, 823 )
+		set_t2( ret , 831, 832, 833 )
+		function = ret
+	end function
+
+	TEST( default )
+
+		dim as T1    x1, y1, z1
+		dim as T1.T2 x2, y2, z2
+
+		'' outer instance / outer argument
+		set_t1( x1, 101, 102, 103 )
+		set_t1( y1, 111, 112, 113 )
+		x1.p1( y1 )
+		chk_t1( x1, 121, 122, 123 )
+		chk_t1( y1, 111, 112, 113 )
+
+		'' outer instance / inner argument
+		set_t1( x1, 201, 202, 203 )
+		set_t2( y2, 211, 212, 213 )
+		x1.p2( y2 )
+		chk_t1( x1, 221, 222, 223 )
+		chk_t2( y2, 211, 212, 213 )
+
+		'' inner instance / outer argument
+		set_t2( x2, 301, 302, 303 )
+		set_t1( y1, 311, 312, 313 )
+		x2.p1( y1 )
+		chk_t2( x2, 321, 322, 323 )
+		chk_t1( y1, 311, 312, 313 )
+
+		'' inner instance / inner argument
+		set_t2( x2, 401, 402, 403 )
+		set_t2( y2, 411, 412, 413 )
+		x2.p2( y2 )
+		chk_t2( x2, 421, 422, 423 )
+		chk_t2( y2, 411, 412, 413 )
+
+		'' outer instance / outer result
+		set_t1( x1, 501, 502, 503 )
+		set_t1( z1, 511, 512, 513 )
+		z1 = x1.f1()
+		chk_t1( x1, 521, 522, 523 )
+		chk_t1( z1, 531, 532, 533 )
+
+		'' outer instance / inner result
+		set_t1( x1, 601, 602, 603 )
+		set_t2( z2, 611, 612, 613 )
+		z2 = x1.f2()
+		chk_t1( x1, 621, 622, 623 )
+		chk_t2( z2, 631, 632, 633 )
+
+		'' inner instance / outer result
+		set_t2( x2, 701, 702, 703 )
+		set_t1( z1, 711, 712, 713 )
+		z1 = x2.f1()
+		chk_t2( x2, 721, 722, 723 )
+		chk_t1( z1, 731, 732, 733 )
+
+		'' inner instance / inner result
+		set_t2( x2, 801, 802, 803 )
+		set_t2( z2, 811, 813, 813 )
+		z2 = x2.f2()
+		chk_t2( x2, 821, 822, 823 )
+		chk_t2( z2, 831, 832, 833 )
+
+	END_TEST
+
+END_SUITE

--- a/tests/syntax/len-sizeof.bas
+++ b/tests/syntax/len-sizeof.bas
@@ -1,0 +1,32 @@
+#macro t ? ( n, stmt... )
+#print stmt
+stmt
+#if( n = 0 )
+#print OK
+#endif
+#endmacro
+
+'' ------------------------------------
+
+type TOuter
+	a as byte
+	type TInner
+		a as short
+	end type
+	m as TInner
+end type
+
+dim n as integer
+dim x as TOuter
+
+t( 0, n = sizeof( TOuter ) )
+t( 0, n = sizeof( TOuter.a ) )
+t( 0, n = sizeof( TOuter.TInner ) )
+t( 0, n = sizeof( TOuter.TInner.a ) )
+t( 0, n = sizeof( x ) )
+t( 0, n = sizeof( x.a ) )
+t( 0, n = sizeof( x.m ) )
+t( 0, n = sizeof( x.m.a ) )
+
+t( 1, n = sizeof( x.TInner ) )
+t( 1, n = sizeof( x.TInner.a ) )

--- a/tests/syntax/r/dos/len-sizeof.txt
+++ b/tests/syntax/r/dos/len-sizeof.txt
@@ -1,0 +1,20 @@
+n =sizeof( TOuter )
+OK
+n =sizeof( TOuter.a )
+OK
+n =sizeof( TOuter.TInner )
+OK
+n =sizeof( TOuter.TInner.a )
+OK
+n =sizeof( x )
+OK
+n =sizeof( x.a )
+OK
+n =sizeof( x.m )
+OK
+n =sizeof( x.m.a )
+OK
+n =sizeof( x.TInner )
+len-sizeof.bas(31) error 18: Element not defined, TInner in 't( 1, n = sizeof( x.TInner ) )'
+n =sizeof( x.TInner.a )
+len-sizeof.bas(32) error 9: Expected expression, found '.' in 't( 1, n = sizeof( x.TInner.a ) )'

--- a/tests/syntax/r/dos/type-decl.txt
+++ b/tests/syntax/r/dos/type-decl.txt
@@ -2,3 +2,7 @@
 2 errors for field members as parent type
 type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
 type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'
+---
+2 errors for named type/union in an anonymous type/union
+type-decl.bas(24) error 17: Syntax error, found 'NAMED1' in 'type NAMED1'
+type-decl.bas(31) error 17: Syntax error, found 'NAMED2' in 'union NAMED2'

--- a/tests/syntax/r/dos/type-decl.txt
+++ b/tests/syntax/r/dos/type-decl.txt
@@ -1,0 +1,4 @@
+member1 as T1
+type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
+as T1 member2
+type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'

--- a/tests/syntax/r/dos/type-decl.txt
+++ b/tests/syntax/r/dos/type-decl.txt
@@ -1,4 +1,4 @@
-member1 as T1
-type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
-as T1 member2
-type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'
+---
+2 errors for field members as parent type
+type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
+type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'

--- a/tests/syntax/r/dos/vis-nested-0.txt
+++ b/tests/syntax/r/dos/vis-nested-0.txt
@@ -13,7 +13,9 @@ vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 79,3
 vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 80,1
+vis-nested-0.bas(80) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 80,2
+vis-nested-0.bas(80) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 86,4
 vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 88,3
 vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 89,1
+vis-nested-0.bas(89) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 89,2
+vis-nested-0.bas(89) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 95,3
 vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,10 +49,13 @@ vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 97,1
 vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,2
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,3
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 98,1
 vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 98,2
+vis-nested-0.bas(98) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 104,3
 vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -65,12 +72,13 @@ vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 106,1
 vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,2
-vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,3
-vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 107,1
 vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 107,2
+vis-nested-0.bas(107) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 113,3
 vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -87,12 +95,13 @@ vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 115,1
 vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,2
-vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,3
-vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 116,1
 vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 116,2
+vis-nested-0.bas(116) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 122,3
 vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -109,10 +118,13 @@ vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 124,1
 vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,2
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,3
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 125,1
 vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 125,2
+vis-nested-0.bas(125) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 131,3
 vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -129,12 +141,13 @@ vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 133,1
 vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,2
-vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,3
-vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 134,1
 vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 134,2
+vis-nested-0.bas(134) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 140,3
 vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -151,12 +164,13 @@ vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 142,1
 vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,2
-vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,3
-vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 143,1
 vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 143,2
+vis-nested-0.bas(143) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 149,2
 vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -169,15 +183,21 @@ vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 150,1
 vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,2
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,3
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,4
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 151,1
 vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,2
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,3
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-0.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 158,2
 vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -190,19 +210,21 @@ vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 159,1
 vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,2
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,3
-vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,4
-vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 160,1
 vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,2
-vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,3
-vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-0.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 167,2
 vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -215,19 +237,21 @@ vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 168,1
 vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,2
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,3
-vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,4
-vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 169,1
 vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,2
-vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,3
-vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 170,1
 vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-0.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 176,2
 vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -240,18 +264,21 @@ vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 177,1
 vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,2
-vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,3
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,4
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 178,1
 vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,2
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,3
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 179,1
 vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 179,2
+vis-nested-0.bas(179) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 185,2
 vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -264,20 +291,21 @@ vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 186,1
 vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,2
-vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,3
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,4
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 187,1
 vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,2
-vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,3
-vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 188,1
 vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 188,2
+vis-nested-0.bas(188) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 194,2
 vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -290,20 +318,21 @@ vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 195,1
 vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,2
-vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,3
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,4
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 196,1
 vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,2
-vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,3
-vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 197,1
 vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 197,2
+vis-nested-0.bas(197) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 203,2
 vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -316,18 +345,21 @@ vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 204,1
 vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,2
-vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,3
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,4
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 205,1
 vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,2
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,3
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 206,1
 vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 206,2
+vis-nested-0.bas(206) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 212,2
 vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -340,20 +372,21 @@ vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 213,1
 vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,2
-vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,3
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,4
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 214,1
 vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,2
-vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,3
-vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 215,1
 vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 215,2
+vis-nested-0.bas(215) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 221,2
 vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -366,20 +399,21 @@ vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 222,1
 vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,2
-vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,3
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,4
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 223,1
 vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,2
-vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,3
-vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 224,1
 vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 224,2
+vis-nested-0.bas(224) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 230,2
 vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -392,15 +426,21 @@ vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 231,1
 vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,2
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,3
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,4
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,3
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 233,1
 vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 233,2
+vis-nested-0.bas(233) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 239,2
 vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -413,19 +453,21 @@ vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-0.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 248,2
 vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -438,19 +480,21 @@ vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 249,1
 vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,2
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,3
-vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,4
-vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 250,1
 vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,2
-vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,3
-vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-0.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 257,2
 vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -463,18 +507,21 @@ vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 258,1
 vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,2
-vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,3
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,4
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 259,1
 vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,2
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,3
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 260,1
 vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-0.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 266,2
 vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -487,20 +534,21 @@ vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 267,1
 vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,2
-vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,3
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,4
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 268,1
 vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,2
-vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,3
-vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 269,1
 vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 269,2
+vis-nested-0.bas(269) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 275,2
 vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -513,20 +561,21 @@ vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 276,1
 vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,2
-vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,3
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,4
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 277,1
 vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,2
-vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,3
-vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 278,1
 vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 278,2
+vis-nested-0.bas(278) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 284,2
 vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -539,18 +588,21 @@ vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 285,1
 vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,2
-vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,3
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,4
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 286,1
 vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,2
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,3
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 287,1
 vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 287,2
+vis-nested-0.bas(287) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 293,2
 vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -563,20 +615,21 @@ vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 294,1
 vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,2
-vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,3
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,4
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 295,1
 vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,2
-vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,3
-vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 296,1
 vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 296,2
+vis-nested-0.bas(296) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 302,2
 vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -589,17 +642,18 @@ vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 303,1
 vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,2
-vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,3
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,4
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 304,1
 vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,2
-vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,3
-vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 305,1
 vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 305,2
+vis-nested-0.bas(305) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/dos/vis-nested-0.txt
+++ b/tests/syntax/r/dos/vis-nested-0.txt
@@ -1,0 +1,605 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 77,4
+vis-nested-0.bas(77) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 77,5
+vis-nested-0.bas(77) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,3
+vis-nested-0.bas(78) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 78,4
+vis-nested-0.bas(78) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,2
+vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,1
+Expect error to follow @ 80,2
+---------- public/public/private
+Expect error to follow @ 86,4
+vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 86,5
+vis-nested-0.bas(86) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 87,3
+vis-nested-0.bas(87) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 87,4
+vis-nested-0.bas(87) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 88,2
+vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 89,1
+Expect error to follow @ 89,2
+---------- public/protected/public
+Expect error to follow @ 95,3
+vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,4
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,5
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 96,2
+vis-nested-0.bas(96) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,3
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,4
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 97,1
+vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 97,2
+Expect error to follow @ 97,3
+Expect error to follow @ 98,1
+vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 98,2
+---------- public/protected/protected
+Expect error to follow @ 104,3
+vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,4
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,5
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 105,2
+vis-nested-0.bas(105) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,3
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,4
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 106,1
+vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,2
+vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 107,2
+---------- public/protected/private
+Expect error to follow @ 113,3
+vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,4
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,5
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 114,2
+vis-nested-0.bas(114) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,3
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,4
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 115,1
+vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,2
+vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 116,2
+---------- public/private/public
+Expect error to follow @ 122,3
+vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,4
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,5
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 123,2
+vis-nested-0.bas(123) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,3
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,4
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 124,1
+vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 124,2
+Expect error to follow @ 124,3
+Expect error to follow @ 125,1
+vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 125,2
+---------- public/private/protected
+Expect error to follow @ 131,3
+vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,4
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,5
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 132,2
+vis-nested-0.bas(132) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,3
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,4
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 133,1
+vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,2
+vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 134,2
+---------- public/private/private
+Expect error to follow @ 140,3
+vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,5
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-0.bas(141) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,4
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 143,2
+---------- protected/public/public
+Expect error to follow @ 149,2
+vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,3
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 150,1
+vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 150,2
+Expect error to follow @ 150,3
+Expect error to follow @ 150,4
+Expect error to follow @ 151,1
+vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 151,2
+Expect error to follow @ 151,3
+Expect error to follow @ 152,1
+vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/protected
+Expect error to follow @ 158,2
+vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,3
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,4
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,5
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,1
+vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,2
+Expect error to follow @ 159,3
+vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 161,2
+---------- protected/public/private
+Expect error to follow @ 167,2
+vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,3
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,4
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,5
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 168,1
+vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,2
+Expect error to follow @ 168,3
+vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,4
+vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 169,1
+vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 170,2
+---------- protected/protected/public
+Expect error to follow @ 176,2
+vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,3
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,4
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,5
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 177,1
+vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,2
+vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,3
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,4
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 178,1
+vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 178,2
+Expect error to follow @ 178,3
+Expect error to follow @ 179,1
+vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 179,2
+---------- protected/protected/protected
+Expect error to follow @ 185,2
+vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,3
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,4
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,5
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 186,1
+vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,2
+vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,3
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,4
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 187,1
+vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 188,2
+---------- protected/protected/private
+Expect error to follow @ 194,2
+vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,3
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,4
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,5
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 195,1
+vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,2
+vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,3
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,4
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 196,1
+vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 197,2
+---------- protected/private/public
+Expect error to follow @ 203,2
+vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,3
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,4
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,5
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 204,1
+vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,2
+vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,3
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,4
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 205,1
+vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 205,2
+Expect error to follow @ 205,3
+Expect error to follow @ 206,1
+vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 206,2
+---------- protected/private/protected
+Expect error to follow @ 212,2
+vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,3
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,4
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,5
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 213,1
+vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,2
+vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,3
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,4
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 214,1
+vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 215,2
+---------- protected/private/private
+Expect error to follow @ 221,2
+vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,3
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,4
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,5
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 222,1
+vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,2
+vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,3
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,4
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 223,1
+vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 224,2
+---------- private/public/public
+Expect error to follow @ 230,2
+vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,5
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 231,2
+Expect error to follow @ 231,3
+Expect error to follow @ 231,4
+Expect error to follow @ 232,1
+vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 232,2
+Expect error to follow @ 232,3
+Expect error to follow @ 233,1
+vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 233,2
+---------- private/public/protected
+Expect error to follow @ 239,2
+vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+Expect error to follow @ 240,3
+vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/private
+Expect error to follow @ 248,2
+vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,3
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,4
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,5
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,1
+vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,2
+Expect error to follow @ 249,3
+vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 251,2
+---------- private/protected/public
+Expect error to follow @ 257,2
+vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,3
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,4
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,5
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 258,1
+vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,2
+vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,3
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,4
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 259,1
+vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 259,2
+Expect error to follow @ 259,3
+Expect error to follow @ 260,1
+vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 260,2
+---------- private/protected/protected
+Expect error to follow @ 266,2
+vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,3
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,4
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,5
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 267,1
+vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,2
+vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,3
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,4
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 268,1
+vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 269,2
+---------- private/protected/private
+Expect error to follow @ 275,2
+vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,3
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,4
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,5
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 276,1
+vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,2
+vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,3
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,4
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 277,1
+vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 278,2
+---------- private/private/public
+Expect error to follow @ 284,2
+vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,3
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,4
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,5
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 285,1
+vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,2
+vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,3
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,4
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 286,1
+vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 286,2
+Expect error to follow @ 286,3
+Expect error to follow @ 287,1
+vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 287,2
+---------- private/private/protected
+Expect error to follow @ 293,2
+vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,3
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,4
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,5
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 294,1
+vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,2
+vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,3
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,4
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 295,1
+vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 296,2
+---------- private/private/private
+Expect error to follow @ 302,2
+vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,3
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,4
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,5
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 303,1
+vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,2
+vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,3
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,4
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 304,1
+vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,2
+vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,3
+vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 305,1
+vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 305,2

--- a/tests/syntax/r/dos/vis-nested-1.txt
+++ b/tests/syntax/r/dos/vis-nested-1.txt
@@ -13,7 +13,9 @@ vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 80,3
 vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 81,1
+vis-nested-1.bas(81) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 81,2
+vis-nested-1.bas(81) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 88,4
 vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 90,3
 vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 91,1
+vis-nested-1.bas(91) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 91,2
+vis-nested-1.bas(91) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 98,3
 vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,13 +49,17 @@ vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 100,1
 vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,2
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,3
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 101,1
 vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 101,2
+vis-nested-1.bas(101) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,1
 vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,2
+vis-nested-1.bas(102) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 109,3
 vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -68,12 +76,13 @@ vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 111,1
 vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,2
-vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,3
-vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 112,1
 vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 112,2
+vis-nested-1.bas(112) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 119,3
 vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -90,12 +99,13 @@ vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 121,1
 vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,2
-vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,3
-vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 122,1
 vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 122,2
+vis-nested-1.bas(122) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 129,3
 vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -112,10 +122,13 @@ vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 131,1
 vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,2
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,3
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 132,1
 vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 132,2
+vis-nested-1.bas(132) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 139,3
 vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -132,12 +145,13 @@ vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 141,1
 vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,2
-vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,3
-vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 142,1
 vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 142,2
+vis-nested-1.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 149,3
 vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -154,12 +168,13 @@ vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 151,1
 vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,2
-vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,3
-vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-1.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 159,2
 vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -172,15 +187,21 @@ vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 160,1
 vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,2
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,3
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,4
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,3
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 162,1
 vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 162,2
+vis-nested-1.bas(162) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 169,2
 vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -193,19 +214,21 @@ vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 170,1
 vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,3
-vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,4
-vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 171,1
 vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,2
-vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,3
-vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 172,1
 vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 172,2
+vis-nested-1.bas(172) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 179,2
 vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -218,19 +241,21 @@ vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 180,1
 vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,2
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,3
-vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,4
-vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 181,1
 vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,2
-vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,3
-vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 182,1
 vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 182,2
+vis-nested-1.bas(182) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 189,2
 vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -243,18 +268,21 @@ vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 190,1
 vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,2
-vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,3
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,4
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 191,1
 vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,2
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,3
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 192,1
 vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 192,2
+vis-nested-1.bas(192) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 199,2
 vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -267,20 +295,21 @@ vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 200,1
 vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,2
-vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,3
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,4
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 201,1
 vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,2
-vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,3
-vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 202,1
 vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 202,2
+vis-nested-1.bas(202) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 209,2
 vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -293,20 +322,21 @@ vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 210,1
 vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,2
-vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,3
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,4
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 211,1
 vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,2
-vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,3
-vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 212,1
 vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 212,2
+vis-nested-1.bas(212) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 219,2
 vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -319,18 +349,21 @@ vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 220,1
 vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,2
-vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,3
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,4
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 221,1
 vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,2
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,3
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 222,1
 vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 222,2
+vis-nested-1.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 229,2
 vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -343,20 +376,21 @@ vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 230,1
 vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,2
-vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,3
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,4
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 231,1
 vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,2
-vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,3
-vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-1.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 239,2
 vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -369,20 +403,21 @@ vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
-vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-1.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 249,2
 vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -395,15 +430,21 @@ vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 250,1
 vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,2
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,3
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,4
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,3
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 252,1
 vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 252,2
+vis-nested-1.bas(252) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 259,2
 vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -416,19 +457,21 @@ vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 260,1
 vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,3
-vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,4
-vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 261,1
 vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,2
-vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,3
-vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 262,1
 vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 262,2
+vis-nested-1.bas(262) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 269,2
 vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -441,19 +484,21 @@ vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 270,1
 vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,2
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,3
-vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,4
-vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 271,1
 vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,2
-vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,3
-vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 272,1
 vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 272,2
+vis-nested-1.bas(272) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 279,2
 vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -466,18 +511,21 @@ vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 280,1
 vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,2
-vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,3
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,4
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 281,1
 vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,2
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,3
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 282,1
 vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 282,2
+vis-nested-1.bas(282) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 289,2
 vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -490,20 +538,21 @@ vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 290,1
 vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,2
-vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,3
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,4
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 291,1
 vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,2
-vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,3
-vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 292,1
 vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 292,2
+vis-nested-1.bas(292) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 299,2
 vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -516,20 +565,21 @@ vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 300,1
 vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,2
-vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,3
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,4
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 301,1
 vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,2
-vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,3
-vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 302,1
 vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 302,2
+vis-nested-1.bas(302) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 309,2
 vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -542,18 +592,21 @@ vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 310,1
 vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,2
-vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,3
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,4
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 311,1
 vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,2
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,3
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 312,1
 vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 312,2
+vis-nested-1.bas(312) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 319,2
 vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -566,20 +619,21 @@ vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 320,1
 vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,2
-vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,3
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,4
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 321,1
 vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,2
-vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,3
-vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 322,1
 vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 322,2
+vis-nested-1.bas(322) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 329,2
 vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -592,17 +646,18 @@ vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 330,1
 vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,2
-vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,3
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,4
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 331,1
 vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,2
-vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,3
-vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 332,1
 vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 332,2
+vis-nested-1.bas(332) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/dos/vis-nested-1.txt
+++ b/tests/syntax/r/dos/vis-nested-1.txt
@@ -1,0 +1,608 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 78,4
+vis-nested-1.bas(78) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,5
+vis-nested-1.bas(78) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-1.bas(79) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-1.bas(79) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 81,1
+Expect error to follow @ 81,2
+---------- public/public/private
+Expect error to follow @ 88,4
+vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 88,5
+vis-nested-1.bas(88) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-1.bas(89) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 89,4
+vis-nested-1.bas(89) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 90,3
+vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 91,1
+Expect error to follow @ 91,2
+---------- public/protected/public
+Expect error to follow @ 98,3
+vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,4
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,5
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-1.bas(99) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,3
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,4
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 100,2
+Expect error to follow @ 100,3
+Expect error to follow @ 101,1
+vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 101,2
+Expect error to follow @ 102,1
+vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 102,2
+---------- public/protected/protected
+Expect error to follow @ 109,3
+vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,4
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,5
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 110,2
+vis-nested-1.bas(110) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,3
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,4
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 111,1
+vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,2
+vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,3
+vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 112,1
+vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 112,2
+---------- public/protected/private
+Expect error to follow @ 119,3
+vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,4
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,5
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 120,2
+vis-nested-1.bas(120) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,3
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,4
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 121,1
+vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,2
+vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,3
+vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 122,1
+vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 122,2
+---------- public/private/public
+Expect error to follow @ 129,3
+vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,4
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,5
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 130,2
+vis-nested-1.bas(130) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,3
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,4
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 131,1
+vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 131,2
+Expect error to follow @ 131,3
+Expect error to follow @ 132,1
+vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 132,2
+---------- public/private/protected
+Expect error to follow @ 139,3
+vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,4
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,5
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,2
+vis-nested-1.bas(140) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,3
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 141,1
+vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 142,2
+---------- public/private/private
+Expect error to follow @ 149,3
+vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 150,2
+vis-nested-1.bas(150) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,3
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,4
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 151,1
+vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/public
+Expect error to follow @ 159,2
+vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,3
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,5
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+Expect error to follow @ 160,3
+Expect error to follow @ 160,4
+Expect error to follow @ 161,1
+vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 161,2
+Expect error to follow @ 161,3
+Expect error to follow @ 162,1
+vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 162,2
+---------- protected/public/protected
+Expect error to follow @ 169,2
+vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,5
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+Expect error to follow @ 170,3
+vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,4
+vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,3
+vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 172,2
+---------- protected/public/private
+Expect error to follow @ 179,2
+vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,4
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,5
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,2
+Expect error to follow @ 180,3
+vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,4
+vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,2
+vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,3
+vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 182,1
+vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 182,2
+---------- protected/protected/public
+Expect error to follow @ 189,2
+vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,3
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,4
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,5
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,2
+vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,3
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,4
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 191,1
+vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 191,2
+Expect error to follow @ 191,3
+Expect error to follow @ 192,1
+vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 192,2
+---------- protected/protected/protected
+Expect error to follow @ 199,2
+vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,3
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,4
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,5
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 200,1
+vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,2
+vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,3
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,4
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 201,1
+vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,2
+vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,3
+vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 202,1
+vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 202,2
+---------- protected/protected/private
+Expect error to follow @ 209,2
+vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,3
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,4
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,5
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 210,1
+vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,2
+vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,3
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,4
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 211,1
+vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,2
+vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,3
+vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 212,1
+vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 212,2
+---------- protected/private/public
+Expect error to follow @ 219,2
+vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,3
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,4
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,5
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 220,1
+vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,2
+vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,3
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,4
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 221,1
+vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 221,2
+Expect error to follow @ 221,3
+Expect error to follow @ 222,1
+vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 222,2
+---------- protected/private/protected
+Expect error to follow @ 229,2
+vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,3
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,4
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,5
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,1
+vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,2
+vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,2
+vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,3
+vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 232,1
+vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 232,2
+---------- protected/private/private
+Expect error to follow @ 239,2
+vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,3
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/public
+Expect error to follow @ 249,2
+vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,3
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,5
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+Expect error to follow @ 250,3
+Expect error to follow @ 250,4
+Expect error to follow @ 251,1
+vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 251,2
+Expect error to follow @ 251,3
+Expect error to follow @ 252,1
+vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 252,2
+---------- private/public/protected
+Expect error to follow @ 259,2
+vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,5
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+Expect error to follow @ 260,3
+vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,4
+vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,3
+vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 262,2
+---------- private/public/private
+Expect error to follow @ 269,2
+vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,4
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,5
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,2
+Expect error to follow @ 270,3
+vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,4
+vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,2
+vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,3
+vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 272,1
+vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 272,2
+---------- private/protected/public
+Expect error to follow @ 279,2
+vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,3
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,4
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,5
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,2
+vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,3
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,4
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 281,1
+vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 281,2
+Expect error to follow @ 281,3
+Expect error to follow @ 282,1
+vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 282,2
+---------- private/protected/protected
+Expect error to follow @ 289,2
+vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,3
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,4
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,5
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 290,1
+vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,2
+vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,3
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,4
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 291,1
+vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,2
+vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,3
+vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 292,1
+vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 292,2
+---------- private/protected/private
+Expect error to follow @ 299,2
+vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,3
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,4
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,5
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 300,1
+vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,2
+vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,3
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,4
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 301,1
+vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,2
+vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,3
+vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 302,1
+vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 302,2
+---------- private/private/public
+Expect error to follow @ 309,2
+vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,3
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,4
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,5
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 310,1
+vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,2
+vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,3
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,4
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 311,1
+vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 311,2
+Expect error to follow @ 311,3
+Expect error to follow @ 312,1
+vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 312,2
+---------- private/private/protected
+Expect error to follow @ 319,2
+vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,3
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,4
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,5
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 320,1
+vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,2
+vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,3
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,4
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 321,1
+vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,2
+vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,3
+vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 322,1
+vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 322,2
+---------- private/private/private
+Expect error to follow @ 329,2
+vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,3
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,4
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,5
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 330,1
+vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,2
+vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,3
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,4
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 331,1
+vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,2
+vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,3
+vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 332,1
+vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 332,2

--- a/tests/syntax/r/dos/vis-nested-2.txt
+++ b/tests/syntax/r/dos/vis-nested-2.txt
@@ -1,0 +1,523 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 70,3
+vis-nested-2.bas(70) error 202: Illegal member access, found 'c2' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 70,4
+vis-nested-2.bas(70) error 202: Illegal member access, found 'UDT023' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 71,2
+vis-nested-2.bas(71) error 202: Illegal member access, found 'c2' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 71,3
+vis-nested-2.bas(71) error 202: Illegal member access, found 'UDT023' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 72,1
+vis-nested-2.bas(72) error 202: Illegal member access, found 'c2' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 72,2
+vis-nested-2.bas(72) error 202: Illegal member access, found 'UDT023' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 73,1
+vis-nested-2.bas(73) error 202: Illegal member access, found 'UDT023' in 'test_X3( UDT02,          1, 1 )'
+---------- public/public/private
+Expect error to follow @ 79,3
+vis-nested-2.bas(79) error 202: Illegal member access, found 'c2' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-2.bas(79) error 202: Illegal member access, found 'UDT033' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-2.bas(80) error 202: Illegal member access, found 'c2' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-2.bas(80) error 202: Illegal member access, found 'UDT033' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 81,1
+vis-nested-2.bas(81) error 202: Illegal member access, found 'c2' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 81,2
+vis-nested-2.bas(81) error 202: Illegal member access, found 'UDT033' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 82,1
+vis-nested-2.bas(82) error 202: Illegal member access, found 'UDT033' in 'test_X3( UDT03,          1, 1 )'
+---------- public/protected/public
+Expect error to follow @ 88,2
+vis-nested-2.bas(88) error 202: Illegal member access, found 'c1' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,4
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 89,1
+vis-nested-2.bas(89) error 202: Illegal member access, found 'c1' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,2
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 90,1
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 91,1
+vis-nested-2.bas(91) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+---------- public/protected/protected
+Expect error to follow @ 97,2
+vis-nested-2.bas(97) error 202: Illegal member access, found 'c1' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,3
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,4
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,1
+vis-nested-2.bas(98) error 202: Illegal member access, found 'c1' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,2
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,3
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 99,1
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-2.bas(100) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+---------- public/protected/private
+Expect error to follow @ 106,2
+vis-nested-2.bas(106) error 202: Illegal member access, found 'c1' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,4
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-2.bas(107) error 202: Illegal member access, found 'c1' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,2
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,3
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 108,1
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 108,2
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 109,1
+vis-nested-2.bas(109) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+---------- public/private/public
+Expect error to follow @ 115,2
+vis-nested-2.bas(115) error 202: Illegal member access, found 'c1' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,4
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-2.bas(116) error 202: Illegal member access, found 'c1' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,2
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,3
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 117,1
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 117,2
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 118,1
+vis-nested-2.bas(118) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+---------- public/private/protected
+Expect error to follow @ 124,2
+vis-nested-2.bas(124) error 202: Illegal member access, found 'c1' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,3
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,4
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 125,1
+vis-nested-2.bas(125) error 202: Illegal member access, found 'c1' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,2
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,3
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 126,1
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 126,2
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 127,1
+vis-nested-2.bas(127) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+---------- public/private/private
+Expect error to follow @ 133,2
+vis-nested-2.bas(133) error 202: Illegal member access, found 'c1' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,4
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-2.bas(134) error 202: Illegal member access, found 'c1' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,2
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,3
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 135,1
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 135,2
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 136,1
+vis-nested-2.bas(136) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+---------- protected/public/public
+Expect error to follow @ 142,1
+vis-nested-2.bas(142) error 202: Illegal member access, found 'c0' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,4
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,2
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,3
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 144,1
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 144,2
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 145,1
+vis-nested-2.bas(145) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+---------- protected/public/protected
+Expect error to follow @ 151,1
+vis-nested-2.bas(151) error 202: Illegal member access, found 'c0' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,4
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,2
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,3
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 153,1
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 153,2
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 154,1
+vis-nested-2.bas(154) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+---------- protected/public/private
+Expect error to follow @ 160,1
+vis-nested-2.bas(160) error 202: Illegal member access, found 'c0' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,4
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,2
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,3
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 162,1
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 162,2
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 163,1
+vis-nested-2.bas(163) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+---------- protected/protected/public
+Expect error to follow @ 169,1
+vis-nested-2.bas(169) error 202: Illegal member access, found 'c0' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,3
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-2.bas(172) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+---------- protected/protected/protected
+Expect error to follow @ 178,1
+vis-nested-2.bas(178) error 202: Illegal member access, found 'c0' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,2
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,3
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,4
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,1
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,2
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 180,2
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-2.bas(181) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+---------- protected/protected/private
+Expect error to follow @ 187,1
+vis-nested-2.bas(187) error 202: Illegal member access, found 'c0' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,4
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,2
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,3
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 189,1
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 189,2
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-2.bas(190) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+---------- protected/private/public
+Expect error to follow @ 196,1
+vis-nested-2.bas(196) error 202: Illegal member access, found 'c0' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,4
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,2
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,3
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 198,1
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 198,2
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 199,1
+vis-nested-2.bas(199) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+---------- protected/private/protected
+Expect error to follow @ 205,1
+vis-nested-2.bas(205) error 202: Illegal member access, found 'c0' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,2
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,3
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,4
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 206,1
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,2
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,3
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 207,1
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 207,2
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 208,1
+vis-nested-2.bas(208) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+---------- protected/private/private
+Expect error to follow @ 214,1
+vis-nested-2.bas(214) error 202: Illegal member access, found 'c0' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,4
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,2
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,3
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 216,1
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 216,2
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 217,1
+vis-nested-2.bas(217) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+---------- private/public/public
+Expect error to follow @ 223,1
+vis-nested-2.bas(223) error 202: Illegal member access, found 'c0' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,4
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,2
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,3
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 225,1
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 225,2
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 226,1
+vis-nested-2.bas(226) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+---------- private/public/protected
+Expect error to follow @ 232,1
+vis-nested-2.bas(232) error 202: Illegal member access, found 'c0' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,2
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,3
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,4
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 233,1
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,2
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,3
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 234,1
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 234,2
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 235,1
+vis-nested-2.bas(235) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+---------- private/public/private
+Expect error to follow @ 241,1
+vis-nested-2.bas(241) error 202: Illegal member access, found 'c0' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,4
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,2
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,3
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 243,1
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 243,2
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 244,1
+vis-nested-2.bas(244) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+---------- private/protected/public
+Expect error to follow @ 250,1
+vis-nested-2.bas(250) error 202: Illegal member access, found 'c0' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,4
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,2
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,3
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 252,1
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 252,2
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 253,1
+vis-nested-2.bas(253) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+---------- private/protected/protected
+Expect error to follow @ 259,1
+vis-nested-2.bas(259) error 202: Illegal member access, found 'c0' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,2
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,3
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-2.bas(262) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+---------- private/protected/private
+Expect error to follow @ 268,1
+vis-nested-2.bas(268) error 202: Illegal member access, found 'c0' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,4
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,2
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 270,2
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-2.bas(271) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+---------- private/private/public
+Expect error to follow @ 277,1
+vis-nested-2.bas(277) error 202: Illegal member access, found 'c0' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,4
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,2
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,3
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 279,1
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 279,2
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-2.bas(280) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+---------- private/private/protected
+Expect error to follow @ 286,1
+vis-nested-2.bas(286) error 202: Illegal member access, found 'c0' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,2
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,3
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,4
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 287,1
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,2
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,3
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 288,1
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 288,2
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 289,1
+vis-nested-2.bas(289) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+---------- private/private/private
+Expect error to follow @ 295,1
+vis-nested-2.bas(295) error 202: Illegal member access, found 'c0' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,4
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,2
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,3
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 297,1
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 297,2
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 298,1
+vis-nested-2.bas(298) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/linux-x86/len-sizeof.txt
+++ b/tests/syntax/r/linux-x86/len-sizeof.txt
@@ -1,0 +1,20 @@
+n =sizeof( TOuter )
+OK
+n =sizeof( TOuter.a )
+OK
+n =sizeof( TOuter.TInner )
+OK
+n =sizeof( TOuter.TInner.a )
+OK
+n =sizeof( x )
+OK
+n =sizeof( x.a )
+OK
+n =sizeof( x.m )
+OK
+n =sizeof( x.m.a )
+OK
+n =sizeof( x.TInner )
+len-sizeof.bas(31) error 18: Element not defined, TInner in 't( 1, n = sizeof( x.TInner ) )'
+n =sizeof( x.TInner.a )
+len-sizeof.bas(32) error 9: Expected expression, found '.' in 't( 1, n = sizeof( x.TInner.a ) )'

--- a/tests/syntax/r/linux-x86/type-decl.txt
+++ b/tests/syntax/r/linux-x86/type-decl.txt
@@ -2,3 +2,7 @@
 2 errors for field members as parent type
 type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
 type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'
+---
+2 errors for named type/union in an anonymous type/union
+type-decl.bas(24) error 17: Syntax error, found 'NAMED1' in 'type NAMED1'
+type-decl.bas(31) error 17: Syntax error, found 'NAMED2' in 'union NAMED2'

--- a/tests/syntax/r/linux-x86/type-decl.txt
+++ b/tests/syntax/r/linux-x86/type-decl.txt
@@ -1,0 +1,4 @@
+member1 as T1
+type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
+as T1 member2
+type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'

--- a/tests/syntax/r/linux-x86/type-decl.txt
+++ b/tests/syntax/r/linux-x86/type-decl.txt
@@ -1,4 +1,4 @@
-member1 as T1
-type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
-as T1 member2
-type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'
+---
+2 errors for field members as parent type
+type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
+type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'

--- a/tests/syntax/r/linux-x86/vis-nested-0.txt
+++ b/tests/syntax/r/linux-x86/vis-nested-0.txt
@@ -13,7 +13,9 @@ vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 79,3
 vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 80,1
+vis-nested-0.bas(80) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 80,2
+vis-nested-0.bas(80) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 86,4
 vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 88,3
 vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 89,1
+vis-nested-0.bas(89) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 89,2
+vis-nested-0.bas(89) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 95,3
 vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,10 +49,13 @@ vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 97,1
 vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,2
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,3
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 98,1
 vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 98,2
+vis-nested-0.bas(98) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 104,3
 vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -65,12 +72,13 @@ vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 106,1
 vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,2
-vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,3
-vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 107,1
 vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 107,2
+vis-nested-0.bas(107) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 113,3
 vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -87,12 +95,13 @@ vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 115,1
 vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,2
-vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,3
-vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 116,1
 vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 116,2
+vis-nested-0.bas(116) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 122,3
 vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -109,10 +118,13 @@ vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 124,1
 vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,2
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,3
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 125,1
 vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 125,2
+vis-nested-0.bas(125) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 131,3
 vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -129,12 +141,13 @@ vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 133,1
 vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,2
-vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,3
-vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 134,1
 vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 134,2
+vis-nested-0.bas(134) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 140,3
 vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -151,12 +164,13 @@ vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 142,1
 vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,2
-vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,3
-vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 143,1
 vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 143,2
+vis-nested-0.bas(143) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 149,2
 vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -169,15 +183,21 @@ vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 150,1
 vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,2
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,3
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,4
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 151,1
 vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,2
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,3
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-0.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 158,2
 vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -190,19 +210,21 @@ vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 159,1
 vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,2
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,3
-vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,4
-vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 160,1
 vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,2
-vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,3
-vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-0.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 167,2
 vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -215,19 +237,21 @@ vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 168,1
 vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,2
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,3
-vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,4
-vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 169,1
 vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,2
-vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,3
-vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 170,1
 vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-0.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 176,2
 vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -240,18 +264,21 @@ vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 177,1
 vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,2
-vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,3
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,4
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 178,1
 vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,2
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,3
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 179,1
 vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 179,2
+vis-nested-0.bas(179) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 185,2
 vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -264,20 +291,21 @@ vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 186,1
 vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,2
-vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,3
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,4
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 187,1
 vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,2
-vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,3
-vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 188,1
 vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 188,2
+vis-nested-0.bas(188) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 194,2
 vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -290,20 +318,21 @@ vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 195,1
 vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,2
-vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,3
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,4
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 196,1
 vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,2
-vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,3
-vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 197,1
 vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 197,2
+vis-nested-0.bas(197) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 203,2
 vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -316,18 +345,21 @@ vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 204,1
 vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,2
-vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,3
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,4
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 205,1
 vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,2
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,3
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 206,1
 vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 206,2
+vis-nested-0.bas(206) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 212,2
 vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -340,20 +372,21 @@ vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 213,1
 vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,2
-vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,3
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,4
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 214,1
 vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,2
-vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,3
-vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 215,1
 vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 215,2
+vis-nested-0.bas(215) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 221,2
 vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -366,20 +399,21 @@ vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 222,1
 vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,2
-vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,3
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,4
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 223,1
 vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,2
-vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,3
-vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 224,1
 vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 224,2
+vis-nested-0.bas(224) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 230,2
 vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -392,15 +426,21 @@ vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 231,1
 vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,2
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,3
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,4
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,3
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 233,1
 vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 233,2
+vis-nested-0.bas(233) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 239,2
 vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -413,19 +453,21 @@ vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-0.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 248,2
 vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -438,19 +480,21 @@ vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 249,1
 vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,2
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,3
-vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,4
-vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 250,1
 vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,2
-vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,3
-vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-0.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 257,2
 vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -463,18 +507,21 @@ vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 258,1
 vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,2
-vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,3
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,4
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 259,1
 vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,2
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,3
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 260,1
 vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-0.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 266,2
 vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -487,20 +534,21 @@ vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 267,1
 vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,2
-vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,3
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,4
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 268,1
 vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,2
-vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,3
-vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 269,1
 vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 269,2
+vis-nested-0.bas(269) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 275,2
 vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -513,20 +561,21 @@ vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 276,1
 vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,2
-vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,3
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,4
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 277,1
 vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,2
-vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,3
-vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 278,1
 vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 278,2
+vis-nested-0.bas(278) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 284,2
 vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -539,18 +588,21 @@ vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 285,1
 vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,2
-vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,3
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,4
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 286,1
 vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,2
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,3
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 287,1
 vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 287,2
+vis-nested-0.bas(287) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 293,2
 vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -563,20 +615,21 @@ vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 294,1
 vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,2
-vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,3
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,4
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 295,1
 vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,2
-vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,3
-vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 296,1
 vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 296,2
+vis-nested-0.bas(296) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 302,2
 vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -589,17 +642,18 @@ vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 303,1
 vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,2
-vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,3
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,4
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 304,1
 vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,2
-vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,3
-vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 305,1
 vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 305,2
+vis-nested-0.bas(305) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/linux-x86/vis-nested-0.txt
+++ b/tests/syntax/r/linux-x86/vis-nested-0.txt
@@ -1,0 +1,605 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 77,4
+vis-nested-0.bas(77) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 77,5
+vis-nested-0.bas(77) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,3
+vis-nested-0.bas(78) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 78,4
+vis-nested-0.bas(78) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,2
+vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,1
+Expect error to follow @ 80,2
+---------- public/public/private
+Expect error to follow @ 86,4
+vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 86,5
+vis-nested-0.bas(86) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 87,3
+vis-nested-0.bas(87) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 87,4
+vis-nested-0.bas(87) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 88,2
+vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 89,1
+Expect error to follow @ 89,2
+---------- public/protected/public
+Expect error to follow @ 95,3
+vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,4
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,5
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 96,2
+vis-nested-0.bas(96) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,3
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,4
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 97,1
+vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 97,2
+Expect error to follow @ 97,3
+Expect error to follow @ 98,1
+vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 98,2
+---------- public/protected/protected
+Expect error to follow @ 104,3
+vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,4
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,5
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 105,2
+vis-nested-0.bas(105) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,3
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,4
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 106,1
+vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,2
+vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 107,2
+---------- public/protected/private
+Expect error to follow @ 113,3
+vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,4
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,5
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 114,2
+vis-nested-0.bas(114) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,3
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,4
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 115,1
+vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,2
+vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 116,2
+---------- public/private/public
+Expect error to follow @ 122,3
+vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,4
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,5
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 123,2
+vis-nested-0.bas(123) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,3
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,4
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 124,1
+vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 124,2
+Expect error to follow @ 124,3
+Expect error to follow @ 125,1
+vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 125,2
+---------- public/private/protected
+Expect error to follow @ 131,3
+vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,4
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,5
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 132,2
+vis-nested-0.bas(132) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,3
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,4
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 133,1
+vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,2
+vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 134,2
+---------- public/private/private
+Expect error to follow @ 140,3
+vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,5
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-0.bas(141) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,4
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 143,2
+---------- protected/public/public
+Expect error to follow @ 149,2
+vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,3
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 150,1
+vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 150,2
+Expect error to follow @ 150,3
+Expect error to follow @ 150,4
+Expect error to follow @ 151,1
+vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 151,2
+Expect error to follow @ 151,3
+Expect error to follow @ 152,1
+vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/protected
+Expect error to follow @ 158,2
+vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,3
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,4
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,5
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,1
+vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,2
+Expect error to follow @ 159,3
+vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 161,2
+---------- protected/public/private
+Expect error to follow @ 167,2
+vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,3
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,4
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,5
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 168,1
+vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,2
+Expect error to follow @ 168,3
+vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,4
+vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 169,1
+vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 170,2
+---------- protected/protected/public
+Expect error to follow @ 176,2
+vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,3
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,4
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,5
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 177,1
+vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,2
+vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,3
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,4
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 178,1
+vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 178,2
+Expect error to follow @ 178,3
+Expect error to follow @ 179,1
+vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 179,2
+---------- protected/protected/protected
+Expect error to follow @ 185,2
+vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,3
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,4
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,5
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 186,1
+vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,2
+vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,3
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,4
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 187,1
+vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 188,2
+---------- protected/protected/private
+Expect error to follow @ 194,2
+vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,3
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,4
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,5
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 195,1
+vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,2
+vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,3
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,4
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 196,1
+vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 197,2
+---------- protected/private/public
+Expect error to follow @ 203,2
+vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,3
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,4
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,5
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 204,1
+vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,2
+vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,3
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,4
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 205,1
+vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 205,2
+Expect error to follow @ 205,3
+Expect error to follow @ 206,1
+vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 206,2
+---------- protected/private/protected
+Expect error to follow @ 212,2
+vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,3
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,4
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,5
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 213,1
+vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,2
+vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,3
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,4
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 214,1
+vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 215,2
+---------- protected/private/private
+Expect error to follow @ 221,2
+vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,3
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,4
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,5
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 222,1
+vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,2
+vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,3
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,4
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 223,1
+vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 224,2
+---------- private/public/public
+Expect error to follow @ 230,2
+vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,5
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 231,2
+Expect error to follow @ 231,3
+Expect error to follow @ 231,4
+Expect error to follow @ 232,1
+vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 232,2
+Expect error to follow @ 232,3
+Expect error to follow @ 233,1
+vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 233,2
+---------- private/public/protected
+Expect error to follow @ 239,2
+vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+Expect error to follow @ 240,3
+vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/private
+Expect error to follow @ 248,2
+vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,3
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,4
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,5
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,1
+vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,2
+Expect error to follow @ 249,3
+vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 251,2
+---------- private/protected/public
+Expect error to follow @ 257,2
+vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,3
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,4
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,5
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 258,1
+vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,2
+vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,3
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,4
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 259,1
+vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 259,2
+Expect error to follow @ 259,3
+Expect error to follow @ 260,1
+vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 260,2
+---------- private/protected/protected
+Expect error to follow @ 266,2
+vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,3
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,4
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,5
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 267,1
+vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,2
+vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,3
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,4
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 268,1
+vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 269,2
+---------- private/protected/private
+Expect error to follow @ 275,2
+vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,3
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,4
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,5
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 276,1
+vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,2
+vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,3
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,4
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 277,1
+vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 278,2
+---------- private/private/public
+Expect error to follow @ 284,2
+vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,3
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,4
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,5
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 285,1
+vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,2
+vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,3
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,4
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 286,1
+vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 286,2
+Expect error to follow @ 286,3
+Expect error to follow @ 287,1
+vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 287,2
+---------- private/private/protected
+Expect error to follow @ 293,2
+vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,3
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,4
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,5
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 294,1
+vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,2
+vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,3
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,4
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 295,1
+vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 296,2
+---------- private/private/private
+Expect error to follow @ 302,2
+vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,3
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,4
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,5
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 303,1
+vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,2
+vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,3
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,4
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 304,1
+vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,2
+vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,3
+vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 305,1
+vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 305,2

--- a/tests/syntax/r/linux-x86/vis-nested-1.txt
+++ b/tests/syntax/r/linux-x86/vis-nested-1.txt
@@ -13,7 +13,9 @@ vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 80,3
 vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 81,1
+vis-nested-1.bas(81) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 81,2
+vis-nested-1.bas(81) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 88,4
 vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 90,3
 vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 91,1
+vis-nested-1.bas(91) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 91,2
+vis-nested-1.bas(91) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 98,3
 vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,13 +49,17 @@ vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 100,1
 vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,2
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,3
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 101,1
 vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 101,2
+vis-nested-1.bas(101) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,1
 vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,2
+vis-nested-1.bas(102) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 109,3
 vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -68,12 +76,13 @@ vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 111,1
 vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,2
-vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,3
-vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 112,1
 vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 112,2
+vis-nested-1.bas(112) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 119,3
 vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -90,12 +99,13 @@ vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 121,1
 vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,2
-vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,3
-vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 122,1
 vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 122,2
+vis-nested-1.bas(122) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 129,3
 vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -112,10 +122,13 @@ vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 131,1
 vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,2
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,3
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 132,1
 vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 132,2
+vis-nested-1.bas(132) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 139,3
 vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -132,12 +145,13 @@ vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 141,1
 vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,2
-vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,3
-vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 142,1
 vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 142,2
+vis-nested-1.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 149,3
 vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -154,12 +168,13 @@ vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 151,1
 vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,2
-vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,3
-vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-1.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 159,2
 vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -172,15 +187,21 @@ vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 160,1
 vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,2
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,3
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,4
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,3
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 162,1
 vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 162,2
+vis-nested-1.bas(162) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 169,2
 vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -193,19 +214,21 @@ vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 170,1
 vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,3
-vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,4
-vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 171,1
 vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,2
-vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,3
-vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 172,1
 vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 172,2
+vis-nested-1.bas(172) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 179,2
 vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -218,19 +241,21 @@ vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 180,1
 vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,2
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,3
-vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,4
-vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 181,1
 vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,2
-vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,3
-vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 182,1
 vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 182,2
+vis-nested-1.bas(182) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 189,2
 vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -243,18 +268,21 @@ vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 190,1
 vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,2
-vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,3
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,4
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 191,1
 vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,2
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,3
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 192,1
 vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 192,2
+vis-nested-1.bas(192) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 199,2
 vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -267,20 +295,21 @@ vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 200,1
 vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,2
-vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,3
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,4
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 201,1
 vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,2
-vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,3
-vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 202,1
 vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 202,2
+vis-nested-1.bas(202) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 209,2
 vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -293,20 +322,21 @@ vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 210,1
 vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,2
-vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,3
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,4
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 211,1
 vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,2
-vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,3
-vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 212,1
 vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 212,2
+vis-nested-1.bas(212) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 219,2
 vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -319,18 +349,21 @@ vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 220,1
 vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,2
-vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,3
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,4
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 221,1
 vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,2
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,3
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 222,1
 vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 222,2
+vis-nested-1.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 229,2
 vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -343,20 +376,21 @@ vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 230,1
 vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,2
-vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,3
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,4
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 231,1
 vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,2
-vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,3
-vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-1.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 239,2
 vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -369,20 +403,21 @@ vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
-vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-1.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 249,2
 vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -395,15 +430,21 @@ vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 250,1
 vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,2
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,3
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,4
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,3
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 252,1
 vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 252,2
+vis-nested-1.bas(252) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 259,2
 vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -416,19 +457,21 @@ vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 260,1
 vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,3
-vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,4
-vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 261,1
 vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,2
-vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,3
-vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 262,1
 vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 262,2
+vis-nested-1.bas(262) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 269,2
 vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -441,19 +484,21 @@ vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 270,1
 vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,2
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,3
-vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,4
-vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 271,1
 vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,2
-vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,3
-vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 272,1
 vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 272,2
+vis-nested-1.bas(272) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 279,2
 vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -466,18 +511,21 @@ vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 280,1
 vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,2
-vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,3
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,4
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 281,1
 vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,2
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,3
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 282,1
 vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 282,2
+vis-nested-1.bas(282) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 289,2
 vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -490,20 +538,21 @@ vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 290,1
 vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,2
-vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,3
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,4
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 291,1
 vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,2
-vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,3
-vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 292,1
 vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 292,2
+vis-nested-1.bas(292) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 299,2
 vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -516,20 +565,21 @@ vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 300,1
 vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,2
-vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,3
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,4
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 301,1
 vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,2
-vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,3
-vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 302,1
 vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 302,2
+vis-nested-1.bas(302) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 309,2
 vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -542,18 +592,21 @@ vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 310,1
 vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,2
-vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,3
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,4
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 311,1
 vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,2
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,3
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 312,1
 vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 312,2
+vis-nested-1.bas(312) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 319,2
 vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -566,20 +619,21 @@ vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 320,1
 vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,2
-vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,3
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,4
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 321,1
 vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,2
-vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,3
-vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 322,1
 vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 322,2
+vis-nested-1.bas(322) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 329,2
 vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -592,17 +646,18 @@ vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 330,1
 vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,2
-vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,3
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,4
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 331,1
 vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,2
-vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,3
-vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 332,1
 vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 332,2
+vis-nested-1.bas(332) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/linux-x86/vis-nested-1.txt
+++ b/tests/syntax/r/linux-x86/vis-nested-1.txt
@@ -1,0 +1,608 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 78,4
+vis-nested-1.bas(78) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,5
+vis-nested-1.bas(78) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-1.bas(79) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-1.bas(79) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 81,1
+Expect error to follow @ 81,2
+---------- public/public/private
+Expect error to follow @ 88,4
+vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 88,5
+vis-nested-1.bas(88) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-1.bas(89) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 89,4
+vis-nested-1.bas(89) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 90,3
+vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 91,1
+Expect error to follow @ 91,2
+---------- public/protected/public
+Expect error to follow @ 98,3
+vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,4
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,5
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-1.bas(99) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,3
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,4
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 100,2
+Expect error to follow @ 100,3
+Expect error to follow @ 101,1
+vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 101,2
+Expect error to follow @ 102,1
+vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 102,2
+---------- public/protected/protected
+Expect error to follow @ 109,3
+vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,4
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,5
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 110,2
+vis-nested-1.bas(110) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,3
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,4
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 111,1
+vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,2
+vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,3
+vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 112,1
+vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 112,2
+---------- public/protected/private
+Expect error to follow @ 119,3
+vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,4
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,5
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 120,2
+vis-nested-1.bas(120) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,3
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,4
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 121,1
+vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,2
+vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,3
+vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 122,1
+vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 122,2
+---------- public/private/public
+Expect error to follow @ 129,3
+vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,4
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,5
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 130,2
+vis-nested-1.bas(130) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,3
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,4
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 131,1
+vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 131,2
+Expect error to follow @ 131,3
+Expect error to follow @ 132,1
+vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 132,2
+---------- public/private/protected
+Expect error to follow @ 139,3
+vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,4
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,5
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,2
+vis-nested-1.bas(140) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,3
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 141,1
+vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 142,2
+---------- public/private/private
+Expect error to follow @ 149,3
+vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 150,2
+vis-nested-1.bas(150) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,3
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,4
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 151,1
+vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/public
+Expect error to follow @ 159,2
+vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,3
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,5
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+Expect error to follow @ 160,3
+Expect error to follow @ 160,4
+Expect error to follow @ 161,1
+vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 161,2
+Expect error to follow @ 161,3
+Expect error to follow @ 162,1
+vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 162,2
+---------- protected/public/protected
+Expect error to follow @ 169,2
+vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,5
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+Expect error to follow @ 170,3
+vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,4
+vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,3
+vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 172,2
+---------- protected/public/private
+Expect error to follow @ 179,2
+vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,4
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,5
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,2
+Expect error to follow @ 180,3
+vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,4
+vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,2
+vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,3
+vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 182,1
+vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 182,2
+---------- protected/protected/public
+Expect error to follow @ 189,2
+vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,3
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,4
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,5
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,2
+vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,3
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,4
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 191,1
+vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 191,2
+Expect error to follow @ 191,3
+Expect error to follow @ 192,1
+vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 192,2
+---------- protected/protected/protected
+Expect error to follow @ 199,2
+vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,3
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,4
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,5
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 200,1
+vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,2
+vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,3
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,4
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 201,1
+vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,2
+vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,3
+vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 202,1
+vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 202,2
+---------- protected/protected/private
+Expect error to follow @ 209,2
+vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,3
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,4
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,5
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 210,1
+vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,2
+vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,3
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,4
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 211,1
+vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,2
+vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,3
+vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 212,1
+vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 212,2
+---------- protected/private/public
+Expect error to follow @ 219,2
+vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,3
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,4
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,5
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 220,1
+vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,2
+vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,3
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,4
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 221,1
+vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 221,2
+Expect error to follow @ 221,3
+Expect error to follow @ 222,1
+vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 222,2
+---------- protected/private/protected
+Expect error to follow @ 229,2
+vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,3
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,4
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,5
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,1
+vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,2
+vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,2
+vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,3
+vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 232,1
+vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 232,2
+---------- protected/private/private
+Expect error to follow @ 239,2
+vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,3
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/public
+Expect error to follow @ 249,2
+vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,3
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,5
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+Expect error to follow @ 250,3
+Expect error to follow @ 250,4
+Expect error to follow @ 251,1
+vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 251,2
+Expect error to follow @ 251,3
+Expect error to follow @ 252,1
+vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 252,2
+---------- private/public/protected
+Expect error to follow @ 259,2
+vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,5
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+Expect error to follow @ 260,3
+vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,4
+vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,3
+vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 262,2
+---------- private/public/private
+Expect error to follow @ 269,2
+vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,4
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,5
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,2
+Expect error to follow @ 270,3
+vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,4
+vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,2
+vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,3
+vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 272,1
+vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 272,2
+---------- private/protected/public
+Expect error to follow @ 279,2
+vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,3
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,4
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,5
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,2
+vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,3
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,4
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 281,1
+vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 281,2
+Expect error to follow @ 281,3
+Expect error to follow @ 282,1
+vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 282,2
+---------- private/protected/protected
+Expect error to follow @ 289,2
+vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,3
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,4
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,5
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 290,1
+vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,2
+vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,3
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,4
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 291,1
+vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,2
+vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,3
+vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 292,1
+vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 292,2
+---------- private/protected/private
+Expect error to follow @ 299,2
+vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,3
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,4
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,5
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 300,1
+vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,2
+vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,3
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,4
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 301,1
+vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,2
+vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,3
+vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 302,1
+vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 302,2
+---------- private/private/public
+Expect error to follow @ 309,2
+vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,3
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,4
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,5
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 310,1
+vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,2
+vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,3
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,4
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 311,1
+vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 311,2
+Expect error to follow @ 311,3
+Expect error to follow @ 312,1
+vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 312,2
+---------- private/private/protected
+Expect error to follow @ 319,2
+vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,3
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,4
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,5
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 320,1
+vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,2
+vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,3
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,4
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 321,1
+vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,2
+vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,3
+vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 322,1
+vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 322,2
+---------- private/private/private
+Expect error to follow @ 329,2
+vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,3
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,4
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,5
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 330,1
+vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,2
+vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,3
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,4
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 331,1
+vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,2
+vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,3
+vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 332,1
+vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 332,2

--- a/tests/syntax/r/linux-x86/vis-nested-2.txt
+++ b/tests/syntax/r/linux-x86/vis-nested-2.txt
@@ -1,0 +1,523 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 70,3
+vis-nested-2.bas(70) error 202: Illegal member access, found 'c2' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 70,4
+vis-nested-2.bas(70) error 202: Illegal member access, found 'UDT023' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 71,2
+vis-nested-2.bas(71) error 202: Illegal member access, found 'c2' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 71,3
+vis-nested-2.bas(71) error 202: Illegal member access, found 'UDT023' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 72,1
+vis-nested-2.bas(72) error 202: Illegal member access, found 'c2' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 72,2
+vis-nested-2.bas(72) error 202: Illegal member access, found 'UDT023' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 73,1
+vis-nested-2.bas(73) error 202: Illegal member access, found 'UDT023' in 'test_X3( UDT02,          1, 1 )'
+---------- public/public/private
+Expect error to follow @ 79,3
+vis-nested-2.bas(79) error 202: Illegal member access, found 'c2' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-2.bas(79) error 202: Illegal member access, found 'UDT033' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-2.bas(80) error 202: Illegal member access, found 'c2' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-2.bas(80) error 202: Illegal member access, found 'UDT033' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 81,1
+vis-nested-2.bas(81) error 202: Illegal member access, found 'c2' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 81,2
+vis-nested-2.bas(81) error 202: Illegal member access, found 'UDT033' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 82,1
+vis-nested-2.bas(82) error 202: Illegal member access, found 'UDT033' in 'test_X3( UDT03,          1, 1 )'
+---------- public/protected/public
+Expect error to follow @ 88,2
+vis-nested-2.bas(88) error 202: Illegal member access, found 'c1' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,4
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 89,1
+vis-nested-2.bas(89) error 202: Illegal member access, found 'c1' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,2
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 90,1
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 91,1
+vis-nested-2.bas(91) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+---------- public/protected/protected
+Expect error to follow @ 97,2
+vis-nested-2.bas(97) error 202: Illegal member access, found 'c1' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,3
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,4
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,1
+vis-nested-2.bas(98) error 202: Illegal member access, found 'c1' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,2
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,3
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 99,1
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-2.bas(100) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+---------- public/protected/private
+Expect error to follow @ 106,2
+vis-nested-2.bas(106) error 202: Illegal member access, found 'c1' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,4
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-2.bas(107) error 202: Illegal member access, found 'c1' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,2
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,3
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 108,1
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 108,2
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 109,1
+vis-nested-2.bas(109) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+---------- public/private/public
+Expect error to follow @ 115,2
+vis-nested-2.bas(115) error 202: Illegal member access, found 'c1' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,4
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-2.bas(116) error 202: Illegal member access, found 'c1' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,2
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,3
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 117,1
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 117,2
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 118,1
+vis-nested-2.bas(118) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+---------- public/private/protected
+Expect error to follow @ 124,2
+vis-nested-2.bas(124) error 202: Illegal member access, found 'c1' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,3
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,4
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 125,1
+vis-nested-2.bas(125) error 202: Illegal member access, found 'c1' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,2
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,3
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 126,1
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 126,2
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 127,1
+vis-nested-2.bas(127) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+---------- public/private/private
+Expect error to follow @ 133,2
+vis-nested-2.bas(133) error 202: Illegal member access, found 'c1' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,4
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-2.bas(134) error 202: Illegal member access, found 'c1' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,2
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,3
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 135,1
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 135,2
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 136,1
+vis-nested-2.bas(136) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+---------- protected/public/public
+Expect error to follow @ 142,1
+vis-nested-2.bas(142) error 202: Illegal member access, found 'c0' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,4
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,2
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,3
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 144,1
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 144,2
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 145,1
+vis-nested-2.bas(145) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+---------- protected/public/protected
+Expect error to follow @ 151,1
+vis-nested-2.bas(151) error 202: Illegal member access, found 'c0' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,4
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,2
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,3
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 153,1
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 153,2
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 154,1
+vis-nested-2.bas(154) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+---------- protected/public/private
+Expect error to follow @ 160,1
+vis-nested-2.bas(160) error 202: Illegal member access, found 'c0' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,4
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,2
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,3
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 162,1
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 162,2
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 163,1
+vis-nested-2.bas(163) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+---------- protected/protected/public
+Expect error to follow @ 169,1
+vis-nested-2.bas(169) error 202: Illegal member access, found 'c0' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,3
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-2.bas(172) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+---------- protected/protected/protected
+Expect error to follow @ 178,1
+vis-nested-2.bas(178) error 202: Illegal member access, found 'c0' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,2
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,3
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,4
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,1
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,2
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 180,2
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-2.bas(181) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+---------- protected/protected/private
+Expect error to follow @ 187,1
+vis-nested-2.bas(187) error 202: Illegal member access, found 'c0' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,4
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,2
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,3
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 189,1
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 189,2
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-2.bas(190) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+---------- protected/private/public
+Expect error to follow @ 196,1
+vis-nested-2.bas(196) error 202: Illegal member access, found 'c0' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,4
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,2
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,3
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 198,1
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 198,2
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 199,1
+vis-nested-2.bas(199) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+---------- protected/private/protected
+Expect error to follow @ 205,1
+vis-nested-2.bas(205) error 202: Illegal member access, found 'c0' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,2
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,3
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,4
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 206,1
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,2
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,3
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 207,1
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 207,2
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 208,1
+vis-nested-2.bas(208) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+---------- protected/private/private
+Expect error to follow @ 214,1
+vis-nested-2.bas(214) error 202: Illegal member access, found 'c0' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,4
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,2
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,3
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 216,1
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 216,2
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 217,1
+vis-nested-2.bas(217) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+---------- private/public/public
+Expect error to follow @ 223,1
+vis-nested-2.bas(223) error 202: Illegal member access, found 'c0' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,4
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,2
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,3
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 225,1
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 225,2
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 226,1
+vis-nested-2.bas(226) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+---------- private/public/protected
+Expect error to follow @ 232,1
+vis-nested-2.bas(232) error 202: Illegal member access, found 'c0' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,2
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,3
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,4
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 233,1
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,2
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,3
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 234,1
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 234,2
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 235,1
+vis-nested-2.bas(235) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+---------- private/public/private
+Expect error to follow @ 241,1
+vis-nested-2.bas(241) error 202: Illegal member access, found 'c0' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,4
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,2
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,3
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 243,1
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 243,2
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 244,1
+vis-nested-2.bas(244) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+---------- private/protected/public
+Expect error to follow @ 250,1
+vis-nested-2.bas(250) error 202: Illegal member access, found 'c0' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,4
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,2
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,3
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 252,1
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 252,2
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 253,1
+vis-nested-2.bas(253) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+---------- private/protected/protected
+Expect error to follow @ 259,1
+vis-nested-2.bas(259) error 202: Illegal member access, found 'c0' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,2
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,3
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-2.bas(262) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+---------- private/protected/private
+Expect error to follow @ 268,1
+vis-nested-2.bas(268) error 202: Illegal member access, found 'c0' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,4
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,2
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 270,2
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-2.bas(271) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+---------- private/private/public
+Expect error to follow @ 277,1
+vis-nested-2.bas(277) error 202: Illegal member access, found 'c0' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,4
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,2
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,3
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 279,1
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 279,2
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-2.bas(280) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+---------- private/private/protected
+Expect error to follow @ 286,1
+vis-nested-2.bas(286) error 202: Illegal member access, found 'c0' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,2
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,3
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,4
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 287,1
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,2
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,3
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 288,1
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 288,2
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 289,1
+vis-nested-2.bas(289) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+---------- private/private/private
+Expect error to follow @ 295,1
+vis-nested-2.bas(295) error 202: Illegal member access, found 'c0' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,4
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,2
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,3
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 297,1
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 297,2
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 298,1
+vis-nested-2.bas(298) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/linux-x86_64/len-sizeof.txt
+++ b/tests/syntax/r/linux-x86_64/len-sizeof.txt
@@ -1,0 +1,20 @@
+n =sizeof( TOuter )
+OK
+n =sizeof( TOuter.a )
+OK
+n =sizeof( TOuter.TInner )
+OK
+n =sizeof( TOuter.TInner.a )
+OK
+n =sizeof( x )
+OK
+n =sizeof( x.a )
+OK
+n =sizeof( x.m )
+OK
+n =sizeof( x.m.a )
+OK
+n =sizeof( x.TInner )
+len-sizeof.bas(31) error 18: Element not defined, TInner in 't( 1, n = sizeof( x.TInner ) )'
+n =sizeof( x.TInner.a )
+len-sizeof.bas(32) error 9: Expected expression, found '.' in 't( 1, n = sizeof( x.TInner.a ) )'

--- a/tests/syntax/r/linux-x86_64/type-decl.txt
+++ b/tests/syntax/r/linux-x86_64/type-decl.txt
@@ -2,3 +2,7 @@
 2 errors for field members as parent type
 type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
 type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'
+---
+2 errors for named type/union in an anonymous type/union
+type-decl.bas(24) error 17: Syntax error, found 'NAMED1' in 'type NAMED1'
+type-decl.bas(31) error 17: Syntax error, found 'NAMED2' in 'union NAMED2'

--- a/tests/syntax/r/linux-x86_64/type-decl.txt
+++ b/tests/syntax/r/linux-x86_64/type-decl.txt
@@ -1,0 +1,4 @@
+member1 as T1
+type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
+as T1 member2
+type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'

--- a/tests/syntax/r/linux-x86_64/type-decl.txt
+++ b/tests/syntax/r/linux-x86_64/type-decl.txt
@@ -1,4 +1,4 @@
-member1 as T1
-type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
-as T1 member2
-type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'
+---
+2 errors for field members as parent type
+type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
+type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'

--- a/tests/syntax/r/linux-x86_64/vis-nested-0.txt
+++ b/tests/syntax/r/linux-x86_64/vis-nested-0.txt
@@ -13,7 +13,9 @@ vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 79,3
 vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 80,1
+vis-nested-0.bas(80) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 80,2
+vis-nested-0.bas(80) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 86,4
 vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 88,3
 vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 89,1
+vis-nested-0.bas(89) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 89,2
+vis-nested-0.bas(89) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 95,3
 vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,10 +49,13 @@ vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 97,1
 vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,2
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,3
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 98,1
 vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 98,2
+vis-nested-0.bas(98) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 104,3
 vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -65,12 +72,13 @@ vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 106,1
 vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,2
-vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,3
-vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 107,1
 vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 107,2
+vis-nested-0.bas(107) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 113,3
 vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -87,12 +95,13 @@ vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 115,1
 vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,2
-vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,3
-vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 116,1
 vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 116,2
+vis-nested-0.bas(116) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 122,3
 vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -109,10 +118,13 @@ vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 124,1
 vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,2
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,3
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 125,1
 vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 125,2
+vis-nested-0.bas(125) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 131,3
 vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -129,12 +141,13 @@ vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 133,1
 vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,2
-vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,3
-vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 134,1
 vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 134,2
+vis-nested-0.bas(134) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 140,3
 vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -151,12 +164,13 @@ vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 142,1
 vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,2
-vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,3
-vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 143,1
 vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 143,2
+vis-nested-0.bas(143) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 149,2
 vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -169,15 +183,21 @@ vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 150,1
 vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,2
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,3
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,4
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 151,1
 vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,2
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,3
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-0.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 158,2
 vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -190,19 +210,21 @@ vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 159,1
 vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,2
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,3
-vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,4
-vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 160,1
 vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,2
-vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,3
-vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-0.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 167,2
 vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -215,19 +237,21 @@ vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 168,1
 vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,2
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,3
-vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,4
-vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 169,1
 vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,2
-vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,3
-vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 170,1
 vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-0.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 176,2
 vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -240,18 +264,21 @@ vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 177,1
 vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,2
-vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,3
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,4
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 178,1
 vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,2
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,3
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 179,1
 vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 179,2
+vis-nested-0.bas(179) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 185,2
 vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -264,20 +291,21 @@ vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 186,1
 vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,2
-vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,3
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,4
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 187,1
 vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,2
-vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,3
-vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 188,1
 vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 188,2
+vis-nested-0.bas(188) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 194,2
 vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -290,20 +318,21 @@ vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 195,1
 vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,2
-vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,3
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,4
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 196,1
 vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,2
-vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,3
-vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 197,1
 vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 197,2
+vis-nested-0.bas(197) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 203,2
 vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -316,18 +345,21 @@ vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 204,1
 vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,2
-vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,3
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,4
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 205,1
 vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,2
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,3
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 206,1
 vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 206,2
+vis-nested-0.bas(206) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 212,2
 vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -340,20 +372,21 @@ vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 213,1
 vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,2
-vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,3
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,4
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 214,1
 vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,2
-vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,3
-vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 215,1
 vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 215,2
+vis-nested-0.bas(215) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 221,2
 vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -366,20 +399,21 @@ vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 222,1
 vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,2
-vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,3
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,4
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 223,1
 vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,2
-vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,3
-vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 224,1
 vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 224,2
+vis-nested-0.bas(224) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 230,2
 vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -392,15 +426,21 @@ vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 231,1
 vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,2
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,3
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,4
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,3
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 233,1
 vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 233,2
+vis-nested-0.bas(233) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 239,2
 vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -413,19 +453,21 @@ vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-0.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 248,2
 vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -438,19 +480,21 @@ vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 249,1
 vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,2
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,3
-vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,4
-vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 250,1
 vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,2
-vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,3
-vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-0.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 257,2
 vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -463,18 +507,21 @@ vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 258,1
 vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,2
-vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,3
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,4
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 259,1
 vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,2
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,3
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 260,1
 vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-0.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 266,2
 vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -487,20 +534,21 @@ vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 267,1
 vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,2
-vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,3
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,4
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 268,1
 vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,2
-vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,3
-vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 269,1
 vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 269,2
+vis-nested-0.bas(269) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 275,2
 vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -513,20 +561,21 @@ vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 276,1
 vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,2
-vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,3
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,4
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 277,1
 vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,2
-vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,3
-vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 278,1
 vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 278,2
+vis-nested-0.bas(278) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 284,2
 vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -539,18 +588,21 @@ vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 285,1
 vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,2
-vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,3
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,4
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 286,1
 vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,2
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,3
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 287,1
 vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 287,2
+vis-nested-0.bas(287) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 293,2
 vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -563,20 +615,21 @@ vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 294,1
 vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,2
-vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,3
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,4
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 295,1
 vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,2
-vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,3
-vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 296,1
 vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 296,2
+vis-nested-0.bas(296) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 302,2
 vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -589,17 +642,18 @@ vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 303,1
 vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,2
-vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,3
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,4
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 304,1
 vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,2
-vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,3
-vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 305,1
 vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 305,2
+vis-nested-0.bas(305) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/linux-x86_64/vis-nested-0.txt
+++ b/tests/syntax/r/linux-x86_64/vis-nested-0.txt
@@ -1,0 +1,605 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 77,4
+vis-nested-0.bas(77) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 77,5
+vis-nested-0.bas(77) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,3
+vis-nested-0.bas(78) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 78,4
+vis-nested-0.bas(78) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,2
+vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,1
+Expect error to follow @ 80,2
+---------- public/public/private
+Expect error to follow @ 86,4
+vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 86,5
+vis-nested-0.bas(86) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 87,3
+vis-nested-0.bas(87) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 87,4
+vis-nested-0.bas(87) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 88,2
+vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 89,1
+Expect error to follow @ 89,2
+---------- public/protected/public
+Expect error to follow @ 95,3
+vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,4
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,5
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 96,2
+vis-nested-0.bas(96) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,3
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,4
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 97,1
+vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 97,2
+Expect error to follow @ 97,3
+Expect error to follow @ 98,1
+vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 98,2
+---------- public/protected/protected
+Expect error to follow @ 104,3
+vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,4
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,5
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 105,2
+vis-nested-0.bas(105) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,3
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,4
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 106,1
+vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,2
+vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 107,2
+---------- public/protected/private
+Expect error to follow @ 113,3
+vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,4
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,5
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 114,2
+vis-nested-0.bas(114) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,3
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,4
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 115,1
+vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,2
+vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 116,2
+---------- public/private/public
+Expect error to follow @ 122,3
+vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,4
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,5
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 123,2
+vis-nested-0.bas(123) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,3
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,4
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 124,1
+vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 124,2
+Expect error to follow @ 124,3
+Expect error to follow @ 125,1
+vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 125,2
+---------- public/private/protected
+Expect error to follow @ 131,3
+vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,4
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,5
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 132,2
+vis-nested-0.bas(132) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,3
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,4
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 133,1
+vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,2
+vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 134,2
+---------- public/private/private
+Expect error to follow @ 140,3
+vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,5
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-0.bas(141) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,4
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 143,2
+---------- protected/public/public
+Expect error to follow @ 149,2
+vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,3
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 150,1
+vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 150,2
+Expect error to follow @ 150,3
+Expect error to follow @ 150,4
+Expect error to follow @ 151,1
+vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 151,2
+Expect error to follow @ 151,3
+Expect error to follow @ 152,1
+vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/protected
+Expect error to follow @ 158,2
+vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,3
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,4
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,5
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,1
+vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,2
+Expect error to follow @ 159,3
+vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 161,2
+---------- protected/public/private
+Expect error to follow @ 167,2
+vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,3
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,4
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,5
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 168,1
+vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,2
+Expect error to follow @ 168,3
+vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,4
+vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 169,1
+vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 170,2
+---------- protected/protected/public
+Expect error to follow @ 176,2
+vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,3
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,4
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,5
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 177,1
+vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,2
+vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,3
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,4
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 178,1
+vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 178,2
+Expect error to follow @ 178,3
+Expect error to follow @ 179,1
+vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 179,2
+---------- protected/protected/protected
+Expect error to follow @ 185,2
+vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,3
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,4
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,5
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 186,1
+vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,2
+vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,3
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,4
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 187,1
+vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 188,2
+---------- protected/protected/private
+Expect error to follow @ 194,2
+vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,3
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,4
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,5
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 195,1
+vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,2
+vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,3
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,4
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 196,1
+vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 197,2
+---------- protected/private/public
+Expect error to follow @ 203,2
+vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,3
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,4
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,5
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 204,1
+vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,2
+vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,3
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,4
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 205,1
+vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 205,2
+Expect error to follow @ 205,3
+Expect error to follow @ 206,1
+vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 206,2
+---------- protected/private/protected
+Expect error to follow @ 212,2
+vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,3
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,4
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,5
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 213,1
+vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,2
+vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,3
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,4
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 214,1
+vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 215,2
+---------- protected/private/private
+Expect error to follow @ 221,2
+vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,3
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,4
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,5
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 222,1
+vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,2
+vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,3
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,4
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 223,1
+vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 224,2
+---------- private/public/public
+Expect error to follow @ 230,2
+vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,5
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 231,2
+Expect error to follow @ 231,3
+Expect error to follow @ 231,4
+Expect error to follow @ 232,1
+vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 232,2
+Expect error to follow @ 232,3
+Expect error to follow @ 233,1
+vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 233,2
+---------- private/public/protected
+Expect error to follow @ 239,2
+vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+Expect error to follow @ 240,3
+vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/private
+Expect error to follow @ 248,2
+vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,3
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,4
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,5
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,1
+vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,2
+Expect error to follow @ 249,3
+vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 251,2
+---------- private/protected/public
+Expect error to follow @ 257,2
+vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,3
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,4
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,5
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 258,1
+vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,2
+vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,3
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,4
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 259,1
+vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 259,2
+Expect error to follow @ 259,3
+Expect error to follow @ 260,1
+vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 260,2
+---------- private/protected/protected
+Expect error to follow @ 266,2
+vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,3
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,4
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,5
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 267,1
+vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,2
+vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,3
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,4
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 268,1
+vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 269,2
+---------- private/protected/private
+Expect error to follow @ 275,2
+vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,3
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,4
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,5
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 276,1
+vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,2
+vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,3
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,4
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 277,1
+vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 278,2
+---------- private/private/public
+Expect error to follow @ 284,2
+vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,3
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,4
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,5
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 285,1
+vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,2
+vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,3
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,4
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 286,1
+vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 286,2
+Expect error to follow @ 286,3
+Expect error to follow @ 287,1
+vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 287,2
+---------- private/private/protected
+Expect error to follow @ 293,2
+vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,3
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,4
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,5
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 294,1
+vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,2
+vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,3
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,4
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 295,1
+vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 296,2
+---------- private/private/private
+Expect error to follow @ 302,2
+vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,3
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,4
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,5
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 303,1
+vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,2
+vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,3
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,4
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 304,1
+vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,2
+vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,3
+vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 305,1
+vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 305,2

--- a/tests/syntax/r/linux-x86_64/vis-nested-1.txt
+++ b/tests/syntax/r/linux-x86_64/vis-nested-1.txt
@@ -13,7 +13,9 @@ vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 80,3
 vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 81,1
+vis-nested-1.bas(81) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 81,2
+vis-nested-1.bas(81) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 88,4
 vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 90,3
 vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 91,1
+vis-nested-1.bas(91) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 91,2
+vis-nested-1.bas(91) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 98,3
 vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,13 +49,17 @@ vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 100,1
 vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,2
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,3
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 101,1
 vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 101,2
+vis-nested-1.bas(101) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,1
 vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,2
+vis-nested-1.bas(102) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 109,3
 vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -68,12 +76,13 @@ vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 111,1
 vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,2
-vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,3
-vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 112,1
 vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 112,2
+vis-nested-1.bas(112) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 119,3
 vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -90,12 +99,13 @@ vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 121,1
 vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,2
-vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,3
-vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 122,1
 vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 122,2
+vis-nested-1.bas(122) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 129,3
 vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -112,10 +122,13 @@ vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 131,1
 vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,2
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,3
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 132,1
 vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 132,2
+vis-nested-1.bas(132) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 139,3
 vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -132,12 +145,13 @@ vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 141,1
 vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,2
-vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,3
-vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 142,1
 vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 142,2
+vis-nested-1.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 149,3
 vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -154,12 +168,13 @@ vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 151,1
 vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,2
-vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,3
-vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-1.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 159,2
 vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -172,15 +187,21 @@ vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 160,1
 vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,2
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,3
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,4
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,3
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 162,1
 vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 162,2
+vis-nested-1.bas(162) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 169,2
 vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -193,19 +214,21 @@ vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 170,1
 vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,3
-vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,4
-vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 171,1
 vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,2
-vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,3
-vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 172,1
 vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 172,2
+vis-nested-1.bas(172) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 179,2
 vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -218,19 +241,21 @@ vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 180,1
 vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,2
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,3
-vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,4
-vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 181,1
 vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,2
-vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,3
-vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 182,1
 vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 182,2
+vis-nested-1.bas(182) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 189,2
 vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -243,18 +268,21 @@ vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 190,1
 vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,2
-vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,3
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,4
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 191,1
 vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,2
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,3
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 192,1
 vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 192,2
+vis-nested-1.bas(192) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 199,2
 vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -267,20 +295,21 @@ vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 200,1
 vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,2
-vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,3
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,4
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 201,1
 vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,2
-vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,3
-vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 202,1
 vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 202,2
+vis-nested-1.bas(202) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 209,2
 vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -293,20 +322,21 @@ vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 210,1
 vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,2
-vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,3
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,4
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 211,1
 vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,2
-vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,3
-vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 212,1
 vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 212,2
+vis-nested-1.bas(212) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 219,2
 vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -319,18 +349,21 @@ vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 220,1
 vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,2
-vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,3
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,4
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 221,1
 vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,2
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,3
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 222,1
 vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 222,2
+vis-nested-1.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 229,2
 vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -343,20 +376,21 @@ vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 230,1
 vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,2
-vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,3
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,4
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 231,1
 vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,2
-vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,3
-vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-1.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 239,2
 vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -369,20 +403,21 @@ vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
-vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-1.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 249,2
 vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -395,15 +430,21 @@ vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 250,1
 vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,2
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,3
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,4
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,3
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 252,1
 vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 252,2
+vis-nested-1.bas(252) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 259,2
 vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -416,19 +457,21 @@ vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 260,1
 vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,3
-vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,4
-vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 261,1
 vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,2
-vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,3
-vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 262,1
 vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 262,2
+vis-nested-1.bas(262) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 269,2
 vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -441,19 +484,21 @@ vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 270,1
 vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,2
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,3
-vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,4
-vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 271,1
 vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,2
-vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,3
-vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 272,1
 vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 272,2
+vis-nested-1.bas(272) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 279,2
 vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -466,18 +511,21 @@ vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 280,1
 vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,2
-vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,3
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,4
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 281,1
 vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,2
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,3
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 282,1
 vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 282,2
+vis-nested-1.bas(282) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 289,2
 vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -490,20 +538,21 @@ vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 290,1
 vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,2
-vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,3
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,4
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 291,1
 vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,2
-vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,3
-vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 292,1
 vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 292,2
+vis-nested-1.bas(292) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 299,2
 vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -516,20 +565,21 @@ vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 300,1
 vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,2
-vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,3
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,4
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 301,1
 vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,2
-vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,3
-vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 302,1
 vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 302,2
+vis-nested-1.bas(302) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 309,2
 vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -542,18 +592,21 @@ vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 310,1
 vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,2
-vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,3
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,4
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 311,1
 vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,2
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,3
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 312,1
 vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 312,2
+vis-nested-1.bas(312) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 319,2
 vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -566,20 +619,21 @@ vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 320,1
 vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,2
-vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,3
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,4
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 321,1
 vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,2
-vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,3
-vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 322,1
 vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 322,2
+vis-nested-1.bas(322) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 329,2
 vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -592,17 +646,18 @@ vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 330,1
 vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,2
-vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,3
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,4
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 331,1
 vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,2
-vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,3
-vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 332,1
 vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 332,2
+vis-nested-1.bas(332) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/linux-x86_64/vis-nested-1.txt
+++ b/tests/syntax/r/linux-x86_64/vis-nested-1.txt
@@ -1,0 +1,608 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 78,4
+vis-nested-1.bas(78) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,5
+vis-nested-1.bas(78) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-1.bas(79) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-1.bas(79) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 81,1
+Expect error to follow @ 81,2
+---------- public/public/private
+Expect error to follow @ 88,4
+vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 88,5
+vis-nested-1.bas(88) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-1.bas(89) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 89,4
+vis-nested-1.bas(89) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 90,3
+vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 91,1
+Expect error to follow @ 91,2
+---------- public/protected/public
+Expect error to follow @ 98,3
+vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,4
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,5
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-1.bas(99) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,3
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,4
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 100,2
+Expect error to follow @ 100,3
+Expect error to follow @ 101,1
+vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 101,2
+Expect error to follow @ 102,1
+vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 102,2
+---------- public/protected/protected
+Expect error to follow @ 109,3
+vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,4
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,5
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 110,2
+vis-nested-1.bas(110) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,3
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,4
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 111,1
+vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,2
+vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,3
+vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 112,1
+vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 112,2
+---------- public/protected/private
+Expect error to follow @ 119,3
+vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,4
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,5
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 120,2
+vis-nested-1.bas(120) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,3
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,4
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 121,1
+vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,2
+vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,3
+vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 122,1
+vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 122,2
+---------- public/private/public
+Expect error to follow @ 129,3
+vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,4
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,5
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 130,2
+vis-nested-1.bas(130) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,3
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,4
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 131,1
+vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 131,2
+Expect error to follow @ 131,3
+Expect error to follow @ 132,1
+vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 132,2
+---------- public/private/protected
+Expect error to follow @ 139,3
+vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,4
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,5
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,2
+vis-nested-1.bas(140) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,3
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 141,1
+vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 142,2
+---------- public/private/private
+Expect error to follow @ 149,3
+vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 150,2
+vis-nested-1.bas(150) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,3
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,4
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 151,1
+vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/public
+Expect error to follow @ 159,2
+vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,3
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,5
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+Expect error to follow @ 160,3
+Expect error to follow @ 160,4
+Expect error to follow @ 161,1
+vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 161,2
+Expect error to follow @ 161,3
+Expect error to follow @ 162,1
+vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 162,2
+---------- protected/public/protected
+Expect error to follow @ 169,2
+vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,5
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+Expect error to follow @ 170,3
+vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,4
+vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,3
+vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 172,2
+---------- protected/public/private
+Expect error to follow @ 179,2
+vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,4
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,5
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,2
+Expect error to follow @ 180,3
+vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,4
+vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,2
+vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,3
+vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 182,1
+vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 182,2
+---------- protected/protected/public
+Expect error to follow @ 189,2
+vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,3
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,4
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,5
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,2
+vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,3
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,4
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 191,1
+vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 191,2
+Expect error to follow @ 191,3
+Expect error to follow @ 192,1
+vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 192,2
+---------- protected/protected/protected
+Expect error to follow @ 199,2
+vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,3
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,4
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,5
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 200,1
+vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,2
+vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,3
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,4
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 201,1
+vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,2
+vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,3
+vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 202,1
+vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 202,2
+---------- protected/protected/private
+Expect error to follow @ 209,2
+vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,3
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,4
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,5
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 210,1
+vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,2
+vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,3
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,4
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 211,1
+vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,2
+vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,3
+vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 212,1
+vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 212,2
+---------- protected/private/public
+Expect error to follow @ 219,2
+vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,3
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,4
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,5
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 220,1
+vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,2
+vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,3
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,4
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 221,1
+vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 221,2
+Expect error to follow @ 221,3
+Expect error to follow @ 222,1
+vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 222,2
+---------- protected/private/protected
+Expect error to follow @ 229,2
+vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,3
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,4
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,5
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,1
+vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,2
+vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,2
+vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,3
+vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 232,1
+vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 232,2
+---------- protected/private/private
+Expect error to follow @ 239,2
+vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,3
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/public
+Expect error to follow @ 249,2
+vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,3
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,5
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+Expect error to follow @ 250,3
+Expect error to follow @ 250,4
+Expect error to follow @ 251,1
+vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 251,2
+Expect error to follow @ 251,3
+Expect error to follow @ 252,1
+vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 252,2
+---------- private/public/protected
+Expect error to follow @ 259,2
+vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,5
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+Expect error to follow @ 260,3
+vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,4
+vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,3
+vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 262,2
+---------- private/public/private
+Expect error to follow @ 269,2
+vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,4
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,5
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,2
+Expect error to follow @ 270,3
+vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,4
+vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,2
+vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,3
+vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 272,1
+vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 272,2
+---------- private/protected/public
+Expect error to follow @ 279,2
+vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,3
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,4
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,5
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,2
+vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,3
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,4
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 281,1
+vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 281,2
+Expect error to follow @ 281,3
+Expect error to follow @ 282,1
+vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 282,2
+---------- private/protected/protected
+Expect error to follow @ 289,2
+vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,3
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,4
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,5
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 290,1
+vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,2
+vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,3
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,4
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 291,1
+vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,2
+vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,3
+vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 292,1
+vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 292,2
+---------- private/protected/private
+Expect error to follow @ 299,2
+vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,3
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,4
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,5
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 300,1
+vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,2
+vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,3
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,4
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 301,1
+vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,2
+vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,3
+vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 302,1
+vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 302,2
+---------- private/private/public
+Expect error to follow @ 309,2
+vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,3
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,4
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,5
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 310,1
+vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,2
+vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,3
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,4
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 311,1
+vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 311,2
+Expect error to follow @ 311,3
+Expect error to follow @ 312,1
+vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 312,2
+---------- private/private/protected
+Expect error to follow @ 319,2
+vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,3
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,4
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,5
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 320,1
+vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,2
+vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,3
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,4
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 321,1
+vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,2
+vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,3
+vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 322,1
+vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 322,2
+---------- private/private/private
+Expect error to follow @ 329,2
+vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,3
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,4
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,5
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 330,1
+vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,2
+vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,3
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,4
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 331,1
+vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,2
+vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,3
+vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 332,1
+vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 332,2

--- a/tests/syntax/r/linux-x86_64/vis-nested-2.txt
+++ b/tests/syntax/r/linux-x86_64/vis-nested-2.txt
@@ -1,0 +1,523 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 70,3
+vis-nested-2.bas(70) error 202: Illegal member access, found 'c2' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 70,4
+vis-nested-2.bas(70) error 202: Illegal member access, found 'UDT023' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 71,2
+vis-nested-2.bas(71) error 202: Illegal member access, found 'c2' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 71,3
+vis-nested-2.bas(71) error 202: Illegal member access, found 'UDT023' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 72,1
+vis-nested-2.bas(72) error 202: Illegal member access, found 'c2' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 72,2
+vis-nested-2.bas(72) error 202: Illegal member access, found 'UDT023' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 73,1
+vis-nested-2.bas(73) error 202: Illegal member access, found 'UDT023' in 'test_X3( UDT02,          1, 1 )'
+---------- public/public/private
+Expect error to follow @ 79,3
+vis-nested-2.bas(79) error 202: Illegal member access, found 'c2' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-2.bas(79) error 202: Illegal member access, found 'UDT033' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-2.bas(80) error 202: Illegal member access, found 'c2' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-2.bas(80) error 202: Illegal member access, found 'UDT033' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 81,1
+vis-nested-2.bas(81) error 202: Illegal member access, found 'c2' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 81,2
+vis-nested-2.bas(81) error 202: Illegal member access, found 'UDT033' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 82,1
+vis-nested-2.bas(82) error 202: Illegal member access, found 'UDT033' in 'test_X3( UDT03,          1, 1 )'
+---------- public/protected/public
+Expect error to follow @ 88,2
+vis-nested-2.bas(88) error 202: Illegal member access, found 'c1' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,4
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 89,1
+vis-nested-2.bas(89) error 202: Illegal member access, found 'c1' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,2
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 90,1
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 91,1
+vis-nested-2.bas(91) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+---------- public/protected/protected
+Expect error to follow @ 97,2
+vis-nested-2.bas(97) error 202: Illegal member access, found 'c1' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,3
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,4
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,1
+vis-nested-2.bas(98) error 202: Illegal member access, found 'c1' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,2
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,3
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 99,1
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-2.bas(100) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+---------- public/protected/private
+Expect error to follow @ 106,2
+vis-nested-2.bas(106) error 202: Illegal member access, found 'c1' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,4
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-2.bas(107) error 202: Illegal member access, found 'c1' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,2
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,3
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 108,1
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 108,2
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 109,1
+vis-nested-2.bas(109) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+---------- public/private/public
+Expect error to follow @ 115,2
+vis-nested-2.bas(115) error 202: Illegal member access, found 'c1' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,4
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-2.bas(116) error 202: Illegal member access, found 'c1' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,2
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,3
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 117,1
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 117,2
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 118,1
+vis-nested-2.bas(118) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+---------- public/private/protected
+Expect error to follow @ 124,2
+vis-nested-2.bas(124) error 202: Illegal member access, found 'c1' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,3
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,4
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 125,1
+vis-nested-2.bas(125) error 202: Illegal member access, found 'c1' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,2
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,3
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 126,1
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 126,2
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 127,1
+vis-nested-2.bas(127) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+---------- public/private/private
+Expect error to follow @ 133,2
+vis-nested-2.bas(133) error 202: Illegal member access, found 'c1' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,4
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-2.bas(134) error 202: Illegal member access, found 'c1' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,2
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,3
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 135,1
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 135,2
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 136,1
+vis-nested-2.bas(136) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+---------- protected/public/public
+Expect error to follow @ 142,1
+vis-nested-2.bas(142) error 202: Illegal member access, found 'c0' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,4
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,2
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,3
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 144,1
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 144,2
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 145,1
+vis-nested-2.bas(145) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+---------- protected/public/protected
+Expect error to follow @ 151,1
+vis-nested-2.bas(151) error 202: Illegal member access, found 'c0' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,4
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,2
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,3
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 153,1
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 153,2
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 154,1
+vis-nested-2.bas(154) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+---------- protected/public/private
+Expect error to follow @ 160,1
+vis-nested-2.bas(160) error 202: Illegal member access, found 'c0' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,4
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,2
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,3
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 162,1
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 162,2
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 163,1
+vis-nested-2.bas(163) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+---------- protected/protected/public
+Expect error to follow @ 169,1
+vis-nested-2.bas(169) error 202: Illegal member access, found 'c0' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,3
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-2.bas(172) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+---------- protected/protected/protected
+Expect error to follow @ 178,1
+vis-nested-2.bas(178) error 202: Illegal member access, found 'c0' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,2
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,3
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,4
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,1
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,2
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 180,2
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-2.bas(181) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+---------- protected/protected/private
+Expect error to follow @ 187,1
+vis-nested-2.bas(187) error 202: Illegal member access, found 'c0' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,4
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,2
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,3
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 189,1
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 189,2
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-2.bas(190) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+---------- protected/private/public
+Expect error to follow @ 196,1
+vis-nested-2.bas(196) error 202: Illegal member access, found 'c0' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,4
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,2
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,3
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 198,1
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 198,2
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 199,1
+vis-nested-2.bas(199) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+---------- protected/private/protected
+Expect error to follow @ 205,1
+vis-nested-2.bas(205) error 202: Illegal member access, found 'c0' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,2
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,3
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,4
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 206,1
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,2
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,3
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 207,1
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 207,2
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 208,1
+vis-nested-2.bas(208) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+---------- protected/private/private
+Expect error to follow @ 214,1
+vis-nested-2.bas(214) error 202: Illegal member access, found 'c0' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,4
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,2
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,3
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 216,1
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 216,2
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 217,1
+vis-nested-2.bas(217) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+---------- private/public/public
+Expect error to follow @ 223,1
+vis-nested-2.bas(223) error 202: Illegal member access, found 'c0' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,4
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,2
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,3
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 225,1
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 225,2
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 226,1
+vis-nested-2.bas(226) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+---------- private/public/protected
+Expect error to follow @ 232,1
+vis-nested-2.bas(232) error 202: Illegal member access, found 'c0' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,2
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,3
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,4
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 233,1
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,2
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,3
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 234,1
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 234,2
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 235,1
+vis-nested-2.bas(235) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+---------- private/public/private
+Expect error to follow @ 241,1
+vis-nested-2.bas(241) error 202: Illegal member access, found 'c0' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,4
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,2
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,3
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 243,1
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 243,2
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 244,1
+vis-nested-2.bas(244) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+---------- private/protected/public
+Expect error to follow @ 250,1
+vis-nested-2.bas(250) error 202: Illegal member access, found 'c0' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,4
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,2
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,3
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 252,1
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 252,2
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 253,1
+vis-nested-2.bas(253) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+---------- private/protected/protected
+Expect error to follow @ 259,1
+vis-nested-2.bas(259) error 202: Illegal member access, found 'c0' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,2
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,3
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-2.bas(262) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+---------- private/protected/private
+Expect error to follow @ 268,1
+vis-nested-2.bas(268) error 202: Illegal member access, found 'c0' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,4
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,2
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 270,2
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-2.bas(271) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+---------- private/private/public
+Expect error to follow @ 277,1
+vis-nested-2.bas(277) error 202: Illegal member access, found 'c0' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,4
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,2
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,3
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 279,1
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 279,2
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-2.bas(280) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+---------- private/private/protected
+Expect error to follow @ 286,1
+vis-nested-2.bas(286) error 202: Illegal member access, found 'c0' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,2
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,3
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,4
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 287,1
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,2
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,3
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 288,1
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 288,2
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 289,1
+vis-nested-2.bas(289) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+---------- private/private/private
+Expect error to follow @ 295,1
+vis-nested-2.bas(295) error 202: Illegal member access, found 'c0' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,4
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,2
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,3
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 297,1
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 297,2
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 298,1
+vis-nested-2.bas(298) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/win32/len-sizeof.txt
+++ b/tests/syntax/r/win32/len-sizeof.txt
@@ -1,0 +1,20 @@
+n =sizeof( TOuter )
+OK
+n =sizeof( TOuter.a )
+OK
+n =sizeof( TOuter.TInner )
+OK
+n =sizeof( TOuter.TInner.a )
+OK
+n =sizeof( x )
+OK
+n =sizeof( x.a )
+OK
+n =sizeof( x.m )
+OK
+n =sizeof( x.m.a )
+OK
+n =sizeof( x.TInner )
+len-sizeof.bas(31) error 18: Element not defined, TInner in 't( 1, n = sizeof( x.TInner ) )'
+n =sizeof( x.TInner.a )
+len-sizeof.bas(32) error 9: Expected expression, found '.' in 't( 1, n = sizeof( x.TInner.a ) )'

--- a/tests/syntax/r/win32/type-decl.txt
+++ b/tests/syntax/r/win32/type-decl.txt
@@ -2,3 +2,7 @@
 2 errors for field members as parent type
 type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
 type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'
+---
+2 errors for named type/union in an anonymous type/union
+type-decl.bas(24) error 17: Syntax error, found 'NAMED1' in 'type NAMED1'
+type-decl.bas(31) error 17: Syntax error, found 'NAMED2' in 'union NAMED2'

--- a/tests/syntax/r/win32/type-decl.txt
+++ b/tests/syntax/r/win32/type-decl.txt
@@ -1,0 +1,4 @@
+member1 as T1
+type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
+as T1 member2
+type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'

--- a/tests/syntax/r/win32/type-decl.txt
+++ b/tests/syntax/r/win32/type-decl.txt
@@ -1,4 +1,4 @@
-member1 as T1
-type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
-as T1 member2
-type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'
+---
+2 errors for field members as parent type
+type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
+type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'

--- a/tests/syntax/r/win32/vis-nested-0.txt
+++ b/tests/syntax/r/win32/vis-nested-0.txt
@@ -13,7 +13,9 @@ vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 79,3
 vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 80,1
+vis-nested-0.bas(80) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 80,2
+vis-nested-0.bas(80) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 86,4
 vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 88,3
 vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 89,1
+vis-nested-0.bas(89) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 89,2
+vis-nested-0.bas(89) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 95,3
 vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,10 +49,13 @@ vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 97,1
 vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,2
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,3
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 98,1
 vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 98,2
+vis-nested-0.bas(98) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 104,3
 vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -65,12 +72,13 @@ vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 106,1
 vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,2
-vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,3
-vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 107,1
 vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 107,2
+vis-nested-0.bas(107) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 113,3
 vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -87,12 +95,13 @@ vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 115,1
 vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,2
-vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,3
-vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 116,1
 vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 116,2
+vis-nested-0.bas(116) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 122,3
 vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -109,10 +118,13 @@ vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 124,1
 vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,2
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,3
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 125,1
 vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 125,2
+vis-nested-0.bas(125) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 131,3
 vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -129,12 +141,13 @@ vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 133,1
 vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,2
-vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,3
-vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 134,1
 vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 134,2
+vis-nested-0.bas(134) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 140,3
 vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -151,12 +164,13 @@ vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 142,1
 vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,2
-vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,3
-vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 143,1
 vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 143,2
+vis-nested-0.bas(143) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 149,2
 vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -169,15 +183,21 @@ vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 150,1
 vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,2
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,3
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,4
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 151,1
 vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,2
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,3
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-0.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 158,2
 vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -190,19 +210,21 @@ vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 159,1
 vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,2
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,3
-vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,4
-vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 160,1
 vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,2
-vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,3
-vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-0.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 167,2
 vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -215,19 +237,21 @@ vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 168,1
 vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,2
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,3
-vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,4
-vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 169,1
 vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,2
-vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,3
-vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 170,1
 vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-0.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 176,2
 vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -240,18 +264,21 @@ vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 177,1
 vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,2
-vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,3
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,4
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 178,1
 vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,2
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,3
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 179,1
 vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 179,2
+vis-nested-0.bas(179) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 185,2
 vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -264,20 +291,21 @@ vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 186,1
 vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,2
-vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,3
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,4
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 187,1
 vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,2
-vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,3
-vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 188,1
 vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 188,2
+vis-nested-0.bas(188) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 194,2
 vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -290,20 +318,21 @@ vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 195,1
 vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,2
-vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,3
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,4
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 196,1
 vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,2
-vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,3
-vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 197,1
 vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 197,2
+vis-nested-0.bas(197) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 203,2
 vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -316,18 +345,21 @@ vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 204,1
 vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,2
-vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,3
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,4
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 205,1
 vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,2
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,3
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 206,1
 vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 206,2
+vis-nested-0.bas(206) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 212,2
 vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -340,20 +372,21 @@ vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 213,1
 vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,2
-vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,3
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,4
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 214,1
 vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,2
-vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,3
-vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 215,1
 vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 215,2
+vis-nested-0.bas(215) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 221,2
 vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -366,20 +399,21 @@ vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 222,1
 vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,2
-vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,3
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,4
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 223,1
 vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,2
-vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,3
-vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 224,1
 vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 224,2
+vis-nested-0.bas(224) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 230,2
 vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -392,15 +426,21 @@ vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 231,1
 vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,2
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,3
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,4
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,3
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 233,1
 vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 233,2
+vis-nested-0.bas(233) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 239,2
 vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -413,19 +453,21 @@ vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-0.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 248,2
 vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -438,19 +480,21 @@ vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 249,1
 vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,2
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,3
-vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,4
-vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 250,1
 vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,2
-vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,3
-vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-0.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 257,2
 vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -463,18 +507,21 @@ vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 258,1
 vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,2
-vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,3
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,4
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 259,1
 vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,2
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,3
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 260,1
 vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-0.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 266,2
 vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -487,20 +534,21 @@ vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 267,1
 vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,2
-vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,3
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,4
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 268,1
 vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,2
-vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,3
-vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 269,1
 vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 269,2
+vis-nested-0.bas(269) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 275,2
 vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -513,20 +561,21 @@ vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 276,1
 vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,2
-vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,3
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,4
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 277,1
 vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,2
-vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,3
-vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 278,1
 vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 278,2
+vis-nested-0.bas(278) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 284,2
 vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -539,18 +588,21 @@ vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 285,1
 vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,2
-vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,3
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,4
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 286,1
 vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,2
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,3
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 287,1
 vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 287,2
+vis-nested-0.bas(287) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 293,2
 vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -563,20 +615,21 @@ vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 294,1
 vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,2
-vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,3
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,4
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 295,1
 vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,2
-vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,3
-vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 296,1
 vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 296,2
+vis-nested-0.bas(296) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 302,2
 vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -589,17 +642,18 @@ vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 303,1
 vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,2
-vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,3
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,4
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 304,1
 vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,2
-vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,3
-vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 305,1
 vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 305,2
+vis-nested-0.bas(305) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/win32/vis-nested-0.txt
+++ b/tests/syntax/r/win32/vis-nested-0.txt
@@ -1,0 +1,605 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 77,4
+vis-nested-0.bas(77) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 77,5
+vis-nested-0.bas(77) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,3
+vis-nested-0.bas(78) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 78,4
+vis-nested-0.bas(78) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,2
+vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,1
+Expect error to follow @ 80,2
+---------- public/public/private
+Expect error to follow @ 86,4
+vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 86,5
+vis-nested-0.bas(86) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 87,3
+vis-nested-0.bas(87) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 87,4
+vis-nested-0.bas(87) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 88,2
+vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 89,1
+Expect error to follow @ 89,2
+---------- public/protected/public
+Expect error to follow @ 95,3
+vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,4
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,5
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 96,2
+vis-nested-0.bas(96) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,3
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,4
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 97,1
+vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 97,2
+Expect error to follow @ 97,3
+Expect error to follow @ 98,1
+vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 98,2
+---------- public/protected/protected
+Expect error to follow @ 104,3
+vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,4
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,5
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 105,2
+vis-nested-0.bas(105) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,3
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,4
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 106,1
+vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,2
+vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 107,2
+---------- public/protected/private
+Expect error to follow @ 113,3
+vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,4
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,5
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 114,2
+vis-nested-0.bas(114) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,3
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,4
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 115,1
+vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,2
+vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 116,2
+---------- public/private/public
+Expect error to follow @ 122,3
+vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,4
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,5
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 123,2
+vis-nested-0.bas(123) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,3
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,4
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 124,1
+vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 124,2
+Expect error to follow @ 124,3
+Expect error to follow @ 125,1
+vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 125,2
+---------- public/private/protected
+Expect error to follow @ 131,3
+vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,4
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,5
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 132,2
+vis-nested-0.bas(132) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,3
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,4
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 133,1
+vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,2
+vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 134,2
+---------- public/private/private
+Expect error to follow @ 140,3
+vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,5
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-0.bas(141) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,4
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 143,2
+---------- protected/public/public
+Expect error to follow @ 149,2
+vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,3
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 150,1
+vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 150,2
+Expect error to follow @ 150,3
+Expect error to follow @ 150,4
+Expect error to follow @ 151,1
+vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 151,2
+Expect error to follow @ 151,3
+Expect error to follow @ 152,1
+vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/protected
+Expect error to follow @ 158,2
+vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,3
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,4
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,5
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,1
+vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,2
+Expect error to follow @ 159,3
+vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 161,2
+---------- protected/public/private
+Expect error to follow @ 167,2
+vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,3
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,4
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,5
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 168,1
+vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,2
+Expect error to follow @ 168,3
+vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,4
+vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 169,1
+vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 170,2
+---------- protected/protected/public
+Expect error to follow @ 176,2
+vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,3
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,4
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,5
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 177,1
+vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,2
+vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,3
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,4
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 178,1
+vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 178,2
+Expect error to follow @ 178,3
+Expect error to follow @ 179,1
+vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 179,2
+---------- protected/protected/protected
+Expect error to follow @ 185,2
+vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,3
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,4
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,5
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 186,1
+vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,2
+vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,3
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,4
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 187,1
+vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 188,2
+---------- protected/protected/private
+Expect error to follow @ 194,2
+vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,3
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,4
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,5
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 195,1
+vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,2
+vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,3
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,4
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 196,1
+vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 197,2
+---------- protected/private/public
+Expect error to follow @ 203,2
+vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,3
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,4
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,5
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 204,1
+vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,2
+vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,3
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,4
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 205,1
+vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 205,2
+Expect error to follow @ 205,3
+Expect error to follow @ 206,1
+vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 206,2
+---------- protected/private/protected
+Expect error to follow @ 212,2
+vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,3
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,4
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,5
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 213,1
+vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,2
+vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,3
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,4
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 214,1
+vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 215,2
+---------- protected/private/private
+Expect error to follow @ 221,2
+vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,3
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,4
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,5
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 222,1
+vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,2
+vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,3
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,4
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 223,1
+vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 224,2
+---------- private/public/public
+Expect error to follow @ 230,2
+vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,5
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 231,2
+Expect error to follow @ 231,3
+Expect error to follow @ 231,4
+Expect error to follow @ 232,1
+vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 232,2
+Expect error to follow @ 232,3
+Expect error to follow @ 233,1
+vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 233,2
+---------- private/public/protected
+Expect error to follow @ 239,2
+vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+Expect error to follow @ 240,3
+vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/private
+Expect error to follow @ 248,2
+vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,3
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,4
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,5
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,1
+vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,2
+Expect error to follow @ 249,3
+vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 251,2
+---------- private/protected/public
+Expect error to follow @ 257,2
+vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,3
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,4
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,5
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 258,1
+vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,2
+vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,3
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,4
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 259,1
+vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 259,2
+Expect error to follow @ 259,3
+Expect error to follow @ 260,1
+vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 260,2
+---------- private/protected/protected
+Expect error to follow @ 266,2
+vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,3
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,4
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,5
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 267,1
+vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,2
+vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,3
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,4
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 268,1
+vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 269,2
+---------- private/protected/private
+Expect error to follow @ 275,2
+vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,3
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,4
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,5
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 276,1
+vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,2
+vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,3
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,4
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 277,1
+vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 278,2
+---------- private/private/public
+Expect error to follow @ 284,2
+vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,3
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,4
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,5
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 285,1
+vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,2
+vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,3
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,4
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 286,1
+vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 286,2
+Expect error to follow @ 286,3
+Expect error to follow @ 287,1
+vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 287,2
+---------- private/private/protected
+Expect error to follow @ 293,2
+vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,3
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,4
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,5
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 294,1
+vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,2
+vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,3
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,4
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 295,1
+vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 296,2
+---------- private/private/private
+Expect error to follow @ 302,2
+vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,3
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,4
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,5
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 303,1
+vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,2
+vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,3
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,4
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 304,1
+vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,2
+vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,3
+vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 305,1
+vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 305,2

--- a/tests/syntax/r/win32/vis-nested-1.txt
+++ b/tests/syntax/r/win32/vis-nested-1.txt
@@ -13,7 +13,9 @@ vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 80,3
 vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 81,1
+vis-nested-1.bas(81) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 81,2
+vis-nested-1.bas(81) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 88,4
 vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 90,3
 vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 91,1
+vis-nested-1.bas(91) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 91,2
+vis-nested-1.bas(91) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 98,3
 vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,13 +49,17 @@ vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 100,1
 vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,2
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,3
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 101,1
 vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 101,2
+vis-nested-1.bas(101) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,1
 vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,2
+vis-nested-1.bas(102) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 109,3
 vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -68,12 +76,13 @@ vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 111,1
 vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,2
-vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,3
-vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 112,1
 vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 112,2
+vis-nested-1.bas(112) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 119,3
 vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -90,12 +99,13 @@ vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 121,1
 vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,2
-vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,3
-vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 122,1
 vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 122,2
+vis-nested-1.bas(122) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 129,3
 vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -112,10 +122,13 @@ vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 131,1
 vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,2
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,3
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 132,1
 vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 132,2
+vis-nested-1.bas(132) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 139,3
 vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -132,12 +145,13 @@ vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 141,1
 vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,2
-vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,3
-vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 142,1
 vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 142,2
+vis-nested-1.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 149,3
 vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -154,12 +168,13 @@ vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 151,1
 vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,2
-vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,3
-vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-1.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 159,2
 vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -172,15 +187,21 @@ vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 160,1
 vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,2
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,3
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,4
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,3
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 162,1
 vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 162,2
+vis-nested-1.bas(162) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 169,2
 vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -193,19 +214,21 @@ vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 170,1
 vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,3
-vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,4
-vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 171,1
 vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,2
-vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,3
-vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 172,1
 vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 172,2
+vis-nested-1.bas(172) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 179,2
 vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -218,19 +241,21 @@ vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 180,1
 vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,2
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,3
-vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,4
-vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 181,1
 vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,2
-vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,3
-vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 182,1
 vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 182,2
+vis-nested-1.bas(182) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 189,2
 vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -243,18 +268,21 @@ vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 190,1
 vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,2
-vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,3
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,4
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 191,1
 vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,2
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,3
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 192,1
 vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 192,2
+vis-nested-1.bas(192) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 199,2
 vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -267,20 +295,21 @@ vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 200,1
 vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,2
-vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,3
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,4
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 201,1
 vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,2
-vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,3
-vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 202,1
 vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 202,2
+vis-nested-1.bas(202) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 209,2
 vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -293,20 +322,21 @@ vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 210,1
 vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,2
-vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,3
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,4
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 211,1
 vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,2
-vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,3
-vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 212,1
 vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 212,2
+vis-nested-1.bas(212) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 219,2
 vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -319,18 +349,21 @@ vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 220,1
 vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,2
-vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,3
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,4
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 221,1
 vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,2
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,3
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 222,1
 vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 222,2
+vis-nested-1.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 229,2
 vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -343,20 +376,21 @@ vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 230,1
 vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,2
-vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,3
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,4
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 231,1
 vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,2
-vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,3
-vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-1.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 239,2
 vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -369,20 +403,21 @@ vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
-vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-1.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 249,2
 vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -395,15 +430,21 @@ vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 250,1
 vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,2
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,3
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,4
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,3
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 252,1
 vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 252,2
+vis-nested-1.bas(252) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 259,2
 vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -416,19 +457,21 @@ vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 260,1
 vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,3
-vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,4
-vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 261,1
 vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,2
-vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,3
-vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 262,1
 vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 262,2
+vis-nested-1.bas(262) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 269,2
 vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -441,19 +484,21 @@ vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 270,1
 vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,2
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,3
-vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,4
-vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 271,1
 vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,2
-vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,3
-vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 272,1
 vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 272,2
+vis-nested-1.bas(272) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 279,2
 vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -466,18 +511,21 @@ vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 280,1
 vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,2
-vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,3
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,4
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 281,1
 vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,2
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,3
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 282,1
 vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 282,2
+vis-nested-1.bas(282) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 289,2
 vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -490,20 +538,21 @@ vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 290,1
 vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,2
-vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,3
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,4
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 291,1
 vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,2
-vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,3
-vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 292,1
 vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 292,2
+vis-nested-1.bas(292) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 299,2
 vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -516,20 +565,21 @@ vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 300,1
 vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,2
-vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,3
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,4
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 301,1
 vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,2
-vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,3
-vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 302,1
 vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 302,2
+vis-nested-1.bas(302) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 309,2
 vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -542,18 +592,21 @@ vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 310,1
 vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,2
-vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,3
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,4
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 311,1
 vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,2
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,3
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 312,1
 vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 312,2
+vis-nested-1.bas(312) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 319,2
 vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -566,20 +619,21 @@ vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 320,1
 vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,2
-vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,3
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,4
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 321,1
 vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,2
-vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,3
-vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 322,1
 vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 322,2
+vis-nested-1.bas(322) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 329,2
 vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -592,17 +646,18 @@ vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 330,1
 vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,2
-vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,3
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,4
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 331,1
 vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,2
-vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,3
-vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 332,1
 vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 332,2
+vis-nested-1.bas(332) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/win32/vis-nested-1.txt
+++ b/tests/syntax/r/win32/vis-nested-1.txt
@@ -1,0 +1,608 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 78,4
+vis-nested-1.bas(78) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,5
+vis-nested-1.bas(78) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-1.bas(79) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-1.bas(79) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 81,1
+Expect error to follow @ 81,2
+---------- public/public/private
+Expect error to follow @ 88,4
+vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 88,5
+vis-nested-1.bas(88) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-1.bas(89) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 89,4
+vis-nested-1.bas(89) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 90,3
+vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 91,1
+Expect error to follow @ 91,2
+---------- public/protected/public
+Expect error to follow @ 98,3
+vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,4
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,5
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-1.bas(99) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,3
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,4
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 100,2
+Expect error to follow @ 100,3
+Expect error to follow @ 101,1
+vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 101,2
+Expect error to follow @ 102,1
+vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 102,2
+---------- public/protected/protected
+Expect error to follow @ 109,3
+vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,4
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,5
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 110,2
+vis-nested-1.bas(110) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,3
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,4
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 111,1
+vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,2
+vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,3
+vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 112,1
+vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 112,2
+---------- public/protected/private
+Expect error to follow @ 119,3
+vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,4
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,5
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 120,2
+vis-nested-1.bas(120) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,3
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,4
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 121,1
+vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,2
+vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,3
+vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 122,1
+vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 122,2
+---------- public/private/public
+Expect error to follow @ 129,3
+vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,4
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,5
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 130,2
+vis-nested-1.bas(130) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,3
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,4
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 131,1
+vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 131,2
+Expect error to follow @ 131,3
+Expect error to follow @ 132,1
+vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 132,2
+---------- public/private/protected
+Expect error to follow @ 139,3
+vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,4
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,5
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,2
+vis-nested-1.bas(140) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,3
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 141,1
+vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 142,2
+---------- public/private/private
+Expect error to follow @ 149,3
+vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 150,2
+vis-nested-1.bas(150) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,3
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,4
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 151,1
+vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/public
+Expect error to follow @ 159,2
+vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,3
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,5
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+Expect error to follow @ 160,3
+Expect error to follow @ 160,4
+Expect error to follow @ 161,1
+vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 161,2
+Expect error to follow @ 161,3
+Expect error to follow @ 162,1
+vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 162,2
+---------- protected/public/protected
+Expect error to follow @ 169,2
+vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,5
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+Expect error to follow @ 170,3
+vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,4
+vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,3
+vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 172,2
+---------- protected/public/private
+Expect error to follow @ 179,2
+vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,4
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,5
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,2
+Expect error to follow @ 180,3
+vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,4
+vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,2
+vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,3
+vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 182,1
+vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 182,2
+---------- protected/protected/public
+Expect error to follow @ 189,2
+vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,3
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,4
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,5
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,2
+vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,3
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,4
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 191,1
+vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 191,2
+Expect error to follow @ 191,3
+Expect error to follow @ 192,1
+vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 192,2
+---------- protected/protected/protected
+Expect error to follow @ 199,2
+vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,3
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,4
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,5
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 200,1
+vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,2
+vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,3
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,4
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 201,1
+vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,2
+vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,3
+vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 202,1
+vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 202,2
+---------- protected/protected/private
+Expect error to follow @ 209,2
+vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,3
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,4
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,5
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 210,1
+vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,2
+vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,3
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,4
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 211,1
+vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,2
+vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,3
+vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 212,1
+vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 212,2
+---------- protected/private/public
+Expect error to follow @ 219,2
+vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,3
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,4
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,5
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 220,1
+vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,2
+vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,3
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,4
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 221,1
+vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 221,2
+Expect error to follow @ 221,3
+Expect error to follow @ 222,1
+vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 222,2
+---------- protected/private/protected
+Expect error to follow @ 229,2
+vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,3
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,4
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,5
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,1
+vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,2
+vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,2
+vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,3
+vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 232,1
+vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 232,2
+---------- protected/private/private
+Expect error to follow @ 239,2
+vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,3
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/public
+Expect error to follow @ 249,2
+vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,3
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,5
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+Expect error to follow @ 250,3
+Expect error to follow @ 250,4
+Expect error to follow @ 251,1
+vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 251,2
+Expect error to follow @ 251,3
+Expect error to follow @ 252,1
+vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 252,2
+---------- private/public/protected
+Expect error to follow @ 259,2
+vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,5
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+Expect error to follow @ 260,3
+vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,4
+vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,3
+vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 262,2
+---------- private/public/private
+Expect error to follow @ 269,2
+vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,4
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,5
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,2
+Expect error to follow @ 270,3
+vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,4
+vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,2
+vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,3
+vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 272,1
+vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 272,2
+---------- private/protected/public
+Expect error to follow @ 279,2
+vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,3
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,4
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,5
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,2
+vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,3
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,4
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 281,1
+vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 281,2
+Expect error to follow @ 281,3
+Expect error to follow @ 282,1
+vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 282,2
+---------- private/protected/protected
+Expect error to follow @ 289,2
+vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,3
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,4
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,5
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 290,1
+vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,2
+vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,3
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,4
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 291,1
+vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,2
+vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,3
+vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 292,1
+vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 292,2
+---------- private/protected/private
+Expect error to follow @ 299,2
+vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,3
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,4
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,5
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 300,1
+vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,2
+vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,3
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,4
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 301,1
+vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,2
+vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,3
+vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 302,1
+vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 302,2
+---------- private/private/public
+Expect error to follow @ 309,2
+vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,3
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,4
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,5
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 310,1
+vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,2
+vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,3
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,4
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 311,1
+vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 311,2
+Expect error to follow @ 311,3
+Expect error to follow @ 312,1
+vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 312,2
+---------- private/private/protected
+Expect error to follow @ 319,2
+vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,3
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,4
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,5
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 320,1
+vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,2
+vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,3
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,4
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 321,1
+vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,2
+vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,3
+vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 322,1
+vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 322,2
+---------- private/private/private
+Expect error to follow @ 329,2
+vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,3
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,4
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,5
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 330,1
+vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,2
+vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,3
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,4
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 331,1
+vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,2
+vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,3
+vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 332,1
+vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 332,2

--- a/tests/syntax/r/win32/vis-nested-2.txt
+++ b/tests/syntax/r/win32/vis-nested-2.txt
@@ -1,0 +1,523 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 70,3
+vis-nested-2.bas(70) error 202: Illegal member access, found 'c2' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 70,4
+vis-nested-2.bas(70) error 202: Illegal member access, found 'UDT023' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 71,2
+vis-nested-2.bas(71) error 202: Illegal member access, found 'c2' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 71,3
+vis-nested-2.bas(71) error 202: Illegal member access, found 'UDT023' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 72,1
+vis-nested-2.bas(72) error 202: Illegal member access, found 'c2' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 72,2
+vis-nested-2.bas(72) error 202: Illegal member access, found 'UDT023' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 73,1
+vis-nested-2.bas(73) error 202: Illegal member access, found 'UDT023' in 'test_X3( UDT02,          1, 1 )'
+---------- public/public/private
+Expect error to follow @ 79,3
+vis-nested-2.bas(79) error 202: Illegal member access, found 'c2' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-2.bas(79) error 202: Illegal member access, found 'UDT033' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-2.bas(80) error 202: Illegal member access, found 'c2' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-2.bas(80) error 202: Illegal member access, found 'UDT033' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 81,1
+vis-nested-2.bas(81) error 202: Illegal member access, found 'c2' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 81,2
+vis-nested-2.bas(81) error 202: Illegal member access, found 'UDT033' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 82,1
+vis-nested-2.bas(82) error 202: Illegal member access, found 'UDT033' in 'test_X3( UDT03,          1, 1 )'
+---------- public/protected/public
+Expect error to follow @ 88,2
+vis-nested-2.bas(88) error 202: Illegal member access, found 'c1' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,4
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 89,1
+vis-nested-2.bas(89) error 202: Illegal member access, found 'c1' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,2
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 90,1
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 91,1
+vis-nested-2.bas(91) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+---------- public/protected/protected
+Expect error to follow @ 97,2
+vis-nested-2.bas(97) error 202: Illegal member access, found 'c1' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,3
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,4
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,1
+vis-nested-2.bas(98) error 202: Illegal member access, found 'c1' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,2
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,3
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 99,1
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-2.bas(100) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+---------- public/protected/private
+Expect error to follow @ 106,2
+vis-nested-2.bas(106) error 202: Illegal member access, found 'c1' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,4
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-2.bas(107) error 202: Illegal member access, found 'c1' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,2
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,3
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 108,1
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 108,2
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 109,1
+vis-nested-2.bas(109) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+---------- public/private/public
+Expect error to follow @ 115,2
+vis-nested-2.bas(115) error 202: Illegal member access, found 'c1' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,4
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-2.bas(116) error 202: Illegal member access, found 'c1' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,2
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,3
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 117,1
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 117,2
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 118,1
+vis-nested-2.bas(118) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+---------- public/private/protected
+Expect error to follow @ 124,2
+vis-nested-2.bas(124) error 202: Illegal member access, found 'c1' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,3
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,4
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 125,1
+vis-nested-2.bas(125) error 202: Illegal member access, found 'c1' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,2
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,3
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 126,1
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 126,2
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 127,1
+vis-nested-2.bas(127) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+---------- public/private/private
+Expect error to follow @ 133,2
+vis-nested-2.bas(133) error 202: Illegal member access, found 'c1' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,4
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-2.bas(134) error 202: Illegal member access, found 'c1' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,2
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,3
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 135,1
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 135,2
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 136,1
+vis-nested-2.bas(136) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+---------- protected/public/public
+Expect error to follow @ 142,1
+vis-nested-2.bas(142) error 202: Illegal member access, found 'c0' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,4
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,2
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,3
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 144,1
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 144,2
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 145,1
+vis-nested-2.bas(145) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+---------- protected/public/protected
+Expect error to follow @ 151,1
+vis-nested-2.bas(151) error 202: Illegal member access, found 'c0' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,4
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,2
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,3
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 153,1
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 153,2
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 154,1
+vis-nested-2.bas(154) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+---------- protected/public/private
+Expect error to follow @ 160,1
+vis-nested-2.bas(160) error 202: Illegal member access, found 'c0' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,4
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,2
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,3
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 162,1
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 162,2
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 163,1
+vis-nested-2.bas(163) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+---------- protected/protected/public
+Expect error to follow @ 169,1
+vis-nested-2.bas(169) error 202: Illegal member access, found 'c0' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,3
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-2.bas(172) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+---------- protected/protected/protected
+Expect error to follow @ 178,1
+vis-nested-2.bas(178) error 202: Illegal member access, found 'c0' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,2
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,3
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,4
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,1
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,2
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 180,2
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-2.bas(181) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+---------- protected/protected/private
+Expect error to follow @ 187,1
+vis-nested-2.bas(187) error 202: Illegal member access, found 'c0' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,4
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,2
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,3
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 189,1
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 189,2
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-2.bas(190) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+---------- protected/private/public
+Expect error to follow @ 196,1
+vis-nested-2.bas(196) error 202: Illegal member access, found 'c0' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,4
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,2
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,3
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 198,1
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 198,2
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 199,1
+vis-nested-2.bas(199) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+---------- protected/private/protected
+Expect error to follow @ 205,1
+vis-nested-2.bas(205) error 202: Illegal member access, found 'c0' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,2
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,3
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,4
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 206,1
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,2
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,3
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 207,1
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 207,2
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 208,1
+vis-nested-2.bas(208) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+---------- protected/private/private
+Expect error to follow @ 214,1
+vis-nested-2.bas(214) error 202: Illegal member access, found 'c0' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,4
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,2
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,3
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 216,1
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 216,2
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 217,1
+vis-nested-2.bas(217) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+---------- private/public/public
+Expect error to follow @ 223,1
+vis-nested-2.bas(223) error 202: Illegal member access, found 'c0' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,4
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,2
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,3
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 225,1
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 225,2
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 226,1
+vis-nested-2.bas(226) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+---------- private/public/protected
+Expect error to follow @ 232,1
+vis-nested-2.bas(232) error 202: Illegal member access, found 'c0' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,2
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,3
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,4
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 233,1
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,2
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,3
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 234,1
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 234,2
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 235,1
+vis-nested-2.bas(235) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+---------- private/public/private
+Expect error to follow @ 241,1
+vis-nested-2.bas(241) error 202: Illegal member access, found 'c0' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,4
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,2
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,3
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 243,1
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 243,2
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 244,1
+vis-nested-2.bas(244) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+---------- private/protected/public
+Expect error to follow @ 250,1
+vis-nested-2.bas(250) error 202: Illegal member access, found 'c0' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,4
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,2
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,3
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 252,1
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 252,2
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 253,1
+vis-nested-2.bas(253) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+---------- private/protected/protected
+Expect error to follow @ 259,1
+vis-nested-2.bas(259) error 202: Illegal member access, found 'c0' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,2
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,3
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-2.bas(262) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+---------- private/protected/private
+Expect error to follow @ 268,1
+vis-nested-2.bas(268) error 202: Illegal member access, found 'c0' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,4
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,2
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 270,2
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-2.bas(271) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+---------- private/private/public
+Expect error to follow @ 277,1
+vis-nested-2.bas(277) error 202: Illegal member access, found 'c0' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,4
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,2
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,3
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 279,1
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 279,2
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-2.bas(280) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+---------- private/private/protected
+Expect error to follow @ 286,1
+vis-nested-2.bas(286) error 202: Illegal member access, found 'c0' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,2
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,3
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,4
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 287,1
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,2
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,3
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 288,1
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 288,2
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 289,1
+vis-nested-2.bas(289) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+---------- private/private/private
+Expect error to follow @ 295,1
+vis-nested-2.bas(295) error 202: Illegal member access, found 'c0' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,4
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,2
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,3
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 297,1
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 297,2
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 298,1
+vis-nested-2.bas(298) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/win64/len-sizeof.txt
+++ b/tests/syntax/r/win64/len-sizeof.txt
@@ -1,0 +1,20 @@
+n =sizeof( TOuter )
+OK
+n =sizeof( TOuter.a )
+OK
+n =sizeof( TOuter.TInner )
+OK
+n =sizeof( TOuter.TInner.a )
+OK
+n =sizeof( x )
+OK
+n =sizeof( x.a )
+OK
+n =sizeof( x.m )
+OK
+n =sizeof( x.m.a )
+OK
+n =sizeof( x.TInner )
+len-sizeof.bas(31) error 18: Element not defined, TInner in 't( 1, n = sizeof( x.TInner ) )'
+n =sizeof( x.TInner.a )
+len-sizeof.bas(32) error 9: Expected expression, found '.' in 't( 1, n = sizeof( x.TInner.a ) )'

--- a/tests/syntax/r/win64/type-decl.txt
+++ b/tests/syntax/r/win64/type-decl.txt
@@ -2,3 +2,7 @@
 2 errors for field members as parent type
 type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
 type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'
+---
+2 errors for named type/union in an anonymous type/union
+type-decl.bas(24) error 17: Syntax error, found 'NAMED1' in 'type NAMED1'
+type-decl.bas(31) error 17: Syntax error, found 'NAMED2' in 'union NAMED2'

--- a/tests/syntax/r/win64/type-decl.txt
+++ b/tests/syntax/r/win64/type-decl.txt
@@ -1,0 +1,4 @@
+member1 as T1
+type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
+as T1 member2
+type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'

--- a/tests/syntax/r/win64/type-decl.txt
+++ b/tests/syntax/r/win64/type-decl.txt
@@ -1,4 +1,4 @@
-member1 as T1
-type-decl.bas(16) error 24: Invalid data types in 't( 1, member1 as T1 )'
-as T1 member2
-type-decl.bas(17) error 24: Invalid data types, found 'member2' in 't( 1, as T1 member2 )'
+---
+2 errors for field members as parent type
+type-decl.bas(9) error 24: Invalid data types in 'member1 as T1'
+type-decl.bas(10) error 24: Invalid data types, found 'member2' in 'as T1 member2'

--- a/tests/syntax/r/win64/vis-nested-0.txt
+++ b/tests/syntax/r/win64/vis-nested-0.txt
@@ -13,7 +13,9 @@ vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 79,3
 vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 80,1
+vis-nested-0.bas(80) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 80,2
+vis-nested-0.bas(80) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 86,4
 vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 88,3
 vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 89,1
+vis-nested-0.bas(89) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 89,2
+vis-nested-0.bas(89) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 95,3
 vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,10 +49,13 @@ vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 97,1
 vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,2
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 97,3
+vis-nested-0.bas(97) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 98,1
 vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 98,2
+vis-nested-0.bas(98) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 104,3
 vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -65,12 +72,13 @@ vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 106,1
 vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,2
-vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 106,3
-vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-0.bas(106) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 107,1
 vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 107,2
+vis-nested-0.bas(107) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 113,3
 vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -87,12 +95,13 @@ vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 115,1
 vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,2
-vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 115,3
-vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-0.bas(115) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 116,1
 vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 116,2
+vis-nested-0.bas(116) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 122,3
 vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -109,10 +118,13 @@ vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 124,1
 vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,2
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 124,3
+vis-nested-0.bas(124) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 125,1
 vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 125,2
+vis-nested-0.bas(125) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 131,3
 vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -129,12 +141,13 @@ vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 133,1
 vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,2
-vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 133,3
-vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-0.bas(133) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 134,1
 vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 134,2
+vis-nested-0.bas(134) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 140,3
 vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -151,12 +164,13 @@ vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 142,1
 vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,2
-vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 142,3
-vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-0.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 143,1
 vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 143,2
+vis-nested-0.bas(143) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 149,2
 vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -169,15 +183,21 @@ vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 150,1
 vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,2
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,3
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 150,4
+vis-nested-0.bas(150) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 151,1
 vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,2
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 151,3
+vis-nested-0.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-0.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 158,2
 vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -190,19 +210,21 @@ vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 159,1
 vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,2
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,3
-vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 159,4
-vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-0.bas(159) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 160,1
 vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,2
-vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 160,3
-vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-0.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-0.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 167,2
 vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -215,19 +237,21 @@ vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 168,1
 vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,2
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,3
-vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 168,4
-vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-0.bas(168) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 169,1
 vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,2
-vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 169,3
-vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-0.bas(169) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 170,1
 vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-0.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 176,2
 vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -240,18 +264,21 @@ vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 177,1
 vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,2
-vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,3
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 177,4
-vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-0.bas(177) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 178,1
 vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,2
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 178,3
+vis-nested-0.bas(178) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 179,1
 vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 179,2
+vis-nested-0.bas(179) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 185,2
 vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -264,20 +291,21 @@ vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 186,1
 vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,2
-vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,3
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 186,4
-vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-0.bas(186) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 187,1
 vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,2
-vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 187,3
-vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-0.bas(187) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 188,1
 vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 188,2
+vis-nested-0.bas(188) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 194,2
 vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -290,20 +318,21 @@ vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 195,1
 vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,2
-vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,3
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 195,4
-vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-0.bas(195) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 196,1
 vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,2
-vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 196,3
-vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-0.bas(196) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 197,1
 vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 197,2
+vis-nested-0.bas(197) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 203,2
 vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -316,18 +345,21 @@ vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 204,1
 vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,2
-vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,3
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 204,4
-vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-0.bas(204) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 205,1
 vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,2
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 205,3
+vis-nested-0.bas(205) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 206,1
 vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 206,2
+vis-nested-0.bas(206) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 212,2
 vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -340,20 +372,21 @@ vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 213,1
 vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,2
-vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,3
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 213,4
-vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-0.bas(213) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 214,1
 vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,2
-vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 214,3
-vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-0.bas(214) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 215,1
 vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 215,2
+vis-nested-0.bas(215) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 221,2
 vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -366,20 +399,21 @@ vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 222,1
 vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,2
-vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,3
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 222,4
-vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-0.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 223,1
 vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,2
-vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 223,3
-vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-0.bas(223) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 224,1
 vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 224,2
+vis-nested-0.bas(224) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 230,2
 vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -392,15 +426,21 @@ vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 231,1
 vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,2
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,3
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 231,4
+vis-nested-0.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 232,3
+vis-nested-0.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 233,1
 vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 233,2
+vis-nested-0.bas(233) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 239,2
 vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -413,19 +453,21 @@ vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-0.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-0.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-0.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 248,2
 vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -438,19 +480,21 @@ vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 249,1
 vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,2
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,3
-vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 249,4
-vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-0.bas(249) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 250,1
 vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,2
-vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 250,3
-vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-0.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-0.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 257,2
 vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -463,18 +507,21 @@ vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 258,1
 vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,2
-vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,3
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 258,4
-vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-0.bas(258) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 259,1
 vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,2
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 259,3
+vis-nested-0.bas(259) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 260,1
 vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-0.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 266,2
 vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -487,20 +534,21 @@ vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 267,1
 vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,2
-vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,3
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 267,4
-vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-0.bas(267) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 268,1
 vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,2
-vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 268,3
-vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-0.bas(268) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 269,1
 vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 269,2
+vis-nested-0.bas(269) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 275,2
 vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -513,20 +561,21 @@ vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 276,1
 vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,2
-vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,3
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 276,4
-vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-0.bas(276) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 277,1
 vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,2
-vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 277,3
-vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-0.bas(277) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 278,1
 vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 278,2
+vis-nested-0.bas(278) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 284,2
 vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -539,18 +588,21 @@ vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 285,1
 vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,2
-vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,3
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 285,4
-vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-0.bas(285) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 286,1
 vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,2
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 286,3
+vis-nested-0.bas(286) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 287,1
 vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 287,2
+vis-nested-0.bas(287) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 293,2
 vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -563,20 +615,21 @@ vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 294,1
 vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,2
-vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,3
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 294,4
-vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-0.bas(294) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 295,1
 vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,2
-vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 295,3
-vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-0.bas(295) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 296,1
 vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 296,2
+vis-nested-0.bas(296) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 302,2
 vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -589,17 +642,18 @@ vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 303,1
 vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,2
-vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,3
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 303,4
-vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-0.bas(303) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 304,1
 vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,2
-vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 304,3
-vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-0.bas(304) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 305,1
 vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 305,2
+vis-nested-0.bas(305) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/win64/vis-nested-0.txt
+++ b/tests/syntax/r/win64/vis-nested-0.txt
@@ -1,0 +1,605 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 77,4
+vis-nested-0.bas(77) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 77,5
+vis-nested-0.bas(77) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,3
+vis-nested-0.bas(78) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 78,4
+vis-nested-0.bas(78) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,2
+vis-nested-0.bas(79) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-0.bas(79) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,1
+Expect error to follow @ 80,2
+---------- public/public/private
+Expect error to follow @ 86,4
+vis-nested-0.bas(86) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 86,5
+vis-nested-0.bas(86) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 87,3
+vis-nested-0.bas(87) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 87,4
+vis-nested-0.bas(87) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 88,2
+vis-nested-0.bas(88) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-0.bas(88) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 89,1
+Expect error to follow @ 89,2
+---------- public/protected/public
+Expect error to follow @ 95,3
+vis-nested-0.bas(95) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,4
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 95,5
+vis-nested-0.bas(95) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 96,2
+vis-nested-0.bas(96) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,3
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 96,4
+vis-nested-0.bas(96) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 97,1
+vis-nested-0.bas(97) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 97,2
+Expect error to follow @ 97,3
+Expect error to follow @ 98,1
+vis-nested-0.bas(98) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 98,2
+---------- public/protected/protected
+Expect error to follow @ 104,3
+vis-nested-0.bas(104) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,4
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 104,5
+vis-nested-0.bas(104) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 105,2
+vis-nested-0.bas(105) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,3
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 105,4
+vis-nested-0.bas(105) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 106,1
+vis-nested-0.bas(106) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,2
+vis-nested-0.bas(106) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-0.bas(106) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-0.bas(107) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 107,2
+---------- public/protected/private
+Expect error to follow @ 113,3
+vis-nested-0.bas(113) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,4
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 113,5
+vis-nested-0.bas(113) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 114,2
+vis-nested-0.bas(114) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,3
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 114,4
+vis-nested-0.bas(114) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 115,1
+vis-nested-0.bas(115) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,2
+vis-nested-0.bas(115) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-0.bas(115) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-0.bas(116) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 116,2
+---------- public/private/public
+Expect error to follow @ 122,3
+vis-nested-0.bas(122) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,4
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 122,5
+vis-nested-0.bas(122) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 123,2
+vis-nested-0.bas(123) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,3
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 123,4
+vis-nested-0.bas(123) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 124,1
+vis-nested-0.bas(124) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 124,2
+Expect error to follow @ 124,3
+Expect error to follow @ 125,1
+vis-nested-0.bas(125) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 125,2
+---------- public/private/protected
+Expect error to follow @ 131,3
+vis-nested-0.bas(131) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,4
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 131,5
+vis-nested-0.bas(131) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 132,2
+vis-nested-0.bas(132) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,3
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 132,4
+vis-nested-0.bas(132) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 133,1
+vis-nested-0.bas(133) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,2
+vis-nested-0.bas(133) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-0.bas(133) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-0.bas(134) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 134,2
+---------- public/private/private
+Expect error to follow @ 140,3
+vis-nested-0.bas(140) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,5
+vis-nested-0.bas(140) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-0.bas(141) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 141,4
+vis-nested-0.bas(141) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-0.bas(142) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-0.bas(142) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-0.bas(142) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-0.bas(143) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 143,2
+---------- protected/public/public
+Expect error to follow @ 149,2
+vis-nested-0.bas(149) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,3
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-0.bas(149) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 150,1
+vis-nested-0.bas(150) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 150,2
+Expect error to follow @ 150,3
+Expect error to follow @ 150,4
+Expect error to follow @ 151,1
+vis-nested-0.bas(151) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 151,2
+Expect error to follow @ 151,3
+Expect error to follow @ 152,1
+vis-nested-0.bas(152) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/protected
+Expect error to follow @ 158,2
+vis-nested-0.bas(158) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,3
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,4
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 158,5
+vis-nested-0.bas(158) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,1
+vis-nested-0.bas(159) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,2
+Expect error to follow @ 159,3
+vis-nested-0.bas(159) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-0.bas(159) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-0.bas(160) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-0.bas(160) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-0.bas(160) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-0.bas(161) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 161,2
+---------- protected/public/private
+Expect error to follow @ 167,2
+vis-nested-0.bas(167) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,3
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,4
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 167,5
+vis-nested-0.bas(167) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 168,1
+vis-nested-0.bas(168) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,2
+Expect error to follow @ 168,3
+vis-nested-0.bas(168) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 168,4
+vis-nested-0.bas(168) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 169,1
+vis-nested-0.bas(169) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-0.bas(169) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-0.bas(169) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-0.bas(170) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 170,2
+---------- protected/protected/public
+Expect error to follow @ 176,2
+vis-nested-0.bas(176) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,3
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,4
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 176,5
+vis-nested-0.bas(176) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 177,1
+vis-nested-0.bas(177) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,2
+vis-nested-0.bas(177) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,3
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 177,4
+vis-nested-0.bas(177) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 178,1
+vis-nested-0.bas(178) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 178,2
+Expect error to follow @ 178,3
+Expect error to follow @ 179,1
+vis-nested-0.bas(179) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 179,2
+---------- protected/protected/protected
+Expect error to follow @ 185,2
+vis-nested-0.bas(185) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,3
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,4
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 185,5
+vis-nested-0.bas(185) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 186,1
+vis-nested-0.bas(186) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,2
+vis-nested-0.bas(186) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,3
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 186,4
+vis-nested-0.bas(186) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 187,1
+vis-nested-0.bas(187) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-0.bas(187) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-0.bas(187) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-0.bas(188) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 188,2
+---------- protected/protected/private
+Expect error to follow @ 194,2
+vis-nested-0.bas(194) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,3
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,4
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 194,5
+vis-nested-0.bas(194) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 195,1
+vis-nested-0.bas(195) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,2
+vis-nested-0.bas(195) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,3
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 195,4
+vis-nested-0.bas(195) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 196,1
+vis-nested-0.bas(196) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-0.bas(196) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-0.bas(196) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-0.bas(197) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 197,2
+---------- protected/private/public
+Expect error to follow @ 203,2
+vis-nested-0.bas(203) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,3
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,4
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 203,5
+vis-nested-0.bas(203) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 204,1
+vis-nested-0.bas(204) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,2
+vis-nested-0.bas(204) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,3
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 204,4
+vis-nested-0.bas(204) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 205,1
+vis-nested-0.bas(205) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 205,2
+Expect error to follow @ 205,3
+Expect error to follow @ 206,1
+vis-nested-0.bas(206) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 206,2
+---------- protected/private/protected
+Expect error to follow @ 212,2
+vis-nested-0.bas(212) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,3
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,4
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 212,5
+vis-nested-0.bas(212) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 213,1
+vis-nested-0.bas(213) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,2
+vis-nested-0.bas(213) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,3
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 213,4
+vis-nested-0.bas(213) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 214,1
+vis-nested-0.bas(214) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-0.bas(214) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-0.bas(214) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-0.bas(215) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 215,2
+---------- protected/private/private
+Expect error to follow @ 221,2
+vis-nested-0.bas(221) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,3
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,4
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 221,5
+vis-nested-0.bas(221) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 222,1
+vis-nested-0.bas(222) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,2
+vis-nested-0.bas(222) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,3
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 222,4
+vis-nested-0.bas(222) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 223,1
+vis-nested-0.bas(223) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-0.bas(223) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-0.bas(223) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-0.bas(224) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 224,2
+---------- private/public/public
+Expect error to follow @ 230,2
+vis-nested-0.bas(230) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,5
+vis-nested-0.bas(230) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-0.bas(231) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 231,2
+Expect error to follow @ 231,3
+Expect error to follow @ 231,4
+Expect error to follow @ 232,1
+vis-nested-0.bas(232) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 232,2
+Expect error to follow @ 232,3
+Expect error to follow @ 233,1
+vis-nested-0.bas(233) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 233,2
+---------- private/public/protected
+Expect error to follow @ 239,2
+vis-nested-0.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-0.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-0.bas(240) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+Expect error to follow @ 240,3
+vis-nested-0.bas(240) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-0.bas(240) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-0.bas(241) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-0.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-0.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-0.bas(242) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/private
+Expect error to follow @ 248,2
+vis-nested-0.bas(248) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,3
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,4
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 248,5
+vis-nested-0.bas(248) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,1
+vis-nested-0.bas(249) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,2
+Expect error to follow @ 249,3
+vis-nested-0.bas(249) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-0.bas(249) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-0.bas(250) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-0.bas(250) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-0.bas(250) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-0.bas(251) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 251,2
+---------- private/protected/public
+Expect error to follow @ 257,2
+vis-nested-0.bas(257) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,3
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,4
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 257,5
+vis-nested-0.bas(257) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 258,1
+vis-nested-0.bas(258) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,2
+vis-nested-0.bas(258) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,3
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 258,4
+vis-nested-0.bas(258) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 259,1
+vis-nested-0.bas(259) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 259,2
+Expect error to follow @ 259,3
+Expect error to follow @ 260,1
+vis-nested-0.bas(260) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 260,2
+---------- private/protected/protected
+Expect error to follow @ 266,2
+vis-nested-0.bas(266) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,3
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,4
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 266,5
+vis-nested-0.bas(266) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 267,1
+vis-nested-0.bas(267) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,2
+vis-nested-0.bas(267) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,3
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 267,4
+vis-nested-0.bas(267) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 268,1
+vis-nested-0.bas(268) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-0.bas(268) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-0.bas(268) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-0.bas(269) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 269,2
+---------- private/protected/private
+Expect error to follow @ 275,2
+vis-nested-0.bas(275) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,3
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,4
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 275,5
+vis-nested-0.bas(275) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 276,1
+vis-nested-0.bas(276) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,2
+vis-nested-0.bas(276) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,3
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 276,4
+vis-nested-0.bas(276) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 277,1
+vis-nested-0.bas(277) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-0.bas(277) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-0.bas(277) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-0.bas(278) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 278,2
+---------- private/private/public
+Expect error to follow @ 284,2
+vis-nested-0.bas(284) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,3
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,4
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 284,5
+vis-nested-0.bas(284) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 285,1
+vis-nested-0.bas(285) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,2
+vis-nested-0.bas(285) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,3
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 285,4
+vis-nested-0.bas(285) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 286,1
+vis-nested-0.bas(286) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 286,2
+Expect error to follow @ 286,3
+Expect error to follow @ 287,1
+vis-nested-0.bas(287) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 287,2
+---------- private/private/protected
+Expect error to follow @ 293,2
+vis-nested-0.bas(293) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,3
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,4
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 293,5
+vis-nested-0.bas(293) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 294,1
+vis-nested-0.bas(294) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,2
+vis-nested-0.bas(294) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,3
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 294,4
+vis-nested-0.bas(294) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 295,1
+vis-nested-0.bas(295) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-0.bas(295) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-0.bas(295) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-0.bas(296) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 296,2
+---------- private/private/private
+Expect error to follow @ 302,2
+vis-nested-0.bas(302) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,3
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,4
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 302,5
+vis-nested-0.bas(302) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 303,1
+vis-nested-0.bas(303) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,2
+vis-nested-0.bas(303) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,3
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 303,4
+vis-nested-0.bas(303) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 304,1
+vis-nested-0.bas(304) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,2
+vis-nested-0.bas(304) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 304,3
+vis-nested-0.bas(304) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 305,1
+vis-nested-0.bas(305) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 305,2

--- a/tests/syntax/r/win64/vis-nested-1.txt
+++ b/tests/syntax/r/win64/vis-nested-1.txt
@@ -13,7 +13,9 @@ vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 80,3
 vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
 Expect error to follow @ 81,1
+vis-nested-1.bas(81) error 202: Illegal member access in 'test_X3( UDT02,          1, 1 )'
 Expect error to follow @ 81,2
+vis-nested-1.bas(81) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT02,          1, 1 )'
 ---------- public/public/private
 Expect error to follow @ 88,4
 vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
@@ -28,7 +30,9 @@ vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( U
 Expect error to follow @ 90,3
 vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
 Expect error to follow @ 91,1
+vis-nested-1.bas(91) error 202: Illegal member access in 'test_X3( UDT03,          1, 1 )'
 Expect error to follow @ 91,2
+vis-nested-1.bas(91) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT03,          1, 1 )'
 ---------- public/protected/public
 Expect error to follow @ 98,3
 vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
@@ -45,13 +49,17 @@ vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( U
 Expect error to follow @ 100,1
 vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,2
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 100,3
+vis-nested-1.bas(100) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT04,       1, 1, 1 )'
 Expect error to follow @ 101,1
 vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 101,2
+vis-nested-1.bas(101) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,1
 vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
 Expect error to follow @ 102,2
+vis-nested-1.bas(102) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT04,          1, 1 )'
 ---------- public/protected/protected
 Expect error to follow @ 109,3
 vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
@@ -68,12 +76,13 @@ vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 111,1
 vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,2
-vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 111,3
-vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+vis-nested-1.bas(111) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT05,       1, 1, 1 )'
 Expect error to follow @ 112,1
 vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
 Expect error to follow @ 112,2
+vis-nested-1.bas(112) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT05,          1, 1 )'
 ---------- public/protected/private
 Expect error to follow @ 119,3
 vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
@@ -90,12 +99,13 @@ vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 121,1
 vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,2
-vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 121,3
-vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+vis-nested-1.bas(121) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT06,       1, 1, 1 )'
 Expect error to follow @ 122,1
 vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
 Expect error to follow @ 122,2
+vis-nested-1.bas(122) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT06,          1, 1 )'
 ---------- public/private/public
 Expect error to follow @ 129,3
 vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
@@ -112,10 +122,13 @@ vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 131,1
 vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,2
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 131,3
+vis-nested-1.bas(131) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT07,       1, 1, 1 )'
 Expect error to follow @ 132,1
 vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
 Expect error to follow @ 132,2
+vis-nested-1.bas(132) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT07,          1, 1 )'
 ---------- public/private/protected
 Expect error to follow @ 139,3
 vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
@@ -132,12 +145,13 @@ vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 141,1
 vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,2
-vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 141,3
-vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+vis-nested-1.bas(141) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT08,       1, 1, 1 )'
 Expect error to follow @ 142,1
 vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
 Expect error to follow @ 142,2
+vis-nested-1.bas(142) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT08,          1, 1 )'
 ---------- public/private/private
 Expect error to follow @ 149,3
 vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
@@ -154,12 +168,13 @@ vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( 
 Expect error to follow @ 151,1
 vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,2
-vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 151,3
-vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+vis-nested-1.bas(151) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT09,       1, 1, 1 )'
 Expect error to follow @ 152,1
 vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
 Expect error to follow @ 152,2
+vis-nested-1.bas(152) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT09,          1, 1 )'
 ---------- protected/public/public
 Expect error to follow @ 159,2
 vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
@@ -172,15 +187,21 @@ vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 160,1
 vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,2
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,3
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 160,4
+vis-nested-1.bas(160) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT10,    1, 1, 1, 1 )'
 Expect error to follow @ 161,1
 vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,2
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 161,3
+vis-nested-1.bas(161) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT10,       1, 1, 1 )'
 Expect error to follow @ 162,1
 vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
 Expect error to follow @ 162,2
+vis-nested-1.bas(162) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT10,          1, 1 )'
 ---------- protected/public/protected
 Expect error to follow @ 169,2
 vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
@@ -193,19 +214,21 @@ vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 170,1
 vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,2
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,3
-vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 170,4
-vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+vis-nested-1.bas(170) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT11,    1, 1, 1, 1 )'
 Expect error to follow @ 171,1
 vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,2
-vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 171,3
-vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+vis-nested-1.bas(171) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT11,       1, 1, 1 )'
 Expect error to follow @ 172,1
 vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
 Expect error to follow @ 172,2
+vis-nested-1.bas(172) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT11,          1, 1 )'
 ---------- protected/public/private
 Expect error to follow @ 179,2
 vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
@@ -218,19 +241,21 @@ vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 180,1
 vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,2
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,3
-vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 180,4
-vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+vis-nested-1.bas(180) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT12,    1, 1, 1, 1 )'
 Expect error to follow @ 181,1
 vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,2
-vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 181,3
-vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+vis-nested-1.bas(181) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT12,       1, 1, 1 )'
 Expect error to follow @ 182,1
 vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
 Expect error to follow @ 182,2
+vis-nested-1.bas(182) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT12,          1, 1 )'
 ---------- protected/protected/public
 Expect error to follow @ 189,2
 vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
@@ -243,18 +268,21 @@ vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 190,1
 vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,2
-vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,3
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 190,4
-vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+vis-nested-1.bas(190) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT13,    1, 1, 1, 1 )'
 Expect error to follow @ 191,1
 vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,2
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 191,3
+vis-nested-1.bas(191) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT13,       1, 1, 1 )'
 Expect error to follow @ 192,1
 vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
 Expect error to follow @ 192,2
+vis-nested-1.bas(192) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT13,          1, 1 )'
 ---------- protected/protected/protected
 Expect error to follow @ 199,2
 vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
@@ -267,20 +295,21 @@ vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 200,1
 vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,2
-vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,3
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 200,4
-vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+vis-nested-1.bas(200) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT14,    1, 1, 1, 1 )'
 Expect error to follow @ 201,1
 vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,2
-vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 201,3
-vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+vis-nested-1.bas(201) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT14,       1, 1, 1 )'
 Expect error to follow @ 202,1
 vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
 Expect error to follow @ 202,2
+vis-nested-1.bas(202) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT14,          1, 1 )'
 ---------- protected/protected/private
 Expect error to follow @ 209,2
 vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
@@ -293,20 +322,21 @@ vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 210,1
 vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,2
-vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,3
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 210,4
-vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+vis-nested-1.bas(210) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT15,    1, 1, 1, 1 )'
 Expect error to follow @ 211,1
 vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,2
-vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 211,3
-vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+vis-nested-1.bas(211) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT15,       1, 1, 1 )'
 Expect error to follow @ 212,1
 vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
 Expect error to follow @ 212,2
+vis-nested-1.bas(212) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT15,          1, 1 )'
 ---------- protected/private/public
 Expect error to follow @ 219,2
 vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
@@ -319,18 +349,21 @@ vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 220,1
 vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,2
-vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,3
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 220,4
-vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+vis-nested-1.bas(220) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT16,    1, 1, 1, 1 )'
 Expect error to follow @ 221,1
 vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,2
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 221,3
+vis-nested-1.bas(221) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT16,       1, 1, 1 )'
 Expect error to follow @ 222,1
 vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
 Expect error to follow @ 222,2
+vis-nested-1.bas(222) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT16,          1, 1 )'
 ---------- protected/private/protected
 Expect error to follow @ 229,2
 vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
@@ -343,20 +376,21 @@ vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 230,1
 vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,2
-vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,3
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 230,4
-vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+vis-nested-1.bas(230) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT17,    1, 1, 1, 1 )'
 Expect error to follow @ 231,1
 vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,2
-vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 231,3
-vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+vis-nested-1.bas(231) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT17,       1, 1, 1 )'
 Expect error to follow @ 232,1
 vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
 Expect error to follow @ 232,2
+vis-nested-1.bas(232) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT17,          1, 1 )'
 ---------- protected/private/private
 Expect error to follow @ 239,2
 vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
@@ -369,20 +403,21 @@ vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 240,1
 vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,2
-vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,3
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 240,4
-vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+vis-nested-1.bas(240) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT18,    1, 1, 1, 1 )'
 Expect error to follow @ 241,1
 vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,2
-vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 241,3
-vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+vis-nested-1.bas(241) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT18,       1, 1, 1 )'
 Expect error to follow @ 242,1
 vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
 Expect error to follow @ 242,2
+vis-nested-1.bas(242) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT18,          1, 1 )'
 ---------- private/public/public
 Expect error to follow @ 249,2
 vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
@@ -395,15 +430,21 @@ vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 250,1
 vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,2
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,3
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 250,4
+vis-nested-1.bas(250) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT19,    1, 1, 1, 1 )'
 Expect error to follow @ 251,1
 vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,2
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 251,3
+vis-nested-1.bas(251) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT19,       1, 1, 1 )'
 Expect error to follow @ 252,1
 vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
 Expect error to follow @ 252,2
+vis-nested-1.bas(252) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT19,          1, 1 )'
 ---------- private/public/protected
 Expect error to follow @ 259,2
 vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
@@ -416,19 +457,21 @@ vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 260,1
 vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,2
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,3
-vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 260,4
-vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+vis-nested-1.bas(260) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT20,    1, 1, 1, 1 )'
 Expect error to follow @ 261,1
 vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,2
-vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 261,3
-vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+vis-nested-1.bas(261) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT20,       1, 1, 1 )'
 Expect error to follow @ 262,1
 vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
 Expect error to follow @ 262,2
+vis-nested-1.bas(262) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT20,          1, 1 )'
 ---------- private/public/private
 Expect error to follow @ 269,2
 vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
@@ -441,19 +484,21 @@ vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 270,1
 vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,2
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,3
-vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 270,4
-vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+vis-nested-1.bas(270) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT21,    1, 1, 1, 1 )'
 Expect error to follow @ 271,1
 vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,2
-vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 271,3
-vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+vis-nested-1.bas(271) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT21,       1, 1, 1 )'
 Expect error to follow @ 272,1
 vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
 Expect error to follow @ 272,2
+vis-nested-1.bas(272) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT21,          1, 1 )'
 ---------- private/protected/public
 Expect error to follow @ 279,2
 vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
@@ -466,18 +511,21 @@ vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 280,1
 vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,2
-vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,3
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 280,4
-vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+vis-nested-1.bas(280) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT22,    1, 1, 1, 1 )'
 Expect error to follow @ 281,1
 vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,2
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 281,3
+vis-nested-1.bas(281) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT22,       1, 1, 1 )'
 Expect error to follow @ 282,1
 vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
 Expect error to follow @ 282,2
+vis-nested-1.bas(282) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT22,          1, 1 )'
 ---------- private/protected/protected
 Expect error to follow @ 289,2
 vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
@@ -490,20 +538,21 @@ vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 290,1
 vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,2
-vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,3
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 290,4
-vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+vis-nested-1.bas(290) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT23,    1, 1, 1, 1 )'
 Expect error to follow @ 291,1
 vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,2
-vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 291,3
-vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+vis-nested-1.bas(291) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT23,       1, 1, 1 )'
 Expect error to follow @ 292,1
 vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
 Expect error to follow @ 292,2
+vis-nested-1.bas(292) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT23,          1, 1 )'
 ---------- private/protected/private
 Expect error to follow @ 299,2
 vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
@@ -516,20 +565,21 @@ vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 300,1
 vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,2
-vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,3
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 300,4
-vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+vis-nested-1.bas(300) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT24,    1, 1, 1, 1 )'
 Expect error to follow @ 301,1
 vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,2
-vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 301,3
-vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+vis-nested-1.bas(301) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT24,       1, 1, 1 )'
 Expect error to follow @ 302,1
 vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
 Expect error to follow @ 302,2
+vis-nested-1.bas(302) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT24,          1, 1 )'
 ---------- private/private/public
 Expect error to follow @ 309,2
 vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
@@ -542,18 +592,21 @@ vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 310,1
 vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,2
-vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,3
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 310,4
-vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+vis-nested-1.bas(310) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT25,    1, 1, 1, 1 )'
 Expect error to follow @ 311,1
 vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,2
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 311,3
+vis-nested-1.bas(311) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT25,       1, 1, 1 )'
 Expect error to follow @ 312,1
 vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
 Expect error to follow @ 312,2
+vis-nested-1.bas(312) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT25,          1, 1 )'
 ---------- private/private/protected
 Expect error to follow @ 319,2
 vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
@@ -566,20 +619,21 @@ vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 320,1
 vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,2
-vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,3
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 320,4
-vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+vis-nested-1.bas(320) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT26,    1, 1, 1, 1 )'
 Expect error to follow @ 321,1
 vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,2
-vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 321,3
-vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+vis-nested-1.bas(321) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT26,       1, 1, 1 )'
 Expect error to follow @ 322,1
 vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
 Expect error to follow @ 322,2
+vis-nested-1.bas(322) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT26,          1, 1 )'
 ---------- private/private/private
 Expect error to follow @ 329,2
 vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
@@ -592,17 +646,18 @@ vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( 
 Expect error to follow @ 330,1
 vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,2
-vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,3
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 330,4
-vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+vis-nested-1.bas(330) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X1( UDT27,    1, 1, 1, 1 )'
 Expect error to follow @ 331,1
 vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,2
-vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 331,3
-vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+vis-nested-1.bas(331) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X2( UDT27,       1, 1, 1 )'
 Expect error to follow @ 332,1
 vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
 Expect error to follow @ 332,2
+vis-nested-1.bas(332) error 265: Symbol not a CLASS, ENUM, TYPE or UNION type, before '.' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/r/win64/vis-nested-1.txt
+++ b/tests/syntax/r/win64/vis-nested-1.txt
@@ -1,0 +1,608 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 78,4
+vis-nested-1.bas(78) error 202: Illegal member access, found 'i3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 78,5
+vis-nested-1.bas(78) error 202: Illegal member access, found 'm3' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,3
+vis-nested-1.bas(79) error 202: Illegal member access, found 'i3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-1.bas(79) error 202: Illegal member access, found 'm3' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-1.bas(80) error 202: Illegal member access, found 'i3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-1.bas(80) error 202: Illegal member access, found 'm3' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 81,1
+Expect error to follow @ 81,2
+---------- public/public/private
+Expect error to follow @ 88,4
+vis-nested-1.bas(88) error 202: Illegal member access, found 'i3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 88,5
+vis-nested-1.bas(88) error 202: Illegal member access, found 'm3' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-1.bas(89) error 202: Illegal member access, found 'i3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 89,4
+vis-nested-1.bas(89) error 202: Illegal member access, found 'm3' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-1.bas(90) error 202: Illegal member access, found 'i3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 90,3
+vis-nested-1.bas(90) error 202: Illegal member access, found 'm3' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 91,1
+Expect error to follow @ 91,2
+---------- public/protected/public
+Expect error to follow @ 98,3
+vis-nested-1.bas(98) error 202: Illegal member access, found 'i2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,4
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,5
+vis-nested-1.bas(98) error 202: Illegal member access, found 'm2' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-1.bas(99) error 202: Illegal member access, found 'i2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,3
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 99,4
+vis-nested-1.bas(99) error 202: Illegal member access, found 'm2' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-1.bas(100) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 100,2
+Expect error to follow @ 100,3
+Expect error to follow @ 101,1
+vis-nested-1.bas(101) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 101,2
+Expect error to follow @ 102,1
+vis-nested-1.bas(102) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+Expect error to follow @ 102,2
+---------- public/protected/protected
+Expect error to follow @ 109,3
+vis-nested-1.bas(109) error 202: Illegal member access, found 'i2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,4
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 109,5
+vis-nested-1.bas(109) error 202: Illegal member access, found 'm2' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 110,2
+vis-nested-1.bas(110) error 202: Illegal member access, found 'i2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,3
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 110,4
+vis-nested-1.bas(110) error 202: Illegal member access, found 'm2' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 111,1
+vis-nested-1.bas(111) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,2
+vis-nested-1.bas(111) error 202: Illegal member access, found 'i3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 111,3
+vis-nested-1.bas(111) error 202: Illegal member access, found 'm3' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 112,1
+vis-nested-1.bas(112) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+Expect error to follow @ 112,2
+---------- public/protected/private
+Expect error to follow @ 119,3
+vis-nested-1.bas(119) error 202: Illegal member access, found 'i2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,4
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 119,5
+vis-nested-1.bas(119) error 202: Illegal member access, found 'm2' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 120,2
+vis-nested-1.bas(120) error 202: Illegal member access, found 'i2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,3
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 120,4
+vis-nested-1.bas(120) error 202: Illegal member access, found 'm2' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 121,1
+vis-nested-1.bas(121) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,2
+vis-nested-1.bas(121) error 202: Illegal member access, found 'i3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 121,3
+vis-nested-1.bas(121) error 202: Illegal member access, found 'm3' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 122,1
+vis-nested-1.bas(122) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+Expect error to follow @ 122,2
+---------- public/private/public
+Expect error to follow @ 129,3
+vis-nested-1.bas(129) error 202: Illegal member access, found 'i2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,4
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 129,5
+vis-nested-1.bas(129) error 202: Illegal member access, found 'm2' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 130,2
+vis-nested-1.bas(130) error 202: Illegal member access, found 'i2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,3
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 130,4
+vis-nested-1.bas(130) error 202: Illegal member access, found 'm2' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 131,1
+vis-nested-1.bas(131) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 131,2
+Expect error to follow @ 131,3
+Expect error to follow @ 132,1
+vis-nested-1.bas(132) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+Expect error to follow @ 132,2
+---------- public/private/protected
+Expect error to follow @ 139,3
+vis-nested-1.bas(139) error 202: Illegal member access, found 'i2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,4
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 139,5
+vis-nested-1.bas(139) error 202: Illegal member access, found 'm2' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 140,2
+vis-nested-1.bas(140) error 202: Illegal member access, found 'i2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,3
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 140,4
+vis-nested-1.bas(140) error 202: Illegal member access, found 'm2' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 141,1
+vis-nested-1.bas(141) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,2
+vis-nested-1.bas(141) error 202: Illegal member access, found 'i3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 141,3
+vis-nested-1.bas(141) error 202: Illegal member access, found 'm3' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 142,1
+vis-nested-1.bas(142) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+Expect error to follow @ 142,2
+---------- public/private/private
+Expect error to follow @ 149,3
+vis-nested-1.bas(149) error 202: Illegal member access, found 'i2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,4
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 149,5
+vis-nested-1.bas(149) error 202: Illegal member access, found 'm2' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 150,2
+vis-nested-1.bas(150) error 202: Illegal member access, found 'i2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,3
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 150,4
+vis-nested-1.bas(150) error 202: Illegal member access, found 'm2' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 151,1
+vis-nested-1.bas(151) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-1.bas(151) error 202: Illegal member access, found 'i3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-1.bas(151) error 202: Illegal member access, found 'm3' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-1.bas(152) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+Expect error to follow @ 152,2
+---------- protected/public/public
+Expect error to follow @ 159,2
+vis-nested-1.bas(159) error 202: Illegal member access, found 'i1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,3
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,4
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 159,5
+vis-nested-1.bas(159) error 202: Illegal member access, found 'm1' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,1
+vis-nested-1.bas(160) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+Expect error to follow @ 160,3
+Expect error to follow @ 160,4
+Expect error to follow @ 161,1
+vis-nested-1.bas(161) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 161,2
+Expect error to follow @ 161,3
+Expect error to follow @ 162,1
+vis-nested-1.bas(162) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+Expect error to follow @ 162,2
+---------- protected/public/protected
+Expect error to follow @ 169,2
+vis-nested-1.bas(169) error 202: Illegal member access, found 'i1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,5
+vis-nested-1.bas(169) error 202: Illegal member access, found 'm1' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-1.bas(170) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+Expect error to follow @ 170,3
+vis-nested-1.bas(170) error 202: Illegal member access, found 'i3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 170,4
+vis-nested-1.bas(170) error 202: Illegal member access, found 'm3' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-1.bas(171) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-1.bas(171) error 202: Illegal member access, found 'i3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 171,3
+vis-nested-1.bas(171) error 202: Illegal member access, found 'm3' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-1.bas(172) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+Expect error to follow @ 172,2
+---------- protected/public/private
+Expect error to follow @ 179,2
+vis-nested-1.bas(179) error 202: Illegal member access, found 'i1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,4
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,5
+vis-nested-1.bas(179) error 202: Illegal member access, found 'm1' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-1.bas(180) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,2
+Expect error to follow @ 180,3
+vis-nested-1.bas(180) error 202: Illegal member access, found 'i3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 180,4
+vis-nested-1.bas(180) error 202: Illegal member access, found 'm3' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-1.bas(181) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,2
+vis-nested-1.bas(181) error 202: Illegal member access, found 'i3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 181,3
+vis-nested-1.bas(181) error 202: Illegal member access, found 'm3' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 182,1
+vis-nested-1.bas(182) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+Expect error to follow @ 182,2
+---------- protected/protected/public
+Expect error to follow @ 189,2
+vis-nested-1.bas(189) error 202: Illegal member access, found 'i1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,3
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,4
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 189,5
+vis-nested-1.bas(189) error 202: Illegal member access, found 'm1' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-1.bas(190) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,2
+vis-nested-1.bas(190) error 202: Illegal member access, found 'i2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,3
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 190,4
+vis-nested-1.bas(190) error 202: Illegal member access, found 'm2' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 191,1
+vis-nested-1.bas(191) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 191,2
+Expect error to follow @ 191,3
+Expect error to follow @ 192,1
+vis-nested-1.bas(192) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+Expect error to follow @ 192,2
+---------- protected/protected/protected
+Expect error to follow @ 199,2
+vis-nested-1.bas(199) error 202: Illegal member access, found 'i1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,3
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,4
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 199,5
+vis-nested-1.bas(199) error 202: Illegal member access, found 'm1' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 200,1
+vis-nested-1.bas(200) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,2
+vis-nested-1.bas(200) error 202: Illegal member access, found 'i2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,3
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 200,4
+vis-nested-1.bas(200) error 202: Illegal member access, found 'm2' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 201,1
+vis-nested-1.bas(201) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,2
+vis-nested-1.bas(201) error 202: Illegal member access, found 'i3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 201,3
+vis-nested-1.bas(201) error 202: Illegal member access, found 'm3' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 202,1
+vis-nested-1.bas(202) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+Expect error to follow @ 202,2
+---------- protected/protected/private
+Expect error to follow @ 209,2
+vis-nested-1.bas(209) error 202: Illegal member access, found 'i1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,3
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,4
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 209,5
+vis-nested-1.bas(209) error 202: Illegal member access, found 'm1' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 210,1
+vis-nested-1.bas(210) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,2
+vis-nested-1.bas(210) error 202: Illegal member access, found 'i2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,3
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 210,4
+vis-nested-1.bas(210) error 202: Illegal member access, found 'm2' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 211,1
+vis-nested-1.bas(211) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,2
+vis-nested-1.bas(211) error 202: Illegal member access, found 'i3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 211,3
+vis-nested-1.bas(211) error 202: Illegal member access, found 'm3' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 212,1
+vis-nested-1.bas(212) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+Expect error to follow @ 212,2
+---------- protected/private/public
+Expect error to follow @ 219,2
+vis-nested-1.bas(219) error 202: Illegal member access, found 'i1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,3
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,4
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 219,5
+vis-nested-1.bas(219) error 202: Illegal member access, found 'm1' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 220,1
+vis-nested-1.bas(220) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,2
+vis-nested-1.bas(220) error 202: Illegal member access, found 'i2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,3
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 220,4
+vis-nested-1.bas(220) error 202: Illegal member access, found 'm2' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 221,1
+vis-nested-1.bas(221) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 221,2
+Expect error to follow @ 221,3
+Expect error to follow @ 222,1
+vis-nested-1.bas(222) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+Expect error to follow @ 222,2
+---------- protected/private/protected
+Expect error to follow @ 229,2
+vis-nested-1.bas(229) error 202: Illegal member access, found 'i1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,3
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,4
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 229,5
+vis-nested-1.bas(229) error 202: Illegal member access, found 'm1' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 230,1
+vis-nested-1.bas(230) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,2
+vis-nested-1.bas(230) error 202: Illegal member access, found 'i2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,3
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 230,4
+vis-nested-1.bas(230) error 202: Illegal member access, found 'm2' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 231,1
+vis-nested-1.bas(231) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,2
+vis-nested-1.bas(231) error 202: Illegal member access, found 'i3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 231,3
+vis-nested-1.bas(231) error 202: Illegal member access, found 'm3' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 232,1
+vis-nested-1.bas(232) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+Expect error to follow @ 232,2
+---------- protected/private/private
+Expect error to follow @ 239,2
+vis-nested-1.bas(239) error 202: Illegal member access, found 'i1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,3
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,4
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 239,5
+vis-nested-1.bas(239) error 202: Illegal member access, found 'm1' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 240,1
+vis-nested-1.bas(240) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,2
+vis-nested-1.bas(240) error 202: Illegal member access, found 'i2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,3
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 240,4
+vis-nested-1.bas(240) error 202: Illegal member access, found 'm2' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 241,1
+vis-nested-1.bas(241) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-1.bas(241) error 202: Illegal member access, found 'i3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-1.bas(241) error 202: Illegal member access, found 'm3' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-1.bas(242) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+Expect error to follow @ 242,2
+---------- private/public/public
+Expect error to follow @ 249,2
+vis-nested-1.bas(249) error 202: Illegal member access, found 'i1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,3
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,4
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 249,5
+vis-nested-1.bas(249) error 202: Illegal member access, found 'm1' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,1
+vis-nested-1.bas(250) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+Expect error to follow @ 250,3
+Expect error to follow @ 250,4
+Expect error to follow @ 251,1
+vis-nested-1.bas(251) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 251,2
+Expect error to follow @ 251,3
+Expect error to follow @ 252,1
+vis-nested-1.bas(252) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+Expect error to follow @ 252,2
+---------- private/public/protected
+Expect error to follow @ 259,2
+vis-nested-1.bas(259) error 202: Illegal member access, found 'i1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,5
+vis-nested-1.bas(259) error 202: Illegal member access, found 'm1' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-1.bas(260) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+Expect error to follow @ 260,3
+vis-nested-1.bas(260) error 202: Illegal member access, found 'i3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 260,4
+vis-nested-1.bas(260) error 202: Illegal member access, found 'm3' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-1.bas(261) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-1.bas(261) error 202: Illegal member access, found 'i3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 261,3
+vis-nested-1.bas(261) error 202: Illegal member access, found 'm3' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-1.bas(262) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+Expect error to follow @ 262,2
+---------- private/public/private
+Expect error to follow @ 269,2
+vis-nested-1.bas(269) error 202: Illegal member access, found 'i1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,4
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,5
+vis-nested-1.bas(269) error 202: Illegal member access, found 'm1' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-1.bas(270) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,2
+Expect error to follow @ 270,3
+vis-nested-1.bas(270) error 202: Illegal member access, found 'i3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 270,4
+vis-nested-1.bas(270) error 202: Illegal member access, found 'm3' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-1.bas(271) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,2
+vis-nested-1.bas(271) error 202: Illegal member access, found 'i3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 271,3
+vis-nested-1.bas(271) error 202: Illegal member access, found 'm3' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 272,1
+vis-nested-1.bas(272) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+Expect error to follow @ 272,2
+---------- private/protected/public
+Expect error to follow @ 279,2
+vis-nested-1.bas(279) error 202: Illegal member access, found 'i1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,3
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,4
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 279,5
+vis-nested-1.bas(279) error 202: Illegal member access, found 'm1' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-1.bas(280) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,2
+vis-nested-1.bas(280) error 202: Illegal member access, found 'i2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,3
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 280,4
+vis-nested-1.bas(280) error 202: Illegal member access, found 'm2' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 281,1
+vis-nested-1.bas(281) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 281,2
+Expect error to follow @ 281,3
+Expect error to follow @ 282,1
+vis-nested-1.bas(282) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+Expect error to follow @ 282,2
+---------- private/protected/protected
+Expect error to follow @ 289,2
+vis-nested-1.bas(289) error 202: Illegal member access, found 'i1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,3
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,4
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 289,5
+vis-nested-1.bas(289) error 202: Illegal member access, found 'm1' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 290,1
+vis-nested-1.bas(290) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,2
+vis-nested-1.bas(290) error 202: Illegal member access, found 'i2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,3
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 290,4
+vis-nested-1.bas(290) error 202: Illegal member access, found 'm2' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 291,1
+vis-nested-1.bas(291) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,2
+vis-nested-1.bas(291) error 202: Illegal member access, found 'i3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 291,3
+vis-nested-1.bas(291) error 202: Illegal member access, found 'm3' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 292,1
+vis-nested-1.bas(292) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+Expect error to follow @ 292,2
+---------- private/protected/private
+Expect error to follow @ 299,2
+vis-nested-1.bas(299) error 202: Illegal member access, found 'i1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,3
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,4
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 299,5
+vis-nested-1.bas(299) error 202: Illegal member access, found 'm1' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 300,1
+vis-nested-1.bas(300) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,2
+vis-nested-1.bas(300) error 202: Illegal member access, found 'i2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,3
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 300,4
+vis-nested-1.bas(300) error 202: Illegal member access, found 'm2' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 301,1
+vis-nested-1.bas(301) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,2
+vis-nested-1.bas(301) error 202: Illegal member access, found 'i3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 301,3
+vis-nested-1.bas(301) error 202: Illegal member access, found 'm3' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 302,1
+vis-nested-1.bas(302) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+Expect error to follow @ 302,2
+---------- private/private/public
+Expect error to follow @ 309,2
+vis-nested-1.bas(309) error 202: Illegal member access, found 'i1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,3
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,4
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 309,5
+vis-nested-1.bas(309) error 202: Illegal member access, found 'm1' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 310,1
+vis-nested-1.bas(310) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,2
+vis-nested-1.bas(310) error 202: Illegal member access, found 'i2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,3
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 310,4
+vis-nested-1.bas(310) error 202: Illegal member access, found 'm2' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 311,1
+vis-nested-1.bas(311) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 311,2
+Expect error to follow @ 311,3
+Expect error to follow @ 312,1
+vis-nested-1.bas(312) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+Expect error to follow @ 312,2
+---------- private/private/protected
+Expect error to follow @ 319,2
+vis-nested-1.bas(319) error 202: Illegal member access, found 'i1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,3
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,4
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 319,5
+vis-nested-1.bas(319) error 202: Illegal member access, found 'm1' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 320,1
+vis-nested-1.bas(320) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,2
+vis-nested-1.bas(320) error 202: Illegal member access, found 'i2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,3
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 320,4
+vis-nested-1.bas(320) error 202: Illegal member access, found 'm2' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 321,1
+vis-nested-1.bas(321) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,2
+vis-nested-1.bas(321) error 202: Illegal member access, found 'i3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 321,3
+vis-nested-1.bas(321) error 202: Illegal member access, found 'm3' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 322,1
+vis-nested-1.bas(322) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+Expect error to follow @ 322,2
+---------- private/private/private
+Expect error to follow @ 329,2
+vis-nested-1.bas(329) error 202: Illegal member access, found 'i1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,3
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,4
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 329,5
+vis-nested-1.bas(329) error 202: Illegal member access, found 'm1' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 330,1
+vis-nested-1.bas(330) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,2
+vis-nested-1.bas(330) error 202: Illegal member access, found 'i2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,3
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 330,4
+vis-nested-1.bas(330) error 202: Illegal member access, found 'm2' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 331,1
+vis-nested-1.bas(331) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,2
+vis-nested-1.bas(331) error 202: Illegal member access, found 'i3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 331,3
+vis-nested-1.bas(331) error 202: Illegal member access, found 'm3' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 332,1
+vis-nested-1.bas(332) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'
+Expect error to follow @ 332,2

--- a/tests/syntax/r/win64/vis-nested-2.txt
+++ b/tests/syntax/r/win64/vis-nested-2.txt
@@ -1,0 +1,523 @@
+---------- public/public/public
+---------- public/public/protected
+Expect error to follow @ 70,3
+vis-nested-2.bas(70) error 202: Illegal member access, found 'c2' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 70,4
+vis-nested-2.bas(70) error 202: Illegal member access, found 'UDT023' in 'test_X0( UDT02, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 71,2
+vis-nested-2.bas(71) error 202: Illegal member access, found 'c2' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 71,3
+vis-nested-2.bas(71) error 202: Illegal member access, found 'UDT023' in 'test_X1( UDT02,    0, 0, 1, 1 )'
+Expect error to follow @ 72,1
+vis-nested-2.bas(72) error 202: Illegal member access, found 'c2' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 72,2
+vis-nested-2.bas(72) error 202: Illegal member access, found 'UDT023' in 'test_X2( UDT02,       0, 1, 1 )'
+Expect error to follow @ 73,1
+vis-nested-2.bas(73) error 202: Illegal member access, found 'UDT023' in 'test_X3( UDT02,          1, 1 )'
+---------- public/public/private
+Expect error to follow @ 79,3
+vis-nested-2.bas(79) error 202: Illegal member access, found 'c2' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 79,4
+vis-nested-2.bas(79) error 202: Illegal member access, found 'UDT033' in 'test_X0( UDT03, 0, 0, 0, 1, 1 )'
+Expect error to follow @ 80,2
+vis-nested-2.bas(80) error 202: Illegal member access, found 'c2' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 80,3
+vis-nested-2.bas(80) error 202: Illegal member access, found 'UDT033' in 'test_X1( UDT03,    0, 0, 1, 1 )'
+Expect error to follow @ 81,1
+vis-nested-2.bas(81) error 202: Illegal member access, found 'c2' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 81,2
+vis-nested-2.bas(81) error 202: Illegal member access, found 'UDT033' in 'test_X2( UDT03,       0, 1, 1 )'
+Expect error to follow @ 82,1
+vis-nested-2.bas(82) error 202: Illegal member access, found 'UDT033' in 'test_X3( UDT03,          1, 1 )'
+---------- public/protected/public
+Expect error to follow @ 88,2
+vis-nested-2.bas(88) error 202: Illegal member access, found 'c1' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,3
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 88,4
+vis-nested-2.bas(88) error 202: Illegal member access, found 'UDT042' in 'test_X0( UDT04, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 89,1
+vis-nested-2.bas(89) error 202: Illegal member access, found 'c1' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,2
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 89,3
+vis-nested-2.bas(89) error 202: Illegal member access, found 'UDT042' in 'test_X1( UDT04,    0, 1, 1, 1 )'
+Expect error to follow @ 90,1
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 90,2
+vis-nested-2.bas(90) error 202: Illegal member access, found 'UDT042' in 'test_X2( UDT04,       1, 1, 1 )'
+Expect error to follow @ 91,1
+vis-nested-2.bas(91) error 202: Illegal member access, found 'UDT042' in 'test_X3( UDT04,          1, 1 )'
+---------- public/protected/protected
+Expect error to follow @ 97,2
+vis-nested-2.bas(97) error 202: Illegal member access, found 'c1' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,3
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 97,4
+vis-nested-2.bas(97) error 202: Illegal member access, found 'UDT052' in 'test_X0( UDT05, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 98,1
+vis-nested-2.bas(98) error 202: Illegal member access, found 'c1' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,2
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 98,3
+vis-nested-2.bas(98) error 202: Illegal member access, found 'UDT052' in 'test_X1( UDT05,    0, 1, 1, 1 )'
+Expect error to follow @ 99,1
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 99,2
+vis-nested-2.bas(99) error 202: Illegal member access, found 'UDT052' in 'test_X2( UDT05,       1, 1, 1 )'
+Expect error to follow @ 100,1
+vis-nested-2.bas(100) error 202: Illegal member access, found 'UDT052' in 'test_X3( UDT05,          1, 1 )'
+---------- public/protected/private
+Expect error to follow @ 106,2
+vis-nested-2.bas(106) error 202: Illegal member access, found 'c1' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,3
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 106,4
+vis-nested-2.bas(106) error 202: Illegal member access, found 'UDT062' in 'test_X0( UDT06, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 107,1
+vis-nested-2.bas(107) error 202: Illegal member access, found 'c1' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,2
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 107,3
+vis-nested-2.bas(107) error 202: Illegal member access, found 'UDT062' in 'test_X1( UDT06,    0, 1, 1, 1 )'
+Expect error to follow @ 108,1
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 108,2
+vis-nested-2.bas(108) error 202: Illegal member access, found 'UDT062' in 'test_X2( UDT06,       1, 1, 1 )'
+Expect error to follow @ 109,1
+vis-nested-2.bas(109) error 202: Illegal member access, found 'UDT062' in 'test_X3( UDT06,          1, 1 )'
+---------- public/private/public
+Expect error to follow @ 115,2
+vis-nested-2.bas(115) error 202: Illegal member access, found 'c1' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,3
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 115,4
+vis-nested-2.bas(115) error 202: Illegal member access, found 'UDT072' in 'test_X0( UDT07, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 116,1
+vis-nested-2.bas(116) error 202: Illegal member access, found 'c1' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,2
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 116,3
+vis-nested-2.bas(116) error 202: Illegal member access, found 'UDT072' in 'test_X1( UDT07,    0, 1, 1, 1 )'
+Expect error to follow @ 117,1
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 117,2
+vis-nested-2.bas(117) error 202: Illegal member access, found 'UDT072' in 'test_X2( UDT07,       1, 1, 1 )'
+Expect error to follow @ 118,1
+vis-nested-2.bas(118) error 202: Illegal member access, found 'UDT072' in 'test_X3( UDT07,          1, 1 )'
+---------- public/private/protected
+Expect error to follow @ 124,2
+vis-nested-2.bas(124) error 202: Illegal member access, found 'c1' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,3
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 124,4
+vis-nested-2.bas(124) error 202: Illegal member access, found 'UDT082' in 'test_X0( UDT08, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 125,1
+vis-nested-2.bas(125) error 202: Illegal member access, found 'c1' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,2
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 125,3
+vis-nested-2.bas(125) error 202: Illegal member access, found 'UDT082' in 'test_X1( UDT08,    0, 1, 1, 1 )'
+Expect error to follow @ 126,1
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 126,2
+vis-nested-2.bas(126) error 202: Illegal member access, found 'UDT082' in 'test_X2( UDT08,       1, 1, 1 )'
+Expect error to follow @ 127,1
+vis-nested-2.bas(127) error 202: Illegal member access, found 'UDT082' in 'test_X3( UDT08,          1, 1 )'
+---------- public/private/private
+Expect error to follow @ 133,2
+vis-nested-2.bas(133) error 202: Illegal member access, found 'c1' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,3
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 133,4
+vis-nested-2.bas(133) error 202: Illegal member access, found 'UDT092' in 'test_X0( UDT09, 0, 0, 1, 1, 1 )'
+Expect error to follow @ 134,1
+vis-nested-2.bas(134) error 202: Illegal member access, found 'c1' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,2
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 134,3
+vis-nested-2.bas(134) error 202: Illegal member access, found 'UDT092' in 'test_X1( UDT09,    0, 1, 1, 1 )'
+Expect error to follow @ 135,1
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 135,2
+vis-nested-2.bas(135) error 202: Illegal member access, found 'UDT092' in 'test_X2( UDT09,       1, 1, 1 )'
+Expect error to follow @ 136,1
+vis-nested-2.bas(136) error 202: Illegal member access, found 'UDT092' in 'test_X3( UDT09,          1, 1 )'
+---------- protected/public/public
+Expect error to follow @ 142,1
+vis-nested-2.bas(142) error 202: Illegal member access, found 'c0' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,2
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,3
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 142,4
+vis-nested-2.bas(142) error 202: Illegal member access, found 'UDT101' in 'test_X0( UDT10, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 143,1
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,2
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 143,3
+vis-nested-2.bas(143) error 202: Illegal member access, found 'UDT101' in 'test_X1( UDT10,    1, 1, 1, 1 )'
+Expect error to follow @ 144,1
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 144,2
+vis-nested-2.bas(144) error 202: Illegal member access, found 'UDT101' in 'test_X2( UDT10,       1, 1, 1 )'
+Expect error to follow @ 145,1
+vis-nested-2.bas(145) error 202: Illegal member access, found 'UDT101' in 'test_X3( UDT10,          1, 1 )'
+---------- protected/public/protected
+Expect error to follow @ 151,1
+vis-nested-2.bas(151) error 202: Illegal member access, found 'c0' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,2
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,3
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 151,4
+vis-nested-2.bas(151) error 202: Illegal member access, found 'UDT111' in 'test_X0( UDT11, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 152,1
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,2
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 152,3
+vis-nested-2.bas(152) error 202: Illegal member access, found 'UDT111' in 'test_X1( UDT11,    1, 1, 1, 1 )'
+Expect error to follow @ 153,1
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 153,2
+vis-nested-2.bas(153) error 202: Illegal member access, found 'UDT111' in 'test_X2( UDT11,       1, 1, 1 )'
+Expect error to follow @ 154,1
+vis-nested-2.bas(154) error 202: Illegal member access, found 'UDT111' in 'test_X3( UDT11,          1, 1 )'
+---------- protected/public/private
+Expect error to follow @ 160,1
+vis-nested-2.bas(160) error 202: Illegal member access, found 'c0' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,2
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,3
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 160,4
+vis-nested-2.bas(160) error 202: Illegal member access, found 'UDT121' in 'test_X0( UDT12, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 161,1
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,2
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 161,3
+vis-nested-2.bas(161) error 202: Illegal member access, found 'UDT121' in 'test_X1( UDT12,    1, 1, 1, 1 )'
+Expect error to follow @ 162,1
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 162,2
+vis-nested-2.bas(162) error 202: Illegal member access, found 'UDT121' in 'test_X2( UDT12,       1, 1, 1 )'
+Expect error to follow @ 163,1
+vis-nested-2.bas(163) error 202: Illegal member access, found 'UDT121' in 'test_X3( UDT12,          1, 1 )'
+---------- protected/protected/public
+Expect error to follow @ 169,1
+vis-nested-2.bas(169) error 202: Illegal member access, found 'c0' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,2
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,3
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 169,4
+vis-nested-2.bas(169) error 202: Illegal member access, found 'UDT131' in 'test_X0( UDT13, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 170,1
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,2
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 170,3
+vis-nested-2.bas(170) error 202: Illegal member access, found 'UDT131' in 'test_X1( UDT13,    1, 1, 1, 1 )'
+Expect error to follow @ 171,1
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 171,2
+vis-nested-2.bas(171) error 202: Illegal member access, found 'UDT131' in 'test_X2( UDT13,       1, 1, 1 )'
+Expect error to follow @ 172,1
+vis-nested-2.bas(172) error 202: Illegal member access, found 'UDT131' in 'test_X3( UDT13,          1, 1 )'
+---------- protected/protected/protected
+Expect error to follow @ 178,1
+vis-nested-2.bas(178) error 202: Illegal member access, found 'c0' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,2
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,3
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 178,4
+vis-nested-2.bas(178) error 202: Illegal member access, found 'UDT141' in 'test_X0( UDT14, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 179,1
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,2
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 179,3
+vis-nested-2.bas(179) error 202: Illegal member access, found 'UDT141' in 'test_X1( UDT14,    1, 1, 1, 1 )'
+Expect error to follow @ 180,1
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 180,2
+vis-nested-2.bas(180) error 202: Illegal member access, found 'UDT141' in 'test_X2( UDT14,       1, 1, 1 )'
+Expect error to follow @ 181,1
+vis-nested-2.bas(181) error 202: Illegal member access, found 'UDT141' in 'test_X3( UDT14,          1, 1 )'
+---------- protected/protected/private
+Expect error to follow @ 187,1
+vis-nested-2.bas(187) error 202: Illegal member access, found 'c0' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,2
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,3
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 187,4
+vis-nested-2.bas(187) error 202: Illegal member access, found 'UDT151' in 'test_X0( UDT15, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 188,1
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,2
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 188,3
+vis-nested-2.bas(188) error 202: Illegal member access, found 'UDT151' in 'test_X1( UDT15,    1, 1, 1, 1 )'
+Expect error to follow @ 189,1
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 189,2
+vis-nested-2.bas(189) error 202: Illegal member access, found 'UDT151' in 'test_X2( UDT15,       1, 1, 1 )'
+Expect error to follow @ 190,1
+vis-nested-2.bas(190) error 202: Illegal member access, found 'UDT151' in 'test_X3( UDT15,          1, 1 )'
+---------- protected/private/public
+Expect error to follow @ 196,1
+vis-nested-2.bas(196) error 202: Illegal member access, found 'c0' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,2
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,3
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 196,4
+vis-nested-2.bas(196) error 202: Illegal member access, found 'UDT161' in 'test_X0( UDT16, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 197,1
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,2
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 197,3
+vis-nested-2.bas(197) error 202: Illegal member access, found 'UDT161' in 'test_X1( UDT16,    1, 1, 1, 1 )'
+Expect error to follow @ 198,1
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 198,2
+vis-nested-2.bas(198) error 202: Illegal member access, found 'UDT161' in 'test_X2( UDT16,       1, 1, 1 )'
+Expect error to follow @ 199,1
+vis-nested-2.bas(199) error 202: Illegal member access, found 'UDT161' in 'test_X3( UDT16,          1, 1 )'
+---------- protected/private/protected
+Expect error to follow @ 205,1
+vis-nested-2.bas(205) error 202: Illegal member access, found 'c0' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,2
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,3
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 205,4
+vis-nested-2.bas(205) error 202: Illegal member access, found 'UDT171' in 'test_X0( UDT17, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 206,1
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,2
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 206,3
+vis-nested-2.bas(206) error 202: Illegal member access, found 'UDT171' in 'test_X1( UDT17,    1, 1, 1, 1 )'
+Expect error to follow @ 207,1
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 207,2
+vis-nested-2.bas(207) error 202: Illegal member access, found 'UDT171' in 'test_X2( UDT17,       1, 1, 1 )'
+Expect error to follow @ 208,1
+vis-nested-2.bas(208) error 202: Illegal member access, found 'UDT171' in 'test_X3( UDT17,          1, 1 )'
+---------- protected/private/private
+Expect error to follow @ 214,1
+vis-nested-2.bas(214) error 202: Illegal member access, found 'c0' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,2
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,3
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 214,4
+vis-nested-2.bas(214) error 202: Illegal member access, found 'UDT181' in 'test_X0( UDT18, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 215,1
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,2
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 215,3
+vis-nested-2.bas(215) error 202: Illegal member access, found 'UDT181' in 'test_X1( UDT18,    1, 1, 1, 1 )'
+Expect error to follow @ 216,1
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 216,2
+vis-nested-2.bas(216) error 202: Illegal member access, found 'UDT181' in 'test_X2( UDT18,       1, 1, 1 )'
+Expect error to follow @ 217,1
+vis-nested-2.bas(217) error 202: Illegal member access, found 'UDT181' in 'test_X3( UDT18,          1, 1 )'
+---------- private/public/public
+Expect error to follow @ 223,1
+vis-nested-2.bas(223) error 202: Illegal member access, found 'c0' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,2
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,3
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 223,4
+vis-nested-2.bas(223) error 202: Illegal member access, found 'UDT191' in 'test_X0( UDT19, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 224,1
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,2
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 224,3
+vis-nested-2.bas(224) error 202: Illegal member access, found 'UDT191' in 'test_X1( UDT19,    1, 1, 1, 1 )'
+Expect error to follow @ 225,1
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 225,2
+vis-nested-2.bas(225) error 202: Illegal member access, found 'UDT191' in 'test_X2( UDT19,       1, 1, 1 )'
+Expect error to follow @ 226,1
+vis-nested-2.bas(226) error 202: Illegal member access, found 'UDT191' in 'test_X3( UDT19,          1, 1 )'
+---------- private/public/protected
+Expect error to follow @ 232,1
+vis-nested-2.bas(232) error 202: Illegal member access, found 'c0' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,2
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,3
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 232,4
+vis-nested-2.bas(232) error 202: Illegal member access, found 'UDT201' in 'test_X0( UDT20, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 233,1
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,2
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 233,3
+vis-nested-2.bas(233) error 202: Illegal member access, found 'UDT201' in 'test_X1( UDT20,    1, 1, 1, 1 )'
+Expect error to follow @ 234,1
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 234,2
+vis-nested-2.bas(234) error 202: Illegal member access, found 'UDT201' in 'test_X2( UDT20,       1, 1, 1 )'
+Expect error to follow @ 235,1
+vis-nested-2.bas(235) error 202: Illegal member access, found 'UDT201' in 'test_X3( UDT20,          1, 1 )'
+---------- private/public/private
+Expect error to follow @ 241,1
+vis-nested-2.bas(241) error 202: Illegal member access, found 'c0' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,2
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,3
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 241,4
+vis-nested-2.bas(241) error 202: Illegal member access, found 'UDT211' in 'test_X0( UDT21, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 242,1
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,2
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 242,3
+vis-nested-2.bas(242) error 202: Illegal member access, found 'UDT211' in 'test_X1( UDT21,    1, 1, 1, 1 )'
+Expect error to follow @ 243,1
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 243,2
+vis-nested-2.bas(243) error 202: Illegal member access, found 'UDT211' in 'test_X2( UDT21,       1, 1, 1 )'
+Expect error to follow @ 244,1
+vis-nested-2.bas(244) error 202: Illegal member access, found 'UDT211' in 'test_X3( UDT21,          1, 1 )'
+---------- private/protected/public
+Expect error to follow @ 250,1
+vis-nested-2.bas(250) error 202: Illegal member access, found 'c0' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,2
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,3
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 250,4
+vis-nested-2.bas(250) error 202: Illegal member access, found 'UDT221' in 'test_X0( UDT22, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 251,1
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,2
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 251,3
+vis-nested-2.bas(251) error 202: Illegal member access, found 'UDT221' in 'test_X1( UDT22,    1, 1, 1, 1 )'
+Expect error to follow @ 252,1
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 252,2
+vis-nested-2.bas(252) error 202: Illegal member access, found 'UDT221' in 'test_X2( UDT22,       1, 1, 1 )'
+Expect error to follow @ 253,1
+vis-nested-2.bas(253) error 202: Illegal member access, found 'UDT221' in 'test_X3( UDT22,          1, 1 )'
+---------- private/protected/protected
+Expect error to follow @ 259,1
+vis-nested-2.bas(259) error 202: Illegal member access, found 'c0' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,2
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,3
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 259,4
+vis-nested-2.bas(259) error 202: Illegal member access, found 'UDT231' in 'test_X0( UDT23, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 260,1
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,2
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 260,3
+vis-nested-2.bas(260) error 202: Illegal member access, found 'UDT231' in 'test_X1( UDT23,    1, 1, 1, 1 )'
+Expect error to follow @ 261,1
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 261,2
+vis-nested-2.bas(261) error 202: Illegal member access, found 'UDT231' in 'test_X2( UDT23,       1, 1, 1 )'
+Expect error to follow @ 262,1
+vis-nested-2.bas(262) error 202: Illegal member access, found 'UDT231' in 'test_X3( UDT23,          1, 1 )'
+---------- private/protected/private
+Expect error to follow @ 268,1
+vis-nested-2.bas(268) error 202: Illegal member access, found 'c0' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,2
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,3
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 268,4
+vis-nested-2.bas(268) error 202: Illegal member access, found 'UDT241' in 'test_X0( UDT24, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 269,1
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,2
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 269,3
+vis-nested-2.bas(269) error 202: Illegal member access, found 'UDT241' in 'test_X1( UDT24,    1, 1, 1, 1 )'
+Expect error to follow @ 270,1
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 270,2
+vis-nested-2.bas(270) error 202: Illegal member access, found 'UDT241' in 'test_X2( UDT24,       1, 1, 1 )'
+Expect error to follow @ 271,1
+vis-nested-2.bas(271) error 202: Illegal member access, found 'UDT241' in 'test_X3( UDT24,          1, 1 )'
+---------- private/private/public
+Expect error to follow @ 277,1
+vis-nested-2.bas(277) error 202: Illegal member access, found 'c0' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,2
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,3
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 277,4
+vis-nested-2.bas(277) error 202: Illegal member access, found 'UDT251' in 'test_X0( UDT25, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 278,1
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,2
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 278,3
+vis-nested-2.bas(278) error 202: Illegal member access, found 'UDT251' in 'test_X1( UDT25,    1, 1, 1, 1 )'
+Expect error to follow @ 279,1
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 279,2
+vis-nested-2.bas(279) error 202: Illegal member access, found 'UDT251' in 'test_X2( UDT25,       1, 1, 1 )'
+Expect error to follow @ 280,1
+vis-nested-2.bas(280) error 202: Illegal member access, found 'UDT251' in 'test_X3( UDT25,          1, 1 )'
+---------- private/private/protected
+Expect error to follow @ 286,1
+vis-nested-2.bas(286) error 202: Illegal member access, found 'c0' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,2
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,3
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 286,4
+vis-nested-2.bas(286) error 202: Illegal member access, found 'UDT261' in 'test_X0( UDT26, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 287,1
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,2
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 287,3
+vis-nested-2.bas(287) error 202: Illegal member access, found 'UDT261' in 'test_X1( UDT26,    1, 1, 1, 1 )'
+Expect error to follow @ 288,1
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 288,2
+vis-nested-2.bas(288) error 202: Illegal member access, found 'UDT261' in 'test_X2( UDT26,       1, 1, 1 )'
+Expect error to follow @ 289,1
+vis-nested-2.bas(289) error 202: Illegal member access, found 'UDT261' in 'test_X3( UDT26,          1, 1 )'
+---------- private/private/private
+Expect error to follow @ 295,1
+vis-nested-2.bas(295) error 202: Illegal member access, found 'c0' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,2
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,3
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 295,4
+vis-nested-2.bas(295) error 202: Illegal member access, found 'UDT271' in 'test_X0( UDT27, 0, 1, 1, 1, 1 )'
+Expect error to follow @ 296,1
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,2
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 296,3
+vis-nested-2.bas(296) error 202: Illegal member access, found 'UDT271' in 'test_X1( UDT27,    1, 1, 1, 1 )'
+Expect error to follow @ 297,1
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 297,2
+vis-nested-2.bas(297) error 202: Illegal member access, found 'UDT271' in 'test_X2( UDT27,       1, 1, 1 )'
+Expect error to follow @ 298,1
+vis-nested-2.bas(298) error 202: Illegal member access, found 'UDT271' in 'test_X3( UDT27,          1, 1 )'

--- a/tests/syntax/type-decl.bas
+++ b/tests/syntax/type-decl.bas
@@ -11,3 +11,24 @@ namespace n1
 		end type
 	end type
 end namespace
+
+'' ------------------------------------
+#print "---"
+#print "2 errors for named type/union in an anonymous type/union"
+
+namespace n2
+	type T1
+		a as integer
+		union
+			b as integer
+			type NAMED1
+		end union
+	end type
+	union U1
+		a as integer
+		type
+			b as integer
+			union NAMED2
+		end type
+	end union
+end namespace

--- a/tests/syntax/type-decl.bas
+++ b/tests/syntax/type-decl.bas
@@ -1,0 +1,20 @@
+#macro t ? ( n, stmt... )
+#print stmt
+stmt
+#if( n = 0 )
+#print OK
+#endif
+#endmacro
+
+'' ------------------------------------
+'' check that field type is not also parent type
+
+namespace n1
+type T1
+	__ as integer
+	type T2
+		t( 1, member1 as T1 )
+		t( 1, as T1 member2 )
+	end type
+end type
+end namespace

--- a/tests/syntax/type-decl.bas
+++ b/tests/syntax/type-decl.bas
@@ -1,20 +1,13 @@
-#macro t ? ( n, stmt... )
-#print stmt
-stmt
-#if( n = 0 )
-#print OK
-#endif
-#endmacro
-
 '' ------------------------------------
-'' check that field type is not also parent type
+#print "---"
+#print "2 errors for field members as parent type"
 
 namespace n1
-type T1
-	__ as integer
-	type T2
-		t( 1, member1 as T1 )
-		t( 1, as T1 member2 )
+	type T1
+		__ as integer
+		type T2
+			member1 as T1
+			as T1 member2
+		end type
 	end type
-end type
 end namespace

--- a/tests/syntax/vis-nested-0.bas
+++ b/tests/syntax/vis-nested-0.bas
@@ -1,0 +1,306 @@
+'' Test visibility declaring (DIM) a variable from outside
+'' a type containing nested (inner scoped) types 3 levels deep
+'' within a local scope
+''
+'' each combination of public, protected, private is checked for
+'' each nested level requiring 3*3*3=27 cases
+''
+''
+''
+''
+
+#define msg(lineno,arg) "Expect error to follow @" lineno,arg
+#macro t( iserror, arg, statement )
+	#if( iserror <> 0 )
+		#print msg(__LINE__,arg)
+	#endif
+	statement
+#endmacro
+
+#macro decl_T( basename, scope1, scope2, scope3 )
+	type basename##0
+		scope1:
+			i1 as integer
+			type basename##1
+				scope2:
+					i2 as integer
+					type basename##2
+						scope3:
+							i3 as integer
+							type basename##3
+								d as integer
+							end type
+							m3 as basename##3
+					end type
+					m2 as basename##2
+			end type
+			m1 as basename##1
+	end type
+#endmacro
+
+#macro test_X0( basename, r1, r2, r3, r4, r5 )
+	t( r1, 1, dim x0 as basename##0 )
+	t( r2, 2, x0.i1 = 1 )
+	t( r3, 3, x0.m1.i2 = 1 )
+	t( r4, 4, x0.m1.m2.i3 = 1 )
+	t( r5, 5, x0.m1.m2.m3.d = 1 )
+#endmacro
+#macro test_X1( basename, r1, r2, r3, r4 )
+	t( r1, 1, dim x1 as basename##0.basename##1 )
+	t( r2, 2, x1.i2 = 1 )
+	t( r3, 3, x1.m2.i3 = 1 )
+	t( r4, 4, x1.m2.m3.d = 1 )
+#endmacro
+#macro test_X2( basename, r1, r2, r3 )
+	t( r1, 1, dim x2 as basename##0.basename##1.basename##2 )
+	t( r2, 2, x2.i3 = 1 )
+	t( r3, 3, x2.m3.d = 1 )
+#endmacro
+#macro test_X3( basename, r1, r2 )
+	t( r1, 1, dim x3 as basename##0.basename##1.basename##2.basename##3 )
+	t( r2, 2, x3.d = 1 )
+#endmacro
+
+#print "---------- public/public/public"
+scope
+	decl_T( UDT01, public, public, public )
+	test_X0( UDT01, 0, 0, 0, 0, 0 )
+	test_X1( UDT01,    0, 0, 0, 0 )
+	test_X2( UDT01,       0, 0, 0 )
+	test_X3( UDT01,          0, 0 )
+end scope
+
+
+#print "---------- public/public/protected"
+scope
+	decl_T( UDT02, public, public, protected )
+	test_X0( UDT02, 0, 0, 0, 1, 1 )
+	test_X1( UDT02,    0, 0, 1, 1 )
+	test_X2( UDT02,       0, 1, 1 )
+	test_X3( UDT02,          1, 1 )
+end scope
+
+#print "---------- public/public/private"
+scope
+	decl_T( UDT03, public, public, private )
+	test_X0( UDT03, 0, 0, 0, 1, 1 )
+	test_X1( UDT03,    0, 0, 1, 1 )
+	test_X2( UDT03,       0, 1, 1 )
+	test_X3( UDT03,          1, 1 )
+end scope
+
+#print "---------- public/protected/public"
+scope
+	decl_T( UDT04, public, protected, public )
+	test_X0( UDT04, 0, 0, 1, 1, 1 )
+	test_X1( UDT04,    0, 1, 1, 1 )
+	test_X2( UDT04,       1, 1, 1 )
+	test_X3( UDT04,          1, 1 )
+end scope
+
+#print "---------- public/protected/protected"
+scope
+	decl_T( UDT05, public, protected, protected )
+	test_X0( UDT05, 0, 0, 1, 1, 1 )
+	test_X1( UDT05,    0, 1, 1, 1 )
+	test_X2( UDT05,       1, 1, 1 )
+	test_X3( UDT05,          1, 1 )
+end scope
+
+#print "---------- public/protected/private"
+scope
+	decl_T( UDT06, public, protected, private )
+	test_X0( UDT06, 0, 0, 1, 1, 1 )
+	test_X1( UDT06,    0, 1, 1, 1 )
+	test_X2( UDT06,       1, 1, 1 )
+	test_X3( UDT06,          1, 1 )
+end scope
+
+#print "---------- public/private/public"
+scope
+	decl_T( UDT07, public, private, public )
+	test_X0( UDT07, 0, 0, 1, 1, 1 )
+	test_X1( UDT07,    0, 1, 1, 1 )
+	test_X2( UDT07,       1, 1, 1 )
+	test_X3( UDT07,          1, 1 )
+end scope
+
+#print "---------- public/private/protected"
+scope
+	decl_T( UDT08, public, private, protected )
+	test_X0( UDT08, 0, 0, 1, 1, 1 )
+	test_X1( UDT08,    0, 1, 1, 1 )
+	test_X2( UDT08,       1, 1, 1 )
+	test_X3( UDT08,          1, 1 )
+end scope
+
+#print "---------- public/private/private"
+scope
+	decl_T( UDT09, public, private, private )
+	test_X0( UDT09, 0, 0, 1, 1, 1 )
+	test_X1( UDT09,    0, 1, 1, 1 )
+	test_X2( UDT09,       1, 1, 1 )
+	test_X3( UDT09,          1, 1 )
+end scope
+
+#print "---------- protected/public/public"
+scope
+	decl_T( UDT10, protected, public, public )
+	test_X0( UDT10, 0, 1, 1, 1, 1 )
+	test_X1( UDT10,    1, 1, 1, 1 )
+	test_X2( UDT10,       1, 1, 1 )
+	test_X3( UDT10,          1, 1 )
+end scope
+
+#print "---------- protected/public/protected"
+scope
+	decl_T( UDT11, protected, public, protected )
+	test_X0( UDT11, 0, 1, 1, 1, 1 )
+	test_X1( UDT11,    1, 1, 1, 1 )
+	test_X2( UDT11,       1, 1, 1 )
+	test_X3( UDT11,          1, 1 )
+end scope
+
+#print "---------- protected/public/private"
+scope
+	decl_T( UDT12, protected, public, private )
+	test_X0( UDT12, 0, 1, 1, 1, 1 )
+	test_X1( UDT12,    1, 1, 1, 1 )
+	test_X2( UDT12,       1, 1, 1 )
+	test_X3( UDT12,          1, 1 )
+end scope
+
+#print "---------- protected/protected/public"
+scope
+	decl_T( UDT13, protected, protected, public )
+	test_X0( UDT13, 0, 1, 1, 1, 1 )
+	test_X1( UDT13,    1, 1, 1, 1 )
+	test_X2( UDT13,       1, 1, 1 )
+	test_X3( UDT13,          1, 1 )
+end scope
+
+#print "---------- protected/protected/protected"
+scope
+	decl_T( UDT14, protected, protected, protected )
+	test_X0( UDT14, 0, 1, 1, 1, 1 )
+	test_X1( UDT14,    1, 1, 1, 1 )
+	test_X2( UDT14,       1, 1, 1 )
+	test_X3( UDT14,          1, 1 )
+end scope
+
+#print "---------- protected/protected/private"
+scope
+	decl_T( UDT15, protected, protected, private )
+	test_X0( UDT15, 0, 1, 1, 1, 1 )
+	test_X1( UDT15,    1, 1, 1, 1 )
+	test_X2( UDT15,       1, 1, 1 )
+	test_X3( UDT15,          1, 1 )
+end scope
+
+#print "---------- protected/private/public"
+scope
+	decl_T( UDT16, protected, private, public )
+	test_X0( UDT16, 0, 1, 1, 1, 1 )
+	test_X1( UDT16,    1, 1, 1, 1 )
+	test_X2( UDT16,       1, 1, 1 )
+	test_X3( UDT16,          1, 1 )
+end scope
+
+#print "---------- protected/private/protected"
+scope
+	decl_T( UDT17, protected, private, protected )
+	test_X0( UDT17, 0, 1, 1, 1, 1 )
+	test_X1( UDT17,    1, 1, 1, 1 )
+	test_X2( UDT17,       1, 1, 1 )
+	test_X3( UDT17,          1, 1 )
+end scope
+
+#print "---------- protected/private/private"
+scope
+	decl_T( UDT18, protected, private, private )
+	test_X0( UDT18, 0, 1, 1, 1, 1 )
+	test_X1( UDT18,    1, 1, 1, 1 )
+	test_X2( UDT18,       1, 1, 1 )
+	test_X3( UDT18,          1, 1 )
+end scope
+
+#print "---------- private/public/public"
+scope
+	decl_T( UDT19, private, public, public )
+	test_X0( UDT19, 0, 1, 1, 1, 1 )
+	test_X1( UDT19,    1, 1, 1, 1 )
+	test_X2( UDT19,       1, 1, 1 )
+	test_X3( UDT19,          1, 1 )
+end scope
+
+#print "---------- private/public/protected"
+scope
+	decl_T( UDT20, private, public, protected )
+	test_X0( UDT20, 0, 1, 1, 1, 1 )
+	test_X1( UDT20,    1, 1, 1, 1 )
+	test_X2( UDT20,       1, 1, 1 )
+	test_X3( UDT20,          1, 1 )
+end scope
+
+#print "---------- private/public/private"
+scope
+	decl_T( UDT21, private, public, private )
+	test_X0( UDT21, 0, 1, 1, 1, 1 )
+	test_X1( UDT21,    1, 1, 1, 1 )
+	test_X2( UDT21,       1, 1, 1 )
+	test_X3( UDT21,          1, 1 )
+end scope
+
+#print "---------- private/protected/public"
+scope
+	decl_T( UDT22, private, protected, public )
+	test_X0( UDT22, 0, 1, 1, 1, 1 )
+	test_X1( UDT22,    1, 1, 1, 1 )
+	test_X2( UDT22,       1, 1, 1 )
+	test_X3( UDT22,          1, 1 )
+end scope
+
+#print "---------- private/protected/protected"
+scope
+	decl_T( UDT23, private, protected, protected )
+	test_X0( UDT23, 0, 1, 1, 1, 1 )
+	test_X1( UDT23,    1, 1, 1, 1 )
+	test_X2( UDT23,       1, 1, 1 )
+	test_X3( UDT23,          1, 1 )
+end scope
+
+#print "---------- private/protected/private"
+scope
+	decl_T( UDT24, private, protected, private )
+	test_X0( UDT24, 0, 1, 1, 1, 1 )
+	test_X1( UDT24,    1, 1, 1, 1 )
+	test_X2( UDT24,       1, 1, 1 )
+	test_X3( UDT24,          1, 1 )
+end scope
+
+#print "---------- private/private/public"
+scope
+	decl_T( UDT25, private, private, public )
+	test_X0( UDT25, 0, 1, 1, 1, 1 )
+	test_X1( UDT25,    1, 1, 1, 1 )
+	test_X2( UDT25,       1, 1, 1 )
+	test_X3( UDT25,          1, 1 )
+end scope
+
+#print "---------- private/private/protected"
+scope
+	decl_T( UDT26, private, private, protected )
+	test_X0( UDT26, 0, 1, 1, 1, 1 )
+	test_X1( UDT26,    1, 1, 1, 1 )
+	test_X2( UDT26,       1, 1, 1 )
+	test_X3( UDT26,          1, 1 )
+end scope
+
+#print "---------- private/private/private"
+scope
+	decl_T( UDT27, private, private, private )
+	test_X0( UDT27, 0, 1, 1, 1, 1 )
+	test_X1( UDT27,    1, 1, 1, 1 )
+	test_X2( UDT27,       1, 1, 1 )
+	test_X3( UDT27,          1, 1 )
+end scope

--- a/tests/syntax/vis-nested-1.bas
+++ b/tests/syntax/vis-nested-1.bas
@@ -1,0 +1,333 @@
+'' Test visibility declaring (DIM) a variable from outside
+'' a type containing nested (inner scoped) types 3 levels deep
+'' a module (main procedure) scope
+''
+'' each combination of public, protected, private is checked for
+'' each nested level requiring 3*3*3=27 cases
+''
+''
+''
+''
+
+#define msg(lineno,arg) "Expect error to follow @" lineno,arg
+#macro t( iserror, arg, statement )
+	#if( iserror <> 0 )
+		#print msg(__LINE__,arg)
+	#endif
+	statement
+#endmacro
+
+#macro decl_T( basename, scope1, scope2, scope3 )
+	type basename##0
+		scope1:
+			i1 as integer
+			type basename##1
+				scope2:
+					i2 as integer
+					type basename##2
+						scope3:
+							i3 as integer
+							type basename##3
+								d as integer
+							end type
+							m3 as basename##3
+					end type
+					m2 as basename##2
+			end type
+			m1 as basename##1
+	end type
+#endmacro
+
+#macro test_X0( basename, r1, r2, r3, r4, r5 )
+	t( r1, 1, dim x0 as basename##0 )
+	t( r2, 2, x0.i1 = 1 )
+	t( r3, 3, x0.m1.i2 = 1 )
+	t( r4, 4, x0.m1.m2.i3 = 1 )
+	t( r5, 5, x0.m1.m2.m3.d = 1 )
+#endmacro
+#macro test_X1( basename, r1, r2, r3, r4 )
+	t( r1, 1, dim x1 as basename##0.basename##1 )
+	t( r2, 2, x1.i2 = 1 )
+	t( r3, 3, x1.m2.i3 = 1 )
+	t( r4, 4, x1.m2.m3.d = 1 )
+#endmacro
+#macro test_X2( basename, r1, r2, r3 )
+	t( r1, 1, dim x2 as basename##0.basename##1.basename##2 )
+	t( r2, 2, x2.i3 = 1 )
+	t( r3, 3, x2.m3.d = 1 )
+#endmacro
+#macro test_X3( basename, r1, r2 )
+	t( r1, 1, dim x3 as basename##0.basename##1.basename##2.basename##3 )
+	t( r2, 2, x3.d = 1 )
+#endmacro
+
+#print "---------- public/public/public"
+
+decl_T( UDT01, public, public, public )
+scope
+	test_X0( UDT01, 0, 0, 0, 0, 0 )
+	test_X1( UDT01,    0, 0, 0, 0 )
+	test_X2( UDT01,       0, 0, 0 )
+	test_X3( UDT01,          0, 0 )
+end scope
+
+#print "---------- public/public/protected"
+
+decl_T( UDT02, public, public, protected )
+scope
+	test_X0( UDT02, 0, 0, 0, 1, 1 )
+	test_X1( UDT02,    0, 0, 1, 1 )
+	test_X2( UDT02,       0, 1, 1 )
+	test_X3( UDT02,          1, 1 )
+end scope
+
+#print "---------- public/public/private"
+
+decl_T( UDT03, public, public, private )
+scope
+	test_X0( UDT03, 0, 0, 0, 1, 1 )
+	test_X1( UDT03,    0, 0, 1, 1 )
+	test_X2( UDT03,       0, 1, 1 )
+	test_X3( UDT03,          1, 1 )
+end scope
+
+#print "---------- public/protected/public"
+
+decl_T( UDT04, public, protected, public )
+scope
+	test_X0( UDT04, 0, 0, 1, 1, 1 )
+	test_X1( UDT04,    0, 1, 1, 1 )
+	test_X2( UDT04,       1, 1, 1 )
+	test_X3( UDT04,          1, 1 )
+	test_X3( UDT04,          1, 1 )
+end scope
+
+#print "---------- public/protected/protected"
+
+decl_T( UDT05, public, protected, protected )
+scope
+	test_X0( UDT05, 0, 0, 1, 1, 1 )
+	test_X1( UDT05,    0, 1, 1, 1 )
+	test_X2( UDT05,       1, 1, 1 )
+	test_X3( UDT05,          1, 1 )
+end scope
+
+#print "---------- public/protected/private"
+
+decl_T( UDT06, public, protected, private )
+scope
+	test_X0( UDT06, 0, 0, 1, 1, 1 )
+	test_X1( UDT06,    0, 1, 1, 1 )
+	test_X2( UDT06,       1, 1, 1 )
+	test_X3( UDT06,          1, 1 )
+end scope
+
+#print "---------- public/private/public"
+
+decl_T( UDT07, public, private, public )
+scope
+	test_X0( UDT07, 0, 0, 1, 1, 1 )
+	test_X1( UDT07,    0, 1, 1, 1 )
+	test_X2( UDT07,       1, 1, 1 )
+	test_X3( UDT07,          1, 1 )
+end scope
+
+#print "---------- public/private/protected"
+
+decl_T( UDT08, public, private, protected )
+scope
+	test_X0( UDT08, 0, 0, 1, 1, 1 )
+	test_X1( UDT08,    0, 1, 1, 1 )
+	test_X2( UDT08,       1, 1, 1 )
+	test_X3( UDT08,          1, 1 )
+end scope
+
+#print "---------- public/private/private"
+
+decl_T( UDT09, public, private, private )
+scope
+	test_X0( UDT09, 0, 0, 1, 1, 1 )
+	test_X1( UDT09,    0, 1, 1, 1 )
+	test_X2( UDT09,       1, 1, 1 )
+	test_X3( UDT09,          1, 1 )
+end scope
+
+#print "---------- protected/public/public"
+
+decl_T( UDT10, protected, public, public )
+scope
+	test_X0( UDT10, 0, 1, 1, 1, 1 )
+	test_X1( UDT10,    1, 1, 1, 1 )
+	test_X2( UDT10,       1, 1, 1 )
+	test_X3( UDT10,          1, 1 )
+end scope
+
+#print "---------- protected/public/protected"
+
+decl_T( UDT11, protected, public, protected )
+scope
+	test_X0( UDT11, 0, 1, 1, 1, 1 )
+	test_X1( UDT11,    1, 1, 1, 1 )
+	test_X2( UDT11,       1, 1, 1 )
+	test_X3( UDT11,          1, 1 )
+end scope
+
+#print "---------- protected/public/private"
+
+decl_T( UDT12, protected, public, private )
+scope
+	test_X0( UDT12, 0, 1, 1, 1, 1 )
+	test_X1( UDT12,    1, 1, 1, 1 )
+	test_X2( UDT12,       1, 1, 1 )
+	test_X3( UDT12,          1, 1 )
+end scope
+
+#print "---------- protected/protected/public"
+
+decl_T( UDT13, protected, protected, public )
+scope
+	test_X0( UDT13, 0, 1, 1, 1, 1 )
+	test_X1( UDT13,    1, 1, 1, 1 )
+	test_X2( UDT13,       1, 1, 1 )
+	test_X3( UDT13,          1, 1 )
+end scope
+
+#print "---------- protected/protected/protected"
+
+decl_T( UDT14, protected, protected, protected )
+scope
+	test_X0( UDT14, 0, 1, 1, 1, 1 )
+	test_X1( UDT14,    1, 1, 1, 1 )
+	test_X2( UDT14,       1, 1, 1 )
+	test_X3( UDT14,          1, 1 )
+end scope
+
+#print "---------- protected/protected/private"
+
+decl_T( UDT15, protected, protected, private )
+scope
+	test_X0( UDT15, 0, 1, 1, 1, 1 )
+	test_X1( UDT15,    1, 1, 1, 1 )
+	test_X2( UDT15,       1, 1, 1 )
+	test_X3( UDT15,          1, 1 )
+end scope
+
+#print "---------- protected/private/public"
+
+decl_T( UDT16, protected, private, public )
+scope
+	test_X0( UDT16, 0, 1, 1, 1, 1 )
+	test_X1( UDT16,    1, 1, 1, 1 )
+	test_X2( UDT16,       1, 1, 1 )
+	test_X3( UDT16,          1, 1 )
+end scope
+
+#print "---------- protected/private/protected"
+
+decl_T( UDT17, protected, private, protected )
+scope
+	test_X0( UDT17, 0, 1, 1, 1, 1 )
+	test_X1( UDT17,    1, 1, 1, 1 )
+	test_X2( UDT17,       1, 1, 1 )
+	test_X3( UDT17,          1, 1 )
+end scope
+
+#print "---------- protected/private/private"
+
+decl_T( UDT18, protected, private, private )
+scope
+	test_X0( UDT18, 0, 1, 1, 1, 1 )
+	test_X1( UDT18,    1, 1, 1, 1 )
+	test_X2( UDT18,       1, 1, 1 )
+	test_X3( UDT18,          1, 1 )
+end scope
+
+#print "---------- private/public/public"
+
+decl_T( UDT19, private, public, public )
+scope
+	test_X0( UDT19, 0, 1, 1, 1, 1 )
+	test_X1( UDT19,    1, 1, 1, 1 )
+	test_X2( UDT19,       1, 1, 1 )
+	test_X3( UDT19,          1, 1 )
+end scope
+
+#print "---------- private/public/protected"
+
+decl_T( UDT20, private, public, protected )
+scope
+	test_X0( UDT20, 0, 1, 1, 1, 1 )
+	test_X1( UDT20,    1, 1, 1, 1 )
+	test_X2( UDT20,       1, 1, 1 )
+	test_X3( UDT20,          1, 1 )
+end scope
+
+#print "---------- private/public/private"
+
+decl_T( UDT21, private, public, private )
+scope
+	test_X0( UDT21, 0, 1, 1, 1, 1 )
+	test_X1( UDT21,    1, 1, 1, 1 )
+	test_X2( UDT21,       1, 1, 1 )
+	test_X3( UDT21,          1, 1 )
+end scope
+
+#print "---------- private/protected/public"
+
+decl_T( UDT22, private, protected, public )
+scope
+	test_X0( UDT22, 0, 1, 1, 1, 1 )
+	test_X1( UDT22,    1, 1, 1, 1 )
+	test_X2( UDT22,       1, 1, 1 )
+	test_X3( UDT22,          1, 1 )
+end scope
+
+#print "---------- private/protected/protected"
+
+decl_T( UDT23, private, protected, protected )
+scope
+	test_X0( UDT23, 0, 1, 1, 1, 1 )
+	test_X1( UDT23,    1, 1, 1, 1 )
+	test_X2( UDT23,       1, 1, 1 )
+	test_X3( UDT23,          1, 1 )
+end scope
+
+#print "---------- private/protected/private"
+
+decl_T( UDT24, private, protected, private )
+scope
+	test_X0( UDT24, 0, 1, 1, 1, 1 )
+	test_X1( UDT24,    1, 1, 1, 1 )
+	test_X2( UDT24,       1, 1, 1 )
+	test_X3( UDT24,          1, 1 )
+end scope
+
+#print "---------- private/private/public"
+
+decl_T( UDT25, private, private, public )
+scope
+	test_X0( UDT25, 0, 1, 1, 1, 1 )
+	test_X1( UDT25,    1, 1, 1, 1 )
+	test_X2( UDT25,       1, 1, 1 )
+	test_X3( UDT25,          1, 1 )
+end scope
+
+#print "---------- private/private/protected"
+
+decl_T( UDT26, private, private, protected )
+scope
+	test_X0( UDT26, 0, 1, 1, 1, 1 )
+	test_X1( UDT26,    1, 1, 1, 1 )
+	test_X2( UDT26,       1, 1, 1 )
+	test_X3( UDT26,          1, 1 )
+end scope
+
+#print "---------- private/private/private"
+
+decl_T( UDT27, private, private, private )
+scope
+	test_X0( UDT27, 0, 1, 1, 1, 1 )
+	test_X1( UDT27,    1, 1, 1, 1 )
+	test_X2( UDT27,       1, 1, 1 )
+	test_X3( UDT27,          1, 1 )
+end scope

--- a/tests/syntax/vis-nested-2.bas
+++ b/tests/syntax/vis-nested-2.bas
@@ -1,0 +1,299 @@
+'' Test visibility of CONST from outside
+'' a type containing nested (inner scoped) types 3 levels deep
+'' within a local scope
+''
+'' each combination of public, protected, private is checked for
+'' each nested level requiring 3*3*3=27 cases
+''
+''
+''
+''
+
+#define msg(lineno,arg) "Expect error to follow @" lineno,arg
+#macro t( iserror, arg, statement )
+	#if( iserror <> 0 )
+		#print msg(__LINE__,arg)
+	#endif
+	statement
+#endmacro
+
+#macro decl_T( basename, scope1, scope2, scope3 )
+	type basename##0 extends object
+		scope1:
+			const c0 = 1
+			type basename##1 extends object
+				scope2:
+					const c1 = 2
+					type basename##2 extends object
+						scope3:
+							const c2 = 3
+							type basename##3 extends object
+								const c3 = 4
+							end type
+					end type
+			end type
+	end type
+#endmacro
+
+#macro test_X0( basename, rt, r0, r1, r2, r3 )
+	t( r0, 1, var i00 = basename##0.c0 )
+	t( r1, 2, var i01 = basename##0.basename##1.c1 )
+	t( r2, 3, var i02 = basename##0.basename##1.basename##2.c2 )
+	t( r3, 4, var i03 = basename##0.basename##1.basename##2.basename##3.c3 )
+#endmacro
+#macro test_X1( basename, r0, r1, r2, r3 )
+	t( r1, 1, var i11 = basename##0.basename##1.c1 )
+	t( r2, 2, var i12 = basename##0.basename##1.basename##2.c2 )
+	t( r3, 3, var i13 = basename##0.basename##1.basename##2.basename##3.c3 )
+#endmacro
+#macro test_X2( basename, r0, r2, r3 )
+	t( r2, 1, var i22 = basename##0.basename##1.basename##2.c2 )
+	t( r3, 2, var i23 = basename##0.basename##1.basename##2.basename##3.c3 )
+#endmacro
+#macro test_X3( basename, r0, r3 )
+	t( r3, 1, var i33 = basename##0.basename##1.basename##2.basename##3.c3 )
+#endmacro
+
+#print "---------- public/public/public"
+decl_T( UDT01, public, public, public )
+scope
+	test_X0( UDT01, 0, 0, 0, 0, 0 )
+	test_X1( UDT01,    0, 0, 0, 0 )
+	test_X2( UDT01,       0, 0, 0 )
+	test_X3( UDT01,          0, 0 )
+end scope
+
+
+#print "---------- public/public/protected"
+decl_T( UDT02, public, public, protected )
+scope
+	test_X0( UDT02, 0, 0, 0, 1, 1 )
+	test_X1( UDT02,    0, 0, 1, 1 )
+	test_X2( UDT02,       0, 1, 1 )
+	test_X3( UDT02,          1, 1 )
+end scope
+
+#print "---------- public/public/private"
+decl_T( UDT03, public, public, private )
+scope
+	test_X0( UDT03, 0, 0, 0, 1, 1 )
+	test_X1( UDT03,    0, 0, 1, 1 )
+	test_X2( UDT03,       0, 1, 1 )
+	test_X3( UDT03,          1, 1 )
+end scope
+
+#print "---------- public/protected/public"
+decl_T( UDT04, public, protected, public )
+scope
+	test_X0( UDT04, 0, 0, 1, 1, 1 )
+	test_X1( UDT04,    0, 1, 1, 1 )
+	test_X2( UDT04,       1, 1, 1 )
+	test_X3( UDT04,          1, 1 )
+end scope
+
+#print "---------- public/protected/protected"
+decl_T( UDT05, public, protected, protected )
+scope
+	test_X0( UDT05, 0, 0, 1, 1, 1 )
+	test_X1( UDT05,    0, 1, 1, 1 )
+	test_X2( UDT05,       1, 1, 1 )
+	test_X3( UDT05,          1, 1 )
+end scope
+
+#print "---------- public/protected/private"
+decl_T( UDT06, public, protected, private )
+scope
+	test_X0( UDT06, 0, 0, 1, 1, 1 )
+	test_X1( UDT06,    0, 1, 1, 1 )
+	test_X2( UDT06,       1, 1, 1 )
+	test_X3( UDT06,          1, 1 )
+end scope
+
+#print "---------- public/private/public"
+decl_T( UDT07, public, private, public )
+scope
+	test_X0( UDT07, 0, 0, 1, 1, 1 )
+	test_X1( UDT07,    0, 1, 1, 1 )
+	test_X2( UDT07,       1, 1, 1 )
+	test_X3( UDT07,          1, 1 )
+end scope
+
+#print "---------- public/private/protected"
+decl_T( UDT08, public, private, protected )
+scope
+	test_X0( UDT08, 0, 0, 1, 1, 1 )
+	test_X1( UDT08,    0, 1, 1, 1 )
+	test_X2( UDT08,       1, 1, 1 )
+	test_X3( UDT08,          1, 1 )
+end scope
+
+#print "---------- public/private/private"
+decl_T( UDT09, public, private, private )
+scope
+	test_X0( UDT09, 0, 0, 1, 1, 1 )
+	test_X1( UDT09,    0, 1, 1, 1 )
+	test_X2( UDT09,       1, 1, 1 )
+	test_X3( UDT09,          1, 1 )
+end scope
+
+#print "---------- protected/public/public"
+decl_T( UDT10, protected, public, public )
+scope
+	test_X0( UDT10, 0, 1, 1, 1, 1 )
+	test_X1( UDT10,    1, 1, 1, 1 )
+	test_X2( UDT10,       1, 1, 1 )
+	test_X3( UDT10,          1, 1 )
+end scope
+
+#print "---------- protected/public/protected"
+decl_T( UDT11, protected, public, protected )
+scope
+	test_X0( UDT11, 0, 1, 1, 1, 1 )
+	test_X1( UDT11,    1, 1, 1, 1 )
+	test_X2( UDT11,       1, 1, 1 )
+	test_X3( UDT11,          1, 1 )
+end scope
+
+#print "---------- protected/public/private"
+decl_T( UDT12, protected, public, private )
+scope
+	test_X0( UDT12, 0, 1, 1, 1, 1 )
+	test_X1( UDT12,    1, 1, 1, 1 )
+	test_X2( UDT12,       1, 1, 1 )
+	test_X3( UDT12,          1, 1 )
+end scope
+
+#print "---------- protected/protected/public"
+decl_T( UDT13, protected, protected, public )
+scope
+	test_X0( UDT13, 0, 1, 1, 1, 1 )
+	test_X1( UDT13,    1, 1, 1, 1 )
+	test_X2( UDT13,       1, 1, 1 )
+	test_X3( UDT13,          1, 1 )
+end scope
+
+#print "---------- protected/protected/protected"
+decl_T( UDT14, protected, protected, protected )
+scope
+	test_X0( UDT14, 0, 1, 1, 1, 1 )
+	test_X1( UDT14,    1, 1, 1, 1 )
+	test_X2( UDT14,       1, 1, 1 )
+	test_X3( UDT14,          1, 1 )
+end scope
+
+#print "---------- protected/protected/private"
+decl_T( UDT15, protected, protected, private )
+scope
+	test_X0( UDT15, 0, 1, 1, 1, 1 )
+	test_X1( UDT15,    1, 1, 1, 1 )
+	test_X2( UDT15,       1, 1, 1 )
+	test_X3( UDT15,          1, 1 )
+end scope
+
+#print "---------- protected/private/public"
+decl_T( UDT16, protected, private, public )
+scope
+	test_X0( UDT16, 0, 1, 1, 1, 1 )
+	test_X1( UDT16,    1, 1, 1, 1 )
+	test_X2( UDT16,       1, 1, 1 )
+	test_X3( UDT16,          1, 1 )
+end scope
+
+#print "---------- protected/private/protected"
+decl_T( UDT17, protected, private, protected )
+scope
+	test_X0( UDT17, 0, 1, 1, 1, 1 )
+	test_X1( UDT17,    1, 1, 1, 1 )
+	test_X2( UDT17,       1, 1, 1 )
+	test_X3( UDT17,          1, 1 )
+end scope
+
+#print "---------- protected/private/private"
+decl_T( UDT18, protected, private, private )
+scope
+	test_X0( UDT18, 0, 1, 1, 1, 1 )
+	test_X1( UDT18,    1, 1, 1, 1 )
+	test_X2( UDT18,       1, 1, 1 )
+	test_X3( UDT18,          1, 1 )
+end scope
+
+#print "---------- private/public/public"
+decl_T( UDT19, private, public, public )
+scope
+	test_X0( UDT19, 0, 1, 1, 1, 1 )
+	test_X1( UDT19,    1, 1, 1, 1 )
+	test_X2( UDT19,       1, 1, 1 )
+	test_X3( UDT19,          1, 1 )
+end scope
+
+#print "---------- private/public/protected"
+decl_T( UDT20, private, public, protected )
+scope
+	test_X0( UDT20, 0, 1, 1, 1, 1 )
+	test_X1( UDT20,    1, 1, 1, 1 )
+	test_X2( UDT20,       1, 1, 1 )
+	test_X3( UDT20,          1, 1 )
+end scope
+
+#print "---------- private/public/private"
+decl_T( UDT21, private, public, private )
+scope
+	test_X0( UDT21, 0, 1, 1, 1, 1 )
+	test_X1( UDT21,    1, 1, 1, 1 )
+	test_X2( UDT21,       1, 1, 1 )
+	test_X3( UDT21,          1, 1 )
+end scope
+
+#print "---------- private/protected/public"
+decl_T( UDT22, private, protected, public )
+scope
+	test_X0( UDT22, 0, 1, 1, 1, 1 )
+	test_X1( UDT22,    1, 1, 1, 1 )
+	test_X2( UDT22,       1, 1, 1 )
+	test_X3( UDT22,          1, 1 )
+end scope
+
+#print "---------- private/protected/protected"
+decl_T( UDT23, private, protected, protected )
+scope
+	test_X0( UDT23, 0, 1, 1, 1, 1 )
+	test_X1( UDT23,    1, 1, 1, 1 )
+	test_X2( UDT23,       1, 1, 1 )
+	test_X3( UDT23,          1, 1 )
+end scope
+
+#print "---------- private/protected/private"
+decl_T( UDT24, private, protected, private )
+scope
+	test_X0( UDT24, 0, 1, 1, 1, 1 )
+	test_X1( UDT24,    1, 1, 1, 1 )
+	test_X2( UDT24,       1, 1, 1 )
+	test_X3( UDT24,          1, 1 )
+end scope
+
+#print "---------- private/private/public"
+decl_T( UDT25, private, private, public )
+scope
+	test_X0( UDT25, 0, 1, 1, 1, 1 )
+	test_X1( UDT25,    1, 1, 1, 1 )
+	test_X2( UDT25,       1, 1, 1 )
+	test_X3( UDT25,          1, 1 )
+end scope
+
+#print "---------- private/private/protected"
+decl_T( UDT26, private, private, protected )
+scope
+	test_X0( UDT26, 0, 1, 1, 1, 1 )
+	test_X1( UDT26,    1, 1, 1, 1 )
+	test_X2( UDT26,       1, 1, 1 )
+	test_X3( UDT26,          1, 1 )
+end scope
+
+#print "---------- private/private/private"
+decl_T( UDT27, private, private, private )
+scope
+	test_X0( UDT27, 0, 1, 1, 1, 1 )
+	test_X1( UDT27,    1, 1, 1, 1 )
+	test_X2( UDT27,       1, 1, 1 )
+	test_X3( UDT27,          1, 1 )
+end scope


### PR DESCRIPTION
This change allows TYPEs and UNIONs to be declared inside of other TYPEs and UNIONs.  The main purpose is to scope a structure inside the namespace of another structure.  Secondarily, this should also generate a compatible c++ name mangling for nested types and parameters of member procedures.

For example:
~~~
type T
	n as integer
	type A
		i as integer
	end type
end type
dim x as T.A
~~~

This style of declaration does only specifies scope - it does not declare fields/members.  To declare field/member of the inner type within the outer type, a member must be named.  For example:
~~~
type T
	n as integer
	type A
		i as integer
	end type
	member as A
end type

dim x as T
x.member.i = 1
~~~

Also allowed is the declaration of static / non-static member procedures, extended types, and so on with the following rules:
- the definition of procedures must appear outside of the outermost type
- inner types may not extend an outer type but may extend an unrelated type, for example:
~~~
type T extends object
	type A extends object
	end type
end type
~~~

Private/Protected inner types are not well supported and will require further work to complete.  Since private/protected access is a compile time check only, generated code and overall name lookup should be valid.  However, more testing will be required in future.