### PR TITLE
fbc: Add -nolib command line option

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -44,6 +44,7 @@ Version 1.10.0
 - gfxlib2: SCREENCONTROL: add getters for GL parameters - new GET_GL_* constants in fbgfx.bi
 - Name mangling for c++ 'char' through BYTE/UBYTE parameters using the form "[unsigned] byte alias "char".  Data type size is still 8 byte signed/unsigned from fbc side, but will mangled as 'char'; neither signed nor unsigned for the c++ side.
 - Support 'SOURCE_DATE_EPOCH' environment variable for controlling the instrinsic __DATE__, __DATE_ISO__, __TIME__ macros.  This in turn controls __FB_BUILD_DATE__ and __FB_BUILD_DATE_ISO__ macros when building the compiler.  Report error message on malformed values.
+- fbc -nolib a,b,c command line option for selectively excluding specific libraries when linking (more fine-grained control than -nodeflibs, and not only for default libraries)
 
 [fixed]
 - gas64: missing restoring of use of one virtual register on sqr for float (SARG)

--- a/doc/fbc.1
+++ b/doc/fbc.1
@@ -124,10 +124,13 @@ Only show \fIn\fR errors
 Use thread-safe FB runtime
 .TP
 \fB\-nodeflibs\fR
-Do not include the default libraries
+Do not include the default libraries when linking
 .TP
 \fB\-noerrline\fR
 Do not show source context in error messages
+.TP
+\fB\-nolib\fR \fIa,b,c\fR
+Do not include the specified libraries when linking
 .TP
 \fB\-noobjinfo\fR
 Do not read/write compile-time info from/to .o and .a files

--- a/src/compiler/hash.bi
+++ b/src/compiler/hash.bi
@@ -66,6 +66,7 @@ declare sub hashDel _
 type TSTRSETITEM
 	as string s
 	as integer userdata
+	as HASHITEM ptr hashitem
 end type
 
 type TSTRSET
@@ -79,6 +80,7 @@ declare sub strsetAdd _
 		byref s as string, _
 		byval userdata as integer _
 	)
+declare sub strsetDel(byval set as TSTRSET ptr, byref s as const string)
 declare sub strsetCopy(byval target as TSTRSET ptr, byval source as TSTRSET ptr)
 declare sub strsetInit(byval set as TSTRSET ptr, byval nodes as integer)
 declare sub strsetEnd(byval set as TSTRSET ptr)


### PR DESCRIPTION
The new option allows excluding specific libraries when linking, no matter where it came from (default lib, #inclib, -l, objinfo...).

This allows selectively blacklisting libraries and can be used to...

- remove unused dependencies when linking against shared libraries (when linking against static libraries via -l, the linker automatically skips unused libs, but not for shared libraries)

- override unwanted #inclibs (although arguably this is not the ideal solution for that, but just a last resort)

- disable only some default libs, instead of all as done by -nodeflibs. For example, this could be used to specifically omit libtinfo. Using -nodeflibs would omit a lot more (including fbrt0.o) which would have to be re-added manually again.