### PR TITLE
The default value of the parameter was passed incorrectly when calling the pointer function.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -61,6 +61,7 @@ Version 1.10.0
 - sf.net #916: fbc: 'LINE INPUT [#1 | prompt,] variable [, maxchars]' requires length parameter for ZSTRING/WSTRING PTR variable
 - sf.net #916: fbc: Error on LINE INPUT [#1] if either missing or irrelevant max length argument
 - sf.net #892: fbc: Bug when default calling via a pointer to a 'Sub' defined with the only 'Any Ptr' optional parameter
+- github #403: fbc: The default value of the parameter was passed incorrectly when calling the pointer function (Skyfish) [optional parameter values are specified by the function pointer declaration]
 - sf.net #944: fbc: regression - local static arrays shouldn't have the array descriptor moved to global scope - partially revert #944 and add test
 - fbc: parser skips extra token on error recovery for #if/#ifndef/defined() statements
 - sf.net #455: fbc: Number lexing allows much bad input - a show a warning message "Expected digit" where '&o', '&h', '&b' has no digits following

--- a/src/compiler/symb-proc.bas
+++ b/src/compiler/symb-proc.bas
@@ -1154,7 +1154,7 @@ function symbLookupInternallyMangledSubtype _
 				lookup_param = symbGetProcHeadParam( sym )
 				proc_param = symbGetProcHeadParam( proc )
 				while( (lookup_param <> NULL) and (proc_param <> NULL) )
-					if( (symbGetParamOptExpr( lookup_param ) <> NULL) <> (symbGetParamOptExpr( proc_param ) <> NULL) ) then
+					if astIsEqualParamInit( symbGetParamOptExpr( lookup_param ), symbGetParamOptExpr( proc_param ) ) = FALSE then
 						exit while
 					end if
 					lookup_param = symbGetParamNext( lookup_param )

--- a/tests/pointers/procptr-optional-arg.bas
+++ b/tests/pointers/procptr-optional-arg.bas
@@ -1,0 +1,82 @@
+#include "fbcunit.bi"
+
+SUITE( fbc_tests.pointers.procptr_optional_arg )
+
+	function f1( byval arg as long ) as long
+		return 1000+arg
+	end function
+	function f2( byval arg as long = 2 ) as long
+		return 2000+arg
+	end function
+	function f3( byval arg as long = 3 ) as long
+		return 3000+arg
+	end function
+
+	TEST( default )
+	    '' default initializers are stored with the function pointer
+		var pf1 = procptr( f1 )
+		var pf2 = procptr( f2 )
+		var pf3 = procptr( f3 )
+
+		CU_ASSERT( pf1(1) = 1001 ) '' f1(1)
+		CU_ASSERT( pf2()  = 2002 ) '' f2(2)
+		CU_ASSERT( pf3()  = 3003 ) '' f3(3)
+
+		CU_ASSERT( pf2(5) = 2005 ) '' f2(5)
+		CU_ASSERT( pf3(6) = 3006 ) '' f3(6)
+
+		'' swap proc addresses, but not initializers
+		'' because function pointer declaration is still
+		'' same as originally typed
+
+		swap pf2, pf3
+		CU_ASSERT( pf1(1) = 1001 ) '' f1(1)
+		CU_ASSERT( pf2()  = 3002 ) '' f3(2)
+		CU_ASSERT( pf3()  = 2003 ) '' f2(3)
+
+		CU_ASSERT( pf1(4) = 1004 ) '' f1(1)
+		CU_ASSERT( pf2(5) = 3005 ) '' f3(5)
+		CU_ASSERT( pf3(6) = 2006 ) '' f2(6)
+
+		swap pf1, pf2
+		CU_ASSERT( pf1(1) = 3001 ) '' f3(1)
+		CU_ASSERT( pf2()  = 1002 ) '' f1(2)
+		CU_ASSERT( pf3()  = 2003 ) '' f2(3)
+
+		CU_ASSERT( pf1(4) = 3004 ) '' f3(1)
+		CU_ASSERT( pf2(5) = 1005 ) '' f1(2)
+		CU_ASSERT( pf3(6) = 2006 ) '' f2(3)
+	END_TEST
+
+	function f4( byval f as function( byval arg as long = 4 ) as long ) as long
+		return f()
+	end function
+
+	TEST( fptr_arg )
+		var pf1 = procptr( f1 )
+		var pf2 = procptr( f2 )
+		var pf3 = procptr( f3 )
+
+		CU_ASSERT( f4(pf1) = 1004 )
+		CU_ASSERT( f4(pf2) = 2004 )
+		CU_ASSERT( f4(pf3) = 3004 )
+	END_TEST
+
+	Type T
+		s1 As Sub( byval compare as long, byval value As Long=123 )
+		s2 As Sub( byval compare as long, byval value As Long=456 )
+		s3 As Sub( byval compare as long, byval value As Long=789 )
+	End Type
+
+	sub check_field ( byval compare as long, byval value as long )
+		CU_ASSERT( compare = value )
+	end sub
+
+	TEST( fptr_field )
+		dim x as T = ( @check_field, @check_field, @check_field )
+		x.s1(123)
+		x.s2(456)
+		x.s3(789)
+	END_TEST
+
+END_SUITE


### PR DESCRIPTION
When multiple function pointers of the same type are defined, their corresponding parameter initialization values are different, although their prototypes are the same. In this case, only the parameter initializers of the first function pointer will be used.

Type OptionalError
	Test1 As Sub(Byval value As Long=123)
	Test2 As Sub(Byval value As Long=456)
	Test3 As Sub(Byval value As Long=789)
End Type

Sub Test (Byval value As Long)
	print value
End Sub

Dim As OptionalError vOErr = ( @test, @test, @test )
vOErr.Test1()
vOErr.Test2()
vOErr.Test3()

'Output:
'       123
'       123
'       123