### PR TITLE
rtlib: Fix uninitialized values returned by fb_GetMouse64(), and some other fixes

### DIFF
--- a/src/gfxlib2/dos/gfx_dos.c
+++ b/src/gfxlib2/dos/gfx_dos.c
@@ -267,11 +267,11 @@ int fb_dos_get_mouse(int *x, int *y, int *z, int *buttons, int *clip)
 {
 	if (!fb_dos.mouse_ok) return -1;
 	
-	*x = fb_dos_mouse_x;
-	*y = fb_dos_mouse_y;
-	*z = (fb_dos.mouse_wheel_ok ? fb_dos_mouse_z : 0);
-	*buttons = fb_dos_mouse_buttons;
-	*clip = fb_dos.mouse_clip;
+	if (x) *x = fb_dos_mouse_x;
+	if (y) *y = fb_dos_mouse_y;
+	if (z) *z = (fb_dos.mouse_wheel_ok ? fb_dos_mouse_z : 0);
+	if (buttons) *buttons = fb_dos_mouse_buttons;
+	if (clip) *clip = fb_dos.mouse_clip;
 	
 	return 0;
 }

--- a/src/gfxlib2/gfx_getmouse.c
+++ b/src/gfxlib2/gfx_getmouse.c
@@ -5,16 +5,9 @@
 int fb_GfxGetMouse(int *x, int *y, int *z, int *buttons, int *clip)
 {
 	int failure = TRUE;
-	int temp_z, temp_buttons, temp_clip;
 
 	FB_GRAPHICS_LOCK( );
 
-	if (!z)
-		z = &temp_z;
-	if (!buttons)
-		buttons = &temp_buttons;
-	if (!clip)
-		clip = &temp_clip;
 	if ((__fb_gfx) && (__fb_gfx->driver->get_mouse)) {
 		DRIVER_LOCK();
 		failure = __fb_gfx->driver->get_mouse(x, y, z, buttons, clip);
@@ -24,7 +17,11 @@ int fb_GfxGetMouse(int *x, int *y, int *z, int *buttons, int *clip)
 	FB_GRAPHICS_UNLOCK( );
 
 	if (failure) {
-		*x = *y = *z = *buttons = *clip = -1;
+		if (x) *x = -1;
+		if (y) *y = -1;
+		if (z) *z = -1;
+		if (buttons) *buttons = -1;
+		if (clip) *clip = -1;
 		return fb_ErrorSetNum(FB_RTERROR_ILLEGALFUNCTIONCALL);
 	}
 	return fb_ErrorSetNum( FB_RTERROR_OK );

--- a/src/gfxlib2/js/gfx_driver.c
+++ b/src/gfxlib2/js/gfx_driver.c
@@ -219,10 +219,10 @@ static int driver_get_mouse(int *x, int *y, int *z, int *buttons, int *clip)
 {
 	SDL_PumpEvents();
 
-	*buttons = fb_js_sdl_buttons_to_fb_buttons(SDL_GetMouseState(x, y));
-
-	*z = 0;
-	*clip = 0;
+	uint32_t state = SDL_GetMouseState(x, y);
+	if (buttons) *buttons = fb_js_sdl_buttons_to_fb_buttons(state);
+	if (z) *z = 0;
+	if (clip) *clip = 0;
 
 	return 0;
 }

--- a/src/gfxlib2/linux/gfx_driver_fbdev.c
+++ b/src/gfxlib2/linux/gfx_driver_fbdev.c
@@ -641,11 +641,11 @@ static int driver_get_mouse(int *x, int *y, int *z, int *buttons, int *clip)
 {
 	if (mouse_fd < 0)
 		return -1;
-	*x = mouse_x;
-	*y = mouse_y;
-	*z = mouse_z;
-	*buttons = mouse_buttons;
-	*clip = mouse_clip;
+	if (x) *x = mouse_x;
+	if (y) *y = mouse_y;
+	if (z) *z = mouse_z;
+	if (buttons) *buttons = mouse_buttons;
+	if (clip) *clip = mouse_clip;
 	return 0;
 }
 

--- a/src/gfxlib2/unix/gfx_x11.c
+++ b/src/gfxlib2/unix/gfx_x11.c
@@ -696,20 +696,22 @@ int fb_hX11GetMouse(int *x, int *y, int *z, int *buttons, int *clip)
 		return -1;
 
 	/* prefer XQueryPointer to have a more responsive mouse position retrieval */
-	*z = mouse_wheel;
+	if (z) *z = mouse_wheel;
 	if (XQueryPointer(fb_x11.display, fb_x11.window, &root, &child, &root_x, &root_y, &win_x, &win_y, &buttons_mask)) {
-		*x = win_x;
-		*y = win_y;
-		*buttons = (buttons_mask & Button1Mask ? 0x1 : 0) |
+		if (x) *x = win_x;
+		if (y) *y = win_y;
+		if (buttons) {
+			*buttons = (buttons_mask & Button1Mask ? 0x1 : 0) |
 				   (buttons_mask & Button3Mask ? 0x2 : 0) |
 				   (buttons_mask & Button2Mask ? 0x4 : 0);
+		}
 	} else {
-		*x = mouse_x;
-		*y = mouse_y;
-		*buttons = mouse_buttons;
+		if (x) *x = mouse_x;
+		if (y) *y = mouse_y;
+		if (buttons) *buttons = mouse_buttons;
 	}
 
-	*clip = fb_x11.mouse_clip;
+	if (clip) *clip = fb_x11.mouse_clip;
 	return 0;
 }
 

--- a/src/gfxlib2/win32/gfx_win32.c
+++ b/src/gfxlib2/win32/gfx_win32.c
@@ -712,11 +712,11 @@ int fb_hWin32GetMouse(int *x, int *y, int *z, int *buttons, int *clip)
 	if ((!fb_win32.is_active) || (!mouse_on))
 		return -1;
 
-	*x = mouse_x;
-	*y = mouse_y;
-	*z = mouse_wheel;
-	*buttons = mouse_buttons;
-	*clip = fb_win32.mouse_clip;
+	if (x) *x = mouse_x;
+	if (y) *y = mouse_y;
+	if (z) *z = mouse_wheel;
+	if (buttons) *buttons = mouse_buttons;
+	if (clip) *clip = fb_win32.mouse_clip;
 
 	return 0;
 }

--- a/src/gfxlib2/xbox/gfx_driver.c
+++ b/src/gfxlib2/xbox/gfx_driver.c
@@ -88,6 +88,12 @@ static void driver_wait_vsync(void)
 static int driver_get_mouse(int *x, int *y, int *z, int *buttons)
 {
 	/* !!!WRITEME!!! */
+	if (x) *x = -1;
+	if (y) *y = -1;
+	if (z) *z = -1;
+	if (buttons) *buttons = -1;
+	if (clip) *clip = -1;
+	return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
 }
 
 static void driver_set_mouse(int x, int y, int cursor)

--- a/src/rtlib/darwin/io_mouse.c
+++ b/src/rtlib/darwin/io_mouse.c
@@ -4,6 +4,11 @@
 
 int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 {
+	if (x) *x = -1;
+	if (y) *y = -1;
+	if (z) *z = -1;
+	if (buttons) *buttons = -1;
+	if (clip) *clip = -1;
 	return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
 }
 

--- a/src/rtlib/dos/io_mouse.c
+++ b/src/rtlib/dos/io_mouse.c
@@ -28,6 +28,7 @@ int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 		if (y) *y = -1;
 		if (z) *z = -1;
 		if (buttons) *buttons = -1;
+		if (clip) *clip = -1;
 		return fb_ErrorSetNum(FB_RTERROR_ILLEGALFUNCTIONCALL);
 	}
 

--- a/src/rtlib/dragonfly/io_mouse.c
+++ b/src/rtlib/dragonfly/io_mouse.c
@@ -4,6 +4,11 @@
 
 int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 {
+	if (x) *x = -1;
+	if (y) *y = -1;
+	if (z) *z = -1;
+	if (buttons) *buttons = -1;
+	if (clip) *clip = -1;
 	return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
 }
 

--- a/src/rtlib/freebsd/io_mouse.c
+++ b/src/rtlib/freebsd/io_mouse.c
@@ -4,6 +4,11 @@
 
 int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 {
+	if (x) *x = -1;
+	if (y) *y = -1;
+	if (z) *z = -1;
+	if (buttons) *buttons = -1;
+	if (clip) *clip = -1;
 	return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
 }
 

--- a/src/rtlib/hook_getmouse64.c
+++ b/src/rtlib/hook_getmouse64.c
@@ -2,14 +2,15 @@
 
 FBCALL int fb_GetMouse64( long long *x, long long *y, long long *z, long long *buttons, long long *clip )
 {
-	int res, ix, iy, iz, ibuttons, iclip;
+	int ix = -1, iy = -1, iz = -1, ibuttons = -1, iclip = -1;
 
-	res = fb_GetMouse( &ix, &iy, &iz, &ibuttons, &iclip );
+	int res = fb_GetMouse( &ix, &iy, &iz, &ibuttons, &iclip );
 
-	*x = ix;
-	*y = iy;
-	*z = iz;
-	*buttons = ibuttons;
-	*clip = iclip;
+	if (x) *x = ix;
+	if (y) *y = iy;
+	if (z) *z = iz;
+	if (buttons) *buttons = ibuttons;
+	if (clip) *clip = iclip;
+
 	return res;
 }

--- a/src/rtlib/js/io_mouse.c
+++ b/src/rtlib/js/io_mouse.c
@@ -8,8 +8,14 @@ int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 {
 	EmscriptenMouseEvent mouseState;
 
-	if( emscripten_get_mouse_status( &mouseState ) != EMSCRIPTEN_RESULT_SUCCESS )
+	if( emscripten_get_mouse_status( &mouseState ) != EMSCRIPTEN_RESULT_SUCCESS ) {
+		if (x) *x = -1;
+		if (y) *y = -1;
+		if (z) *z = -1;
+		if (buttons) *buttons = -1;
+		if (clip) *clip = -1;
         return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
+	}
 
     if( x != NULL )
         *x = mouseState.clientX;

--- a/src/rtlib/linux/io_mouse.c
+++ b/src/rtlib/linux/io_mouse.c
@@ -187,15 +187,14 @@ static void mouse_exit(void)
 
 int fb_ConsoleGetMouse(int *x, int *y, int *z, int *buttons, int *clip)
 {
-	int temp_z, temp_buttons;
-
-	if (!__fb_con.inited)
+	if (!__fb_con.inited) {
+		if (x) *x = -1;
+		if (y) *y = -1;
+		if (z) *z = -1;
+		if (buttons) *buttons = -1;
+		if (clip) *clip = -1;
 		return fb_ErrorSetNum(FB_RTERROR_ILLEGALFUNCTIONCALL);
-
-	if (!z)
-		z = &temp_z;
-	if (!buttons)
-		buttons = &temp_buttons;
+	}
 
 	BG_LOCK();
 
@@ -207,7 +206,11 @@ int fb_ConsoleGetMouse(int *x, int *y, int *z, int *buttons, int *clip)
 			__fb_con.mouse_exit = mouse_exit;
 			__fb_con.mouse_handler = mouse_handler;
 		} else {
-			*x = *y = *z = *buttons = -1;
+			if (x) *x = -1;
+			if (y) *y = -1;
+			if (z) *z = -1;
+			if (buttons) *buttons = -1;
+			if (clip) *clip = -1;
 			BG_UNLOCK();
 			return fb_ErrorSetNum(FB_RTERROR_ILLEGALFUNCTIONCALL);
 		}
@@ -216,11 +219,11 @@ int fb_ConsoleGetMouse(int *x, int *y, int *z, int *buttons, int *clip)
 	if (__fb_con.inited != INIT_CONSOLE)
 		fb_hGetCh(FALSE);
 
-	*x = mouse_x;
-	*y = mouse_y;
-	*z = mouse_z;
-	*buttons = mouse_buttons;
-	*clip = 0;
+	if (x) *x = mouse_x;
+	if (y) *y = mouse_y;
+	if (z) *z = mouse_z;
+	if (buttons) *buttons = mouse_buttons;
+	if (clip) *clip = 0;
 
 	BG_UNLOCK();
 

--- a/src/rtlib/linux/io_serial.c
+++ b/src/rtlib/linux/io_serial.c
@@ -18,9 +18,10 @@
 #define SERIAL_TIMEOUT	3	/* seconds  for write on open*/
 #define SREAD_TIMEOUT	70	/* if not receive any character in less 50 millisecs finish read process */
 
-static void alrm()
+static void alrm(int signal_number)
 {
 	/* signal callback, do nothing */
+	(void)signal_number;
 }
 
 static speed_t get_speed( int speed )

--- a/src/rtlib/netbsd/io_mouse.c
+++ b/src/rtlib/netbsd/io_mouse.c
@@ -4,6 +4,11 @@
 
 int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 {
+	if (x) *x = -1;
+	if (y) *y = -1;
+	if (z) *z = -1;
+	if (buttons) *buttons = -1;
+	if (clip) *clip = -1;
 	return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
 }
 

--- a/src/rtlib/openbsd/io_mouse.c
+++ b/src/rtlib/openbsd/io_mouse.c
@@ -4,6 +4,11 @@
 
 int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 {
+	if (x) *x = -1;
+	if (y) *y = -1;
+	if (z) *z = -1;
+	if (buttons) *buttons = -1;
+	if (clip) *clip = -1;
 	return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
 }
 

--- a/src/rtlib/unix/hinit.c
+++ b/src/rtlib/unix/hinit.c
@@ -368,7 +368,7 @@ int fb_hTermOut( int code, int param1, int param2 )
  * the libc functions such as dlopen() and fork()/exec() directly, instead of
  * the FB keywords.
  */
-int fb_hInitConsole( )
+int fb_hInitConsole(void)
 {
 	struct termios term_out, term_in;
 

--- a/src/rtlib/unix/io_inkey.c
+++ b/src/rtlib/unix/io_inkey.c
@@ -98,7 +98,7 @@ static void add_key(NODE **node, char *key, short code)
 		n->code = code;
 }
 
-static void init_keys()
+static void init_keys(void)
 {
 	KEY_DATA *data;
 	char *key;
@@ -143,7 +143,7 @@ static void init_keys()
 	add_key(&root_node, "[M", KEY_MOUSE);
 }
 
-static int get_input()
+static int get_input(void)
 {
 	NODE *node;
 	int k, cb, cx, cy;

--- a/src/rtlib/win32/io_gethnd.c
+++ b/src/rtlib/win32/io_gethnd.c
@@ -32,7 +32,7 @@ HANDLE fb_hConsoleGetHandle( int is_input )
 	return (is_input? __fb_con.inHandle : __fb_con.pgHandleTb[__fb_con.active]);
 }
 
-void fb_hConsoleResetHandles()
+void fb_hConsoleResetHandles(void)
 {
 	/* 
 		Called by fb_FileResetEx() to cause fb_hConsoleGetHandle() 

--- a/src/rtlib/win32/io_mouse.c
+++ b/src/rtlib/win32/io_mouse.c
@@ -31,7 +31,11 @@ int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 	}
 
 	if( inited == 0 ) {
-		*x = *y = *z = *buttons = -1;
+		if (x) *x = -1;
+		if (y) *y = -1;
+		if (z) *z = -1;
+		if (buttons) *buttons = -1;
+		if (clip) *clip = -1;
 		return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
 	}
 
@@ -49,11 +53,11 @@ int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 
 	fb_ConsoleProcessEvents( );
 
-	*x = last_x - 1;
-	*y = last_y - 1;
-	*z = last_z;
-	*buttons = last_buttons;
-	*clip = 0;
+	if (x) *x = last_x - 1;
+	if (y) *y = last_y - 1;
+	if (z) *z = last_z;
+	if (buttons) *buttons = last_buttons;
+	if (clip) *clip = 0;
 
 	fb_hConvertFromConsole( x, y, NULL, NULL );
 

--- a/src/rtlib/win32/io_multikey.c
+++ b/src/rtlib/win32/io_multikey.c
@@ -51,7 +51,7 @@ const unsigned char __fb_keytable[][3] = {
 	{ 0,            0,          0           }
 };
 
-static HWND find_window()
+static HWND find_window(void)
 {
 	TCHAR old_title[MAX_PATH];
 	TCHAR title[MAX_PATH];

--- a/src/rtlib/xbox/io_mouse.c
+++ b/src/rtlib/xbox/io_mouse.c
@@ -4,6 +4,11 @@
 
 int fb_ConsoleGetMouse( int *x, int *y, int *z, int *buttons, int *clip )
 {
+	if (x) *x = -1;
+	if (y) *y = -1;
+	if (z) *z = -1;
+	if (buttons) *buttons = -1;
+	if (clip) *clip = -1;
 	return fb_ErrorSetNum( FB_RTERROR_ILLEGALFUNCTIONCALL );
 }
 


### PR DESCRIPTION
The main issue was `fb_GetMouse64()` which didn't initialize its output variables, plus some of the internal getmouse functions used by it didn't set some or even all of the output variables either. Now I changed it to clearly set the values everywhere, for consistency and to avoid anything being uninitialized. See commit message for some more details.

Additionally there are some other small function signature fixes in here.