### PR TITLE
Add examples makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,120 @@
+#!/usr/bin/make -f
+#
+# examples makefile - attempts to build all examples
+#
+# Several examples will not build if their libraries are not
+# present.
+#
+# To make all examples:
+#   $ make
+# To make a subset, use the dirname in lower case
+#   $ make unicode
+#
+# If fbc[.exe] is not in your path, pass it to make
+#   $ make FBC=d:/path/to/fbc
+#
+
+OS := $(shell uname)
+ifeq ($(OS),Linux)
+    EXEEXT :=
+else
+    EXEEXT := .exe
+endif
+
+FBC := fbc$(EXEEXT)
+STOP_ON_ERROR := n
+
+
+
+BASICS		:= $(subst .bas,,$(wildcard *.bas))
+COMPRESSION	:= $(subst .bas,,$(wildcard compression/*.bas))
+CONSOLE		:= $(subst .bas,,$(wildcard console/*.bas)) \
+			$(subst .bas,,$(wildcard console/curses/*.bas)) \
+			$(subst .bas,,$(wildcard console/caca/*.bas))
+DATABASE	:= $(subst .bas,,$(wildcard database/*.bas))
+DLL		:= dll/dylib dll/libmydll.so dll/test
+DOS		:= $(subst .bas,,$(wildcard DOS/*.bas))
+FILES		:= $(subst .bas,,$(wildcard files/*.bas files/*/*.bas))
+GRAPHICS	:= $(subst .bas,,$(wildcard graphics/*.bas graphics/*/*.bas))
+GUI		:= $(subst .bas,,$(wildcard GUI/*/*.bas GUI/*/*/*.bas))
+MANUAL		:= $(subst .bas,,$(wildcard manual/*.bas manual/*/*.bas))
+MATH		:= $(subst .bas,,$(wildcard math/*.bas math/*/*.bas))
+MISC		:= $(subst .bas,,$(wildcard misc/*/*.bas))
+NETWORK		:= $(subst .bas,,$(wildcard network/*.bas network/*/*.bas \
+			network/*/*/*.bas))
+#OPTIMIZE	:= $(subst .bas,,$(wildcard OptimizePureAbstractTypes/*.bas))
+#REGEX		:= $(subst .bas,,$(wildcard regex/*/*.bas))
+SOUND		:= $(subst .bas,,$(wildcard sound/*/*.bas))
+THREADS		:= $(subst .bas,,$(wildcard threads/*.bas)) \
+			threads/timer-lib/libtimer.so threads/timer-lib/test
+UNICODE		:= $(subst .bas,,$(wildcard unicode/*.bas))
+#WIN32 := $(subst .bas,,$(wildcard sound/*/*.bas))
+XML		:= $(subst .bas,,$(wildcard xml/*.bas))
+
+
+ALL_FILES := \
+	$(BASICS) $(COMPRESSION) $(CONSOLE) $(DATABASE) \
+	$(DLL) $(DOS) $(FILES) $(GRAPHICS) $(GUI) $(MANUAL) \
+	$(MATH) $(MISC) $(NETWORK) $(OPTIMIZE) $(SOUND) \
+	$(THREADS) $(UNICODE) $(XML)
+
+all: $(ALL_FILES)
+
+basics: $(BASICS)
+compression: $(COMPRESSION)
+console: $(CONSOLE)
+database: $(DATABASE)
+dll: $(DLL)
+dos: $(DOS)
+files: $(FILES)
+graphics: $(GRAPHICS)
+gui: $(GUI)
+manual: $(MANUAL)
+math: $(MATH)
+misc: $(MISC)
+#network: checklib.curl checklib.CHttp .WAIT $(NETWORK)
+network: $(NETWORK)
+optimize: $(OPTIMIZE)
+sound: $(SOUND)
+threads: $(THREADS)
+unicode: $(UNICODE)
+xml: $(XML)
+
+
+checklib.%:
+	@echo check library: "lib$*"
+	@ldconfig -p | grep "lib$*.so" > /dev/null
+
+
+dll/libmydll.so: dll/mydll.bas
+	$(FBC) -dylib $<
+
+dll/test: dll/test.bas dll/libmydll.so
+	$(FBC) -p dll dll/test.bas
+
+ifeq ($(OS),Linux)
+DOS/%: DOS/%.bas
+	@echo "SKIP $@ on Linux"
+else
+DOS/%: DOS/%.bas
+	$(FBC) $<
+endif
+
+threads/timer-lib/libtimer.so: threads/timer-lib/timer.bas
+	$(FBC) -dylib -mt $<
+
+threads/timer-lib/test: threads/timer-lib/test.bas threads/timer-lib/libtimer.so
+	$(FBC) -p $(dir $@) -mt $<
+
+%: %.bas
+ifeq ($(STOP_ON_ERROR),n)
+	@echo fbc -p $(dir $@) $<
+	@$(FBC) -p $(dir $@) $< || \
+		echo "Failed to compile '$<' - check for missing libraries"
+else
+	$(FBC) -p $(dir $@) $<
+endif
+
+clean:
+	@echo CLEAN binary files
+	@rm -fv $(ALL_FILES)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,8 +17,10 @@
 OS := $(shell uname)
 ifeq ($(OS),Linux)
     EXEEXT :=
+    DLLEXT := .so
 else
     EXEEXT := .exe
+    DLLEXT := .dll
 endif
 
 FBC := fbc$(EXEEXT)
@@ -32,7 +34,7 @@ CONSOLE		:= $(subst .bas,,$(wildcard console/*.bas)) \
 			$(subst .bas,,$(wildcard console/curses/*.bas)) \
 			$(subst .bas,,$(wildcard console/caca/*.bas))
 DATABASE	:= $(subst .bas,,$(wildcard database/*.bas))
-DLL		:= dll/dylib dll/libmydll.so dll/test
+DLL		:= dll/dylib dll/libmydll$(DLLEXT) dll/test
 DOS		:= $(subst .bas,,$(wildcard DOS/*.bas))
 FILES		:= $(subst .bas,,$(wildcard files/*.bas files/*/*.bas))
 GRAPHICS	:= $(subst .bas,,$(wildcard graphics/*.bas graphics/*/*.bas))
@@ -46,7 +48,7 @@ NETWORK		:= $(subst .bas,,$(wildcard network/*.bas network/*/*.bas \
 #REGEX		:= $(subst .bas,,$(wildcard regex/*/*.bas))
 SOUND		:= $(subst .bas,,$(wildcard sound/*/*.bas))
 THREADS		:= $(subst .bas,,$(wildcard threads/*.bas)) \
-			threads/timer-lib/libtimer.so threads/timer-lib/test
+			threads/timer-lib/libtimer$(DLLEXT) threads/timer-lib/test
 UNICODE		:= $(subst .bas,,$(wildcard unicode/*.bas))
 #WIN32 := $(subst .bas,,$(wildcard sound/*/*.bas))
 XML		:= $(subst .bas,,$(wildcard xml/*.bas))
@@ -86,24 +88,29 @@ checklib.%:
 	@ldconfig -p | grep "lib$*.so" > /dev/null
 
 
-dll/libmydll.so: dll/mydll.bas
+dll/libmydll$(DLLEXT): dll/mydll.bas
 	$(FBC) -dylib $<
 
-dll/test: dll/test.bas dll/libmydll.so
+dll/test: dll/test.bas dll/libmydll$(DLLEXT)
 	$(FBC) -p dll dll/test.bas
 
 ifeq ($(OS),Linux)
 DOS/%: DOS/%.bas
 	@echo "SKIP $@ on Linux"
+else 
+ifeq ($(OS),Windows_NT)
+DOS/%: DOS/%.bas
+	@echo "SKIP $@ on Windows"
 else
 DOS/%: DOS/%.bas
 	$(FBC) $<
 endif
+endif
 
-threads/timer-lib/libtimer.so: threads/timer-lib/timer.bas
+threads/timer-lib/libtimer$(DLLEXT): threads/timer-lib/timer.bas
 	$(FBC) -dylib -mt $<
 
-threads/timer-lib/test: threads/timer-lib/test.bas threads/timer-lib/libtimer.so
+threads/timer-lib/test: threads/timer-lib/test.bas threads/timer-lib/libtimer$(DLLEXT)
 	$(FBC) -p $(dir $@) -mt $<
 
 %: %.bas

--- a/examples/compression/libzip.bas
+++ b/examples/compression/libzip.bas
@@ -24,7 +24,7 @@ End Sub
 
 '' Asks libzip for information on file number 'i' in the .zip file,
 '' and then extracts it, while creating directories as needed.
-Private Sub unpack_zip_file(ByVal zip As zip Ptr, ByVal i As Integer)
+Private Sub unpack_zip_file(ByVal zip As zip_t Ptr, ByVal i As Integer)
     #define BUFFER_SIZE (1024 * 512)
     Static As UByte chunk(0 To (BUFFER_SIZE - 1))
     #define buffer (@chunk(0))
@@ -58,7 +58,7 @@ Private Sub unpack_zip_file(ByVal zip As zip Ptr, ByVal i As Integer)
     End If
 
     '' Input for the file comes from libzip
-    Dim As zip_file Ptr fi = zip_fopen_index(zip, i, 0)
+    Dim As zip_file_t Ptr fi = zip_fopen_index(zip, i, 0)
     Do
         '' Write out the file content as returned by zip_fread(), which
         '' also does the decoding and everything.
@@ -88,7 +88,7 @@ Private Sub unpack_zip_file(ByVal zip As zip Ptr, ByVal i As Integer)
 End Sub
 
 Sub unpack_zip(ByRef archive As String)
-    Dim As zip Ptr zip = zip_open(archive, ZIP_CHECKCONS, NULL)
+    Dim As zip_t Ptr zip = zip_open(archive, ZIP_CHECKCONS, NULL)
     If (zip = NULL) Then
         Print "could not open input file " & archive
         Return

--- a/examples/threads/timer-lib/timer.bas
+++ b/examples/threads/timer-lib/timer.bas
@@ -6,7 +6,7 @@
 
 #include once "timer.bi"
 
-sub CTimer.threadcb( byval ctx as CTimer ptr )
+sub CTimer.threadcb( byval ctx as CTimer ptr ) export
 	do
 		select case ctx->state
 		case TIMER_STATE_EXITING
@@ -43,7 +43,7 @@ constructor CTimer _
 		byval interval as integer, _
 		byval callback as TIMER_CALLBACK, _
 		byval userdata as integer = 0 _
-	)
+	) export
 	this.state      = TIMER_STATE_STOPPED
 	this.interval   = interval
 	this.callback   = callback
@@ -54,7 +54,7 @@ constructor CTimer _
 	this.waiting    = -1
 end constructor
 
-sub CTimer.on( )
+sub CTimer.on( ) export
 	if( this.state = TIMER_STATE_KILLED ) then
 		exit sub
 	end if
@@ -66,14 +66,14 @@ sub CTimer.on( )
 	mutexunlock( this.cond_mutex )
 end sub
 
-sub CTimer.off( )
+sub CTimer.off( ) export
 	if( this.state = TIMER_STATE_KILLED ) then
 		exit sub
 	end if
 	this.state = TIMER_STATE_STOPPED
 end sub
 
-destructor CTimer( )
+destructor CTimer( ) export
 	if( this.state = TIMER_STATE_KILLED ) then
 		return
 	end if

--- a/inc/quicklz.bi
+++ b/inc/quicklz.bi
@@ -67,7 +67,7 @@ type ui16 as ushort
 #endif
 
 ' Detect if pointer size is 64-bit. It's not fatal if some 64-bit target is not detected because this is only for adding an optional 64-bit optimization.
-#if __FB_64BIT__
+#if defined(__FB_64BIT__)
 	#define QLZ_PTR_64
 #endif
 


### PR DESCRIPTION
Makefile to compile all examples/ along with minor compile fixes to examples/compression

When reading the examples, it's helpful to have them compiled already to compare output.
Also various examples are slightly out of date with modern libraries and FreeBASIC, so attempting to correct some of those examples along the way.