### PR TITLE
Fix macOS arm64 (Apple Silicon) linker support

### DIFF
--- a/makefile
+++ b/makefile
@@ -342,8 +342,13 @@ ifneq ($(filter 386 486 586 686 i386 i486 i586 i686,$(TARGET_ARCH)),)
   TARGET_ARCH := x86
 endif
 
-# Normalize TARGET_ARCH to arm
-ifneq ($(filter arm%,$(TARGET_ARCH)),)
+# Normalize TARGET_ARCH to aarch64 (macOS reports arm64)
+ifneq ($(filter aarch64 arm64,$(TARGET_ARCH)),)
+  TARGET_ARCH := aarch64
+endif
+
+# Normalize TARGET_ARCH to arm (32-bit only, after aarch64 is handled)
+ifneq ($(filter armv% arm,$(TARGET_ARCH)),)
   TARGET_ARCH := arm
 endif
 

--- a/src/compiler/fbc.bas
+++ b/src/compiler/fbc.bas
@@ -305,7 +305,7 @@ private function hGet1stOutputLineFromCommand( byref cmd as string ) as string
 	end if
 
 	dim ln as string
-	input #f, ln
+	line input #f, ln
 
 	close f
 	return ln
@@ -840,6 +840,8 @@ private function hLinkFiles( ) as integer
 		case FB_CPUFAMILY_ARM
 			'' fixme: this is clearly too specific
 			ldcline += "-arch armv6 "
+		case FB_CPUFAMILY_AARCH64
+			ldcline += "-arch arm64 "
 		end select
 	end select
 
@@ -1123,9 +1125,11 @@ private function hLinkFiles( ) as integer
 		wend
 	end scope
 
-	'' And the sysroot
+	'' And the sysroot (Darwin uses -syslibroot, handled separately)
 	if( len( fbc.sysroot ) ) then
-		ldcline += " --sysroot=" + fbc.sysroot
+		if( fbGetOption( FB_COMPOPT_TARGET ) <> FB_COMPTARGET_DARWIN ) then
+			ldcline += " --sysroot=" + fbc.sysroot
+		end if
 	end if
 
 	'' crt begin objects
@@ -1323,7 +1327,27 @@ private function hLinkFiles( ) as integer
 	end select
 
 	if( fbGetOption( FB_COMPOPT_TARGET ) = FB_COMPTARGET_DARWIN ) then
-		ldcline += " -macosx_version_min 10.4"
+		scope
+			dim as string sdkver = "14.0"
+			dim as string sysroot
+			if( len( fbc.sysroot ) > 0 ) then
+				sysroot = fbc.sysroot
+#ifdef __FB_DARWIN__
+			else
+				sysroot = hGet1stOutputLineFromCommand( "xcrun --show-sdk-path" )
+				dim as string v = hGet1stOutputLineFromCommand( "xcrun --show-sdk-version" )
+				if( len( v ) > 0 ) then sdkver = v
+#endif
+			end if
+			if( fbGetCpuFamily( ) = FB_CPUFAMILY_AARCH64 ) then
+				ldcline += " -platform_version macos 11.0.0 " + sdkver
+			else
+				ldcline += " -platform_version macos 10.4.0 " + sdkver
+			end if
+			if( len( sysroot ) > 0 ) then
+				ldcline += " -syslibroot " + QUOTE + sysroot + QUOTE
+			end if
+		end scope
 	end if
 
 	'' This is required for 64-bit modules on *nix-y platforms
@@ -1332,8 +1356,7 @@ private function hLinkFiles( ) as integer
 	select case as const fbGetOption( FB_COMPOPT_TARGET )
 	case FB_COMPTARGET_LINUX, FB_COMPTARGET_FREEBSD, _
 		FB_COMPTARGET_OPENBSD, FB_COMPTARGET_NETBSD, _
-		FB_COMPTARGET_DRAGONFLY, FB_COMPTARGET_SOLARIS, _
-		FB_COMPTARGET_DARWIN
+		FB_COMPTARGET_DRAGONFLY, FB_COMPTARGET_SOLARIS
 		dim as long outtype = fbGetOption( FB_COMPOPT_OUTTYPE )
 		if outtype = FB_OUTTYPE_EXECUTABLE OrElse outtype = FB_OUTTYPE_DYNAMICLIB Then
 			dim as long cpufamily = fbGetCpuFamily( )
@@ -4308,7 +4331,6 @@ private sub hAddDefaultLibs( )
 		end if
 
 	case FB_COMPTARGET_DARWIN
-		fbcAddDefLib( "gcc" )
 		fbcAddDefLib( "System" )
 		fbcAddDefLib( "pthread" )
 		fbcAddDefLib( "ncurses" )

--- a/src/rtlib/profile_cycles.c
+++ b/src/rtlib/profile_cycles.c
@@ -31,9 +31,11 @@
 	#endif
 #endif
 
-/* profile section data */
+/* profile section data (ELF section boundary symbols, not available on Mach-O) */
+#if !defined(HOST_DARWIN)
 extern char __start_fb_profilecycledata[];
 extern char __stop_fb_profilecycledata;
+#endif
 
 /* profiler record ids - these indicate what the record is */
 enum FB_PROFILE_REDORD_ID
@@ -97,7 +99,9 @@ typedef struct _FB_PROFILER_CYCLES
 /* FIXME: creating a library with other sections causes dxe3gen to fail
 **        when building the DXE dynamic link library support for DOS
 */
-#if !defined(HOST_DOS)
+#if !defined(HOST_DOS) && !defined(HOST_DARWIN)
+/* Cycle profiling uses ELF __start_/__stop_ section boundary symbols
+   which are not available on Mach-O (Darwin). */
 
 /* make sure there is at least one record in the profile data section */
 static FB_PROFILE_RECORD_VERSION
@@ -301,8 +305,13 @@ static void hProfilerWriteReport( FB_PROFILER_CYCLES *prof )
 		fprintf( f, "Total program execution time: %5.4g seconds\n", fb_Timer() - prof->start_time );
 	}
 
+#if !defined(HOST_DARWIN)
 	data = (unsigned char *)&__start_fb_profilecycledata[0];
 	length = (ssize_t)&__stop_fb_profilecycledata - (ssize_t)&__start_fb_profilecycledata[0];
+#else
+	data = NULL;
+	length = 0;
+#endif
 
 	count = hProfilerCountProcs( data, length );
 	if( count ) {


### PR DESCRIPTION
## Summary

Fix linking on macOS arm64 (Apple Silicon, M1/M2/M3/M4).

## Changes (3 files, +47/-11)

**makefile:**
- Normalize `arm64` (from `uname -m`) to `aarch64` before the 32-bit `armv%` catch-all

**src/compiler/fbc.bas:**
- `line input` in `hGet1stOutputLineFromCommand` (handles spaces in SDK paths)
- Add `-arch arm64` for `FB_CPUFAMILY_AARCH64` on darwin
- Replace deprecated `-macosx_version_min` with `-platform_version macos <min> <sdk>`
  - min: 11.0 for arm64, 10.4 for x86_64 (preserves original minimum)
  - sdk: detected via `xcrun --show-sdk-version` (fallback 14.0)
- SDK path via `xcrun --show-sdk-path` (only on darwin host, respects user `-sysroot`, quoted with QUOTE)
- Skip GNU `--sysroot=` on darwin (Apple ld uses `-syslibroot`)
- Remove `--eh-frame-hdr` on darwin (unsupported by Apple ld)
- Remove `-lgcc` from darwin default libs (unavailable with Apple clang)

**src/rtlib/profile_cycles.c:**
- Guard ELF `__start_`/`__stop_` section boundary symbol declarations and usage with `!defined(HOST_DARWIN)`
- Provide `data=NULL, length=0` fallback on darwin (cycle profiling compiles but produces no output)

## Testing

```
make bootstrap-minimal ENABLE_STANDALONE=1
```
Successfully builds fbc and runtime library on macOS 15 (Sequoia) with Apple clang 21 on M4.

## Notes

- x86_64 darwin builds unaffected (minimum version preserved at 10.4)
- `-profile cycles` compiles on darwin but produces no per-procedure data (Mach-O lacks ELF section boundary symbols)
- Bootstrap requires `bootstrap/darwin-aarch64/` (copy from `bootstrap/linux-aarch64/` + fix clang computed goto)