### PR TITLE
makefile:  Windows LLVM build failure due to truncated object file names in libfb.a

### DIFF
--- a/makefile
+++ b/makefile
@@ -860,7 +860,10 @@ else ifneq ($(findstring MSYS_NT,$(shell uname)),)
 	$(QUIET)rm -f $@
 	$(QUIET_AR)$(AR) rcs $@ $(libfbobjdir)/*.o
 else
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 endif
 $(LIBFB_C): $(libfbobjdir)/%.o: %.c $(LIBFB_H) | $(libfbobjdir)
 	$(QUIET_CC)$(CC) $(ALLCFLAGS) -c $< -o $@
@@ -868,7 +871,10 @@ $(LIBFB_S): $(libfbobjdir)/%.o: %.s $(LIBFB_H) | $(libfbobjdir)
 	$(QUIET_CPPAS)$(CC) -x assembler-with-cpp $(ALLCFLAGS) -c $< -o $@
 
 $(libdir)/libfbpic.a: $(LIBFBPIC_C) $(LIBFBPIC_S) | $(libdir)
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 $(LIBFBPIC_C): $(libfbpicobjdir)/%.o: %.c $(LIBFB_H) | $(libfbpicobjdir)
 	$(QUIET_CC)$(CC) -fPIC $(ALLCFLAGS) -c $< -o $@
 $(LIBFBPIC_S): $(libfbpicobjdir)/%.o: %.s $(LIBFB_H) | $(libfbpicobjdir)
@@ -884,7 +890,10 @@ else ifneq ($(findstring MSYS_NT,$(shell uname)),)
 	$(QUIET)rm -f $@
 	$(QUIET_AR)$(AR) rcs $@ $(libfbmtobjdir)/*.o
 else
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 endif
 $(LIBFBMT_C): $(libfbmtobjdir)/%.o: %.c $(LIBFB_H) | $(libfbmtobjdir)
 	$(QUIET_CC)$(CC) -DENABLE_MT $(ALLCFLAGS) -c $< -o $@
@@ -892,7 +901,10 @@ $(LIBFBMT_S): $(libfbmtobjdir)/%.o: %.s $(LIBFB_H) | $(libfbmtobjdir)
 	$(QUIET_CPPAS)$(CC) -x assembler-with-cpp -DENABLE_MT $(ALLCFLAGS) -c $< -o $@
 
 $(libdir)/libfbmtpic.a: $(LIBFBMTPIC_C) $(LIBFBMTPIC_S) | $(libdir)
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 $(LIBFBMTPIC_C): $(libfbmtpicobjdir)/%.o: %.c $(LIBFB_H) | $(libfbmtpicobjdir)
 	$(QUIET_CC)$(CC) -DENABLE_MT -fPIC $(ALLCFLAGS) -c $< -o $@
 $(LIBFBMTPIC_S): $(libfbmtpicobjdir)/%.o: %.s $(LIBFB_H) | $(libfbmtpicobjdir)
@@ -934,7 +946,10 @@ else
 ifneq ($(LIBFBRT_C),)
 	$(QUIET_AR)rm -f $@; cp $(LIBFBRT_C) $(libfbrtobjdir); $(AR) rcs $@ $^
 else
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 endif
 endif
 $(LIBFBRT_BAS): $(libfbrtobjdir)/%.o: %.bas $(LIBFBRT_BI) | $(libfbrtobjdir)
@@ -966,7 +981,10 @@ else
 ifneq ($(LIBFBRTMT_C),)
 	$(QUIET_AR)rm -f $@; cp $(LIBFBRTMT_C) $(libfbrtmtobjdir); $(AR) rcs $@ $^
 else
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 endif
 endif
 $(LIBFBRTMT_BAS): $(libfbrtmtobjdir)/%.o: %.bas $(LIBFBRT_BI) | $(libfbrtmtobjdir)
@@ -985,26 +1003,38 @@ $(LIBFBMTRTPIC_BAS): $(libfbrtmtpicobjdir)/%.o: %.c $(LIBFBRT_BI) | $(libfbrtmtp
 gfxlib2: $(GFX_LIBS)
 
 $(libdir)/libfbgfx.a: $(LIBFBGFX_C) $(LIBFBGFX_S) | $(libdir)
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 $(LIBFBGFX_C): $(libfbgfxobjdir)/%.o: %.c $(LIBFBGFX_H) | $(libfbgfxobjdir)
 	$(QUIET_CC)$(CC) $(ALLCFLAGS) -c $< -o $@
 $(LIBFBGFX_S): $(libfbgfxobjdir)/%.o: %.s $(LIBFBGFX_H) | $(libfbgfxobjdir)
 	$(QUIET_CPPAS)$(CC) -x assembler-with-cpp $(ALLCFLAGS) -c $< -o $@
 
 $(libdir)/libfbgfxpic.a: $(LIBFBGFXPIC_C) | $(libdir)
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 $(LIBFBGFXPIC_C): $(libfbgfxpicobjdir)/%.o: %.c $(LIBFBGFX_H) | $(libfbgfxpicobjdir)
 	$(QUIET_CC)$(CC) -fPIC $(ALLCFLAGS) -c $< -o $@
 
 $(libdir)/libfbgfxmt.a: $(LIBFBGFXMT_C) $(LIBFBGFXMT_S) | $(libdir)
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 $(LIBFBGFXMT_C): $(libfbgfxmtobjdir)/%.o: %.c $(LIBFBGFX_H) | $(libfbgfxmtobjdir)
 	$(QUIET_CC)$(CC) -DENABLE_MT $(ALLCFLAGS) -c $< -o $@
 $(LIBFBGFXMT_S): $(libfbgfxmtobjdir)/%.o: %.s $(LIBFBGFX_H) | $(libfbgfxmtobjdir)
 	$(QUIET_CPPAS)$(CC) -x assembler-with-cpp -DENABLE_MT $(ALLCFLAGS) -c $< -o $@
 
 $(libdir)/libfbgfxmtpic.a: $(LIBFBGFXMTPIC_C) | $(libdir)
-	$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^
+	$(QUIET_AR)rm -f $@; \
+for f in $(libfbobjdir)/*.o; do \
+  $(AR) q $@ $$f; \
+done
 $(LIBFBGFXMTPIC_C): $(libfbgfxmtpicobjdir)/%.o: %.c $(LIBFBGFX_H) | $(libfbgfxmtpicobjdir)
 	$(QUIET_CC)$(CC) -DENABLE_MT -fPIC $(ALLCFLAGS) -c $< -o $@
 


### PR DESCRIPTION
## Description

When building FreeBASIC with the LLVM toolchain on Windows, llvm-ar reports an error:llvm-ar.exe: error: src/rtlib/obj/win32/io_lprint_: No such file or directory
The cause is that the Makefile uses `$^` when packaging libfb.a. The expanded content of `$^` is too long, which leads to filename truncation (for example, io_lprint_bool.o is truncated to io_lprint_), making it impossible to find the corresponding target file.

## Solution

Modify the rule for packaging libfb.a in the Makefile. Avoid using `$^` to pass all dependencies directly; instead, use a loop to add .o files one by one to prevent command-line truncation.

## Diff

Change `$(QUIET_AR)rm -f $@; $(AR) rcs $@ $^` to
```make
$(QUIET_AR)rm -f $@; \
for f in $(libfbobjdir)/*.o; do \
  $(AR) q $@ $$f; \
done
```

I tested on my machine; it worked well :)