### PR TITLE
libfbdoc SSL: try to use native CA certs, fix readme

### DIFF
--- a/doc/fbchkdoc/readme.txt
+++ b/doc/fbchkdoc/readme.txt
@@ -175,12 +175,12 @@ the '-ini FILE' command line option to any of the tools.
         are given.  Set or override this url with the '-url URL' command
         line option
 
-    web_cert_file
+    web_certificate
         path and file name to the certificate for web url.  Selected when the
         '-web' or '-web+' command line option given.  Set or override this
         option with the '-certificate FILE' command line option.
 
-    dev_cert_file
+    dev_certificate
         path and file name to the certificate for dev url.  Selected when the
         '-dev' or '-dev+' command line option given.  Set or override this
         option with the '-certificate FILE' command line option.

--- a/doc/libfbdoc/CHttpStream.bas
+++ b/doc/libfbdoc/CHttpStream.bas
@@ -164,6 +164,8 @@ namespace fb
 
 		if( ca_file ) then
 			ret = curl_easy_setopt( curl, CURLOPT_CAINFO, ca_file )
+		else
+			curl_easy_setopt( curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA )
 		end if
 
 		'' This option should not be needed.  It wasn't in earlier version
@@ -302,6 +304,8 @@ namespace fb
 
 		if( ca_file ) then
 			curl_easy_setopt( curl, CURLOPT_CAINFO, ca_file )
+		else
+			curl_easy_setopt( curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA )
 		end if
 
 		ret = curl_easy_perform( curl )


### PR DESCRIPTION
this PR contains two small changes:
- **fix fbchkdoc documentation mentioning wrong argument names for CA certs**
  argument names mentioned in the readme did not match the ones in https://github.com/freebasic/fbc/blob/master/doc/fbchkdoc/cmd_opts.bas#L577
- **enable native CA by default if no custom CA file specified**
  this will make it work on windows and a few other supported systems without specifying a CA file. see https://curl.se/libcurl/c/CURLOPT_SSL_OPTIONS.html for details  
  I tested it on Windows 11 and Ubuntu 20.