### PR TITLE
Bugfix: byref initializer bug, sf.net 922 bug, and sf.net 824 bug

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -80,6 +80,8 @@ Version 1.10.0
 - fbc: show an error on byref initializers that can't take address of.  Previously this was checked by fbc debug assertion only.
 - sf.net #894: Can't initialise a UDT as copy of another if the first element is a UNION, fixed by sf.net #968
 - sf.net #922: Sometimes can't use extra backets inside TYPE UDT initialiser - now, don't allow optional parentheses when parsing type<UDT>(...) if left parenthesis is found
+- sf.net #824: Illegal destructor call after '#print typeof( f() )' when f() is a function returning an object by value
+- fbc: delete destructor calls of discarded expressions in IIF(), previously, unscoped dtors (to be called after the expression) and deleted dtors (to be never called) were being handled the same
 
 
 Version 1.09.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -78,6 +78,8 @@ Version 1.10.0
 - github #393: rtlib: OPEN fails when opening an encoded file for append.  Check the BOM on existing files for INPUT/APPEND, write the BOM for new files for OUTPUT/APPEND.
 - sf.net #968: fbc: major changes how initializers are handled and pairing of a UDT's (internal) structure and the initializer list given by the user.
 - fbc: show an error on byref initializers that can't take address of.  Previously this was checked by fbc debug assertion only.
+- sf.net #894: Can't initialise a UDT as copy of another if the first element is a UNION, fixed by sf.net #968
+- sf.net #922: Sometimes can't use extra backets inside TYPE UDT initialiser - now, don't allow optional parentheses when parsing type<UDT>(...) if left parenthesis is found
 
 
 Version 1.09.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -77,6 +77,7 @@ Version 1.10.0
 - gfxlib2: LINE statement computing an incorrect line style pattern on any non-X86 (i.e. 64-bit, etc)
 - github #393: rtlib: OPEN fails when opening an encoded file for append.  Check the BOM on existing files for INPUT/APPEND, write the BOM for new files for OUTPUT/APPEND.
 - sf.net #968: fbc: major changes how initializers are handled and pairing of a UDT's (internal) structure and the initializer list given by the user.
+- fbc: show an error on byref initializers that can't take address of.  Previously this was checked by fbc debug assertion only.
 
 
 Version 1.09.0

--- a/src/compiler/ast-misc.bas
+++ b/src/compiler/ast-misc.bas
@@ -47,14 +47,14 @@ function astIsTreeEqual _
 		byval r as ASTNODE ptr _
 	) as integer
 
-    function = FALSE
+	function = FALSE
 
-    if( (l = NULL) or (r = NULL) ) then
-    	if( l = r ) then
-    		function = TRUE
-    	end if
-    	exit function
-    end if
+	if( (l = NULL) or (r = NULL) ) then
+		if( l = r ) then
+			function = TRUE
+		end if
+		exit function
+	end if
 
 	if( l->class <> r->class ) then
 		exit function
@@ -162,7 +162,7 @@ function astIsTreeEqual _
 
 	end select
 
-    '' check childs
+	'' check childs
 	if( astIsTreeEqual( l->l, r->l ) = FALSE ) then
 		exit function
 	end if
@@ -171,7 +171,7 @@ function astIsTreeEqual _
 		exit function
 	end if
 
-    ''
+	''
 	function = TRUE
 
 end function
@@ -516,9 +516,9 @@ function astGetStrLitSymbol _
 
 	dim as FBSYMBOL ptr s = any
 
-    function = NULL
+	function = NULL
 
-   	if( astIsVAR( n ) ) then
+	if( astIsVAR( n ) ) then
 		s = astGetSymbol( n )
 		if( s <> NULL ) then
 			if( symbGetIsLiteral( s ) ) then
@@ -579,10 +579,10 @@ sub astCheckConst _
 		case 0.0, 2e-45 to 3e+38 '' definitely no overflow: comfortably within SINGLE bounds
 			result = TRUE
 		case else '' might overflow - slower/more thorough test
-			
+
 			sval = csng( dval )
 
-		  	#define IS_INFINITY_OR_ZERO(x) ( (x) + (x) = (x) )
+			#define IS_INFINITY_OR_ZERO(x) ( (x) + (x) = (x) )
 			'' if sval is infinity or 0, then dval must also have been otherwise there was an overflow/underflow
 			if IS_INFINITY_OR_ZERO( sval ) then
 				result = IS_INFINITY_OR_ZERO( dval )
@@ -746,9 +746,9 @@ function astBuildBranch _
 		return NULL
 	end if
 
-    '' CHAR and WCHAR literals are also from the INTEGER class
-    select case as const dtype
-    case FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
+	'' CHAR and WCHAR literals are also from the INTEGER class
+	select case as const dtype
+	case FB_DATATYPE_CHAR, FB_DATATYPE_WCHAR
 		'' don't allow, unless it's a deref pointer
 		if( astIsDEREF( expr ) = FALSE ) then
 			return NULL
@@ -996,7 +996,7 @@ sub astDtorListDump( )
 		if( i->cookie = -1 ) then
 			print "    "; "*deleted*"; " cookie: ";i->cookie;" refcount: ";i->refcount
 		else
-			print "    ";symbDumpToStr( i->sym );" cookie: ";i->cookie;" refcount: ";i->refcount;" has dtor? ";hHasDtor( i->sym )			
+			print "    ";symbDumpToStr( i->sym );" cookie: ";i->cookie;" refcount: ";i->refcount;" has dtor? ";hHasDtor( i->sym )
 		end if
 		i = listGetPrev( i )
 	wend
@@ -1073,7 +1073,7 @@ sub astDtorListRemoveRef( byval sym as FBSYMBOL ptr )
 end sub
 
 function astDtorListFlush( byval cookie as integer ) as ASTNODE ptr
-    dim as AST_DTORLIST_ITEM ptr n = any, p = any
+	dim as AST_DTORLIST_ITEM ptr n = any, p = any
 	dim as ASTNODE ptr t = any
 
 	'' call the dtors in the reverse order
@@ -1175,7 +1175,7 @@ end function
 ''
 '' if cookie = -1 then delete the dtor at next astDtorListFlush(0)
 ''    This is useful if an expression was at first parsed with a,
-''    dtor list scope, but then it turns out that it's not needed, 
+''    dtor list scope, but then it turns out that it's not needed,
 ''    and can be undone using this function
 ''
 private sub hastDtorListRescope( byval cookie as integer, byval newcookie as integer )
@@ -1224,8 +1224,8 @@ sub astSetType _
 	end if
 #endif
 
-    astGetFullType( n ) = dtype
-    n->subtype = subtype
+	astGetFullType( n ) = dtype
+	n->subtype = subtype
 
 	select case n->class
 	case AST_NODECLASS_LINK

--- a/src/compiler/ast-node-iif.bas
+++ b/src/compiler/ast-node-iif.bas
@@ -185,10 +185,12 @@ function astNewIIF _
 		'' treated as a var-len string, and there is no temp var...
 		if( astConstEqZero( condexpr ) ) then
 			astDelTree( truexpr )
+			astDtorListScopeDelete( truecookie )
 			function = falsexpr
 			astDtorListUnscope( falsecookie )
 		else
 			astDelTree( falsexpr )
+			astDtorListScopeDelete( falsecookie )
 			function = truexpr
 			astDtorListUnscope( truecookie )
 		end if

--- a/src/compiler/ast.bi
+++ b/src/compiler/ast.bi
@@ -1333,6 +1333,7 @@ declare sub astDtorListDel( byval sym as FBSYMBOL ptr )
 declare sub astDtorListScopeBegin( byval cookie as integer = 0 )
 declare function astDtorListScopeEnd( ) as integer
 declare sub astDtorListUnscope( byval cookie as integer )
+declare sub astDtorListScopeDelete( byval cookie as integer )
 
 declare sub astSetType _
 	( _

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -353,9 +353,16 @@ sub cTypeOf _
 	)
 
 	dim as ASTNODE ptr expr = any
+	dim as integer dtorlistcookie = any
+
+	astDtorListScopeBegin( )
 
 	'' Type or an Expression
 	expr = cTypeOrExpression( FB_TK_TYPEOF, dtype, subtype, lgt, is_fixlenstr )
+
+	'' discard all dtors that may have been generated
+	dtorlistcookie = astDtorListScopeEnd( )
+	astDtorListScopeDelete( dtorlistcookie )
 
 	'' Was it a type?
 	if( expr = NULL ) then

--- a/src/compiler/parser-decl-symbtype.bas
+++ b/src/compiler/parser-decl-symbtype.bas
@@ -28,7 +28,7 @@ function cConstIntExpr _
 		expr = astNewCONSTi( 0, dtype )
 	end if
 
-	'' flush the expr to the specified dtype.  
+	'' flush the expr to the specified dtype.
 	'' default is FB_DATATYPE_INTEGER, if not specified in call to cConstIntExpr()
 	function = astConstFlushToInt( expr, dtype )
 end function
@@ -456,17 +456,17 @@ private function cMangleModifier _
 						dtype = typeSetMangleDt( dtype, FB_DATATYPE_UINT )
 						function = TRUE
 					case else
-						errReport( FB_ERRMSG_SYNTAXERROR )	
+						errReport( FB_ERRMSG_SYNTAXERROR )
 					end select
 				else
 					select case dtype
 					case FB_DATATYPE_LONG
 					case FB_DATATYPE_ULONG
 					case else
-						errReport( FB_ERRMSG_SYNTAXERROR )	
+						errReport( FB_ERRMSG_SYNTAXERROR )
 					end select
 				end if
-				
+
 			case "char"
 				select case dtype
 				case FB_DATATYPE_VOID
@@ -474,7 +474,7 @@ private function cMangleModifier _
 				case FB_DATATYPE_BYTE, FB_DATATYPE_UBYTE
 					dtype = typeSetMangleDt( dtype, FB_DATATYPE_CHAR )
 				case else
-					errReport( FB_ERRMSG_SYNTAXERROR )	
+					errReport( FB_ERRMSG_SYNTAXERROR )
 				end select
 
 			case "__builtin_va_list", "__builtin_va_list[]"
@@ -491,14 +491,14 @@ private function cMangleModifier _
 					'' subtype = symbCloneSymbol( subtype )
 					symbSetUdtValistType( subtype, fbGetBackendValistType() )
 				case else
-					errReport( FB_ERRMSG_SYNTAXERROR )	
+					errReport( FB_ERRMSG_SYNTAXERROR )
 				end select
 
 			case ""
 				errReport( FB_ERRMSG_EMPTYALIASSTRING )
 
 			case else
-				errReport( FB_ERRMSG_SYNTAXERROR )	
+				errReport( FB_ERRMSG_SYNTAXERROR )
 			end select
 
 			'' "literal"
@@ -513,17 +513,17 @@ end function
 
 '':::::
 ''SymbolType      =   CONST? UNSIGNED? (
-''				      ANY
-''				  |   BOOLEAN (BYTE|INTEGER)?
-''				  |   CHAR|BYTE
-''				  |	  SHORT|WORD
-''				  |	  INTEGER|LONG|DWORD
-''				  |   SINGLE
-''				  |   DOUBLE
+''                    ANY
+''                |   BOOLEAN (BYTE|INTEGER)?
+''                |   CHAR|BYTE
+''                |   SHORT|WORD
+''                |   INTEGER|LONG|DWORD
+''                |   SINGLE
+''                |   DOUBLE
 ''                |   STRING ('*' NUM_LIT)?
 ''                |   USERDEFTYPE
-''				  |   (FUNCTION|SUB) ('(' args ')') (AS SymbolType)?
-''				      (CONST? (PTR|POINTER))* .
+''                |   (FUNCTION|SUB) ('(' args ')') (AS SymbolType)?
+''                    (CONST? (PTR|POINTER))* .
 ''
 function cSymbolType _
 	( _
@@ -865,9 +865,9 @@ function cSymbolType _
 			end if
 
 			'' note: len of "wstring * expr" symbols will be actually
-			''		 the number of chars times sizeof(wstring), so
-			''		 always use symbGetWstrLen( ) to retrieve the
-			''		 len in characters, not the bytes
+			''       the number of chars times sizeof(wstring), so
+			''       always use symbGetWstrLen( ) to retrieve the
+			''       len in characters, not the bytes
 			if( typeGet( dtype ) = FB_DATATYPE_WCHAR ) then
 				lgt *= typeGetSize( FB_DATATYPE_WCHAR )
 			end if

--- a/src/compiler/parser-decl-var.bas
+++ b/src/compiler/parser-decl-var.bas
@@ -937,6 +937,9 @@ private function hCheckAndBuildByrefInitializer( byval sym as FBSYMBOL ptr, byre
 	'' permitted) that aren't already disallowed in cVarOrDeref()
 	ok and= (not astIsCALL( expr ))
 
+	'' Disallow AST nodes that can't take address of
+	ok and= astCanTakeAddrOf( expr )
+
 	if( ok = FALSE ) then
 		errReport( FB_ERRMSG_INVALIDDATATYPES )
 		astDelTree( expr )

--- a/src/compiler/parser-quirk-casting.bas
+++ b/src/compiler/parser-quirk-casting.bas
@@ -197,7 +197,7 @@ function cAnonType( ) as ASTNODE ptr
 
 	'' UDT?
 	if( typeGetDtAndPtrOnly( dtype ) = FB_DATATYPE_STRUCT ) then
-		'' if it's a UDT and the next token is a 
+		'' if it's a UDT and the next token is a
 		'' left parenthesis, don't handle parentheses as optional
 		if( lexGetToken() = CHAR_LPRNT ) then
 			fbSetPrntOptional( FALSE )

--- a/src/compiler/parser-quirk-casting.bas
+++ b/src/compiler/parser-quirk-casting.bas
@@ -197,6 +197,12 @@ function cAnonType( ) as ASTNODE ptr
 
 	'' UDT?
 	if( typeGetDtAndPtrOnly( dtype ) = FB_DATATYPE_STRUCT ) then
+		'' if it's a UDT and the next token is a 
+		'' left parenthesis, don't handle parentheses as optional
+		if( lexGetToken() = CHAR_LPRNT ) then
+			fbSetPrntOptional( FALSE )
+		end if
+
 		'' Has a ctor?
 		if( symbGetCompCtorHead( subtype ) ) then
 			return cCtorCall( subtype )

--- a/tests/pp/typeof-no-dtors.bas
+++ b/tests/pp/typeof-no-dtors.bas
@@ -1,0 +1,39 @@
+' TEST_MODE : COMPILE_AND_RUN_OK
+
+'' check that no dtors are added for
+'' expressions that should be discarded
+'' as in TYPEOF( expr... )
+
+dim shared ctor_call as integer = 0
+dim shared dtor_call as integer = 0
+
+type t
+	s as string
+	declare constructor()
+	declare destructor()
+end type
+
+constructor T()
+	ctor_call += 1
+end constructor
+
+destructor T()
+	dtor_call += 1
+end destructor
+
+function f() as T
+	return type<T>
+end function
+
+dim x as T
+assert( ctor_call = 1 )
+assert( dtor_call = 0 )
+
+#print typeof(T)
+#print typeof(f())
+#print typeof(f().s)
+#print typeof(iif(true,x,f()).s)
+#print typeof(iif(false,x,f()).s)
+
+assert( ctor_call = 1 )
+assert( dtor_call = 0 )

--- a/tests/structs/anon-param.bas
+++ b/tests/structs/anon-param.bas
@@ -1,0 +1,337 @@
+#include "fbcunit.bi"
+
+SUITE( fbc_tests.structs.anon_param )
+
+	type t1
+		a as short
+	end type
+
+	sub proc1( byval arg as integer, byval compare1 as integer )
+		CU_ASSERT( arg = compare1 )
+	end sub
+
+	sub proc2( byref arg as t1, byval compare1 as integer )
+		CU_ASSERT( arg.a = compare1 )
+	end sub
+
+
+	TEST( test1 )
+		scope
+			dim x as integer
+			x = type<integer>1
+			proc1( x, 1 )
+			x = type<integer>(2)
+			proc1( x, 2 )
+			x = type<integer>((3))
+			proc1( x, 3 )
+			x = (type<integer>4)
+			proc1( x, 4 )
+			x = (type<integer>(5))
+			proc1( x, 5 )
+			x = (type<integer>((6)))
+			proc1( x, 6 )
+			x = ((type<integer>((7))))
+			proc1( x, 7 )
+		end scope
+		scope
+			dim x1 as integer = type<integer>1
+			CU_ASSERT( x1 = 1 )
+			dim x2 as integer = type<integer>(2)
+			CU_ASSERT( x2 = 2 )
+			dim x3 as integer = type<integer>((3))
+			CU_ASSERT( x3 = 3 )
+			dim x4 as integer = (type<integer>4)
+			CU_ASSERT( x4 = 4 )
+			dim x5 as integer = (type<integer>(5))
+			CU_ASSERT( x5 = 5 )
+			dim x6 as integer = (type<integer>((6)))
+			CU_ASSERT( x6 = 6 )
+			dim x7 as integer = ((type<integer>((7))))
+			CU_ASSERT( x7 = 7 )
+		end scope
+		scope
+			proc1  1, 1
+			proc1( 2, 2 )
+			proc1   type<integer>3 ,  3
+			proc1  (type<integer>4),  4
+			proc1   type<integer>5 , (5)
+			proc1 ( type<integer>6 ,  6 )
+			proc1 ((type<integer>7),  7 )
+			proc1 ( type<integer>8 , (8))
+		end scope
+	END_TEST
+
+	TEST( test2 )
+		scope
+			dim x as t1
+			x = type<t1>(2)
+			proc2( x, 2 )
+			x = type<t1>((3))
+			proc2( x, 3 )
+			x = (type<t1>(5))
+			proc2( x, 5 )
+			x = (type<t1>((6)))
+			proc2( x, 6 )
+			x = ((type<t1>((7))))
+			proc2( x, 7 )
+		end scope
+		scope
+			dim x2 as t1 = type<t1>(2)
+			proc2( x2, 2 )
+			dim x3 as t1 = type<t1>((3))
+			proc2( x3, 3 )
+			dim x5 as t1 = (type<t1>(5))
+			proc2( x5, 5 )
+			dim x6 as t1 = (type<t1>((6)))
+			proc2( x6, 6 )
+			dim x7 as t1 = ((type<t1>((7))))
+			proc2( x7, 7 )
+		end scope
+		scope
+			proc2   type<t1>(3) ,  3
+			proc2  (type<t1>(4)),  4
+			proc2   type<t1>(5) , (5)
+			proc2 ( type<t1>(6) ,  6 )
+			proc2 ((type<t1>(7)),  7 )
+			proc2 ( type<t1>(8) , (8))
+
+			proc2   type<t1>(((3))) ,  3
+			proc2  (type<t1>(((4)))),  4
+			proc2   type<t1>(((5))) , (5)
+			proc2 ( type<t1>(((6))) ,  6 )
+			proc2 ((type<t1>(((7)))),  7 )
+			proc2 ( type<t1>(((8))) , (8))
+		end scope
+	END_TEST
+
+	TEST( test3 )
+		scope
+			dim x as t1, y as t1
+			y.a = 2
+			x = type<t1>(y)
+			proc2( x, 2 )
+			y.a = 4
+			x = type<t1>((y))
+			proc2( x, 4 )
+			y.a = 5
+			x = (type<t1>(y))
+			proc2( x, 5 )
+			y.a = 6
+			x = (type<t1>((y)))
+			proc2( x, 6 )
+			y.a = 7
+			x = ((type<t1>((y))))
+			proc2( x, 7 )
+		end scope
+		scope
+			dim x as t1, y as t1
+			y.a = 2
+			x = type<t1>(y.a)
+			proc2( x, 2 )
+			y.a = 4
+			x = type<t1>((y.a))
+			proc2( x, 4 )
+			y.a = 5
+			x = (type<t1>(y.a))
+			proc2( x, 5 )
+			y.a = 6
+			x = (type<t1>((y.a)))
+			proc2( x, 6 )
+			y.a = 7
+			x = ((type<t1>((y.a))))
+			proc2( x, 7 )
+		end scope
+		scope
+			dim x as t1, y as t1
+			y.a = 4
+			x = type<t1>((y).a)
+			proc2( x, 4 )
+			y.a = 6
+			x = (type<t1>((y).a))
+			proc2( x, 6 )
+			y.a = 7
+			x = ((type<t1>((y).a)))
+			proc2( x, 7 )
+		end scope
+		scope
+			dim x as t1, y as t1
+			y.a = 4
+			x = type<t1>(((y)).a)
+			proc2( x, 4 )
+			y.a = 6
+			x = (type<t1>(((y)).a))
+			proc2( x, 6 )
+			y.a = 7
+			x = ((type<t1>(((y)).a)))
+			proc2( x, 7 )
+		end scope
+	END_TEST
+
+	TEST( test4 )
+		scope
+			dim y as t1
+			y.a = 2
+			dim x2 as t1 = type<t1>(y)
+			proc2( x2, 2 )
+			y.a = 4
+			dim x4 as t1 = type<t1>((y))
+			proc2( x4, 4 )
+			y.a = 5
+			dim x5 as t1 = (type<t1>(y))
+			proc2( x5, 5 )
+			y.a = 6
+			dim x6 as t1 = (type<t1>((y)))
+			proc2( x6, 6 )
+			y.a = 7
+			dim x7 as t1 = ((type<t1>((y))))
+			proc2( x7, 7 )
+		end scope
+		scope
+			dim y as t1
+			y.a = 2
+			dim x2 as t1  = type<t1>(y.a)
+			proc2( x2, 2 )
+			y.a = 4
+			dim x4 as t1  = type<t1>((y.a))
+			proc2( x4, 4 )
+			y.a = 5
+			dim x5 as t1  = (type<t1>(y.a))
+			proc2( x5, 5 )
+			y.a = 6
+			dim x6 as t1  = (type<t1>((y.a)))
+			proc2( x6, 6 )
+			y.a = 7
+			dim x7 as t1 = ((type<t1>((y.a))))
+			proc2( x7, 7 )
+		end scope
+		scope
+			dim y as t1
+			y.a = 4
+			dim x4 as t1 = type<t1>((y).a)
+			proc2( x4, 4 )
+			y.a = 6
+			dim x6 as t1 = (type<t1>((y).a))
+			proc2( x6, 6 )
+			y.a = 7
+			dim x7 as t1 = ((type<t1>((y).a)))
+			proc2( x7, 7 )
+		end scope
+		scope
+			dim y as t1
+			y.a = 4
+			dim x4 as t1 = type<t1>(((y)).a)
+			proc2( x4, 4 )
+			y.a = 6
+			dim x6 as t1 = (type<t1>(((y)).a))
+			proc2( x6, 6 )
+			y.a = 7
+			dim x7 as t1 = ((type<t1>(((y)).a)))
+			proc2( x7, 7 )
+		end scope
+	END_TEST
+
+	TEST( test5 )
+		scope
+			dim y as t1
+			y.a = 3
+			proc2   type<t1>(y) ,  3
+			y.a = 4
+			proc2  (type<t1>(y)),  4
+			y.a = 5
+			proc2   type<t1>(y) , (5)
+			y.a = 6
+			proc2 ( type<t1>(y) ,  6 )
+			y.a = 7
+			proc2 ((type<t1>(y)),  7 )
+			y.a = 8
+			proc2 ( type<t1>(y) , (8))
+
+			y.a = 3
+			proc2   type<t1>((y)) ,  3
+			y.a = 4
+			proc2  (type<t1>((y))),  4
+			y.a = 5
+			proc2   type<t1>((y)) , (5)
+			y.a = 6
+			proc2 ( type<t1>((y)) ,  6 )
+			y.a = 7
+			proc2 ((type<t1>((y))),  7 )
+			y.a = 8
+			proc2 ( type<t1>((y)) , (8))
+		end scope
+		scope
+			dim y as t1
+			y.a = 3
+			proc2   type<t1>(y.a) ,  3
+			y.a = 4
+			proc2  (type<t1>(y.a)),  4
+			y.a = 5
+			proc2   type<t1>(y.a) , (5)
+			y.a = 6
+			proc2 ( type<t1>(y.a) ,  6 )
+			y.a = 7
+			proc2 ((type<t1>(y.a)),  7 )
+			y.a = 8
+			proc2 ( type<t1>(y.a) , (8))
+
+			y.a = 3
+			proc2   type<t1>((y.a)) ,  3
+			y.a = 4
+			proc2  (type<t1>((y.a))),  4
+			y.a = 5
+			proc2   type<t1>((y.a)) , (5)
+			y.a = 6
+			proc2 ( type<t1>((y.a)) ,  6 )
+			y.a = 7
+			proc2 ((type<t1>((y.a))),  7 )
+			y.a = 8
+			proc2 ( type<t1>((y.a)) , (8))
+		end scope
+		scope
+			dim y as t1
+			y.a = 3
+			proc2   type<t1>((y).a) ,  3
+			y.a = 4
+			proc2  (type<t1>((y).a)),  4
+			y.a = 5
+			proc2   type<t1>((y).a) , (5)
+			y.a = 6
+			proc2 ( type<t1>((y).a) ,  6 )
+			y.a = 7
+			proc2 ((type<t1>((y).a)),  7 )
+			y.a = 8
+			proc2 ( type<t1>((y).a) , (8))
+		end scope
+		scope
+			dim y as t1
+			y.a = 3
+			proc2   type<t1>(((y).a)) ,  3
+			y.a = 4
+			proc2  (type<t1>(((y).a))),  4
+			y.a = 5
+			proc2   type<t1>(((y).a)) , (5)
+			y.a = 6
+			proc2 ( type<t1>(((y).a)) ,  6 )
+			y.a = 7
+			proc2 ((type<t1>(((y).a))),  7 )
+			y.a = 8
+			proc2 ( type<t1>(((y).a)) , (8))
+		end scope
+		scope
+			dim y as t1
+			y.a = 3
+			proc2   type<t1>(((y).a+1)) ,  3+1
+			y.a = 4
+			proc2  (type<t1>(((y).a+1))),  4+1
+			y.a = 5
+			proc2   type<t1>(((y).a+1)) , (5+1)
+			y.a = 6
+			proc2 ( type<t1>(((y).a+1)) ,  6+1 )
+			y.a = 7
+			proc2 ((type<t1>(((y).a+1))),  7+1 )
+			y.a = 8
+			proc2 ( type<t1>(((y).a+1)) , (8+1))
+		end scope
+	END_TEST
+
+END_SUITE

--- a/tests/structs/bitfield-byref.bas
+++ b/tests/structs/bitfield-byref.bas
@@ -1,0 +1,8 @@
+' TEST_MODE : COMPILE_ONLY_FAIL
+
+type T
+	n:1 as integer
+end type
+
+dim x as T
+dim byref y as integer = x.n


### PR DESCRIPTION
This change fixes bugs (re)discovered while writing tests trying to break #397 

Byref Initializer Bug
- fbc: show an error on byref initializers that can't take address of.  Previously this was checked by fbc debug assertion only.

Parsing bug for initializers
- sf.net #922: Sometimes can't use extra backets inside TYPE UDT initialiser - now, don't allow optional parentheses when parsing type<UDT>(...) if left parenthesis is found

Parsing/ast bug for temporaries
- sf.net #824: Illegal destructor call after '#print typeof( f() )' when f() is a function returning an object by value
- fbc: delete destructor calls of discarded expressions in IIF(), previously, unscoped dtors (to be called after the expression) and deleted dtors (to be never called) were being handled the same

changelog.txt updated to reflect that #396 also fixes sf.net # 894
- [#894 Can't initialise a UDT as copy of another if the first element is a UNION](https://sourceforge.net/p/fbc/bugs/894/)
