### PR TITLE
Initialize variables

### DIFF
--- a/src/compiler/ast-node-addr.bas
+++ b/src/compiler/ast-node-addr.bas
@@ -48,7 +48,7 @@ private function astNewOFFSET( byval l as ASTNODE ptr ) as ASTNODE ptr
 end function
 
 function astLoadOFFSET( byval n as ASTNODE ptr ) as IRVREG ptr
-	dim as IRVREG ptr vr = any
+	dim as IRVREG ptr vr = NULL
 	dim as FBSYMBOL ptr sym = any
 	dim as ASTNODE ptr l = any
 
@@ -231,7 +231,7 @@ end function
 
 function astLoadADDROF( byval n as ASTNODE ptr ) as IRVREG ptr
 	dim as ASTNODE ptr p = any
-	dim as IRVREG ptr v1 = any, vr = any
+	dim as IRVREG ptr v1 = any, vr = NULL
 
 	p  = n->l
 	if( p = NULL ) then

--- a/src/compiler/ast-node-bop.bas
+++ b/src/compiler/ast-node-bop.bas
@@ -1669,7 +1669,7 @@ end function
 function astLoadBOP( byval n as ASTNODE ptr ) as IRVREG ptr
 	dim as ASTNODE ptr l = any, r = any
 	dim as integer op = any
-	dim as IRVREG ptr v1 = any, v2 = any, vr = any
+	dim as IRVREG ptr v1 = any, v2 = any, vr = NULL
 
 	op = n->op.op
 	l  = n->l

--- a/src/compiler/ast-node-call.bas
+++ b/src/compiler/ast-node-call.bas
@@ -155,7 +155,7 @@ function astLoadCALL( byval n as ASTNODE ptr ) as IRVREG ptr
 	dim as FBSYMBOL ptr proc = any
 	dim as integer bytestopop = any, bytestoalign = any, argbytes = any
 	dim as integer prev_totalstackbytes = totalstackbytes
-	dim as IRVREG ptr vr = any, v1 = any, lreg = NULL
+	dim as IRVREG ptr vr = NULL, v1 = any, lreg = NULL
 
 	'' ARGs can contain CALLs themselves, then astLoadCALL() will recurse
 	reclevel += 1

--- a/src/compiler/ast-node-conv.bas
+++ b/src/compiler/ast-node-conv.bas
@@ -722,7 +722,7 @@ function astLoadCONV _
 	) as IRVREG ptr
 
 	dim as ASTNODE ptr l = any
-	dim as IRVREG ptr vs = any, vr = any
+	dim as IRVREG ptr vs = any, vr = NULL
 
 	l = n->l
 

--- a/src/compiler/ast-node-idx.bas
+++ b/src/compiler/ast-node-idx.bas
@@ -26,7 +26,7 @@ end function
 
 function astLoadIDX( byval n as ASTNODE ptr ) as IRVREG ptr
 	dim as ASTNODE ptr var_ = any, idx = any
-	dim as IRVREG ptr vidx = any, vr = any
+	dim as IRVREG ptr vidx = any, vr = NULL
 	dim as FBSYMBOL ptr s = any
 	dim as longint ofs = any
 

--- a/src/compiler/ast-node-ptr.bas
+++ b/src/compiler/ast-node-ptr.bas
@@ -97,7 +97,7 @@ end function
 
 function astLoadDEREF( byval n as ASTNODE ptr ) as IRVREG ptr
 	dim as ASTNODE ptr l = any
-	dim as IRVREG ptr v1 = any, vp = any, vr = any
+	dim as IRVREG ptr v1 = any, vp = any, vr = NULL
 
 	l = n->l
 	'' no index? can happen with absolute addresses + ptr typecasting

--- a/src/compiler/ast-node-uop.bas
+++ b/src/compiler/ast-node-uop.bas
@@ -325,7 +325,7 @@ function astLoadUOP _
 
 	dim as ASTNODE ptr o = any
 	dim as integer op = any
-	dim as IRVREG ptr v1 = any, vr = any
+	dim as IRVREG ptr v1 = any, vr = NULL
 
 	o = n->l
 	op = n->op.op

--- a/src/compiler/symb-proc.bas
+++ b/src/compiler/symb-proc.bas
@@ -2256,7 +2256,7 @@ private function hCheckOvlProc _
 	) as integer
 
 	dim as FBSYMBOL ptr param = any
-	dim as FB_OVLPROC_MATCH_SCORE arg_matchscore = any, matchscore = any
+	dim as FB_OVLPROC_MATCH_SCORE arg_matchscore = any, matchscore = FB_OVLPROC_NO_MATCH
 	dim as integer matchcount = any
 	dim as FB_CALL_ARG ptr arg = any
 
@@ -2293,7 +2293,6 @@ private function hCheckOvlProc _
 			param = param->next
 		end if
 
-		matchscore = FB_OVLPROC_NO_MATCH
 		exact_matches = 0
 
 		'' for each arg..


### PR DESCRIPTION
Initialize variables with NULL and 0 value because it may be used uninitialized