### PR TITLE
Fix for boolean bitfield container size

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ Version 1.20.0
 - github #410: give consistent floating point comparisons results involving NaNs.
 - consistent handling for float comparisons involving NaN's.  gcc/gas64/gas/gas+SSE (LLVM not-tested) - this includes IF expr then, IIF(), CBOOL, result = (a rel-op b), etc.
 - sf.net #984: Incorrect syntax for a member array passed as argument to a procedure
+- github #292: Boolean bitfields writes treated as 32/64-bit rather than 8-bit
 
 
 Version 1.10.1

--- a/src/compiler/ir-gas64.bas
+++ b/src/compiler/ir-gas64.bas
@@ -4443,9 +4443,11 @@ private sub _emitconvert( byval v1 as IRVREG ptr, byval v2 as IRVREG ptr )
 
 	if v1->typ=IR_VREGTYPE_REG and v2->typ=IR_VREGTYPE_REG and (typeGetSize( v1dtype )  = typeGetSize( v2dtype )) and _
 	   (typeGetClass( v1dtype )=typeGetClass( v2dtype ) ) then
-	   asm_info("no move as exactly same size, vreg changed"+Str(v1->reg)+" becomes "+Str(v2->reg))
-	   v1->reg=v2->reg
-	   exit sub
+		if( v2dtype <> FB_DATATYPE_BOOLEAN ) then
+			asm_info("no move as exactly same size, vreg changed"+Str(v1->reg)+" becomes "+Str(v2->reg))
+			v1->reg=v2->reg
+			exit sub
+		end if
 	end if
 
 	if (v1dtype=FB_DATATYPE_LONGINT and v2dtype=FB_DATATYPE_LONGINT) or (v1dtype=FB_DATATYPE_ULONGINT and v2dtype=FB_DATATYPE_ULONGINT) then

--- a/tests/boolean/boolean_bitfield.bas
+++ b/tests/boolean/boolean_bitfield.bas
@@ -1,6 +1,6 @@
 # include "fbcunit.bi"
 
-'' - don't mix false/true intrinsic constants 
+'' - don't mix false/true intrinsic constants
 ''   of the compiler in with the tests
 #undef FALSE
 #undef TRUE
@@ -203,6 +203,71 @@ SUITE( fbc_tests.boolean_.boolean_bitfield )
 			CU_ASSERT_EQUAL( x.b, 0 )
 			CU_ASSERT_EQUAL( x.c, -1 )
 		end scope
+
+	END_TEST
+
+	type T2bits
+		as boolean b0:1
+		as boolean b1:1
+		as boolean b2:1
+		as boolean b3:1
+	end type
+
+	type T2
+		union
+			bits as T2bits
+			as long x
+		end union
+	end type
+
+	TEST( WriteBits )
+
+		dim as T2 a
+		dim as T2bits ptr b = @a.bits
+		dim as integer n1, n2, n3
+
+		#macro toggle_bit( bitno, value, bvalue0, bvalue1 )
+			n2 = n1 or value
+			n3 = n1 and not value
+			a.x = n1
+
+			b->b##bitno = bvalue1
+			CU_ASSERT_EQUAL( a.x, n2 )
+			CU_ASSERT_EQUAL( b->b##bitno, cint(cbool(bvalue1)) )
+
+			b->b##bitno = bvalue0
+			CU_ASSERT_EQUAL( a.x, n3 )
+			CU_ASSERT_EQUAL( b->b##bitno, cint(cbool(bvalue0)) )
+		#endmacro
+
+		for i as long = 0 to 15
+			n1 = &h7FFFFF00L or i
+
+			toggle_bit( 0, 1, 0, 1 )
+			toggle_bit( 1, 2, 0, 1  )
+			toggle_bit( 2, 4, 0, 1  )
+			toggle_bit( 3, 8, 0, 1  )
+
+			toggle_bit( 0, 1, 0, -1 )
+			toggle_bit( 1, 2, 0, -1 )
+			toggle_bit( 2, 4, 0, -1 )
+			toggle_bit( 3, 8, 0, -1 )
+
+			toggle_bit( 0, 1, 0, 1L  )
+			toggle_bit( 1, 2, 0, 1L  )
+			toggle_bit( 2, 4, 0, 1L  )
+			toggle_bit( 3, 8, 0, 1L  )
+
+			toggle_bit( 0, 1, 0, 1U  )
+			toggle_bit( 1, 2, 0, 1U  )
+			toggle_bit( 2, 4, 0, 1U  )
+			toggle_bit( 3, 8, 0, 1U  )
+
+			toggle_bit( 0, 1, false, true )
+			toggle_bit( 1, 2, false, true )
+			toggle_bit( 2, 4, false, true )
+			toggle_bit( 3, 8, false, true )
+		next
 
 	END_TEST
 


### PR DESCRIPTION
This change intends to at least prevent fbc from generating code that overwrites memory outside of a boolean bitfield.  The container for boolean bitfields is expected to be byte sized at 8 bits maximum.

This should partially fix github #292: Boolean bitfields writes treated as 32/64-bit rather than 8-bit.

Tested on x86, x86_64, and emscripten targets.

Not tested for big endian.

This probably won't generate the most efficient code for accessing boolean but would still like to get something working first, then worry about optimizing if needed.